### PR TITLE
Better management of LVM partitions in SpaceMaker

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Oct 27 12:49:59 UTC 2016 - ancor@suse.com
+
+- Better management of LVM partitions in Proposal::SpaceMaker
+
+-------------------------------------------------------------------
 Thu Oct 27 13:46:39 CEST 2016 - aschnell@suse.com
 
 - mount special filesystems in target during installation

--- a/src/lib/y2storage.rb
+++ b/src/lib/y2storage.rb
@@ -22,6 +22,7 @@
 require "y2storage/boot_requirements_checker"
 require "y2storage/devices_lists"
 require "y2storage/disk_analyzer"
+require "y2storage/existing_filesystem"
 require "y2storage/disk_size"
 require "y2storage/fake_device_factory"
 require "y2storage/free_disk_space"

--- a/src/lib/y2storage/disk_analyzer.rb
+++ b/src/lib/y2storage/disk_analyzer.rb
@@ -543,7 +543,12 @@ module Y2Storage
       lvm_pv = ::Storage::LvmPv.all(devicegraph).to_a.detect { |pv| pv.blk_device.name == name }
       return nil unless lvm_pv
 
-      lvm_pv.lvm_vg.vg_name
+      begin
+        lvm_pv.lvm_vg.vg_name
+      rescue ::Storage::WrongNumberOfChildren
+        # Unassigned PV
+        nil
+      end
     end
   end
 end

--- a/src/lib/y2storage/existing_filesystem.rb
+++ b/src/lib/y2storage/existing_filesystem.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+#
+# encoding: utf-8
+
+# Copyright (c) [2015] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+module Y2Storage
+  #
+  # Class representing a filesystem in the system and providing
+  # convenience methods to inspect its content
+  #
+  class ExistingFilesystem
+    include Yast::Logger
+
+    def initialize(device_name)
+      @device_name = device_name
+    end
+
+    # Mount the filesystem, perform the check given in 'block' while mounted,
+    # and then unmount. The block will get the mount point as a parameter.
+    #
+    # @return the return value of 'block' or 'nil' if there was an error.
+    #
+    def mount_and_check(&block)
+      raise ArgumentError, "Code block required" unless block_given?
+      mount_point = "/mnt" # FIXME
+      begin
+        # check if we have a filesystem
+        # return false unless vol.filesystem
+        mount(mount_point)
+        check_result = block.call(mount_point)
+        umount(mount_point)
+        check_result
+      rescue RuntimeError => ex # FIXME: rescue ::Storage::Exception when SWIG bindings are fixed
+        log.error("CAUGHT exception: #{ex} for #{device_name}")
+        nil
+      end
+    end
+
+  protected
+
+    attr_reader :device_name
+
+    # Mount the device.
+    #
+    # This is a temporary workaround until the new libstorage can handle that.
+    #
+    def mount(mount_point)
+      # FIXME: use libstorage function when available
+      cmd = "/usr/bin/mount #{device_name} #{mount_point} >/dev/null 2>&1"
+      log.debug("Trying to mount #{device_name}: #{cmd}")
+      raise "mount failed for #{device_name}" unless system(cmd)
+    end
+
+    # Unmount a device.
+    #
+    # This is a temporary workaround until the new libstorage can handle that.
+    #
+    def umount(mount_point)
+      # FIXME: use libstorage function when available
+      cmd = "/usr/bin/umount #{mount_point}"
+      log.debug("Unmounting: #{cmd}")
+      raise "umount failed for #{mount_point}" unless system(cmd)
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/space_maker.rb
+++ b/src/lib/y2storage/proposal/space_maker.rb
@@ -338,7 +338,7 @@ module Y2Storage
       # Deletes the given partition and all other partitions in the candidate
       # disks that are part of the same LVM volume group
       #
-      # Rational: when deleting a partition that holds a PV of a given VG, we
+      # Rationale: when deleting a partition that holds a PV of a given VG, we
       # are effectively killing the whole VG. It makes no sense to leave the
       # other PVs alive. So let's reclaim all the space.
       #

--- a/test/existing_filesystem_test.rb
+++ b/test/existing_filesystem_test.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2016] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+describe Y2Storage::ExistingFilesystem do
+
+  let(:device_name) { "/dev/sdz" }
+  subject(:filesystem) { described_class.new(device_name) }
+
+  before do
+    allow(filesystem).to receive(:system).and_return true
+  end
+
+  describe "#mount_and_check" do
+    it "mounts the device" do
+      expect(filesystem).to receive(:system).with(/\/usr\/bin\/mount #{device_name}/).and_return true
+      filesystem.mount_and_check { |_m| true }
+    end
+
+    it "executes the passed block with the mount point as argument" do
+      expect { |b| filesystem.mount_and_check(&b) }.to yield_with_args("/mnt")
+    end
+
+    it "umounts the device" do
+      expect(filesystem).to receive(:system).with(/\/usr\/bin\/umount/).and_return true
+      filesystem.mount_and_check { |_m| true }
+    end
+
+    it "returns the result of the passed block" do
+      result = filesystem.mount_and_check { |_m| true }
+      expect(result).to eq true
+      result = filesystem.mount_and_check { |_m| false }
+      expect(result).to eq false
+    end
+
+    it "returns nil if mounting fails" do
+      allow(filesystem).to receive(:system).with(/\/mount/).and_return false
+      result = filesystem.mount_and_check { |_m| true }
+      expect(result).to be_nil
+    end
+
+    it "returns nil if unmounting fails" do
+      allow(filesystem).to receive(:system).with(/\/umount/).and_return false
+      result = filesystem.mount_and_check { |_m| true }
+      expect(result).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
When deleting a partition that holds a PV, it now also deletes all the other partitions in the same VG.

Rationale: when deleting a partition that holds a PV of a given VG, we are effectively killing the whole VG (not only implicitly, but even explicitly thanks to libstorage). It makes no sense to leave the other PVs alive. So let's reclaim all the space.
