### PR TITLE
libstorage-ng does not longer use id linux for extended partitions

### DIFF
--- a/test/data/devicegraphs/output/multi-linux-pc-sep-home.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-sep-home.yml
@@ -34,7 +34,6 @@
         size: unlimited
         name: "/dev/sda4"
         type: extended
-        id: linux
 
     - partition:
         size: 300.00 GiB

--- a/test/data/devicegraphs/output/multi-linux-pc.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc.yml
@@ -30,7 +30,6 @@
         size: unlimited
         name: "/dev/sda4"
         type: extended
-        id: linux
     - partition:
         size: 300.00 GiB
         name: "/dev/sda5"

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-sep-home.yml
@@ -30,7 +30,7 @@
         size: unlimited
         name: "/dev/sda4"
         type: extended
-        id: linux
+        id: extended
     - partition:
         size: unlimited
         name: "/dev/sda5"

--- a/test/data/devicegraphs/output/windows-pc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-sep-home.yml
@@ -24,7 +24,7 @@
         size: 12.00 GiB
         name: "/dev/sda4"
         type: extended
-        id: linux
+        id: extended
 
     - partition:
         size: 2.00 GiB

--- a/test/data/devicegraphs/output/windows-pc.yml
+++ b/test/data/devicegraphs/output/windows-pc.yml
@@ -24,7 +24,7 @@
         size: 2.00 GiB
         name: "/dev/sda4"
         type: extended
-        id: linux
+        id: extended
 
     - partition:
         size: unlimited


### PR DESCRIPTION
Adapt the tests to the fix introduced in https://github.com/openSUSE/libstorage-ng/pull/160