### PR TITLE
Proposal: logical partitions overhead (EBR)

### DIFF
--- a/src/lib/y2storage/proposal/assigned_space.rb
+++ b/src/lib/y2storage/proposal/assigned_space.rb
@@ -43,8 +43,9 @@ module Y2Storage
       def_delegators :@disk_space, :disk_name, :disk_size, :slot, :disk
 
       def initialize(disk_space, volumes)
-        @disk_space = disk_space
-        @volumes    = volumes
+        @disk_space  = disk_space
+        @volumes     = volumes
+        @num_logical = 0
       end
 
       # Checks if the volumes really fit into the assigned space
@@ -76,12 +77,15 @@ module Y2Storage
       #
       # Substracts from the total the space that will be used by new data
       # structures, like the EBRs of the planned logical partitions
+      # See https://en.wikipedia.org/wiki/Extended_boot_record
       #
       # @return [DiskSize]
       def usable_size
+        return disk_space.disk_size if num_logical.zero?
+
         logical = num_logical
-        # If the extended partition already exists, the overhead of our first
-        # logical partition is already counted
+        # If this space is inside an already existing extended partition,
+        # libstorage has already substracted the the overhead of the first EBR.
         logical -= 1 if partition_type == :logical
         disk_space.disk_size - overhead_of_logical * logical
       end

--- a/src/lib/y2storage/proposal/assigned_space.rb
+++ b/src/lib/y2storage/proposal/assigned_space.rb
@@ -31,15 +31,16 @@ module Y2Storage
       attr_reader :disk_space
       # @return [PlannedVolumesList]
       attr_reader :volumes
-      # @return [Symbol] :primary, :extended or nil.
-      #   Spaces with a value of :primary should only contain primary partitions.
-      #   Spaces with :extended should only contain logical (and eventually one
-      #   extended) partitions.
-      #   A value of nil means there are no restrictions imposed by the
-      #   distribution (restrictions imposed by the disk itself still apply)
+      # Restriction imposed by the disk and the already existent partitions
+      # @return [Symbol, nil] :primary, :logical
+      #   Spaces with a value of :primary can only contain primary partitions.
+      #   Spaces with :logical can only contain logical partitions.
+      #   A value of nil means there are no restrictions imposed by the disk
       attr_accessor :partition_type
+      # Number of logical partitions that must be created in the space
+      attr_accessor :num_logical
 
-      def_delegators :@disk_space, :disk_name, :disk_size, :slot
+      def_delegators :@disk_space, :disk_name, :disk_size, :slot, :disk
 
       def initialize(disk_space, volumes)
         @disk_space = disk_space
@@ -62,6 +63,43 @@ module Y2Storage
       def unused
         max = volumes.max_disk_size
         max >= disk_size ? 0 : disk_size - max
+      end
+
+      # Space available in addition to the target
+      #
+      # @return [DiskSize]
+      def extra_size
+        disk_size - volumes.target_disk_size
+      end
+
+      # Space that can be distributed among the planned volumes.
+      #
+      # Substracts from the total the space that will be used by new data
+      # structures, like the EBRs of the planned logical partitions
+      #
+      # @return [DiskSize]
+      def usable_size
+        logical = num_logical
+        # If the extended partition already exists, the overhead of our first
+        # logical partition is already counted
+        logical -= 1 if partition_type == :logical
+        disk_space.disk_size - overhead_of_logical * logical
+      end
+
+      # Space consumed by the EBR of one logical partition in a given disk
+      # See https://en.wikipedia.org/wiki/Extended_boot_record
+      #
+      # @param disk [#topology]
+      # @return [DiskSize]
+      def self.overhead_of_logical(disk)
+        DiskSize.B(disk.topology.minimal_grain)
+      end
+
+      # Space consumed by the EBR of one logical partition within this space
+      #
+      # @return [DiskSize]
+      def overhead_of_logical
+        AssignedSpace.overhead_of_logical(disk)
       end
 
       def to_s

--- a/src/lib/y2storage/proposal/partition_creator.rb
+++ b/src/lib/y2storage/proposal/partition_creator.rb
@@ -53,11 +53,7 @@ module Y2Storage
         self.devicegraph = original_graph.duplicate
 
         distribution.spaces.each do |space|
-          vols = space.volumes
-          disk_space = space.disk_space
-          num_logical = space.num_logical
-          usable_size = space.usable_size
-          process_space(vols, disk_space, usable_size, num_logical)
+          process_free_space(space.disk_space, space.volumes, space.usable_size, space.num_logical)
         end
 
         devicegraph
@@ -71,13 +67,13 @@ module Y2Storage
 
       # Create partitions in a single slot of free disk space.
       #
-      # @param volumes   [PlannedVolumesList] volumes to create
       # @param free_space [FreeDiskSpace] the slot
+      # @param volumes   [PlannedVolumesList] volumes to create
       # @params usable_size [DiskSize] real space to distribute among the
       #       volumes (part of free_space could be used for data structures)
       # @param num_logical [Integer] how many volumes should be placed in
       #       logical partitions
-      def process_space(volumes, free_space, usable_size, num_logical)
+      def process_free_space(free_space, volumes, usable_size, num_logical)
         volumes.each do |vol|
           log.info(
             "vol #{vol.mount_point}\tmin: #{vol.min_disk_size}\tmax: #{vol.max_disk_size} " \

--- a/src/lib/y2storage/proposal/space_distribution.rb
+++ b/src/lib/y2storage/proposal/space_distribution.rb
@@ -187,13 +187,13 @@ module Y2Storage
 
         if ptable.extended_possible
           if ptable.has_extended
-            log.info "There is already a extended partition in the disk"
+            log.info "There is already a extended partition on the disk"
             (extended, primary) = spaces.partition { |s| space_inside_extended?(s) }
             if too_many_primary?(primary, ptable)
               raise NoMorePartitionSlotError, "Too many primary partitions needed"
             end
           else
-            log.info "There is no extended partition in the disk"
+            log.info "There is no extended partition on the disk"
           end
         else
           log.info "An extended partition makes no sense in this disk"

--- a/src/lib/y2storage/proposal/space_distribution.rb
+++ b/src/lib/y2storage/proposal/space_distribution.rb
@@ -53,7 +53,11 @@ module Y2Storage
         end
         @spaces.freeze
         spaces_by_disk.each do |disk_name, spaces|
-          set_partition_types_for(disk_name, spaces)
+          disk = ::Storage::Disk.find_by_name(devicegraph, disk_name)
+          ptable = disk.partition_table
+
+          set_partition_types_for(spaces, ptable)
+          set_num_logical_for(spaces, ptable)
         end
       end
 
@@ -131,6 +135,19 @@ module Y2Storage
         spaces_strings.sort.join
       end
 
+      # Number of logical partitions that will be allocated in a newly created
+      # extended one
+      #
+      # @param partitions [Integer] total number of partitions to create
+      # @param ptable [Storage::PartitionTable]
+      # @return [Integer]
+      def self.partitions_in_new_extended(partitions, ptable)
+        free_primary_slots = ptable.max_primary - ptable.num_primary
+        return 0 if free_primary_slots >= partitions
+        # One slot consumed by the extended partition
+        partitions - free_primary_slots + 1
+      end
+
     protected
 
       attr_reader :devicegraph
@@ -159,68 +176,94 @@ module Y2Storage
         end
       end
 
-      # Sets #partition_type for all the assigned spaces
+      # Sets #partition_type for the assigned spaces that are subject to
+      # restrictions
       #
-      # @param disk_name [String]
       # @param spaces [Array<AssignedSpace] spaces allocated in the disk
-      def set_partition_types_for(disk_name, spaces)
-        disk = ::Storage::Disk.find_by_name(devicegraph, disk_name)
-        ptable = disk.partition_table
+      # @param ptable [Storage::PartitionTable]
+      def set_partition_types_for(spaces, ptable)
+        primary = []
+        extended = []
 
-        if ptable.has_extended
-          log.info "There is already a extended partition in the disk"
-          (primary, extended) = spaces_by_type_with_extended(spaces, ptable)
-        elsif ptable.extended_possible
-          log.info "There is no extended partition in the disk"
-          (primary, extended) = spaces_by_type_without_extended(spaces, ptable)
+        if ptable.extended_possible
+          if ptable.has_extended
+            log.info "There is already a extended partition in the disk"
+            (extended, primary) = spaces.partition { |s| space_inside_extended?(s) }
+            if too_many_primary?(primary, ptable)
+              raise NoMorePartitionSlotError, "Too many primary partitions needed"
+            end
+          else
+            log.info "There is no extended partition in the disk"
+          end
         else
           log.info "An extended partition makes no sense in this disk"
           primary = spaces
-          extended = []
         end
 
         primary.each { |s| s.partition_type = :primary }
-        extended.each { |s| s.partition_type = :extended }
+        extended.each { |s| s.partition_type = :logical }
       end
 
-      # @return [Array<Array<AssignedSpace>>] first element is the list of
-      #       primary spaces, second one the list of extended
-      def spaces_by_type_with_extended(spaces, ptable)
-        (extended, primary) = spaces.partition { |s| space_inside_extended?(s) }
-        if too_many_primary?(primary, ptable)
-          raise NoMorePartitionSlotError, "Too many primary partitions needed"
+      # Sets #num_logical for all the assigned spaces.
+      #
+      # @param spaces [Array<AssignedSpace] spaces allocated in the disk
+      #     and with a correct value for #partition_type
+      # @param ptable [Storage::PartitionTable]
+      def set_num_logical_for(spaces, ptable)
+        # There are only two possible scenarios, either all the spaces got
+        # a restricted #partition_type, either none
+        if spaces.first.partition_type.nil?
+          calculate_num_logical_for(spaces, ptable)
+        else
+          spaces.each do |space|
+            prim = space.partition_type == :primary
+            space.num_logical = prim ? 0 : space.volumes.size
+          end
         end
-        [primary, extended]
       end
 
-      # @return [Array<Array<AssignedSpace>>] first element is the list of
-      #       primary spaces, second one the list of extended
-      def spaces_by_type_without_extended(spaces, ptable)
+      def calculate_num_logical_for(spaces, ptable)
         if ptable.num_primary + spaces.size > ptable.max_primary
           log.error "Too sparce: #{ptable.num_primary} + #{spaces.size} > #{ptable.max_primary}"
           raise NoMorePartitionSlotError, "Too sparce distribution"
         end
 
+        logical = SpaceDistribution.partitions_in_new_extended(num_partitions(spaces), ptable)
+        if logical.zero?
+          log.info "The total number of partitions will be low. No need of logical ones."
+          spaces.each { |s| s.num_logical = 0 }
+          return
+        end
+
+        calculate_num_logical_with_new_extended(spaces, ptable)
+      end
+
+      def calculate_num_logical_with_new_extended(spaces, ptable)
+        # Try to create as few logical partitions as possible, since they
+        # come at a rounding cost
+        partitions = num_partitions(spaces)
+        num_logical = SpaceDistribution.partitions_in_new_extended(partitions, ptable)
+
         if spaces.size == 1
-          log.info "No need to impose type restrictions."
-          return [], []
+          space = spaces.first
+          if !room_for_logical?(space, num_logical)
+            raise NoDiskSpaceError, "No space for the logical partitions"
+          end
+          space.num_logical = num_logical
         end
 
-        num_partitions = ptable.num_primary + num_partitions(spaces)
-        if spaces.size == 1 || num_partitions < ptable.max_primary
-          log.info "The total number of partitions will be low. No need to impose type restrictions."
-          return [], []
+        # One space will host all the logical partitions (and maybe some primary)
+        # The rest should be all primary.
+        extended_space = extended_space(spaces, num_logical)
+        if extended_space.nil?
+          raise NoDiskSpaceError, "No suitable space to create the extended partition"
         end
-
-        # At this point, one space will be used to create a new extended
-        # partition. The rest should be primary.
-        extended = [extended_space(spaces)].compact
-        primary = spaces - extended
-        if too_many_primary?(primary, ptable)
+        primary_spaces = spaces - [extended_space]
+        if too_many_primary?(primary_spaces, ptable)
           raise NoMorePartitionSlotError, "Too many primary partitions needed"
         end
-
-        [primary, extended]
+        extended_space.num_logical = num_logical
+        primary_spaces.each { |s| s.num_logical = 0 }
       end
 
       def too_many_primary?(primary_spaces, ptable)
@@ -229,12 +272,13 @@ module Y2Storage
         num_primary > ptable.max_primary
       end
 
-      # Best candidate to hold the extended partition
+      # Best candidate to hold the logical partition
       #
       # @param [Array<AssignedSpace>] list of possible candidates
-      # @return [AssignedSpace]
-      def extended_space(spaces)
-        # Let's use as extended the space with more volumes (start as
+      # @return [AssignedSpace, nil]
+      def extended_space(spaces, num_logical)
+        spaces = spaces.select { |s| room_for_logical?(s, num_logical) }
+        # Let's place the extended in the space with more volumes (start as
         # secondary criteria just to ensure stable sorting)
         spaces.sort_by { |s| [s.volumes.count, s.slot.region.start] }.last
       end
@@ -271,6 +315,17 @@ module Y2Storage
       def volume_list_comparable_string(vol_list)
         volumes_strings = vol_list.to_a.map { |vol| vol.to_s }.sort
         "<target=#{vol_list.target}, volumes=#{volumes_strings.join}>"
+      end
+
+      # Checks whether an assigned space can host the overhead produced by
+      # logical partitions, in addition to its volumes
+      #
+      # @param assigned_space [AssignedSpace]
+      # @param num [Integer] number of partitions that should be logical
+      # @return [Boolean]
+      def room_for_logical?(assigned_space, num)
+        overhead = assigned_space.overhead_of_logical
+        assigned_space.extra_size >= overhead * num
       end
     end
   end

--- a/src/lib/y2storage/proposal/space_maker.rb
+++ b/src/lib/y2storage/proposal/space_maker.rb
@@ -171,9 +171,9 @@ module Y2Storage
       # order to reach the goal
       #
       # @return [DiskSize]
-      def resizing_size(volumes, disk)
+      def resizing_size(partition, volumes, disk)
         spaces = free_spaces(new_graph, disk).to_a
-        dist_calculator.resizing_size(volumes, spaces)
+        dist_calculator.resizing_size(partition, volumes, spaces)
       end
 
       # List of free spaces in the given devicegraph
@@ -219,7 +219,7 @@ module Y2Storage
         success = sorted_resizables(parts_by_disk.values.flatten).any? do |res|
           shrink_size = [
             res[:recoverable_size],
-            resizing_size(volumes, disk)
+            resizing_size(res[:partition], volumes, disk)
           ].min
           shrink_partition(res[:partition], shrink_size)
 

--- a/test/data/devicegraphs/output/windows-linux-lvm-pc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-lvm-pc-sep-home.yml
@@ -30,12 +30,6 @@
     - partition:
         size: unlimited
         name: /dev/sda4
-        type: extended
-        id: extended
-    - partition:
-        size: unlimited
-        name: /dev/sda5
-        type: logical
         id: linux
         file_system: xfs
         mount_point: "/home"

--- a/test/data/devicegraphs/output/windows-linux-lvm-pc.yml
+++ b/test/data/devicegraphs/output/windows-linux-lvm-pc.yml
@@ -20,17 +20,14 @@
         mount_point: "/"
 
     - partition:
-        size: 10 GiB
-        name: /dev/sda4
-        type: extended
-        id: extended
-    - partition:
         size: 2 GiB
-        name: /dev/sda5
-        type: logical
+        name: /dev/sda4
         id: swap
         file_system: swap
         mount_point: swap
+
+    - free:
+        size: 8 GiB
 
     - partition:
         size: unlimited

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-sep-home.yml
@@ -29,12 +29,6 @@
     - partition:
         size: unlimited
         name: "/dev/sda4"
-        type: extended
-        id: extended
-    - partition:
-        size: unlimited
-        name: "/dev/sda5"
-        type: logical
         id: linux
         file_system: xfs
         mount_point: "/home"

--- a/test/data/devicegraphs/output/windows-pc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 728.00 GiB
+        size: 745470 MiB
         name: /dev/sda1
         id: 0x7
         file_system: ntfs
@@ -21,7 +21,7 @@
         mount_point: "/"
 
     - partition:
-        size: 12.00 GiB
+        size: 12290 MiB
         name: "/dev/sda4"
         type: extended
         id: extended
@@ -35,7 +35,7 @@
         mount_point: swap
 
     - partition:
-        size: unlimited
+        size: 10 GiB
         name: "/dev/sda6"
         type: logical
         id: linux

--- a/test/data/devicegraphs/output/windows-pc.yml
+++ b/test/data/devicegraphs/output/windows-pc.yml
@@ -23,13 +23,6 @@
     - partition:
         size: 2.00 GiB
         name: "/dev/sda4"
-        type: extended
-        id: extended
-
-    - partition:
-        size: unlimited
-        name: "/dev/sda5"
-        type: logical
         id: swap
         file_system: swap
         mount_point: swap


### PR DESCRIPTION
replaces #114 

I found out that so far we have been creating partitions that were some MiBs smaller than planned in some situations. 

With these changes, when calculating a proposal we now take into account the overhead produced by creating logical partitions and count with it when resizing windows and when distributing the volumes into the spaces.

I also removed some "unlimited" from the YAML of the tests, to ensure we don't overlook the problem any more.

As bonus, SpaceDistribution now decides in advance which partitions should be logical, as a result, PartitionCreator does not longer creates extended partitions with just one logical inside.