### PR TITLE
Improvements and tests for PReP boot strategy

### DIFF
--- a/doc/boot-partition.md
+++ b/doc/boot-partition.md
@@ -107,6 +107,8 @@ stage2 beyond 2 TB limit when using gpt table.
 
 > dvaleev: 8 MB PReP
 
+> dvaleev: PReP must be one of the first 4 partitions, ideally the first one [citation needed]
+
 - OPAL/PowerNV/Bare metal
 
 > dvaleev:
@@ -168,8 +170,10 @@ i.e. valid for all architectures (s390, see below)
 ppc
 ---
 KVM/LPAR
-- PReP partition dos type 0x41, flag as bootable
-                 gpt type 9e1a2d38-c612-4316-aa26-8b49521e5a8b
+- PReP partition
+   - dos type 0x41, flag as bootable
+   - gpt type 9e1a2d38-c612-4316-aa26-8b49521e5a8b
+   - must be one of the first 4 partitions (we have no evidence of this)
 
 OPAL/PowerNV/Bare metal
 - no PReP is required

--- a/src/lib/storage/boot_requirements_strategies/prep.rb
+++ b/src/lib/storage/boot_requirements_strategies/prep.rb
@@ -47,7 +47,7 @@ module Yast
 
         def prep_partition_required?
           # no need of PReP partition in OPAL/PowerNV/Bare metal
-          !arch.power_nv?
+          !arch.ppc_power_nv?
         end
 
         def prep_volume

--- a/src/lib/storage/disk_analyzer.rb
+++ b/src/lib/storage/disk_analyzer.rb
@@ -73,6 +73,7 @@ module Yast
 
       attr_reader :installation_disks, :candidate_disks
       attr_reader :windows_partitions, :linux_partitions, :efi_partitions
+      attr_reader :prep_partitions
       attr_reader :devicegraph
       attr_accessor :disk_check_limit
 
@@ -82,6 +83,8 @@ module Yast
         @installation_disks = [] # device names of installation media
         @candidate_disks    = [] # device names of disks to install on
         @linux_partitions   = [] # device names of existing Linux parititions
+        @efi_partitions     = [] # device names of existing EFI partitions
+        @prep_partitions    = {} # device names of PReP partitions, indexed by disk
         @windows_partitions = [] # only filled if @linux_partitions is empty
 
         # Maximum number of disks to check. This might be important on
@@ -98,7 +101,8 @@ module Yast
         @installation_disks = find_installation_disks
         @candidate_disks    = find_candidate_disks
         @linux_partitions   = find_linux_partitions
-        @efi_partitions     = find_linux_partitions
+        @efi_partitions     = find_efi_partitions
+        @prep_partitions    = find_prep_partitions
 
         if @linux_partitions.empty?
           @windows_partitions = find_windows_partitions
@@ -161,6 +165,22 @@ module Yast
         disks = devicegraph.disks.with(name: candidate_disks)
         partitions = disks.partitions.with(id: ::Storage::ID_EFI)
         partitions.map(&:name)
+      end
+
+      # Find partitions from any of the candidate disks that can be used as
+      # PReP partition
+      #
+      # The result is a Hash in which each key is the name of a candidate disk
+      # and the value is an Array with the names of all the PReP partitions
+      # present in that disk.
+      #
+      # @return [Hash]
+      def find_prep_partitions
+        disks = devicegraph.disks
+        pairs = candidate_disks.map do |name|
+          [name, disks.with(name: name).partitions.with(id: ::Storage::ID_PPC_PREP).to_a]
+        end
+        Hash[pairs]
       end
 
       # Array with all disks in the devicegraph

--- a/src/lib/storage/planned_volume.rb
+++ b/src/lib/storage/planned_volume.rb
@@ -33,7 +33,7 @@ module Yast
       attr_accessor :mount_point, :filesystem_type, :partition_id, :disk
       attr_accessor :size, :min_size, :max_size, :desired_size, :weight
       attr_accessor :can_live_on_logical_volume, :logical_volume_name
-      attr_accessor :max_start_offset
+      attr_accessor :max_start_offset, :align, :bootable
 
       TO_STRING_ATTRS = [:mount_point, :min_size, :max_size, :desired_size,
                          :disk, :max_start_offset]
@@ -66,12 +66,14 @@ module Yast
         @max_size     = DiskSize.unlimited
         @desired_size = DiskSize.unlimited
         @max_start_offset = nil
+        @align        = nil
+        @bootable     = nil
         @weight       = 0 # For distributing extra space if desired is unlimited
         @can_live_on_logical_volume = false
         @logical_volume_name = nil
 
-        return unless @mount_point.start_with?("/")
-        return if @mount_point.start_with?("/boot")
+        return unless @mount_point && @mount_point.start_with?("/")
+        return if @mount_point && @mount_point.start_with?("/boot")
 
         @can_live_on_logical_volume = true
         if @mount_point == "/"

--- a/src/lib/storage/planned_volume.rb
+++ b/src/lib/storage/planned_volume.rb
@@ -30,10 +30,48 @@ module Yast
     # its constraints
     #
     class PlannedVolume
-      attr_accessor :mount_point, :filesystem_type, :partition_id, :disk
-      attr_accessor :size, :min_size, :max_size, :desired_size, :weight
-      attr_accessor :can_live_on_logical_volume, :logical_volume_name
-      attr_accessor :max_start_offset, :align, :bootable
+      # @return [String] mount point for this volume. This might be a real mount
+      # point ("/", "/boot", "/home") or a pseudo mount point like "swap".
+      attr_accessor :mount_point
+      # @return [::Storage::FsType] the type of filesystem this volume should
+      # get, like ::Storage::FsType_BTRFS or ::Storage::FsType_SWAP. A value of
+      # nil means the volume will not be formatted.
+      attr_accessor :filesystem_type
+      # @return [::Storage::IdNum] id of the partition in a ms-dos style
+      # partition table. If nil, the final id is expected to be inferred from
+      # the filesystem type.
+      attr_accessor :partition_id
+      # @return [String] device name of the disk in which the volume has to be
+      # located. If nil, the volume can be allocated in any disk.
+      attr_accessor :disk
+      # @return [DiskSize] definitive size of the volume
+      attr_accessor :size
+      # @return [DiskSize] minimum acceptable size in case it's not possible to
+      # ensure the desired one. @see #desired_size
+      attr_accessor :min_size
+      # @return [DiskSize] maximum acceptable size
+      attr_accessor :max_size
+      # @return [DiskSize] preferred size
+      attr_accessor :desired_size
+      # @return [Float] factor used to distribute the extra space between
+      # volumes
+      attr_accessor :weight
+      # @return [Boolean] whether the volume can be placed in LVM
+      attr_accessor :can_live_on_logical_volume
+      # @return [String] name to use if the volume is placed in LVM
+      attr_accessor :logical_volume_name
+      # @return [DiskSize] maximum distance from the start of the disk in which
+      # the partition can start
+      attr_accessor :max_start_offset
+      # FIXME: this one is just guessing the final API of alignment
+      # @return [Symbol] modifier to pass to ::Storage::Region#align when
+      # creating the volume. :keep_size to avoid size changes. nil to use
+      # default alignment.
+      attr_accessor :align
+      # @return [Boolean] whether the boot flag should be set. Expected to be
+      # used only with ms-dos style partition tables. GPT has a similar legacy
+      # flag but is not needed in our grub2 setup.
+      attr_accessor :bootable
 
       TO_STRING_ATTRS = [:mount_point, :min_size, :max_size, :desired_size,
                          :disk, :max_start_offset]
@@ -47,15 +85,8 @@ module Yast
 
       # Constructor.
       #
-      # @param mount_point [string] mount point for this volume. This might be
-      #        a real mount point ("/", "/boot", "/home") or a pseudo mount
-      #        point like "swap".
-      #
-      # @param filesystem_type [::Storage::FsType] the type of filesystem this
-      #        volume should get. Typically one of ::Storage::FsType_BTRFS,
-      #        ::Storage::FsType_EXT4, ::Storage::FsType_XFS,
-      #        ::Storage::FsType_SWAP
-      #
+      # @param mount_point [string] @see #mount_point
+      # @param filesystem_type [::Storage::FsType] @see #filesystem_type
       def initialize(mount_point, filesystem_type = nil)
         @mount_point = mount_point
         @filesystem_type = filesystem_type

--- a/src/lib/storage/proposal/partition_creator.rb
+++ b/src/lib/storage/proposal/partition_creator.rb
@@ -276,6 +276,7 @@ module Yast
           region = new_region_with_size(free_slot, vol.size)
           partition = ptable.create_partition(dev_name, region, partition_type)
           partition.id = partition_id
+          partition.boot = !!vol.bootable
           partition
         end
 

--- a/test/boot_requirements_checker_test.rb
+++ b/test/boot_requirements_checker_test.rb
@@ -206,7 +206,7 @@ describe Yast::Storage::BootRequirementsChecker do
       let(:prep_id) { ::Storage::ID_PPC_PREP }
 
       before do
-        allow(storage_arch).to receive(:power_nv?).and_return(power_nv)
+        allow(storage_arch).to receive(:ppc_power_nv?).and_return(power_nv)
         allow(analyzer).to receive(:prep_partitions).and_return prep_partitions
       end
 

--- a/test/boot_requirements_checker_test.rb
+++ b/test/boot_requirements_checker_test.rb
@@ -217,7 +217,7 @@ describe Yast::Storage::BootRequirementsChecker do
           let(:use_lvm) { false }
 
           context "if there are no PReP partitions" do
-            let(:prep_partitions) { {"/dev/sda" => []} }
+            let(:prep_partitions) { { "/dev/sda" => [] } }
 
             it "requires only a PReP partition" do
               expect(checker.needed_partitions).to contain_exactly(
@@ -227,7 +227,7 @@ describe Yast::Storage::BootRequirementsChecker do
           end
 
           context "if the existent PReP partition is not in the target disk" do
-            let(:prep_partitions) { {"/dev/sdb" => ["/dev/sdb"]} }
+            let(:prep_partitions) { { "/dev/sdb" => ["/dev/sdb"] } }
 
             it "requires only a PReP partition" do
               expect(checker.needed_partitions).to contain_exactly(
@@ -237,7 +237,7 @@ describe Yast::Storage::BootRequirementsChecker do
           end
 
           context "if there is already a PReP partition in the disk" do
-            let(:prep_partitions) { {"/dev/sda" => ["/dev/sda1"]} }
+            let(:prep_partitions) { { "/dev/sda" => ["/dev/sda1"] } }
 
             it "does not require any particular volume" do
               expect(checker.needed_partitions).to be_empty
@@ -249,7 +249,7 @@ describe Yast::Storage::BootRequirementsChecker do
           let(:use_lvm) { true }
 
           context "if there are no PReP partitions" do
-            let(:prep_partitions) { {"/dev/sda" => []} }
+            let(:prep_partitions) { { "/dev/sda" => [] } }
 
             it "requires /boot and PReP partitions" do
               expect(checker.needed_partitions).to contain_exactly(
@@ -260,7 +260,7 @@ describe Yast::Storage::BootRequirementsChecker do
           end
 
           context "if the existent PReP partition is not in the target disk" do
-            let(:prep_partitions) { {"/dev/sdb" => ["/dev/sdb"]} }
+            let(:prep_partitions) { { "/dev/sdb" => ["/dev/sdb"] } }
 
             it "requires /boot and PReP partitions" do
               expect(checker.needed_partitions).to contain_exactly(
@@ -271,7 +271,7 @@ describe Yast::Storage::BootRequirementsChecker do
           end
 
           context "if there is already a PReP partition in the disk" do
-            let(:prep_partitions) { {"/dev/sda" => ["/dev/sda1"]} }
+            let(:prep_partitions) { { "/dev/sda" => ["/dev/sda1"] } }
 
             it "only requires a /boot partition" do
               expect(checker.needed_partitions).to contain_exactly(


### PR DESCRIPTION
IMPORTANT: it relies on a `::Storage::Arch#open_nv?` that is still not there