### PR TITLE
First RSpec tests (and other improvements) for the BootRequirementsChecker

### DIFF
--- a/src/examples/boot_req_checker_demo.rb
+++ b/src/examples/boot_req_checker_demo.rb
@@ -52,4 +52,3 @@ puts "\n---  needed  ---"
 checker = Yast::Storage::BootRequirementsChecker.new(settings, disk_analyzer)
 needed = checker.needed_partitions
 pp(needed)
-

--- a/src/lib/storage/boot_requirements_checker.rb
+++ b/src/lib/storage/boot_requirements_checker.rb
@@ -68,7 +68,8 @@ module Yast
           @strategy = BootRequirementsStrategies::PReP.new(settings, disk_analyzer)
         end
 
-        @strategy ||= BootRequirementsStrategies::Default.new(settings, disk_analyzer)
+        # Fallback to Legacy as default
+        @strategy ||= BootRequirementsStrategies::Legacy.new(settings, disk_analyzer)
       end
     end
   end

--- a/src/lib/storage/boot_requirements_checker.rb
+++ b/src/lib/storage/boot_requirements_checker.rb
@@ -64,7 +64,7 @@ module Yast
           @strategy = BootRequirementsStrategies::UEFI.new(settings, disk_analyzer)
         elsif arch.s390?
           @strategy = BootRequirementsStrategies::ZIPL.new(settings, disk_analyzer)
-        elsif arch.ppc64?
+        elsif arch.ppc?
           @strategy = BootRequirementsStrategies::PReP.new(settings, disk_analyzer)
         end
 

--- a/src/lib/storage/boot_requirements_strategies.rb
+++ b/src/lib/storage/boot_requirements_strategies.rb
@@ -19,8 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-# Let's add here all the strategies
-require "storage/boot_requirements_strategies/default"
+require "storage/boot_requirements_strategies/legacy"
 require "storage/boot_requirements_strategies/uefi"
 require "storage/boot_requirements_strategies/prep"
 require "storage/boot_requirements_strategies/zipl"

--- a/src/lib/storage/boot_requirements_strategies/base.rb
+++ b/src/lib/storage/boot_requirements_strategies/base.rb
@@ -26,6 +26,8 @@ require "yast"
 module Yast
   module Storage
     module BootRequirementsStrategies
+      # Base class for the strategies used to calculate the boot partitioning
+      # requirements
       class Base
         include Yast::Logger
 

--- a/src/lib/storage/boot_requirements_strategies/default.rb
+++ b/src/lib/storage/boot_requirements_strategies/default.rb
@@ -30,6 +30,8 @@ require "storage/disk_size"
 module Yast
   module Storage
     module BootRequirementsStrategies
+      # Strategy to calculate the boot requirements in a legacy system (x86
+      # without EFI)
       class Default < Base
       end
     end

--- a/src/lib/storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/storage/boot_requirements_strategies/legacy.rb
@@ -32,7 +32,7 @@ module Yast
     module BootRequirementsStrategies
       # Strategy to calculate the boot requirements in a legacy system (x86
       # without EFI)
-      class Default < Base
+      class Legacy < Base
       end
     end
   end

--- a/src/lib/storage/boot_requirements_strategies/prep.rb
+++ b/src/lib/storage/boot_requirements_strategies/prep.rb
@@ -30,6 +30,7 @@ require "storage/disk_size"
 module Yast
   module Storage
     module BootRequirementsStrategies
+      # Strategy to calculate boot requirements in systems using PReP
       class PReP < Base
         def needed_partitions
           volumes = super

--- a/src/lib/storage/boot_requirements_strategies/uefi.rb
+++ b/src/lib/storage/boot_requirements_strategies/uefi.rb
@@ -40,8 +40,7 @@ module Yast
       protected
 
         def efi_partition_missing?
-          true	# #efi_partitions not implemented yet
-          # disk_analyzer.efi_partitions.empty?
+          disk_analyzer.efi_partitions.empty?
         end
 
         def efi_volume

--- a/src/lib/storage/boot_requirements_strategies/uefi.rb
+++ b/src/lib/storage/boot_requirements_strategies/uefi.rb
@@ -30,6 +30,7 @@ require "storage/disk_size"
 module Yast
   module Storage
     module BootRequirementsStrategies
+      # Strategy to calculate boot requirements in UEFI systems
       class UEFI < Base
         def needed_partitions
           volumes = super
@@ -50,7 +51,7 @@ module Yast
           vol.max_size = DiskSize.unlimited
           vol.desired_size = DiskSize.MiB(500)
           vol.can_live_on_logical_volume = false
-          # TODO: additional requirement - position below 2TB 
+          # TODO: additional requirement - position below 2TB
           vol
         end
       end

--- a/src/lib/storage/boot_requirements_strategies/zipl.rb
+++ b/src/lib/storage/boot_requirements_strategies/zipl.rb
@@ -30,6 +30,7 @@ require "storage/disk_size"
 module Yast
   module Storage
     module BootRequirementsStrategies
+      # Strategy to calculate boot requirements in systems using ZIPL
       class ZIPL < Base
         def needed_partitions
           volumes = super

--- a/test/boot_requirements_checker_test.rb
+++ b/test/boot_requirements_checker_test.rb
@@ -44,7 +44,7 @@ describe Yast::Storage::BootRequirementsChecker do
       allow(Yast::Storage::StorageManager.instance).to receive(:arch).and_return(storage_arch)
 
       allow(storage_arch).to receive(:x86?).and_return(architecture == :x86)
-      allow(storage_arch).to receive(:ppc64?).and_return(architecture == :ppc)
+      allow(storage_arch).to receive(:ppc?).and_return(architecture == :ppc)
       allow(storage_arch).to receive(:s390?).and_return(architecture == :s390)
     end
 
@@ -189,7 +189,7 @@ describe Yast::Storage::BootRequirementsChecker do
     end
 
     context "in a PPC64 system" do
-      let(:arch) { :ppc64 }
+      let(:arch) { :ppc }
 
       context "using KVM" do
         context "with a partitions-based proposal" do

--- a/test/boot_requirements_checker_test.rb
+++ b/test/boot_requirements_checker_test.rb
@@ -1,0 +1,219 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2016] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "storage/proposal"
+require "storage/boot_requirements_checker"
+require "storage/refinements/size_casts"
+
+def find_vol(mount_point, volumes)
+  volumes.find {|p| p.mount_point == mount_point }
+end
+
+describe Yast::Storage::BootRequirementsChecker do
+  describe "#needed_partitions" do
+    using Yast::Storage::Refinements::SizeCasts
+
+    subject(:checker) { described_class.new(settings, analyzer) }
+
+    let(:settings) { Yast::Storage::Proposal::Settings.new }
+    let(:analyzer) { instance_double("Yast::Storage::DiskAnalyzer") }
+    let(:storage_arch) { instance_double("::Storage::Arch") }
+
+    before do
+      Yast::Storage::FakeProbing.new
+      allow(Yast::Storage::StorageManager.instance).to receive(:arch).and_return(storage_arch)
+
+      allow(storage_arch).to receive(:x86?).and_return(architecture == :x86)
+      allow(storage_arch).to receive(:ppc64?).and_return(architecture == :ppc)
+      allow(storage_arch).to receive(:s390?).and_return(architecture == :s390)
+    end
+
+    context "in a x86 system" do
+      let(:architecture) { :x86 }
+
+      before do
+        allow(storage_arch).to receive(:efiboot?).and_return(efiboot)
+      end
+
+      context "using UEFI" do
+        let(:efiboot) { true }
+
+        before do
+          allow(analyzer).to receive(:efi_partitions).and_return efi_partitions
+        end
+
+        context "with a partitions-based proposal" do
+          before do
+            settings.use_lvm = false
+          end
+
+          context "if there are no EFI partitions" do
+            let(:efi_partitions) { [] }
+
+            it "requires only a /boot/efi partition" do
+              expect(checker.needed_partitions).to contain_exactly(
+                an_object_with_fields(mount_point: "/boot/efi")
+              )
+            end
+
+            it "requires /boot/efi to be vfat with at least 33 MiB" do
+              efi_part = find_vol("/boot/efi", checker.needed_partitions)
+              expect(efi_part.filesystem_type).to eq ::Storage::FsType_VFAT
+              expect(efi_part.min_size).to eq 33.MiB
+            end
+
+            it "recommends /boot/efi to be 500 MiB" do
+              efi_part = find_vol("/boot/efi", checker.needed_partitions)
+              expect(efi_part.desired_size).to eq 500.MiB
+            end
+          end
+
+          context "if there is already an EFI partition" do
+            let(:efi_partitions) { ["/dev/sda1"] }
+          
+            it "does not require any particular volume" do
+              expect(checker.needed_partitions).to be_empty
+            end
+          end
+        end
+
+        context "with a LVM-based proposal" do
+          before do
+            settings.use_lvm = true
+          end
+
+          context "if there are no EFI partitions" do
+            let(:efi_partitions) { [] }
+
+            it "requires /boot and /boot/efi partitions" do
+              expect(checker.needed_partitions).to contain_exactly(
+                an_object_with_fields(mount_point: "/boot"),
+                an_object_with_fields(mount_point: "/boot/efi")
+              )
+            end
+
+            it "requires /boot/efi to be vfat out of the LVM with at least 33 MiB" do
+              efi_part = find_vol("/boot/efi", checker.needed_partitions)
+              expect(efi_part.filesystem_type).to eq ::Storage::FsType_VFAT
+              expect(efi_part.min_size).to eq 33.MiB
+              expect(efi_part.can_live_on_logical_volume).to eq false
+            end
+
+            it "recommends /boot/efi to be 500 MiB" do
+              efi_part = find_vol("/boot/efi", checker.needed_partitions)
+              expect(efi_part.desired_size).to eq 500.MiB
+            end
+
+            it "requires /boot to be ext4 out of the LVM with at least 100 MiB" do
+              efi_part = find_vol("/boot", checker.needed_partitions)
+              expect(efi_part.filesystem_type).to eq ::Storage::FsType_EXT4
+              expect(efi_part.min_size).to eq 100.MiB
+              expect(efi_part.can_live_on_logical_volume).to eq false
+            end
+
+            it "recommends /boot to be 200 MiB" do
+              efi_part = find_vol("/boot", checker.needed_partitions)
+              expect(efi_part.desired_size).to eq 200.MiB
+            end
+          end
+
+          context "if there is already an EFI partition" do
+            let(:efi_partitions) { ["/dev/sda1"] }
+          
+            it "requires only a /boot partition" do
+              expect(checker.needed_partitions).to contain_exactly(
+                an_object_with_fields(mount_point: "/boot")
+              )
+            end
+          end
+        end
+      end
+
+      context "not using UEFI (legacy PC)" do
+        let(:efiboot) { false }
+
+        context "with a partitions-based proposal" do
+          before do
+            settings.use_lvm = false
+          end
+
+          it "does not require any particular volume" do
+            expect(checker.needed_partitions).to be_empty
+          end
+        end
+
+        context "with a LVM-based proposal" do
+          before do
+            settings.use_lvm = true
+          end
+
+          it "requires only a /boot partition" do
+            expect(checker.needed_partitions).to contain_exactly(
+              an_object_with_fields(mount_point: "/boot")
+            )
+          end
+
+          it "requires /boot to be ext4 out of the LVM with at least 100 MiB" do
+            efi_part = find_vol("/boot", checker.needed_partitions)
+            expect(efi_part.filesystem_type).to eq ::Storage::FsType_EXT4
+            expect(efi_part.min_size).to eq 100.MiB
+            expect(efi_part.can_live_on_logical_volume).to eq false
+          end
+
+          it "recommends /boot to be 200 MiB" do
+            efi_part = find_vol("/boot", checker.needed_partitions)
+            expect(efi_part.desired_size).to eq 200.MiB
+          end
+        end
+      end
+    end
+
+    context "in a PPC64 system" do
+      let(:arch) { :ppc64 }
+
+      context "using KVM" do
+        context "with a partitions-based proposal" do
+        end
+
+        context "with a LVM-based proposal" do
+        end
+      end
+
+      context "using LPAR" do
+        context "with a partitions-based proposal" do
+        end
+
+        context "with a LVM-based proposal" do
+        end
+      end
+
+      context "in bare metal (PowerNV)" do
+        context "with a partitions-based proposal" do
+        end
+
+        context "with a LVM-based proposal" do
+        end
+      end
+    end
+  end
+end

--- a/test/boot_requirements_checker_test.rb
+++ b/test/boot_requirements_checker_test.rb
@@ -26,7 +26,7 @@ require "storage/boot_requirements_checker"
 require "storage/refinements/size_casts"
 
 def find_vol(mount_point, volumes)
-  volumes.find {|p| p.mount_point == mount_point }
+  volumes.find { |p| p.mount_point == mount_point }
 end
 
 describe Yast::Storage::BootRequirementsChecker do
@@ -90,7 +90,7 @@ describe Yast::Storage::BootRequirementsChecker do
 
           context "if there is already an EFI partition" do
             let(:efi_partitions) { ["/dev/sda1"] }
-          
+
             it "does not require any particular volume" do
               expect(checker.needed_partitions).to be_empty
             end
@@ -139,7 +139,7 @@ describe Yast::Storage::BootRequirementsChecker do
 
           context "if there is already an EFI partition" do
             let(:efi_partitions) { ["/dev/sda1"] }
-          
+
             it "requires only a /boot partition" do
               expect(checker.needed_partitions).to contain_exactly(
                 an_object_with_fields(mount_point: "/boot")

--- a/test/proposal_test.rb
+++ b/test/proposal_test.rb
@@ -24,6 +24,7 @@ require_relative "spec_helper"
 require "storage"
 require "storage/proposal"
 require "storage/refinements/test_devicegraph"
+require "storage/boot_requirements_checker"
 
 describe Yast::Storage::Proposal do
   describe "#propose" do
@@ -32,9 +33,13 @@ describe Yast::Storage::Proposal do
     before do
       fake_scenario(scenario)
       fake_to_probed
+      allow(Yast::Storage::BootRequirementsChecker).to receive(:new).and_return boot_checker
+      allow(boot_checker).to receive(:needed_partitions).and_return []
     end
 
     subject(:proposal) { described_class.new(settings: settings) }
+
+    let(:boot_checker) { instance_double("Yast::Storage::BootRequirementChecker") }
 
     let(:settings) do
       settings = Yast::Storage::Proposal::Settings.new


### PR DESCRIPTION
Very important: this pull request assumes that code like this works with libstorage-ng-ruby
```ruby
arch = Yast::Storage::StorageManager.instance.arch
arch.efiboot?
arch.x86?
```
Currently it does not because the libstorage-ng bindings don't provide access to `::Storage::Arch`.

@aschnell, @shundhammer Can you please add it (I failed miserably).