### PR TITLE
Proposal: extended partitions overhead (EBR)

### DIFF
--- a/src/lib/y2storage/proposal/assigned_space.rb
+++ b/src/lib/y2storage/proposal/assigned_space.rb
@@ -64,6 +64,13 @@ module Y2Storage
         max >= disk_size ? 0 : disk_size - max
       end
 
+      # Space available in addition to the target
+      #
+      # @return [DiskSize]
+      def extra_size
+        disk_size - volumes.target_disk_size
+      end
+
       def to_s
         "#<AssignedSpace disk_space=#{disk_space}, volumes=#{volumes}>"
       end

--- a/src/lib/y2storage/proposal/space_distribution_calculator.rb
+++ b/src/lib/y2storage/proposal/space_distribution_calculator.rb
@@ -102,10 +102,14 @@ module Y2Storage
       # @param free_spaces [Array<FreeDiskSpace>]
       # @return [DiskSize]
       def resizing_size(volumes, free_spaces)
-        # Let's assume the worst case - resizing produces a new space and the
-        # LVM must be spread among all the available spaces
+        # We are going to resize this partition only once, so let's assume the
+        # worst case:
+        #  - resizing produces a new space
+        #  - a new extended partition must be created
+        #  - the LVM must be spread among all the available spaces
         pvs_to_create = free_spaces.size + 1
-        needed = volumes.target_disk_size + lvm_space_to_make(pvs_to_create)
+        overhead = SpaceDistribution.overhead_of_new_extended
+        needed = volumes.target_disk_size + lvm_space_to_make(pvs_to_create) + overhead
         needed - available_space(free_spaces)
       end
 

--- a/test/data/devicegraphs/output/windows-pc-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-lvm-sep-home.yml
@@ -6,14 +6,14 @@
     partitions:
 
     - partition:
-        size: 745471 MiB
+        size: 745469 MiB
         name: /dev/sda1
         id: ntfs
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 53249 MiB
+        size: 53251 MiB
         name: /dev/sda3
         id: lvm
 

--- a/test/data/devicegraphs/output/windows-pc-lvm.yml
+++ b/test/data/devicegraphs/output/windows-pc-lvm.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 755711 MiB
+        size: 755709 MiB
         name: /dev/sda1
         id: ntfs
         file_system: ntfs
@@ -16,6 +16,11 @@
         size: 43009 MiB
         name: /dev/sda3
         id: lvm
+
+    # FIXME: even if these 2 MiB are useless for LVM,
+    # leaving them there does not look good
+    - free:
+        size: 2 MiB
 
     - partition:
         size: unlimited

--- a/test/data/devicegraphs/output/windows-pc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 728.00 GiB
+        size: 745470 MiB
         name: /dev/sda1
         id: 0x7
         file_system: ntfs
@@ -21,7 +21,7 @@
         mount_point: "/"
 
     - partition:
-        size: 12.00 GiB
+        size: 12290 MiB
         name: "/dev/sda4"
         type: extended
         id: extended
@@ -35,7 +35,7 @@
         mount_point: swap
 
     - partition:
-        size: unlimited
+        size: 10.00 GiB
         name: "/dev/sda6"
         type: logical
         id: linux

--- a/test/data/devicegraphs/output/windows-pc.yml
+++ b/test/data/devicegraphs/output/windows-pc.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 738.00 GiB
+        size: 755710 MiB
         name: /dev/sda1
         id: 0x7
         file_system: ntfs
@@ -21,13 +21,13 @@
         mount_point: "/"
 
     - partition:
-        size: 2.00 GiB
+        size: 2050 MiB
         name: "/dev/sda4"
         type: extended
         id: extended
 
     - partition:
-        size: unlimited
+        size: 2.00 GiB
         name: "/dev/sda5"
         type: logical
         id: swap

--- a/test/proposal/space_maker_test.rb
+++ b/test/proposal/space_maker_test.rb
@@ -98,7 +98,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         it "resizes Windows partitions to free additional needed space" do
           result = maker.provide_space(volumes)
           expect(result[:devicegraph].partitions).to contain_exactly(
-            an_object_with_fields(label: "windows", size: (200.GiB - 1.MiB).to_i)
+            an_object_with_fields(label: "windows", size: (200.GiB - 3.MiB).to_i)
           )
         end
       end
@@ -122,7 +122,8 @@ describe Y2Storage::Proposal::SpaceMaker do
         it "shrinks the Windows partition by the required size" do
           result = maker.provide_space(volumes)
           win_partition = result[:devicegraph].partitions.with(name: "/dev/sda1").first
-          expect(win_partition.size).to eq 740.GiB.to_i
+          size = 740.GiB - 2.MiB
+          expect(win_partition.size).to eq size.to_i
         end
 
         it "leaves other partitions untouched" do
@@ -200,7 +201,8 @@ describe Y2Storage::Proposal::SpaceMaker do
       it "shrinks first the less full Windows partition" do
         result = maker.provide_space(volumes)
         win2_partition = result[:devicegraph].partitions.with(name: "/dev/sdb1").first
-        expect(win2_partition.size).to eq 160.GiB.to_i
+        size = 160.GiB - 2.MiB
+        expect(win2_partition.size).to eq size.to_i
       end
 
       it "leaves other partitions untouched if possible" do


### PR DESCRIPTION
I found out that so far we have been creating partitions that were 2 MiB smaller than planned in some situations.

With this change, when calculating a proposal we now take into account the overhead produced by creating an extended partition and count with it when resizing Windows.

I also removed some "unlimited" from the YAML of the tests, to ensure we don't overlook that any more.