### PR TITLE
Added root_device and candidate_devices to Proposal::Settings

### DIFF
--- a/src/lib/storage/proposal/devicegraph_generator.rb
+++ b/src/lib/storage/proposal/devicegraph_generator.rb
@@ -50,7 +50,7 @@ module Yast
         #           valid devicegraph
         def devicegraph(volumes, initial_graph, disk_analyzer)
           graph = provide_space(volumes, initial_graph, disk_analyzer)
-          graph = create_partitions(volumes, graph, disk_analyzer)
+          graph = create_partitions(volumes, graph)
           graph
         end
 
@@ -68,8 +68,7 @@ module Yast
         # @raise Proposal::NoDiskSpaceError if both attempts fail
         #
         # @param volumes [PlannedVolumesList] set of volumes to make space for
-        # @param initial_graph [::Storage::Devicegraph] proposal-refined initial
-        #           devicegraph (@see RefinedDevicegraph)
+        # @param initial_graph [::Storage::Devicegraph] initial devicegraph
         # @param disk_analyzer [DiskAnalyzer] analysis of the initial_graph
         #
         # @return [::Storage::Devicegraph]
@@ -94,13 +93,11 @@ module Yast
         # by #provide_space
         #
         # @param volumes [PlannedVolumesList] set of volumes to create
-        # @param initial_graph [::Storage::Devicegraph] proposal-refined initial
-        #           devicegraph (@see RefinedDevicegraph)
-        # @param disk_analyzer [DiskAnalyzer]
+        # @param initial_graph [::Storage::Devicegraph] initial devicegraph
         #
         # @return [::Storage::Devicegraph]
-        def create_partitions(volumes, initial_graph, disk_analyzer)
-          partition_creator = PartitionCreator.new(initial_graph, disk_analyzer, settings)
+        def create_partitions(volumes, initial_graph)
+          partition_creator = PartitionCreator.new(initial_graph, settings)
           target = got_desired_space? ? :desired : :min
           partition_creator.create_partitions(volumes, target)
         end

--- a/src/lib/storage/proposal/exceptions.rb
+++ b/src/lib/storage/proposal/exceptions.rb
@@ -32,6 +32,8 @@ module Yast
       end
       class UnexpectedCallError < Error
       end
+      class NoSuitableDeviceError < Error
+      end
     end
   end
 end

--- a/src/lib/storage/proposal/partition_creator.rb
+++ b/src/lib/storage/proposal/partition_creator.rb
@@ -45,11 +45,9 @@ module Yast
         # Initialize.
         #
         # @param original_graph [::Storage::Devicegraph] initial devicegraph
-        # @param disk_analyzer [DiskAnalyzer] information about original_graph
         # @param settings [Proposal::Settings] proposal settings
-        def initialize(original_graph, disk_analyzer, settings)
+        def initialize(original_graph, settings)
           @original_graph = original_graph
-          @disk_analyzer = disk_analyzer
           @settings = settings
         end
 
@@ -78,7 +76,7 @@ module Yast
 
         # Working devicegraph
         attr_accessor :devicegraph
-        attr_reader :original_graph, :disk_analyzer
+        attr_reader :original_graph
 
         # Sum up the sizes of all slots in the devicegraph
         #
@@ -98,7 +96,7 @@ module Yast
 
         # @return [Array<String>]
         def candidate_disk_names
-          disk_analyzer.candidate_disks
+          settings.candidate_devices
         end
 
         # Query in the target devicegraph restricted to the candidate disks

--- a/src/lib/storage/proposal/settings.rb
+++ b/src/lib/storage/proposal/settings.rb
@@ -37,6 +37,7 @@ module Yast
         attr_accessor :root_filesystem_type, :use_snapshots
         attr_accessor :use_separate_home, :home_filesystem_type
         attr_accessor :enlarge_swap_for_suspend
+        attr_accessor :root_device, :candidate_devices
 
         def initialize
           @use_lvm                  = false

--- a/src/lib/storage/proposal/space_maker.rb
+++ b/src/lib/storage/proposal/space_maker.rb
@@ -102,7 +102,7 @@ module Yast
 
         # @return [Array<String>]
         def candidate_disk_names
-          disk_analyzer.candidate_disks
+          settings.candidate_devices
         end
 
         # Try to resize an existing windows partition - unless there already is

--- a/src/lib/storage/proposal/volumes_generator.rb
+++ b/src/lib/storage/proposal/volumes_generator.rb
@@ -47,9 +47,18 @@ module Yast
 
         # Volumes that needs to be created to satisfy the settings
         #
-        # @return [PlannedVolumnesList]
-        def volumes
-          PlannedVolumesList.new(boot_volumes.to_a + standard_volumes)
+        # @return [PlannedVolumesList]
+        def all_volumes
+          PlannedVolumesList.new(base_volumes.to_a + additional_volumes)
+        end
+
+        # Minimal set of volumes that need to fit in the same disk than "/"
+        #
+        # This includes "/" itself and the volumes needed for booting
+        #
+        # @return [PlannedVolumesList]
+        def base_volumes
+          PlannedVolumesList.new(boot_volumes.to_a + [root_volume])
         end
 
       protected
@@ -67,8 +76,8 @@ module Yast
         # Standard volumes for the root, swap and /home
         #
         # @return [Array<PlannedVolumes>]
-        def standard_volumes
-          volumes = [swap_volume, root_volume]
+        def additional_volumes
+          volumes = [swap_volume]
           volumes << home_volume if @settings.use_separate_home
           volumes
         end

--- a/test/data/output/multi-linux-pc-sep-home.yml
+++ b/test/data/output/multi-linux-pc-sep-home.yml
@@ -5,19 +5,19 @@
     partition_table: msdos
     partitions:
     - partition:
-        size: 2.00 GiB
-        name: "/dev/sda1"
-        type: primary
-        id: swap
-        file_system: swap
-        mount_point: swap
-    - partition:
         size: 40.00 GiB
-        name: "/dev/sda2"
+        name: "/dev/sda1"
         type: primary
         id: linux
         file_system: btrfs
         mount_point: "/"
+    - partition:
+        size: 2.00 GiB
+        name: "/dev/sda2"
+        type: primary
+        id: swap
+        file_system: swap
+        mount_point: swap
     - partition:
         size: 22.00 GiB
         name: "/dev/sda7"

--- a/test/data/output/multi-linux-pc.yml
+++ b/test/data/output/multi-linux-pc.yml
@@ -5,19 +5,19 @@
     partition_table: msdos
     partitions:
     - partition:
-        size: 2.00 GiB
-        name: "/dev/sda1"
-        type: primary
-        id: swap
-        file_system: swap
-        mount_point: swap
-    - partition:
         size: 40.00 GiB
-        name: "/dev/sda2"
+        name: "/dev/sda1"
         type: primary
         id: linux
         file_system: btrfs
         mount_point: "/"
+    - partition:
+        size: 2.00 GiB
+        name: "/dev/sda2"
+        type: primary
+        id: swap
+        file_system: swap
+        mount_point: swap
     - free:
         size: 22.00 GiB
     - partition:

--- a/test/data/output/windows-linux-multiboot-pc-sep-home.yml
+++ b/test/data/output/windows-linux-multiboot-pc-sep-home.yml
@@ -12,19 +12,19 @@
         file_system: ntfs
         label: windows
     - partition:
-        size: 2.00 GiB
-        name: "/dev/sda2"
-        type: primary
-        id: swap
-        file_system: swap
-        mount_point: swap
-    - partition:
         size: 40.00 GiB
-        name: "/dev/sda3"
+        name: "/dev/sda2"
         type: primary
         id: linux
         file_system: btrfs
         mount_point: "/"
+    - partition:
+        size: 2.00 GiB
+        name: "/dev/sda3"
+        type: primary
+        id: swap
+        file_system: swap
+        mount_point: swap
     - partition:
         size: 208.00 GiB
         name: "/dev/sda4"

--- a/test/data/output/windows-linux-multiboot-pc.yml
+++ b/test/data/output/windows-linux-multiboot-pc.yml
@@ -12,18 +12,18 @@
         file_system: ntfs
         label: windows
     - partition:
-        size: 2.00 GiB
-        name: "/dev/sda2"
-        type: primary
-        id: swap
-        file_system: swap
-        mount_point: swap
-    - partition:
         size: 40.00 GiB
-        name: "/dev/sda3"
+        name: "/dev/sda2"
         type: primary
         id: linux
         file_system: btrfs
         mount_point: "/"
+    - partition:
+        size: 2.00 GiB
+        name: "/dev/sda3"
+        type: primary
+        id: swap
+        file_system: swap
+        mount_point: swap
     - free:
         size: 208.00 GiB

--- a/test/data/output/windows-pc-sep-home.yml
+++ b/test/data/output/windows-pc-sep-home.yml
@@ -5,19 +5,19 @@
     partition_table: msdos
     partitions:
     - partition:
-        size: 2.00 GiB
-        name: "/dev/sda1"
-        type: primary
-        id: swap
-        file_system: swap
-        mount_point: swap
-    - partition:
         size: 40.00 GiB
-        name: "/dev/sda3"
+        name: "/dev/sda1"
         type: primary
         id: linux
         file_system: btrfs
         mount_point: "/"
+    - partition:
+        size: 2.00 GiB
+        name: "/dev/sda3"
+        type: primary
+        id: swap
+        file_system: swap
+        mount_point: swap
     - partition:
         size: 738.00 GiB
         name: "/dev/sda4"

--- a/test/data/output/windows-pc.yml
+++ b/test/data/output/windows-pc.yml
@@ -5,19 +5,19 @@
     partition_table: msdos
     partitions:
     - partition:
-        size: 2.00 GiB
-        name: "/dev/sda1"
-        type: primary
-        id: swap
-        file_system: swap
-        mount_point: swap
-    - partition:
         size: 40.00 GiB
-        name: "/dev/sda3"
+        name: "/dev/sda1"
         type: primary
         id: linux
         file_system: btrfs
         mount_point: "/"
+    - partition:
+        size: 2.00 GiB
+        name: "/dev/sda3"
+        type: primary
+        id: swap
+        file_system: swap
+        mount_point: swap
     - free:
         size: 738 GiB
     - partition:

--- a/test/proposal/partition_creator_test.rb
+++ b/test/proposal/partition_creator_test.rb
@@ -33,13 +33,15 @@ describe Yast::Storage::Proposal::PartitionCreator do
 
     before do
       fake_scenario(scenario)
-      allow(analyzer).to receive(:candidate_disks).and_return candidate_disks
     end
 
-    let(:settings) { Yast::Storage::Proposal::Settings.new }
-    let(:analyzer) { instance_double("Yast::Storage::DiskAnalyzer") }
+    let(:settings) do
+      settings = Yast::Storage::Proposal::Settings.new
+      settings.candidate_devices = ["/dev/sda"]
+      settings.root_device = "/dev/sda"
+      settings
+    end
     let(:scenario) { "empty_hard_disk_50GiB" }
-    let(:candidate_disks) { ["/dev/sda"] }
     let(:target_size) { :desired }
 
     let(:root_volume) { Yast::Storage::PlannedVolume.new("/", ::Storage::FsType_EXT4) }
@@ -47,7 +49,7 @@ describe Yast::Storage::Proposal::PartitionCreator do
     let(:swap_volume) { Yast::Storage::PlannedVolume.new("swap", ::Storage::FsType_EXT4) }
     let(:volumes) { Yast::Storage::PlannedVolumesList.new([root_volume, home_volume, swap_volume]) }
 
-    subject(:creator) { described_class.new(fake_devicegraph, analyzer, settings) }
+    subject(:creator) { described_class.new(fake_devicegraph, settings) }
 
     context "when the exact space is available" do
       before do

--- a/test/proposal/space_maker_test.rb
+++ b/test/proposal/space_maker_test.rb
@@ -39,7 +39,12 @@ describe Yast::Storage::Proposal::SpaceMaker do
       disk_analyzer.analyze(fake_devicegraph)
       disk_analyzer
     end
-    let(:settings) { Yast::Storage::Proposal::Settings.new }
+    let(:settings) do
+      settings = Yast::Storage::Proposal::Settings.new
+      settings.candidate_devices = ["/dev/sda"]
+      settings.root_device = "/dev/sda"
+      settings
+    end
     subject(:maker) { described_class.new(fake_devicegraph, analyzer, settings) }
 
     context "if the disk is not big enough" do

--- a/test/proposal/volumes_generator_test.rb
+++ b/test/proposal/volumes_generator_test.rb
@@ -29,7 +29,7 @@ require "storage/refinements/size_casts"
 require "storage/boot_requirements_checker"
 
 describe Yast::Storage::Proposal::VolumesGenerator do
-  describe "#volumes" do
+  describe "#all_volumes" do
     using Yast::Storage::Refinements::SizeCasts
 
     # Just to shorten
@@ -56,11 +56,11 @@ describe Yast::Storage::Proposal::VolumesGenerator do
     end
 
     it "returns a list of volumes" do
-      expect(subject.volumes).to be_a Yast::Storage::PlannedVolumesList
+      expect(subject.all_volumes).to be_a Yast::Storage::PlannedVolumesList
     end
 
     it "includes the volumes needed by BootRequirementChecker" do
-      expect(subject.volumes).to include(
+      expect(subject.all_volumes).to include(
         an_object_with_fields(mount_point: "/one_boot", filesystem_type: xfs),
         an_object_with_fields(mount_point: "/other_boot", filesystem_type: vfat)
       )
@@ -72,7 +72,7 @@ describe Yast::Storage::Proposal::VolumesGenerator do
       end
 
       it "includes a big swap volume" do
-        expect(subject.volumes).to include(
+        expect(subject.all_volumes).to include(
           # This value is currently hard-coded
           an_object_with_fields(mount_point: "swap", min_size: 8.GiB, max_size: 8.GiB)
         )
@@ -85,7 +85,7 @@ describe Yast::Storage::Proposal::VolumesGenerator do
       end
 
       it "includes a small swap volume" do
-        expect(subject.volumes).to include(
+        expect(subject.all_volumes).to include(
           # This value is currently hard-coded
           an_object_with_fields(mount_point: "swap", min_size: 2.GiB, max_size: 2.GiB)
         )
@@ -101,7 +101,7 @@ describe Yast::Storage::Proposal::VolumesGenerator do
       end
 
       it "includes a /home volume with the configured settings" do
-        expect(subject.volumes).to include(
+        expect(subject.all_volumes).to include(
           an_object_with_fields(
             mount_point:     "/home",
             min_size:        settings.home_min_size,
@@ -118,7 +118,7 @@ describe Yast::Storage::Proposal::VolumesGenerator do
       end
 
       it "does not include a /home volume" do
-        expect(subject.volumes).to_not include(
+        expect(subject.all_volumes).to_not include(
           an_object_with_fields(mount_point: "/home")
         )
       end
@@ -137,7 +137,7 @@ describe Yast::Storage::Proposal::VolumesGenerator do
         end
 
         it "uses the normal sizes" do
-          expect(subject.volumes).to include(
+          expect(subject.all_volumes).to include(
             an_object_with_fields(
               mount_point:     "/",
               min_size:        10.GiB,
@@ -154,7 +154,7 @@ describe Yast::Storage::Proposal::VolumesGenerator do
         end
 
         it "increases all the sizes by btrfs_increase_percentage" do
-          expect(subject.volumes).to include(
+          expect(subject.all_volumes).to include(
             an_object_with_fields(
               mount_point:     "/",
               min_size:        17.5.GiB,


### PR DESCRIPTION
* Allows the caller to decide where / (and related partitions) is going to be installed.
* Knowing the root_device in advance allows BootRequirementsChecker to properly do its job.
* If root_device and candidate_device are not provided, they are calculated in a new additional first step.