### PR TITLE
Devices lists

### DIFF
--- a/src/lib/storage/devices_list.rb
+++ b/src/lib/storage/devices_list.rb
@@ -1,0 +1,104 @@
+# encoding: utf-8
+
+# Copyright (c) [2016] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Yast
+  module Storage
+    class DevicesList
+      include Enumerable
+
+      class << self
+        attr_accessor :device_class
+        attr_accessor :default_delegate
+
+        def list_of(klass)
+          self.device_class = klass
+        end
+
+        def by_default_delegate_to(list)
+          self.default_delegate = list
+        end
+      end
+
+      attr_reader :devicegraph
+
+      def initialize(devicegraph, list: nil)
+        @devicegraph = devicegraph
+        @list = list || full_list
+      end
+
+      def with(attrs = {})
+        new_list = list.select do |element|
+          attrs.all? { |attr, value| match?(element, attr, value) }
+        end
+        if block_given?
+          new_list.select!(&Proc.new)
+        end
+        self.class.new(devicegraph, list: new_list)
+      end
+
+      def each(&block)
+        @list.each(&block)
+      end
+
+      def dup
+        self.class.new(devicegraph, @list.dup)
+      end
+
+      # Returns true if the list contains no elements
+      #
+      # @return [Boolean]
+      def empty?
+        list.empty?
+      end
+
+      # Number of elements in the list
+      #
+      # @return [Fixnum]
+      def length
+        list.length
+      end
+      alias_method :size, :length
+
+      def method_missing(meth, *args, &block)
+        delegate_list = self.class.default_delegate
+        if delegate_list
+          delegate_list.send(meth, *args, &block)
+        else
+          super
+        end
+      end
+
+    protected
+    
+      attr_accessor :list
+      
+      def full_list
+        self.class.device_class.all(devicegraph).to_a
+      end
+
+      def match?(element, attr, value)
+        real_value = element.send(attr)
+        return true if real_value == value
+        value.is_a?(Array) && value.include?(real_value)
+      end
+    end
+  end
+end

--- a/src/lib/storage/disks_list.rb
+++ b/src/lib/storage/disks_list.rb
@@ -24,14 +24,13 @@ require "storage"
 require "storage/devices_list"
 require "storage/partitions_list"
 require "storage/filesystems_list"
-#require "storage/free_disk_spaces_list"
+require "storage/free_disk_spaces_list"
 require "storage/refinements/disk"
 
 module Yast
   module Storage
     class DisksList < DevicesList
       list_of ::Storage::Disk
-      by_default_delegate_to :partitions
 
       using Refinements::Disk
 

--- a/src/lib/storage/disks_list.rb
+++ b/src/lib/storage/disks_list.rb
@@ -29,16 +29,24 @@ require "storage/refinements/disk"
 
 module Yast
   module Storage
+    # List of disks from a devicegraph
     class DisksList < DevicesList
       list_of ::Storage::Disk
 
       using Refinements::Disk
 
+      # Partitions included in any of the disks
+      #
+      # @return [PartitionsList]
       def partitions
         part_list = list.reduce([]) { |sum, disk| sum + disk.all_partitions }
         PartitionsList.new(devicegraph, list: part_list)
       end
 
+      # Filesystems present in any of the disks, either directly either inside a
+      # partition
+      #
+      # @return [FilesystemsList]
       def filesystems
         fs_list = partitions.filesystems.to_a
         # Add filesystems not included in #partitions (directly on disk)
@@ -48,6 +56,9 @@ module Yast
         FilesystemsList.new(devicegraph, list: fs_list)
       end
 
+      # Free spaces in any of the disks
+      #
+      # @return [FreeDiskSpacesList]
       def free_disk_spaces
         spaces_list = list.reduce([]) { |sum, disk| sum + disk.free_spaces }
         FreeDiskSpacesList.new(devicegraph, list: spaces_list)

--- a/src/lib/storage/disks_list.rb
+++ b/src/lib/storage/disks_list.rb
@@ -1,0 +1,58 @@
+#
+# encoding: utf-8
+
+# Copyright (c) [2016] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "storage"
+require "storage/devices_list"
+require "storage/partitions_list"
+require "storage/filesystems_list"
+#require "storage/free_disk_spaces_list"
+require "storage/refinements/disk"
+
+module Yast
+  module Storage
+    class DisksList < DevicesList
+      list_of ::Storage::Disk
+      by_default_delegate_to :partitions
+
+      using Refinements::Disk
+
+      def partitions
+        part_list = list.reduce([]) { |sum, disk| sum + disk.all_partitions }
+        PartitionsList.new(devicegraph, list: part_list)
+      end
+
+      def filesystems
+        fs_list = partitions.filesystems.to_a
+        # Add filesystems not included in #partitions (directly on disk)
+        list.each do |disk|
+          fs_list << disk.filesystem if !disk.partition_table && disk.filesystem
+        end
+        FilesystemsList.new(devicegraph, list: fs_list)
+      end
+
+      def free_disk_spaces
+        spaces_list = list.reduce([]) { |sum, disk| sum + disk.free_spaces }
+        FreeDiskSpacesList.new(devicegraph, list: spaces_list)
+      end
+    end
+  end
+end

--- a/src/lib/storage/filesystems_list.rb
+++ b/src/lib/storage/filesystems_list.rb
@@ -1,0 +1,32 @@
+#
+# encoding: utf-8
+
+# Copyright (c) [2016] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "storage"
+require "storage/devices_list"
+
+module Yast
+  module Storage
+    class FilesystemsList < DevicesList
+      list_of ::Storage::Filesystem
+    end
+  end
+end

--- a/src/lib/storage/filesystems_list.rb
+++ b/src/lib/storage/filesystems_list.rb
@@ -25,6 +25,7 @@ require "storage/devices_list"
 
 module Yast
   module Storage
+    # List of filesystems from a devicegraph
     class FilesystemsList < DevicesList
       list_of ::Storage::Filesystem
     end

--- a/src/lib/storage/free_disk_spaces_list.rb
+++ b/src/lib/storage/free_disk_spaces_list.rb
@@ -20,53 +20,35 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "storage"
+require "storage/free_disk_space"
 require "storage/disk_size"
+require "storage/devices_list"
 require "storage/refinements/disk"
 
 module Yast
   module Storage
-    # Prototype of a class to allow querying a devigraph for its elements
-    #
-    # The class is now used in the RSpec tests and in the proposal code but the
-    # API will likely change a lot depending on the discussion on
-    # https://lists.opensuse.org/yast-devel/2016-03/msg00053.html
-    # Thus the lack of documentation for the concrete methods
-    class DevicegraphQuery
+    class FreeDiskSpacesList < DevicesList
+      list_of FreeDiskSpace
+
       using Refinements::Disk
 
       # Free disk space below this size will be disregarded
       TINY_FREE_CHUNK = DiskSize.MiB(30)
 
-      attr_reader :devicegraph
-
-      def initialize(devicegraph, disk_names: nil)
-        @devicegraph = devicegraph
-        @disk_names = disk_names
+      def useful
+        new_list = list.select { |space| space.size >= TINY_FREE_CHUNK }
+        self.class.new(devicegraph, list: new_list)
       end
 
-      def disks
-        if @disk_names
-          @disk_names.map { |disk_name| ::Storage::Disk.find(@devicegraph, disk_name) }
-        else
-          devicegraph.all_disks.to_a
-        end
+      def disk_size
+        list.map(&:size).reduce(DiskSize.zero, :+)
       end
 
-      def available_size
-        useful_free_spaces.map(&:size).reduce(DiskSize.zero, :+)
-      end
-
-      def useful_free_spaces
-        free_spaces.select { |space| space.size >= TINY_FREE_CHUNK }
-      end
-
-      def free_spaces
+    protected
+    
+      def full_list
+        disks = devicegraph.all_disks.to_a
         disks.reduce([]) { |sum, disk| sum + disk.free_spaces }
-      end
-
-      def partitions
-        disks.reduce([]) { |sum, disk| sum + disk.all_partitions }
       end
     end
   end

--- a/src/lib/storage/free_disk_spaces_list.rb
+++ b/src/lib/storage/free_disk_spaces_list.rb
@@ -32,14 +32,6 @@ module Yast
 
       using Refinements::Disk
 
-      # Free disk space below this size will be disregarded
-      TINY_FREE_CHUNK = DiskSize.MiB(30)
-
-      def useful
-        new_list = list.select { |space| space.size >= TINY_FREE_CHUNK }
-        self.class.new(devicegraph, list: new_list)
-      end
-
       def disk_size
         list.map(&:size).reduce(DiskSize.zero, :+)
       end

--- a/src/lib/storage/free_disk_spaces_list.rb
+++ b/src/lib/storage/free_disk_spaces_list.rb
@@ -27,17 +27,21 @@ require "storage/refinements/disk"
 
 module Yast
   module Storage
+    # List of free spaces from a devicegraph
     class FreeDiskSpacesList < DevicesList
       list_of FreeDiskSpace
 
       using Refinements::Disk
 
+      # Sum of the sizes of all the spaces
+      #
+      # @return [DiskSize]
       def disk_size
         list.map(&:size).reduce(DiskSize.zero, :+)
       end
 
     protected
-    
+
       def full_list
         disks = devicegraph.all_disks.to_a
         disks.reduce([]) { |sum, disk| sum + disk.free_spaces }

--- a/src/lib/storage/partitions_list.rb
+++ b/src/lib/storage/partitions_list.rb
@@ -1,0 +1,50 @@
+#
+# encoding: utf-8
+
+# Copyright (c) [2016] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "storage"
+require "storage/devices_list"
+require "storage/filesystems_list"
+
+module Yast
+  module Storage
+    class PartitionsList < DevicesList
+
+      list_of ::Storage::Partition
+      by_default_delegate_to :filesystems
+
+      def filesystems
+        FilesystemsList.new(devicegraph, list: list.map(&:filesystem).compact)
+      end
+
+    protected
+
+      def full_list
+        # There is no ::Storage::Partition.all
+        devicegraph.all_disks.to_a.reduce([]) do |sum, disk|
+          if disk.partition_table
+            sum + disk.partition_table.partitions.to_a
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/storage/partitions_list.rb
+++ b/src/lib/storage/partitions_list.rb
@@ -26,9 +26,13 @@ require "storage/filesystems_list"
 
 module Yast
   module Storage
+    # List of partitions from a devicegraph
     class PartitionsList < DevicesList
       list_of ::Storage::Partition
 
+      # Filesystems located in the partitions
+      #
+      # @return [FilesystemsList]
       def filesystems
         fs_list = list.map do |partition|
           begin
@@ -48,6 +52,8 @@ module Yast
         devicegraph.all_disks.to_a.reduce([]) do |sum, disk|
           if disk.partition_table
             sum + disk.partition_table.partitions.to_a
+          else
+            sum
           end
         end
       end

--- a/src/lib/storage/proposal/devicegraph_generator.rb
+++ b/src/lib/storage/proposal/devicegraph_generator.rb
@@ -80,7 +80,7 @@ module Yast
         #           devicegraph (@see RefinedDevicegraph)
         # @return [::Storage::Devicegraph]
         def provide_space(volumes, initial_graph)
-          space_maker = SpaceMaker.new(initial_graph, disk_analyzer)
+          space_maker = SpaceMaker.new(initial_graph, disk_analyzer, settings)
           self.got_desired_space = false
           begin
             result_graph = space_maker.provide_space(volumes.desired_size)

--- a/src/lib/storage/proposal/partition_creator.rb
+++ b/src/lib/storage/proposal/partition_creator.rb
@@ -25,7 +25,7 @@ require "fileutils"
 require "storage/planned_volumes_list"
 require "storage/disk_size"
 require "storage/refinements/devicegraph"
-require "storage/devicegraph_query"
+require "storage/refinements/devicegraph_lists"
 
 module Yast
   module Storage
@@ -34,6 +34,7 @@ module Yast
       # SpaceMaker.
       class PartitionCreator
         using Refinements::Devicegraph
+        using Refinements::DevicegraphLists
         include Yast::Logger
 
         attr_accessor :settings
@@ -84,7 +85,7 @@ module Yast
         # @return [DiskSize] sum
         #
         def total_free_size
-          devgraph_query.available_size
+          free_spaces.disk_size
         end
 
         # List of free spaces in the devicegraph
@@ -92,7 +93,7 @@ module Yast
         # @return [Array<FreeDiskSpace>]
         #
         def free_spaces
-          devgraph_query.useful_free_spaces
+          candidate_disks.free_disk_spaces.useful
         end
 
         # @return [Array<String>]
@@ -102,9 +103,9 @@ module Yast
 
         # Query in the target devicegraph restricted to the candidate disks
         #
-        # @return [DevicegraphQuery]
-        def devgraph_query
-          @devgraph_query ||= DevicegraphQuery.new(devicegraph, disk_names: candidate_disk_names)
+        # @return [DisksList]
+        def candidate_disks
+          @candidate_disks ||= devicegraph.disks.with(name: candidate_disk_names)
         end
 
         # Create volumes on LVM.

--- a/src/lib/storage/proposal/partition_creator.rb
+++ b/src/lib/storage/proposal/partition_creator.rb
@@ -83,17 +83,17 @@ module Yast
         # Sum up the sizes of all slots in the devicegraph
         #
         # @return [DiskSize] sum
-        #
         def total_free_size
           free_spaces.disk_size
         end
 
         # List of free spaces in the devicegraph
         #
-        # @return [Array<FreeDiskSpace>]
-        #
+        # @return [FreeDiskSpacesList]
         def free_spaces
-          candidate_disks.free_disk_spaces.useful
+          candidate_disks.free_disk_spaces.with do |space|
+            space.size >= settings.useful_free_space_min_size
+          end
         end
 
         # @return [Array<String>]

--- a/src/lib/storage/proposal/settings.rb
+++ b/src/lib/storage/proposal/settings.rb
@@ -84,6 +84,12 @@ module Yast
           # Not yet in control.xml
           @home_min_size                 = DiskSize.GiB(10)
           @home_max_size                 = DiskSize.unlimited
+
+          # FIXME: this setting is placed here as a temporary mechanism to share
+          # it between the different Proposal components. There are NO PLANS to
+          # make it configurable in control.xml. In the not-so-far future this
+          # might become a value calculated from our own partition alignment
+          # logic, then we will have a better home for it.
           @useful_free_space_min_size    = DiskSize.MiB(30)
         end
       end

--- a/src/lib/storage/proposal/settings.rb
+++ b/src/lib/storage/proposal/settings.rb
@@ -65,6 +65,8 @@ module Yast
         attr_accessor :btrfs_default_subvolume
         attr_accessor :home_min_size
         attr_accessor :home_max_size
+        # Free disk space below this size will be disregarded
+        attr_accessor :useful_free_space_min_size
 
         def initialize
           super
@@ -82,6 +84,7 @@ module Yast
           # Not yet in control.xml
           @home_min_size                 = DiskSize.GiB(10)
           @home_max_size                 = DiskSize.unlimited
+          @useful_free_space_min_size    = DiskSize.MiB(30)
         end
       end
     end

--- a/src/lib/storage/proposal/space_maker.rb
+++ b/src/lib/storage/proposal/space_maker.rb
@@ -40,13 +40,17 @@ module Yast
         using Refinements::DevicegraphLists
         include Yast::Logger
 
+        attr_accessor :settings
+
         # Initialize.
         #
         # @param original_graph [::Storage::Devicegraph] initial devicegraph
         # @param disk_analyzer [DiskAnalyzer] information about original_graph
-        def initialize(original_graph, disk_analyzer)
+        # @param settings [Proposal::Settings] proposal settings
+        def initialize(original_graph, disk_analyzer, settings)
           @original_graph = original_graph
           @disk_analyzer = disk_analyzer
+          @settings = settings
         end
 
         # Returns a copy of the original devicegraph in which all needed
@@ -76,7 +80,16 @@ module Yast
 
         # @return [DiskSize]
         def available_size(graph)
-          disks_for(graph).free_disk_spaces.disk_size
+          free_spaces(graph).disk_size
+        end
+
+        # List of free spaces in the given devicegraph
+        #
+        # @return [FreeDiskSpacesList]
+        def free_spaces(graph)
+          disks_for(graph).free_disk_spaces.with do |space|
+            space.size >= settings.useful_free_space_min_size
+          end
         end
 
         # List of candidate disks in the given devicegraph

--- a/src/lib/storage/refinements/devicegraph_lists.rb
+++ b/src/lib/storage/refinements/devicegraph_lists.rb
@@ -35,10 +35,10 @@ module Yast
       module DevicegraphLists
         refine ::Storage::Devicegraph do
           DEVICE_LISTS = {
-            :disks            => DisksList,
-            :partitions       => PartitionsList,
-            :filesystems      => FilesystemsList,
-            :free_disk_spaces => FreeDiskSpacesList
+            disks:            DisksList,
+            partitions:       PartitionsList,
+            filesystems:      FilesystemsList,
+            free_disk_spaces: FreeDiskSpacesList
           }
 
           DEVICE_LISTS.each do |list, klass|

--- a/src/lib/storage/refinements/devicegraph_lists.rb
+++ b/src/lib/storage/refinements/devicegraph_lists.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+#
+# encoding: utf-8
+
+# Copyright (c) [2016] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "storage"
+require "storage/disks_list"
+require "storage/partitions_list"
+require "storage/filesystems_list"
+require "storage/free_disk_spaces_list"
+
+module Yast
+  module Storage
+    module Refinements
+      # Refinement for ::Storage::Devicegraph adding shortcuts to the devices
+      # lists
+      module DevicegraphLists
+        refine ::Storage::Devicegraph do
+          DEVICE_LISTS = {
+            :disks            => DisksList,
+            :partitions       => PartitionsList,
+            :filesystems      => FilesystemsList,
+            :free_disk_spaces => FreeDiskSpacesList
+          }
+
+          DEVICE_LISTS.each do |list, klass|
+            define_method(list) do
+              klass.new(self)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/data/input/mixed_disks.yml
+++ b/test/data/input/mixed_disks.yml
@@ -1,0 +1,82 @@
+---
+- disk:
+    name: /dev/sda
+    size: 200 GiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        size:         100 GiB
+        name:         /dev/sda1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+
+    - free:
+        size:         2 GiB
+
+    - partition:
+        size:         98 GiB
+        name:         /dev/sda2
+        file_system:  ext4
+        mount_point:  /
+        label:        root
+
+- disk:
+    name: /dev/sdb
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        size:         4 GiB
+        name:         /dev/sdb1
+        id:           swap
+        file_system:  swap
+        mount_point:  swap
+        label:        swap
+
+    - partition:
+        size:         60 GiB
+        name:         /dev/sdb2
+        file_system:  btrfs
+        label:        suse_root
+
+    - partition:
+        size:         60 GiB
+        name:         /dev/sdb3
+        file_system:  ext4
+        label:        ubuntu_root
+
+    - partition:
+        size:         800 GiB
+        name:         /dev/sdb4
+        type:         extended
+
+    - partition:
+        size:         300 GiB
+        name:         /dev/sdb5
+        type:         logical
+        file_system:  xfs
+        mount_point:  /home
+        label:        home
+
+    - partition:
+        size:         500 GiB
+        name:         /dev/sdb6
+        type:         logical
+        file_system:  xfs
+        label:        data
+
+    - partition:
+        size:         10 GiB
+        name:         /dev/sdb7
+        type:         logical
+
+    - free:
+        size: 90 GiB
+
+- disk:
+    name: /dev/sdc
+    size: 500 GiB
+    partition_table: ms-dos

--- a/test/devices_list_test.rb
+++ b/test/devices_list_test.rb
@@ -1,0 +1,214 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2016] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "storage"
+require "storage/disks_list"
+require "storage/partitions_list"
+require "storage/filesystems_list"
+require "storage/free_disk_spaces_list"
+require "storage/refinements/devicegraph_lists"
+require "storage/refinements/size_casts"
+
+describe "devices lists" do
+  using Yast::Storage::Refinements::DevicegraphLists
+
+  # Just to shorten
+  let(:ext4) { ::Storage::FsType_EXT4 }
+  let(:ntfs) { ::Storage::FsType_NTFS }
+  let(:id_linux) { ::Storage::ID_LINUX }
+  let(:id_swap) { ::Storage::ID_SWAP }
+  let(:primary) { ::Storage::PartitionType_PRIMARY }
+
+  before do
+    fake_scenario("mixed_disks")
+  end
+
+  describe "Yast::Storage::DevicesList" do
+    describe "#with" do
+      it "returns a list of the same class" do
+        result = fake_devicegraph.filesystems.with(type: ext4)
+        expect(result).to be_a(Yast::Storage::FilesystemsList)
+      end
+
+      it "filters by a scalar value" do
+        result = fake_devicegraph.filesystems.with(type: ext4)
+        expect(result).to contain_exactly(
+          an_object_with_fields(label: "root"),
+          an_object_with_fields(label: "ubuntu_root")
+        )
+      end
+
+      it "filters by an array of values" do
+        result = fake_devicegraph.filesystems.with(type: [ext4, ntfs])
+        expect(result).to contain_exactly(
+          an_object_with_fields(label: "root"),
+          an_object_with_fields(label: "ubuntu_root"),
+          an_object_with_fields(label: "windows"),
+        )
+      end
+
+      it "filters by another list of values" do
+        filesystems = fake_devicegraph.filesystems.with(type: [ext4, ntfs])
+        result = fake_devicegraph.partitions.with(filesystem: filesystems)
+        expect(result).to contain_exactly(
+          an_object_with_fields(name: "/dev/sda1"),
+          an_object_with_fields(name: "/dev/sdb3"),
+          an_object_with_fields(name: "/dev/sda2")
+        )
+      end
+
+      it "filters by any combination of scalars and lists" do
+        result = fake_devicegraph.partitions.with(id: [id_swap, id_linux], type: primary)
+        expect(result).to contain_exactly(
+          an_object_with_fields(name: "/dev/sda2"),
+          an_object_with_fields(name: "/dev/sdb1"),
+          an_object_with_fields(name: "/dev/sdb2"),
+          an_object_with_fields(name: "/dev/sdb3")
+        )
+      end
+
+      it "filters by block" do
+        result = fake_devicegraph.filesystems.with do |fs|
+          fs.mountpoints.first == "/"
+        end
+        expect(result).to contain_exactly(
+          an_object_with_fields(label: "root")
+        )
+      end
+    end
+
+    describe "#size" do
+      it "returns the number of elements" do
+        expect(fake_devicegraph.disks.size).to eq 3
+      end
+    end
+
+    describe "#to_a" do
+      it "returns an array with the elements" do
+        array = fake_devicegraph.disks.to_a
+        expect(array).to be_an Array
+        expect(array.size).to eq 3
+      end
+    end
+
+    describe "#empty?" do
+      it "returns true if no elements are found" do
+        disks = fake_devicegraph.disks.with(name: "/dev/sdc")
+        expect(disks.partitions.empty?).to eq true
+      end
+
+      it "returns false if some element is found" do
+        disks = fake_devicegraph.disks.with(name: "/dev/sda")
+        expect(disks.partitions.empty?).to eq false
+      end
+    end
+  end
+
+  describe Yast::Storage::DisksList do
+    let(:disks) { fake_devicegraph.disks }
+
+    it "contains all disks by default" do
+      expect(disks.size).to eq 3
+      expect(described_class.new(fake_devicegraph).size).to eq 3
+    end
+
+    describe "#partitions" do
+      it "returns a filtered list of partitions" do
+        parts_sdb = disks.with(name: "/dev/sdb").partitions
+        parts_sdc = disks.with(name: "/dev/sdc").partitions
+        expect(parts_sdb).to be_a Yast::Storage::PartitionsList
+        expect(parts_sdb.size).to eq 7
+        expect(parts_sdc).to be_a Yast::Storage::PartitionsList
+        expect(parts_sdc.size).to eq 0
+      end
+    end
+
+    describe "#filesystems" do
+      it "returns a filtered list of filesystems" do
+        fs_sdb = disks.with(name: "/dev/sdb").filesystems
+        fs_sdc = disks.with(name: "/dev/sdc").filesystems
+        expect(fs_sdb).to be_a Yast::Storage::FilesystemsList
+        expect(fs_sdb.size).to eq 5
+        expect(fs_sdc).to be_a Yast::Storage::FilesystemsList
+        expect(fs_sdc.size).to eq 0
+      end
+    end
+
+    describe "#free_disk_spaces" do
+      it "returns a filtered list of FreeDiskSpace" do
+        spaces_all = disks.free_disk_spaces
+        spaces_sdc = disks.with(name: "/dev/sdc").free_disk_spaces
+        expect(spaces_all).to be_a Yast::Storage::FreeDiskSpacesList
+        expect(spaces_all.size).to eq 3
+        expect(spaces_sdc).to be_a Yast::Storage::FreeDiskSpacesList
+        expect(spaces_sdc.size).to eq 1
+      end
+    end
+  end
+
+  describe Yast::Storage::PartitionsList do
+    let(:partitions) { fake_devicegraph.partitions }
+
+    it "contains all partitions by default" do
+      expect(partitions.size).to eq 9
+      expect(described_class.new(fake_devicegraph).size).to eq 9
+    end
+
+    describe "#filesystems" do
+      it "returns a filtered list of filesystems" do
+        parts_sda = partitions.with {|p| p.name.start_with? "/dev/sda" }
+        parts_sdb = partitions.with {|p| p.name.start_with? "/dev/sdb" }
+        expect(parts_sda.filesystems).to be_a Yast::Storage::FilesystemsList
+        expect(parts_sda.filesystems.size).to eq 2
+        expect(parts_sdb.filesystems).to be_a Yast::Storage::FilesystemsList
+        expect(parts_sdb.filesystems.size).to eq 5
+      end
+    end
+  end
+
+  describe Yast::Storage::FilesystemsList do
+    let(:filesystems) { fake_devicegraph.filesystems }
+
+    it "contains all filesystems by default" do
+      expect(filesystems.size).to eq 7
+      expect(described_class.new(fake_devicegraph).size).to eq 7
+    end
+  end
+
+  describe Yast::Storage::FreeDiskSpacesList do
+    using Yast::Storage::Refinements::SizeCasts
+
+    let(:spaces) { fake_devicegraph.free_disk_spaces }
+
+    it "contains all spaces by default" do
+      expect(spaces.size).to eq 3
+      expect(described_class.new(fake_devicegraph).size).to eq 3
+    end
+
+    describe "#disk_size" do
+      it "returns to sum of all the spaces sizes" do
+        expect(spaces.disk_size).to eq 602.GiB
+      end
+    end
+  end
+end

--- a/test/devices_list_test.rb
+++ b/test/devices_list_test.rb
@@ -63,7 +63,7 @@ describe "devices lists" do
         expect(result).to contain_exactly(
           an_object_with_fields(label: "root"),
           an_object_with_fields(label: "ubuntu_root"),
-          an_object_with_fields(label: "windows"),
+          an_object_with_fields(label: "windows")
         )
       end
 
@@ -176,8 +176,8 @@ describe "devices lists" do
 
     describe "#filesystems" do
       it "returns a filtered list of filesystems" do
-        parts_sda = partitions.with {|p| p.name.start_with? "/dev/sda" }
-        parts_sdb = partitions.with {|p| p.name.start_with? "/dev/sdb" }
+        parts_sda = partitions.with { |p| p.name.start_with? "/dev/sda" }
+        parts_sdb = partitions.with { |p| p.name.start_with? "/dev/sdb" }
         expect(parts_sda.filesystems).to be_a Yast::Storage::FilesystemsList
         expect(parts_sda.filesystems.size).to eq 2
         expect(parts_sdb.filesystems).to be_a Yast::Storage::FilesystemsList

--- a/test/proposal/partition_creator_test.rb
+++ b/test/proposal/partition_creator_test.rb
@@ -23,12 +23,13 @@
 require_relative "../spec_helper"
 require "storage"
 require "storage/proposal"
-require "storage/devicegraph_query"
+require "storage/refinements/devicegraph_lists"
 require "storage/refinements/size_casts"
 
 describe Yast::Storage::Proposal::PartitionCreator do
   describe "#create_partitions" do
     using Yast::Storage::Refinements::SizeCasts
+    using Yast::Storage::Refinements::DevicegraphLists
 
     before do
       fake_scenario(scenario)
@@ -57,8 +58,7 @@ describe Yast::Storage::Proposal::PartitionCreator do
 
       it "creates partitions matching the volume sizes" do
         result = creator.create_partitions(volumes, target_size)
-        query = Yast::Storage::DevicegraphQuery.new(result)
-        expect(query.partitions).to contain_exactly(
+        expect(result.partitions).to contain_exactly(
           an_object_with_fields(mountpoint: "/", size: 20.GiB),
           an_object_with_fields(mountpoint: "/home", size: 20.GiB),
           an_object_with_fields(mountpoint: "swap", size: 10.GiB)
@@ -78,8 +78,7 @@ describe Yast::Storage::Proposal::PartitionCreator do
 
       it "distributes the extra space" do
         result = creator.create_partitions(volumes, target_size)
-        query = Yast::Storage::DevicegraphQuery.new(result)
-        expect(query.partitions).to contain_exactly(
+        expect(result.partitions).to contain_exactly(
           an_object_with_fields(mountpoint: "/", size: 23.GiB),
           an_object_with_fields(mountpoint: "/home", size: 26.GiB),
           an_object_with_fields(mountpoint: "swap", size: 1.GiB)

--- a/test/proposal/space_maker_test.rb
+++ b/test/proposal/space_maker_test.rb
@@ -22,12 +22,13 @@
 
 require_relative "../spec_helper"
 require "storage/proposal"
-require "storage/devicegraph_query"
+require "storage/refinements/devicegraph_lists"
 require "storage/refinements/size_casts"
 
 describe Yast::Storage::Proposal::SpaceMaker do
   describe "#make_space" do
     using Yast::Storage::Refinements::SizeCasts
+    using Yast::Storage::Refinements::DevicegraphLists
 
     before do
       fake_scenario(scenario)
@@ -56,10 +57,9 @@ describe Yast::Storage::Proposal::SpaceMaker do
 
       it "deletes some of the linux ones" do
         result = maker.provide_space(required_size)
-        query = Yast::Storage::DevicegraphQuery.new(result)
         # FIXME: the result is actually kind of suboptimal, there were no need
         # to delete the swap partition
-        expect(query.partitions).to contain_exactly(
+        expect(result.partitions).to contain_exactly(
           an_object_with_fields(label: "windows", size: 250.GiB)
         )
       end

--- a/test/proposal/space_maker_test.rb
+++ b/test/proposal/space_maker_test.rb
@@ -39,7 +39,8 @@ describe Yast::Storage::Proposal::SpaceMaker do
       disk_analyzer.analyze(fake_devicegraph)
       disk_analyzer
     end
-    subject(:maker) { described_class.new(fake_devicegraph, analyzer) }
+    let(:settings) { Yast::Storage::Proposal::Settings.new }
+    subject(:maker) { described_class.new(fake_devicegraph, analyzer, settings) }
 
     context "if the disk is not big enough" do
       let(:scenario) { "empty_hard_disk_50GiB" }


### PR DESCRIPTION
Inline documentation is still missing

Some usage examples
```ruby
using DevicegraphLists

disks = a_devicegraph.disks.with(name: ["/dev/sda", "/dev/sdb"])
a_devicegraph.partitions.map {|p| p.name } # ["/dev/sda1", "/dev/sdb1", "/dev/sdb2", "/dev/sdc1"]
disks.partitions.map {|p| p.name } # ["/dev/sda1", "/dev/sdb1", "/dev/sdb2"]

primary_parts = disks.partitions.with(type: ::Storage::PartitionType_PRIMARY)
a_device_graph.filesystems.to_a # all file systems in the devicegraph
disks.filesystems.to_a # Filesystems in the chosen disks
primary_parts.filesystems.to_a # fs in primary parts of chosen disks

# Look ma! also with blocks
partitioned_disks = a_devicegraph.disks.with { |disk| disk.partition_table }
partitioned_disks.filesystems.size
```