### PR TITLE
Fixed textdomain in several files.

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 12 13:38:38 UTC 2016 - cwh@suse.com
+
+- Use own textdomain (storage-ng instead of storage) (bsc#1004050)
+- 0.1.4
+
+-------------------------------------------------------------------
 Fri Sep 30 14:05:08 UTC 2016 - ancor@suse.com
 
 - Added new inst_prepdisk client - first version in which the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        0.1.3
+Version:        0.1.4
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/expert_partitioner/dialogs/create_partition.rb
+++ b/src/lib/expert_partitioner/dialogs/create_partition.rb
@@ -34,7 +34,7 @@ module ExpertPartitioner
     include Yast::Logger
 
     def initialize(disk)
-      textdomain "storage"
+      textdomain "storage-ng"
       @disk = disk
     end
 

--- a/src/lib/expert_partitioner/dialogs/create_partition_table.rb
+++ b/src/lib/expert_partitioner/dialogs/create_partition_table.rb
@@ -34,7 +34,7 @@ module ExpertPartitioner
     include Yast::Logger
 
     def initialize(disk)
-      textdomain "storage"
+      textdomain "storage-ng"
       @disk = disk
     end
 

--- a/src/lib/expert_partitioner/dialogs/format.rb
+++ b/src/lib/expert_partitioner/dialogs/format.rb
@@ -35,7 +35,7 @@ module ExpertPartitioner
     include Yast::Logger
 
     def initialize(blk_device)
-      textdomain "storage"
+      textdomain "storage-ng"
       @blk_device = blk_device
     end
 

--- a/src/lib/expert_partitioner/main_dialog.rb
+++ b/src/lib/expert_partitioner/main_dialog.rb
@@ -74,7 +74,7 @@ module ExpertPartitioner
 
     def initialize
       super
-      textdomain "storage"
+      textdomain "storage-ng"
       @view = AllTreeView.new
     end
 

--- a/src/lib/expert_partitioner/popups.rb
+++ b/src/lib/expert_partitioner/popups.rb
@@ -30,7 +30,7 @@ module ExpertPartitioner
   # Popup to ask for confirmation before deleting the descendants of a device
   class RemoveDescendantsPopup
     def initialize(device)
-      textdomain "storage"
+      textdomain "storage-ng"
       @device = device
     end
 

--- a/src/lib/expert_partitioner/tab_views/disk/partitions.rb
+++ b/src/lib/expert_partitioner/tab_views/disk/partitions.rb
@@ -39,10 +39,13 @@ module ExpertPartitioner
     FIELDS = [:sid, :icon, :name, :size, :filesystem, :mountpoint]
 
     def initialize(disk)
+      textdomain "storage-ng"
       @disk = disk
     end
 
     def create
+      # FIXME: Add a describing comment, that helps translators to learn
+      # about the context of the strings.
       VBox(
         Table(Id(:table), Opt(:keepSorting), Storage::Device.table_header(FIELDS), items),
         HBox(

--- a/src/lib/expert_partitioner/tab_views/lvm_vg/lvm_lvs.rb
+++ b/src/lib/expert_partitioner/tab_views/lvm_vg/lvm_lvs.rb
@@ -39,10 +39,13 @@ module ExpertPartitioner
     FIELDS = [:sid, :icon, :name, :lv_name, :size, :stripe_info, :filesystem, :mountpoint]
 
     def initialize(lvm_vg)
+      textdomain "storage-ng"
       @lvm_vg = lvm_vg
     end
 
     def create
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Table(Id(:table), Opt(:keepSorting), Storage::Device.table_header(FIELDS), items),
         HBox(

--- a/src/lib/expert_partitioner/tab_views/md/partitions.rb
+++ b/src/lib/expert_partitioner/tab_views/md/partitions.rb
@@ -39,10 +39,13 @@ module ExpertPartitioner
     FIELDS = [:sid, :icon, :name, :size, :filesystem, :mountpoint]
 
     def initialize(md)
+      textdomain "storage-ng"
       @md = md
     end
 
     def create
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Table(Id(:table), Opt(:keepSorting), Storage::Device.table_header(FIELDS), items),
         HBox(

--- a/src/lib/expert_partitioner/tree.rb
+++ b/src/lib/expert_partitioner/tree.rb
@@ -39,10 +39,12 @@ module ExpertPartitioner
     include Yast::Logger
 
     def initialize
-      textdomain "storage"
+      textdomain "storage-ng"
     end
 
     def tree_items
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       [
         Item(
           Id(:all), "hostname", true,

--- a/src/lib/expert_partitioner/tree_views/actiongraph.rb
+++ b/src/lib/expert_partitioner/tree_views/actiongraph.rb
@@ -28,12 +28,15 @@ include Yast::I18n
 module ExpertPartitioner
   class ActiongraphTreeView < TreeView
     def create
+      textdomain "storage-ng"
       filename = "#{Yast::Directory.tmpdir}/actiongraph.gv"
 
       actiongraph = storage.calculate_actiongraph
       actiongraph.write_graphviz(filename, ::Storage::GraphvizFlags_TOOLTIP |
                                            ::Storage::GraphvizFlags_SID)
 
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(Heading(_("Action Graph"))),
         Yast::Term.new(:Graph, Id(:graph), Opt(:notify, :notifyContextMenu), filename, "dot")

--- a/src/lib/expert_partitioner/tree_views/actionlist.rb
+++ b/src/lib/expert_partitioner/tree_views/actionlist.rb
@@ -28,6 +28,7 @@ include Yast::I18n
 module ExpertPartitioner
   class ActionlistTreeView < TreeView
     def create
+      textdomain "storage-ng"
       # storage.probed().save("./devicegraph-probed.xml")
       # storage.staging().save("./devicegraph-staging.xml")
 

--- a/src/lib/expert_partitioner/tree_views/all.rb
+++ b/src/lib/expert_partitioner/tree_views/all.rb
@@ -32,6 +32,9 @@ module ExpertPartitioner
     FIELDS = [:sid, :icon, :name, :size, :partition_table, :filesystem, :mountpoint]
 
     def create
+      textdomain "storage-ng"
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(IconAndHeading(_("Storage"), Icons::ALL)),
         Table(Id(:table), Opt(:keepSorting), Storage::Device.table_header(FIELDS), items),

--- a/src/lib/expert_partitioner/tree_views/bcache.rb
+++ b/src/lib/expert_partitioner/tree_views/bcache.rb
@@ -31,6 +31,7 @@ include Yast::I18n
 module ExpertPartitioner
   class BcacheTreeView < TreeView
     def initialize(bcache)
+      textdomain "storage-ng"
       @bcache = bcache
     end
 
@@ -47,6 +48,8 @@ module ExpertPartitioner
 
       contents = Yast::HTML.List(tmp)
 
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(IconAndHeading(_("Bcache: %s") % @bcache.name, Icons::BCACHE)),
         RichText(Id(:text), Opt(:hstretch, :vstretch), contents)

--- a/src/lib/expert_partitioner/tree_views/bcache_cset.rb
+++ b/src/lib/expert_partitioner/tree_views/bcache_cset.rb
@@ -31,6 +31,7 @@ include Yast::I18n
 module ExpertPartitioner
   class BcacheCsetTreeView < TreeView
     def initialize(bcache_cset)
+      textdomain "storage-ng"
       @bcache_cset = bcache_cset
     end
 
@@ -47,6 +48,8 @@ module ExpertPartitioner
 
       contents = Yast::HTML.List(tmp)
 
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(IconAndHeading(_("Bcache Cset: %s") % @bcache_cset.uuid, Icons::BCACHE_CSET)),
         RichText(Id(:text), Opt(:hstretch, :vstretch), contents)

--- a/src/lib/expert_partitioner/tree_views/bcache_csets.rb
+++ b/src/lib/expert_partitioner/tree_views/bcache_csets.rb
@@ -35,11 +35,14 @@ module ExpertPartitioner
     FIELDS = [:sid, :icon, :uuid]
 
     def initialize
+      textdomain "storage-ng"
       staging = storage.staging
       @bcache_csets = ::Storage::BcacheCset.all(staging)
     end
 
     def create
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(IconAndHeading(_("Bcache Csets"), Icons::BCACHE_CSET)),
         Table(Id(:table), Opt(:keepSorting), Storage::Device.table_header(FIELDS), items),

--- a/src/lib/expert_partitioner/tree_views/bcaches.rb
+++ b/src/lib/expert_partitioner/tree_views/bcaches.rb
@@ -35,11 +35,14 @@ module ExpertPartitioner
     FIELDS = [:sid, :icon, :name, :size, :filesystem, :mountpoint]
 
     def initialize
+      textdomain "storage-ng"
       staging = storage.staging
       @bcaches = ::Storage::Bcache.all(staging)
     end
 
     def create
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(IconAndHeading(_("Bcaches"), Icons::BCACHE)),
         Table(Id(:table), Opt(:keepSorting), Storage::Device.table_header(FIELDS), items),

--- a/src/lib/expert_partitioner/tree_views/disk.rb
+++ b/src/lib/expert_partitioner/tree_views/disk.rb
@@ -32,6 +32,7 @@ include Yast::Logger
 module ExpertPartitioner
   class DiskTreeView < TreeView
     def initialize(disk)
+      textdomain "storage-ng"
       @disk = disk
     end
 

--- a/src/lib/expert_partitioner/tree_views/disks.rb
+++ b/src/lib/expert_partitioner/tree_views/disks.rb
@@ -37,11 +37,14 @@ module ExpertPartitioner
     FIELDS = [:sid, :icon, :name, :size, :transport, :partition_table, :filesystem, :mountpoint]
 
     def initialize
+      textdomain "storage-ng"
       staging = storage.staging
       @disks = staging.all_disks
     end
 
     def create
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(IconAndHeading(_("Hard Disks"), Icons::DISK)),
         Table(Id(:table), Opt(:keepSorting), Storage::Device.table_header(FIELDS), items),

--- a/src/lib/expert_partitioner/tree_views/filesystem.rb
+++ b/src/lib/expert_partitioner/tree_views/filesystem.rb
@@ -31,6 +31,9 @@ module ExpertPartitioner
     FIELDS = [:sid, :icon, :filesystem, :mountpoint, :mount_by, :label, :uuid]
 
     def create
+      textdomain "storage-ng"
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(IconAndHeading(_("Filesystems"), Icons::FILESYSTEM)),
         Table(Id(:table), Opt(:keepSorting), Storage::Device.table_header(FIELDS), items)

--- a/src/lib/expert_partitioner/tree_views/luks.rb
+++ b/src/lib/expert_partitioner/tree_views/luks.rb
@@ -31,6 +31,7 @@ include Yast::I18n
 module ExpertPartitioner
   class LuksTreeView < TreeView
     def initialize(luks)
+      textdomain "storage-ng"
       @luks = luks
     end
 
@@ -42,6 +43,8 @@ module ExpertPartitioner
 
       contents = Yast::HTML.List(tmp)
 
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(IconAndHeading(_("LUKS: %s") % @luks.dm_table_name, Icons::ENCRYPTION)),
         RichText(Id(:text), Opt(:hstretch, :vstretch), contents)

--- a/src/lib/expert_partitioner/tree_views/lukses.rb
+++ b/src/lib/expert_partitioner/tree_views/lukses.rb
@@ -35,11 +35,14 @@ module ExpertPartitioner
     FIELDS = [:sid, :icon, :name, :size, :filesystem, :mountpoint]
 
     def initialize
+      textdomain "storage-ng"
       staging = storage.staging
       @lukses = ::Storage::Luks.all(staging)
     end
 
     def create
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(IconAndHeading(_("LUKSes"), Icons::ENCRYPTION)),
         Table(Id(:table), Opt(:keepSorting), Storage::Device.table_header(FIELDS), items),

--- a/src/lib/expert_partitioner/tree_views/lvm_lv.rb
+++ b/src/lib/expert_partitioner/tree_views/lvm_lv.rb
@@ -31,6 +31,7 @@ include Yast::I18n
 module ExpertPartitioner
   class LvmLvTreeView < TreeView
     def initialize(lvm_lv)
+      textdomain "storage-ng"
       @lvm_lv = lvm_lv
     end
 
@@ -41,6 +42,8 @@ module ExpertPartitioner
 
       contents = Yast::HTML.List(tmp)
 
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(IconAndHeading(_("LVM LV: %s") % @lvm_lv.lv_name, Icons::LVM_LV)),
         RichText(Id(:text), Opt(:hstretch, :vstretch), contents)

--- a/src/lib/expert_partitioner/tree_views/lvm_vg.rb
+++ b/src/lib/expert_partitioner/tree_views/lvm_vg.rb
@@ -35,6 +35,7 @@ include Yast::Logger
 module ExpertPartitioner
   class LvmVgTreeView < TreeView
     def initialize(lvm_vg)
+      textdomain "storage-ng"
       @lvm_vg = lvm_vg
     end
 

--- a/src/lib/expert_partitioner/tree_views/lvm_vgs.rb
+++ b/src/lib/expert_partitioner/tree_views/lvm_vgs.rb
@@ -35,11 +35,14 @@ module ExpertPartitioner
     FIELDS = [:sid, :icon, :name, :size]
 
     def initialize
+      textdomain "storage-ng"
       staging = storage.staging
       @lvm_vgs = staging.all_lvm_vgs
     end
 
     def create
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(IconAndHeading(_("LVM VGs"), Icons::LVM_VG)),
         Table(Id(:table), Opt(:keepSorting), Storage::Device.table_header(FIELDS), items),

--- a/src/lib/expert_partitioner/tree_views/md.rb
+++ b/src/lib/expert_partitioner/tree_views/md.rb
@@ -35,6 +35,7 @@ include Yast::Logger
 module ExpertPartitioner
   class MdTreeView < TreeView
     def initialize(md)
+      textdomain "storage-ng"
       @md = md
     end
 

--- a/src/lib/expert_partitioner/tree_views/mds.rb
+++ b/src/lib/expert_partitioner/tree_views/mds.rb
@@ -37,11 +37,14 @@ module ExpertPartitioner
     FIELDS = [:sid, :icon, :name, :size, :md_level, :partition_table, :filesystem, :mountpoint]
 
     def initialize
+      textdomain "storage-ng"
       staging = storage.staging
       @mds = staging.all_mds
     end
 
     def create
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(IconAndHeading(_("MD RAIDs"), Icons::MD)),
         Table(Id(:table), Opt(:keepSorting), Storage::Device.table_header(FIELDS), items),

--- a/src/lib/expert_partitioner/tree_views/partition.rb
+++ b/src/lib/expert_partitioner/tree_views/partition.rb
@@ -31,6 +31,7 @@ include Yast::I18n
 module ExpertPartitioner
   class PartitionTreeView < TreeView
     def initialize(partition)
+      textdomain "storage-ng"
       @partition = partition
     end
 
@@ -46,6 +47,8 @@ module ExpertPartitioner
 
       contents = Yast::HTML.List(tmp)
 
+      # FIXME: Add a describing comment, that helps translators to learn
+      # about the context of the strings.
       VBox(
         Left(IconAndHeading(_("Partition: %s") % @partition.name, Icons::PARTITION)),
         RichText(Id(:text), Opt(:hstretch, :vstretch), contents)

--- a/src/lib/expert_partitioner/tree_views/probed_devicegraph.rb
+++ b/src/lib/expert_partitioner/tree_views/probed_devicegraph.rb
@@ -28,6 +28,7 @@ include Yast::I18n
 module ExpertPartitioner
   class ProbedDevicegraphTreeView < TreeView
     def create
+      textdomain "storage-ng"
       filename = "#{Yast::Directory.tmpdir}/devicegraph-probed.gv"
 
       probed = storage.probed
@@ -35,6 +36,8 @@ module ExpertPartitioner
                                       ::Storage::GraphvizFlags_SID |
                                       ::Storage::GraphvizFlags_SIZE)
 
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(Heading(_("Device Graph (probed)"))),
         Yast::Term.new(:Graph, Id(:graph), Opt(:notify, :notifyContextMenu), filename, "dot")

--- a/src/lib/expert_partitioner/tree_views/staging_devicegraph.rb
+++ b/src/lib/expert_partitioner/tree_views/staging_devicegraph.rb
@@ -28,6 +28,7 @@ include Yast::I18n
 module ExpertPartitioner
   class StagingDevicegraphTreeView < TreeView
     def create
+      textdomain "storage-ng"
       filename = "#{Yast::Directory.tmpdir}/devicegraph-staging.gv"
 
       staging = storage.staging
@@ -35,6 +36,8 @@ module ExpertPartitioner
                                        ::Storage::GraphvizFlags_SID |
                                        ::Storage::GraphvizFlags_SIZE)
 
+      # FIXME: Add some comments to help translators to know about the
+      # context of the used strings.
       VBox(
         Left(Heading(_("Device Graph (staging)"))),
         Yast::Term.new(:Graph, Id(:graph), Opt(:notify, :notifyContextMenu), filename, "dot")

--- a/src/lib/storage/extensions.rb
+++ b/src/lib/storage/extensions.rb
@@ -40,7 +40,7 @@ module Storage
 
   class Device
     extend Yast::I18n
-    textdomain "storage"
+    textdomain "storage-ng"
 
     # This code is only executed once (when the class is loaded), but YaST
     # allows to change the language in execution time. Thus, we use N_() here

--- a/src/lib/y2storage/dialogs/inst_disk_proposal.rb
+++ b/src/lib/y2storage/dialogs/inst_disk_proposal.rb
@@ -35,7 +35,7 @@ module Y2Storage
 
       def initialize
         super
-        textdomain "storage"
+        textdomain "storage-ng"
         propose!
       end
 


### PR DESCRIPTION
I added a FIXME in several files moaning about missing comments, that should describe the context of the strings to let translators find proper translations.
I did this only in files that had no comments at all to avoid the GPL-header ending up in the POT file (what indeed happened before).
See also: https://github.com/yast/yast-translations/pull/6