### PR TITLE
More reusable DiskAnalyzer

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Sep 27 06:00:45 UTC 2016 - ancor@suse.com
+
+- More reusable DiskAnalyzer.
+- Use libstorage mechanisms to check for windows partitions.
+- Added new minimalistic inst_disk_proposal client.
+- 0.1.2
+
+-------------------------------------------------------------------
 Mon Aug  1 13:11:13 UTC 2016 - ancor@suse.com
 
 - Namespaces adapted to avoid conflicts with old yast2-storage

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	0.1.1
+Version:        0.1.2
 Release:	0
 BuildArch:	noarch
 

--- a/src/examples/boot_req_checker_demo.rb
+++ b/src/examples/boot_req_checker_demo.rb
@@ -47,11 +47,6 @@ rescue => x
   pp x.backtrace
 end
 
-puts "\n---  disk_analyzer  ---"
-disk_analyzer = Y2Storage::DiskAnalyzer.new
-disk_analyzer.analyze(devicegraph)
-pp(disk_analyzer)
-
 puts "\n---  settings  ---"
 settings = Y2Storage::ProposalSettings.new
 settings.use_lvm = true
@@ -59,6 +54,7 @@ settings.root_device = ARGV[1]
 pp(settings)
 
 puts "\n---  needed  ---"
+disk_analyzer = Y2Storage::DiskAnalyzer.new(devicegraph)
 checker = Y2Storage::BootRequirementsChecker.new(settings, disk_analyzer)
 
 begin

--- a/src/lib/y2storage/disk_analyzer.rb
+++ b/src/lib/y2storage/disk_analyzer.rb
@@ -296,15 +296,9 @@ module Y2Storage
 
       # No need to limit checking - PC arch only (few disks)
       scoped_disks.each do |disk_name|
-        begin
-          possible_windows_partitions(disk_name).each do |partition|
-            next unless windows_partition?(partition)
-
-            windows_partitions[disk_name] ||= []
-            windows_partitions[disk_name] << partition
-          end
-        rescue RuntimeError => ex # FIXME: rescue ::Storage::Exception when SWIG bindings are fixed
-          log.info("CAUGHT exception #{ex}")
+        windows_partitions[disk_name] = []
+        possible_windows_partitions(disk_name).each do |partition|
+          windows_partitions[disk_name] << partition if windows_partition?(partition)
         end
       end
       windows_partitions

--- a/src/lib/y2storage/disk_analyzer.rb
+++ b/src/lib/y2storage/disk_analyzer.rb
@@ -73,7 +73,7 @@ module Y2Storage
     DEFAULT_DISK_CHECK_LIMIT = 10
 
     # @return [Fixnum] Maximum number of disks to check with "expensive"
-    # operations.
+    #   operations.
     #
     # Prevents, for example, mounting every single disk when looking for the
     # installation one.
@@ -83,11 +83,11 @@ module Y2Storage
     attr_reader :disk_check_limit
 
     # @return [Symbol, nil] Scope to limit the searches
-    #   :install_candidates - check only in #candidate_disks
-    #   nil - check all disks
+    #   - :install_candidates - check only in #candidate_disks
+    #   - nil - check all disks
     # @see #candidate_disks
     #
-    # It affects all search methods like #linux_partitions, #mbr_gap, etc.
+    # It affects all search methods like {#linux_partitions}, {#mbr_gap}, etc.
     attr_reader :scope
 
     def initialize(devicegraph, disk_check_limit: DEFAULT_DISK_CHECK_LIMIT, scope: nil)
@@ -98,7 +98,7 @@ module Y2Storage
 
     # Look up devicegraph element by device name.
     #
-    # @return [<::Storage::Device}>]
+    # @return [::Storage::Device]
     def device_by_name(name)
       devicegraph.disks.with(name: name).first
     end
@@ -111,7 +111,7 @@ module Y2Storage
     #
     # @see #scope
     #
-    # @return [Hash{String => Array<::Storage::Partition>}] @see #partitions_by_id
+    # @return [Hash{String => Array<::Storage::Partition>}] see {#partitions_with_id}
     def efi_partitions
       @efi_partitions ||= partitions_with_id(::Storage::ID_EFI, "EFI")
     end
@@ -119,7 +119,7 @@ module Y2Storage
     # Partitions that can be used as PReP partition
     # @see #scope
     #
-    # @return [Hash{String => Array<::Storage::Partition>}] @see #partitions_by_id
+    # @return [Hash{String => Array<::Storage::Partition>}] see {#partitions_with_id}
     def prep_partitions
       @prep_partitions ||= partitions_with_id(::Storage::ID_PPC_PREP, "PReP")
     end
@@ -127,7 +127,7 @@ module Y2Storage
     # GRUB (gpt_bios) partitions
     # @see #scope
     #
-    # @return [Hash{String => Array<::Storage::Partition>}] @see #partitions_by_id
+    # @return [Hash{String => Array<::Storage::Partition>}] see {#partitions_with_id}
     def grub_partitions
       @grub_partitions ||= partitions_with_id(::Storage::ID_GPT_BIOS, "GRUB")
     end
@@ -135,7 +135,7 @@ module Y2Storage
     # Partitions that can be used as swap space
     # @see #scope
     #
-    # @return [Hash{String => Array<::Storage::Partition>}] @see #partitions_by_id
+    # @return [Hash{String => Array<::Storage::Partition>}] see {#partitions_with_id}
     def swap_partitions
       @swap_partitions ||= partitions_with_id(::Storage::ID_SWAP, "Swap")
     end
@@ -144,14 +144,14 @@ module Y2Storage
     # Linux swap partition (type 0x82), an LVM partition, or a RAID partition.
     # @see #scope
     #
-    # @return [Hash{String => Array<::Storage::Partition>}] @see #partitions_by_id
+    # @return [Hash{String => Array<::Storage::Partition>}] see {#partitions_with_id}
     def linux_partitions
       @linux_partitions ||= partitions_with_id(LINUX_PARTITION_IDS, "Linux")
     end
 
     # Disks that are suitable for installing Linux.
     #
-    # @return [Array<string>] device names of candidate disks
+    # @return [Array<String>] device names of candidate disks
     def candidate_disks
       @candidate_disks ||= begin
         @installation_disks = find_installation_disks
@@ -187,7 +187,7 @@ module Y2Storage
     #
     # @see #scope
     #
-    # @return [Hash{String => Array<::Storage::Partition>}] @see #partitions_by_id
+    # @return [Hash{String => Array<::Storage::Partition>}] see {#partitions_with_id}
     def windows_partitions
       @windows_partitions ||= begin
         result = find_windows_partitions
@@ -332,7 +332,7 @@ module Y2Storage
     # Partitions that could potentially contain a MS Windows installation
     #
     # @param disk_name [String] name of the disk to check
-    # @return [PartitionsList]
+    # @return [DevicesLists::PartitionsList]
     def possible_windows_partitions(disk_name)
       prim_parts = disks.with(name: disk_name).partitions.with(type: Storage::PartitionType_PRIMARY)
       prim_parts.with(id: WINDOWS_PARTITION_IDS)
@@ -441,7 +441,7 @@ module Y2Storage
     # (::Storage::Disk, ::Storage::Partition, ...).
     #
     # @param blk_devices [Array<BlkDev>]
-    # @return [Array<string>] names, e.g. ["/dev/sda", "/dev/sdb1", "/dev/sdc3"]
+    # @return [Array<String>] names, e.g. ["/dev/sda", "/dev/sdb1", "/dev/sdc3"]
     #
     def dev_names(blk_devices)
       blk_devices.map(&:to_s)

--- a/src/lib/y2storage/proposal.rb
+++ b/src/lib/y2storage/proposal.rb
@@ -110,11 +110,7 @@ module Y2Storage
     #
     # @return [DiskAnalyzer]
     def disk_analyzer
-      @disk_analyzer ||= begin
-        analyzer = DiskAnalyzer.new
-        analyzer.analyze(initial_graph)
-        analyzer
-      end
+      @disk_analyzer ||= DiskAnalyzer.new(initial_graph, scope: :install_candidates)
     end
 
     def initial_graph

--- a/test/data/devicegraphs/gpt_and_msdos.yml
+++ b/test/data/devicegraphs/gpt_and_msdos.yml
@@ -1,0 +1,39 @@
+---
+- disk:
+    name: /dev/sda
+    size: 200 GiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+
+- disk:
+    name: /dev/sdb
+    size: 1 TiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size:         60 GiB
+        name:         /dev/sdb1
+        file_system:  xfs
+        label:        data
+
+- disk:
+    name: /dev/sdc
+    size: 500 GiB
+    partition_table: ms-dos
+
+- disk:
+    name: /dev/sdd
+    size: 500 GiB
+    partition_table: gpt
+
+- disk:
+    name: /dev/sde
+    size: 500 GiB

--- a/test/disk_analyzer_test.rb
+++ b/test/disk_analyzer_test.rb
@@ -29,10 +29,12 @@ describe Y2Storage::DiskAnalyzer do
   subject(:analyzer) { described_class.new(fake_devicegraph) }
 
   before do
-    fake_scenario("gpt_and_msdos")
+    fake_scenario(scenario)
   end
 
   describe "#mbr_gap" do
+    let(:scenario) { "gpt_and_msdos" }
+
     it "returns the gap for every disk" do
       expect(analyzer.mbr_gap.keys).to eq ["/dev/sda", "/dev/sdb", "/dev/sdc", "/dev/sdd", "/dev/sde"]
     end
@@ -55,6 +57,49 @@ describe Y2Storage::DiskAnalyzer do
 
     it "returns the gap for MS-DOS disks with partitions" do
       expect(analyzer.mbr_gap["/dev/sda"]).to eq 1.MiB
+    end
+  end
+
+  describe "#windows_partitions" do
+    before do
+      allow(Yast::Arch).to receive(:x86_64).and_return true
+      allow_any_instance_of(::Storage::Filesystem).to receive(:detect_content_info)
+        .and_return(content_info)
+    end
+
+    let(:scenario) { "mixed_disks" }
+    let(:content_info) { double("::Storage::ContentInfo", windows?: true) }
+
+    it "includes in the result all existent disks" do
+      expect(analyzer.windows_partitions.keys).to contain_exactly("/dev/sda", "/dev/sdb", "/dev/sdc")
+    end
+
+    it "returns an empty array for disks with no Windows" do
+      expect(analyzer.windows_partitions["/dev/sdb"]).to eq []
+    end
+
+    it "returns an array of partitions for disks with some Windows" do
+      expect(analyzer.windows_partitions["/dev/sda"]).to be_a Array
+      expect(analyzer.windows_partitions["/dev/sda"].size).to eq 1
+      expect(analyzer.windows_partitions["/dev/sda"].first).to be_a ::Storage::Partition
+    end
+  end
+
+  describe "#swap_partitions" do
+    let(:scenario) { "mixed_disks" }
+
+    it "includes in the result all existent disks" do
+      expect(analyzer.swap_partitions.keys).to contain_exactly("/dev/sda", "/dev/sdb", "/dev/sdc")
+    end
+
+    it "returns an empty array for disks with no swap" do
+      expect(analyzer.swap_partitions["/dev/sda"]).to eq []
+    end
+
+    it "returns an array of partitions for disks with some swap" do
+      expect(analyzer.swap_partitions["/dev/sdb"]).to be_a Array
+      expect(analyzer.swap_partitions["/dev/sdb"].size).to eq 1
+      expect(analyzer.swap_partitions["/dev/sdb"].first).to be_a ::Storage::Partition
     end
   end
 end

--- a/test/disk_analyzer_test.rb
+++ b/test/disk_analyzer_test.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2016] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+describe Y2Storage::DiskAnalyzer do
+  using Y2Storage::Refinements::SizeCasts
+
+  subject(:analyzer) { described_class.new(fake_devicegraph) }
+
+  before do
+    fake_scenario("gpt_and_msdos")
+  end
+
+  describe "#mbr_gap" do
+    it "returns the gap for every disk" do
+      expect(analyzer.mbr_gap.keys).to eq ["/dev/sda", "/dev/sdb", "/dev/sdc", "/dev/sdd", "/dev/sde"]
+    end
+
+    it "returns 0 bytes for disks without partition table" do
+      expect(analyzer.mbr_gap["/dev/sde"]).to eq 0.KiB
+    end
+
+    it "returns 0 bytes for GPT disks without partitions" do
+      expect(analyzer.mbr_gap["/dev/sdd"]).to eq 0.KiB
+    end
+
+    it "returns 0 bytes for GPT disks with partitions" do
+      expect(analyzer.mbr_gap["/dev/sdb"]).to eq 0.KiB
+    end
+
+    it "returns 0 bytes for MS-DOS disks without partitions" do
+      expect(analyzer.mbr_gap["/dev/sdc"]).to eq 0.KiB
+    end
+
+    it "returns the gap for MS-DOS disks with partitions" do
+      expect(analyzer.mbr_gap["/dev/sda"]).to eq 1.MiB
+    end
+  end
+end

--- a/test/disk_analyzer_test.rb
+++ b/test/disk_analyzer_test.rb
@@ -61,27 +61,40 @@ describe Y2Storage::DiskAnalyzer do
   end
 
   describe "#windows_partitions" do
-    before do
-      allow(Yast::Arch).to receive(:x86_64).and_return true
-      allow_any_instance_of(::Storage::Filesystem).to receive(:detect_content_info)
-        .and_return(content_info)
-    end
-
     let(:scenario) { "mixed_disks" }
-    let(:content_info) { double("::Storage::ContentInfo", windows?: true) }
 
-    it "includes in the result all existent disks" do
-      expect(analyzer.windows_partitions.keys).to contain_exactly("/dev/sda", "/dev/sdb", "/dev/sdc")
+    context "in a PC" do
+      before do
+        allow(Yast::Arch).to receive(:x86_64).and_return true
+        allow_any_instance_of(::Storage::Filesystem).to receive(:detect_content_info)
+          .and_return(content_info)
+      end
+      let(:content_info) { double("::Storage::ContentInfo", windows?: true) }
+
+      it "includes in the result all existent disks" do
+        expect(analyzer.windows_partitions.keys).to contain_exactly("/dev/sda", "/dev/sdb", "/dev/sdc")
+      end
+
+      it "returns an empty array for disks with no Windows" do
+        expect(analyzer.windows_partitions["/dev/sdb"]).to eq []
+      end
+
+      it "returns an array of partitions for disks with some Windows" do
+        expect(analyzer.windows_partitions["/dev/sda"]).to be_a Array
+        expect(analyzer.windows_partitions["/dev/sda"].size).to eq 1
+        expect(analyzer.windows_partitions["/dev/sda"].first).to be_a ::Storage::Partition
+      end
     end
 
-    it "returns an empty array for disks with no Windows" do
-      expect(analyzer.windows_partitions["/dev/sdb"]).to eq []
-    end
+    context "in a non-PC system" do
+      before do
+        allow(Yast::Arch).to receive(:x86_64).and_return false
+        allow(Yast::Arch).to receive(:i386).and_return false
+      end
 
-    it "returns an array of partitions for disks with some Windows" do
-      expect(analyzer.windows_partitions["/dev/sda"]).to be_a Array
-      expect(analyzer.windows_partitions["/dev/sda"].size).to eq 1
-      expect(analyzer.windows_partitions["/dev/sda"].first).to be_a ::Storage::Partition
+      it "returns an empty hash" do
+        expect(analyzer.windows_partitions).to eq({})
+      end
     end
   end
 

--- a/test/proposal/space_maker_test.rb
+++ b/test/proposal/space_maker_test.rb
@@ -30,13 +30,9 @@ describe Y2Storage::Proposal::SpaceMaker do
 
     before do
       fake_scenario(scenario)
+      allow(analyzer).to receive(:windows_partitions).and_return windows_partitions
     end
 
-    let(:analyzer) do
-      disk_analyzer = Y2Storage::DiskAnalyzer.new
-      disk_analyzer.analyze(fake_devicegraph)
-      disk_analyzer
-    end
     let(:settings) do
       settings = Y2Storage::ProposalSettings.new
       settings.candidate_devices = ["/dev/sda"]
@@ -44,6 +40,8 @@ describe Y2Storage::Proposal::SpaceMaker do
       settings
     end
     let(:volumes) { vols_list(vol1) }
+    let(:analyzer) { Y2Storage::DiskAnalyzer.new(fake_devicegraph) }
+    let(:windows_partitions) { Hash.new }
 
     subject(:maker) { described_class.new(fake_devicegraph, analyzer, settings) }
 
@@ -61,10 +59,6 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:scenario) { "windows-linux-multiboot-pc" }
       let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, desired: 100.GiB) }
       let(:windows_partitions) { { "/dev/sda" => [analyzer_part("/dev/sda1")] } }
-
-      before do
-        allow(analyzer).to receive(:windows_partitions).and_return windows_partitions
-      end
 
       it "deletes linux partitions as needed" do
         result = maker.provide_space(volumes)
@@ -117,7 +111,6 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:windows_partitions) { { "/dev/sda" => [analyzer_part("/dev/sda1")] } }
 
       before do
-        allow(analyzer).to receive(:windows_partitions).and_return windows_partitions
         allow_any_instance_of(::Storage::Filesystem).to receive(:detect_resize_info)
           .and_return(resize_info)
       end
@@ -199,7 +192,6 @@ describe Y2Storage::Proposal::SpaceMaker do
 
       before do
         settings.candidate_devices = ["/dev/sda", "/dev/sdb"]
-        allow(analyzer).to receive(:windows_partitions).and_return windows_partitions
         allow_any_instance_of(::Storage::Filesystem).to receive(:detect_resize_info)
           .and_return(resize_info)
       end
@@ -368,7 +360,6 @@ describe Y2Storage::Proposal::SpaceMaker do
 
       before do
         settings.candidate_devices = ["/dev/sda", "/dev/sdb"]
-        allow(analyzer).to receive(:windows_partitions).and_return windows_partitions
         allow_any_instance_of(::Storage::Filesystem).to receive(:detect_resize_info)
           .and_return(resize_info)
       end

--- a/test/proposal_test.rb
+++ b/test/proposal_test.rb
@@ -41,7 +41,7 @@ describe Y2Storage::Proposal do
 
     subject(:proposal) { described_class.new(settings: settings) }
 
-    let(:disk_analyzer) { Y2Storage::DiskAnalyzer.new }
+    let(:disk_analyzer) { Y2Storage::DiskAnalyzer.new(fake_devicegraph) }
     let(:boot_checker) do
       instance_double("Y2Storage::BootRequirementChecker", needed_partitions: [])
     end


### PR DESCRIPTION
Make DiskAnalyzer reusable in other contexts beyond partitioning proposal, since it includes quite some valuable logic (like checking for Windows partitions).

### Why

Here (https://github.com/yast/yast-country/pull/89#discussion_r80223751) we are discussing the exact code to check for Windows partitions in yast2-country. Checking for Windows implies:
 - checking for the architecture (something that DiskAnalyzer does but our draft in yast2-country forgets)
 - checking for the partition ID (DiskAnalyzer checks for 4 ids, our draft only NTFS)
 - checking for a primary partition (only done by yast2-country)
 - checking for the content of the filesystem

Obviously we should not have two pieces of code  to check that, and `DiskAnalyzer` looks like the perfect candidate to host the one and only code. We just need to generalize it a little bit so it's useful in more contexts.

### What

- Allow operation on all disks (while retaining the "only installation candidates" mode, useful for proposal).
- Don't calculate everything at a time, do it on demand.
- Remove proposal-specific logic, like skipping Windows check if Linux is found... which was actually an error.[1]

## Bonus track

DiskAnalyzer#windows_partitions rewritten to rely on new libstorage windows check (see the above-mentioned discussion in yast2-country).

[1]  We slightly changed the proposal logic (we found cases in which resizing Windows still made sense) and DiskAnalyzer was left behind.