### PR TITLE
Devices list for LVM classes

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Oct 26 12:26:58 UTC 2016 - ancor@suse.com
+
+- LVM classes added to Refinements::DevicegraphLists
+
+-------------------------------------------------------------------
 Wed Oct 12 13:38:38 UTC 2016 - cwh@suse.com
 
 - Use own textdomain (storage-ng instead of storage) (bsc#1004050)

--- a/src/lib/y2storage/devices_lists/lvm_lvs_list.rb
+++ b/src/lib/y2storage/devices_lists/lvm_lvs_list.rb
@@ -1,3 +1,4 @@
+#
 # encoding: utf-8
 
 # Copyright (c) [2016] SUSE LLC
@@ -19,10 +20,14 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2storage/devices_lists/disks_list"
-require "y2storage/devices_lists/filesystems_list"
-require "y2storage/devices_lists/free_disk_spaces_list"
-require "y2storage/devices_lists/partitions_list"
-require "y2storage/devices_lists/lvm_lvs_list"
-require "y2storage/devices_lists/lvm_pvs_list"
-require "y2storage/devices_lists/lvm_vgs_list"
+require "storage"
+require "y2storage/devices_lists/base"
+
+module Y2Storage
+  module DevicesLists
+    # List of LVM logical volumes from a devicegraph
+    class LvmLvsList < Base
+      list_of ::Storage::LvmLv
+    end
+  end
+end

--- a/src/lib/y2storage/devices_lists/lvm_pvs_list.rb
+++ b/src/lib/y2storage/devices_lists/lvm_pvs_list.rb
@@ -1,3 +1,4 @@
+#
 # encoding: utf-8
 
 # Copyright (c) [2016] SUSE LLC
@@ -19,10 +20,14 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2storage/devices_lists/disks_list"
-require "y2storage/devices_lists/filesystems_list"
-require "y2storage/devices_lists/free_disk_spaces_list"
-require "y2storage/devices_lists/partitions_list"
-require "y2storage/devices_lists/lvm_lvs_list"
-require "y2storage/devices_lists/lvm_pvs_list"
-require "y2storage/devices_lists/lvm_vgs_list"
+require "storage"
+require "y2storage/devices_lists/base"
+
+module Y2Storage
+  module DevicesLists
+    # List of LVM physical volumes from a devicegraph
+    class LvmPvsList < Base
+      list_of ::Storage::LvmPv
+    end
+  end
+end

--- a/src/lib/y2storage/devices_lists/lvm_vgs_list.rb
+++ b/src/lib/y2storage/devices_lists/lvm_vgs_list.rb
@@ -1,0 +1,57 @@
+#
+# encoding: utf-8
+
+# Copyright (c) [2016] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "storage"
+require "y2storage/devices_lists/base"
+require "y2storage/devices_lists/lvm_pvs_list"
+require "y2storage/devices_lists/lvm_lvs_list"
+
+module Y2Storage
+  module DevicesLists
+    # List of LVM volume groups from a devicegraph
+    class LvmVgsList < Base
+      list_of ::Storage::LvmVg
+
+      # Physical volumes included in any of the volume groups
+      #
+      # @return [LvmPvsList]
+      def lvm_pvs
+        pvs_list = list.reduce([]) { |sum, vg| sum + vg.lvm_pvs.to_a }
+        LvmPvsList.new(devicegraph, list: pvs_list)
+      end
+
+      alias_method :pvs, :lvm_pvs
+      alias_method :physical_volumes, :lvm_pvs
+
+      # Logical volumes included in any of the volume groups
+      #
+      # @return [LvmLvList]
+      def lvm_lvs
+        lvs_list = list.reduce([]) { |sum, vg| sum + vg.lvm_lvs.to_a }
+        LvmLvsList.new(devicegraph, list: lvs_list)
+      end
+
+      alias_method :lvs, :lvm_lvs
+      alias_method :logical_volumes, :lvm_lvs
+    end
+  end
+end

--- a/src/lib/y2storage/devices_lists/lvm_vgs_list.rb
+++ b/src/lib/y2storage/devices_lists/lvm_vgs_list.rb
@@ -35,7 +35,7 @@ module Y2Storage
       #
       # @return [LvmPvsList]
       def lvm_pvs
-        pvs_list = list.reduce([]) { |sum, vg| sum + vg.lvm_pvs.to_a }
+        pvs_list = list.reduce([]) { |sum, vg| sum.concat(vg.lvm_pvs.to_a) }
         LvmPvsList.new(devicegraph, list: pvs_list)
       end
 
@@ -46,7 +46,7 @@ module Y2Storage
       #
       # @return [LvmLvList]
       def lvm_lvs
-        lvs_list = list.reduce([]) { |sum, vg| sum + vg.lvm_lvs.to_a }
+        lvs_list = list.reduce([]) { |sum, vg| sum.concat(vg.lvm_lvs.to_a) }
         LvmLvsList.new(devicegraph, list: lvs_list)
       end
 

--- a/src/lib/y2storage/refinements/devicegraph_lists.rb
+++ b/src/lib/y2storage/refinements/devicegraph_lists.rb
@@ -34,7 +34,11 @@ module Y2Storage
           disks:            DevicesLists::DisksList,
           partitions:       DevicesLists::PartitionsList,
           filesystems:      DevicesLists::FilesystemsList,
-          free_disk_spaces: DevicesLists::FreeDiskSpacesList
+          free_disk_spaces: DevicesLists::FreeDiskSpacesList,
+          lvm_vgs:          DevicesLists::LvmVgsList,
+          lvm_pvs:          DevicesLists::LvmPvsList,
+          lvm_lvs:          DevicesLists::LvmLvsList
+
         }
 
         DEVICE_LISTS.each do |list, klass|
@@ -42,6 +46,13 @@ module Y2Storage
             klass.new(self)
           end
         end
+
+        alias_method :vgs, :lvm_vgs
+        alias_method :volume_groups, :lvm_vgs
+        alias_method :pvs, :lvm_pvs
+        alias_method :physical_volumes, :lvm_pvs
+        alias_method :lvs, :lvm_lvs
+        alias_method :logical_volumes, :lvm_lvs
       end
     end
   end

--- a/test/data/devicegraphs/lvm-two-vgs.yml
+++ b/test/data/devicegraphs/lvm-two-vgs.yml
@@ -1,0 +1,87 @@
+---
+- disk:
+    name: /dev/sda
+    size: 50 GiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        size:         20 GiB
+        name:         /dev/sda1
+        id:           ntfs
+        file_system:  ntfs
+        label:        windows
+
+    - partition:
+        size:         10 GiB
+        name:         /dev/sda2
+        id:           ntfs
+        file_system:  ntfs
+        label:        data
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda3
+        type:         extended
+
+    - partition:
+        size:         3 GiB
+        name:         /dev/sda5
+        type:         logical
+        id:           lvm
+
+    - partition:
+        size:         5 GiB
+        name:         /dev/sda6
+        type:         logical
+        file_system:  ext4
+        label:        linux1
+
+    - partition:
+        size:         4 GiB
+        name:         /dev/sda7
+        type:         logical
+        id:           lvm
+
+    - partition:
+        size:         5 GiB
+        name:         /dev/sda8
+        type:         logical
+        file_system:  ext4
+        label:        linux2
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda9
+        type:         logical
+        id:           lvm
+
+- lvm_vg:
+    vg_name: vg0
+    lvm_pvs:
+        - lvm_pv:
+            blk_device: /dev/sda7
+
+    lvm_lvs:
+        - lvm_lv:
+            size:         2 GiB
+            lv_name:      lv1
+            file_system:  ext4
+
+        - lvm_lv:
+            size:         2 GiB
+            lv_name:      lv2
+            file_system:  ext4
+
+- lvm_vg:
+    vg_name: vg1
+    lvm_pvs:
+        - lvm_pv:
+            blk_device: /dev/sda5
+        - lvm_pv:
+            blk_device: /dev/sda9
+    lvm_lvs:
+        - lvm_lv:
+            size:         5 GiB
+            lv_name:      lv1
+            file_system:  ext4

--- a/test/devices_list_test.rb
+++ b/test/devices_list_test.rb
@@ -153,7 +153,7 @@ describe "devices lists" do
 
     it "contains all disks by default" do
       expect(disks.size).to eq 3
-      expect(.size).to eq 3
+      expect(full_list.size).to eq 3
     end
 
     describe "#partitions" do

--- a/test/devices_list_test.rb
+++ b/test/devices_list_test.rb
@@ -33,6 +33,8 @@ describe "devices lists" do
   let(:id_swap) { ::Storage::ID_SWAP }
   let(:primary) { ::Storage::PartitionType_PRIMARY }
 
+  subject(:full_list) { described_class.new(fake_devicegraph) }
+
   before do
     fake_scenario(scenario)
   end
@@ -151,7 +153,7 @@ describe "devices lists" do
 
     it "contains all disks by default" do
       expect(disks.size).to eq 3
-      expect(described_class.new(fake_devicegraph).size).to eq 3
+      expect(.size).to eq 3
     end
 
     describe "#partitions" do
@@ -193,7 +195,7 @@ describe "devices lists" do
 
     it "contains all partitions by default" do
       expect(partitions.size).to eq 9
-      expect(described_class.new(fake_devicegraph).size).to eq 9
+      expect(full_list.size).to eq 9
     end
 
     describe "#filesystems" do
@@ -213,7 +215,7 @@ describe "devices lists" do
 
     it "contains all filesystems by default" do
       expect(filesystems.size).to eq 7
-      expect(described_class.new(fake_devicegraph).size).to eq 7
+      expect(full_list.size).to eq 7
     end
   end
 
@@ -224,7 +226,7 @@ describe "devices lists" do
 
     it "contains all spaces by default" do
       expect(spaces.size).to eq 3
-      expect(described_class.new(fake_devicegraph).size).to eq 3
+      expect(full_list.size).to eq 3
     end
 
     describe "#disk_size" do
@@ -242,7 +244,7 @@ describe "devices lists" do
 
     it "contains all volume groups by default" do
       expect(vgs.size).to eq 2
-      expect(described_class.new(fake_devicegraph).size).to eq 2
+      expect(full_list.size).to eq 2
     end
 
     describe "#lvm_pvs" do
@@ -274,7 +276,7 @@ describe "devices lists" do
 
     it "contains all physical volumes by default" do
       expect(pvs.size).to eq 3
-      expect(described_class.new(fake_devicegraph).size).to eq 3
+      expect(full_list.size).to eq 3
     end
   end
 
@@ -284,7 +286,7 @@ describe "devices lists" do
 
     it "contains all logical volumes by default" do
       expect(lvs.size).to eq 3
-      expect(described_class.new(fake_devicegraph).size).to eq 3
+      expect(full_list.size).to eq 3
     end
   end
 end

--- a/test/devices_list_test.rb
+++ b/test/devices_list_test.rb
@@ -34,8 +34,9 @@ describe "devices lists" do
   let(:primary) { ::Storage::PartitionType_PRIMARY }
 
   before do
-    fake_scenario("mixed_disks")
+    fake_scenario(scenario)
   end
+  let(:scenario) { "mixed_disks" }
 
   describe "Y2Storage::DevicesLists::Base" do
     describe "#with" do
@@ -232,6 +233,58 @@ describe "devices lists" do
         # the partition table. Same happens in /dev/sdc (500GiB-1MiB)
         expect(spaces.disk_size).to eq(592.GiB - 2.MiB)
       end
+    end
+  end
+
+  describe Y2Storage::DevicesLists::LvmVgsList do
+    let(:scenario) { "lvm-two-vgs" }
+    let(:vgs) { fake_devicegraph.vgs }
+
+    it "contains all volume groups by default" do
+      expect(vgs.size).to eq 2
+      expect(described_class.new(fake_devicegraph).size).to eq 2
+    end
+
+    describe "#lvm_pvs" do
+      it "returns a filtered list of physical volumes" do
+        pvs_vg0 = vgs.with(vg_name: "vg0").lvm_pvs
+        pvs_vg1 = vgs.with(vg_name: "vg1").lvm_pvs
+        expect(pvs_vg0).to be_a Y2Storage::DevicesLists::LvmPvsList
+        expect(pvs_vg0.size).to eq 1
+        expect(pvs_vg1).to be_a Y2Storage::DevicesLists::LvmPvsList
+        expect(pvs_vg1.size).to eq 2
+      end
+    end
+
+    describe "#lvm_lvs" do
+      it "returns a filtered list of logical volumes" do
+        lvs_vg0 = vgs.with(vg_name: "vg0").lvm_lvs
+        lvs_vg1 = vgs.with(vg_name: "vg1").lvm_lvs
+        expect(lvs_vg0).to be_a Y2Storage::DevicesLists::LvmLvsList
+        expect(lvs_vg0.size).to eq 2
+        expect(lvs_vg1).to be_a Y2Storage::DevicesLists::LvmLvsList
+        expect(lvs_vg1.size).to eq 1
+      end
+    end
+  end
+
+  describe Y2Storage::DevicesLists::LvmPvsList do
+    let(:scenario) { "lvm-two-vgs" }
+    let(:pvs) { fake_devicegraph.pvs }
+
+    it "contains all physical volumes by default" do
+      expect(pvs.size).to eq 3
+      expect(described_class.new(fake_devicegraph).size).to eq 3
+    end
+  end
+
+  describe Y2Storage::DevicesLists::LvmLvsList do
+    let(:scenario) { "lvm-two-vgs" }
+    let(:lvs) { fake_devicegraph.lvs }
+
+    it "contains all logical volumes by default" do
+      expect(lvs.size).to eq 3
+      expect(described_class.new(fake_devicegraph).size).to eq 3
     end
   end
 end


### PR DESCRIPTION
Just to have the same query interface that we have for disks, partitions, etc. That is, for example
```ruby
vgs = devicegraph.volume_groups.with { |vg| vg.vg_name.starts_with?("system") }
vgs.lvs.with(lv_name: "swap")
```