### PR TITLE
Do not set boot flag if not supported

### DIFF
--- a/src/lib/y2storage/proposal/partition_creator.rb
+++ b/src/lib/y2storage/proposal/partition_creator.rb
@@ -157,7 +157,7 @@ module Y2Storage
         region = new_region_with_size(free_space.slot, vol.disk_size)
         partition = ptable.create_partition(dev_name, region, partition_type)
         partition.id = partition_id
-        partition.boot = !!vol.bootable
+        partition.boot = !!vol.bootable if ptable.partition_boot_flag_supported?
         partition
       end
 

--- a/test/data/devicegraphs/empty_hard_disk_gpt_50GiB.yml
+++ b/test/data/devicegraphs/empty_hard_disk_gpt_50GiB.yml
@@ -1,0 +1,5 @@
+---
+- disk:
+    name: /dev/sda
+    size: 50 GiB
+    partition_table: gpt

--- a/test/proposal/partition_creator_test.rb
+++ b/test/proposal/partition_creator_test.rb
@@ -224,5 +224,85 @@ describe Y2Storage::Proposal::PartitionCreator do
         )
       end
     end
+
+    context "when creating a partition" do
+      let(:scenario) { "empty_hard_disk_50GiB" }
+      let(:bootable) { false }
+
+      let(:vol) do
+        planned_vol(
+          type: :vfat, partition_id: Storage::ID_ESP, desired: 1.GiB, bootable: bootable
+        )
+      end
+      let(:distribution) { space_dist(disk_spaces.first => vols_list(vol)) }
+
+      it "correctly sets the libstorage partition id" do
+        partition = creator.create_partitions(distribution).partitions.first
+        expect(partition.id).to eq Storage::ID_ESP
+      end
+
+      it "formats the partition" do
+        partition = creator.create_partitions(distribution).partitions.first
+        expect(partition.filesystem.type).to eq Storage::FsType_VFAT
+      end
+
+      context "with a MBR partition table" do
+        context "if the volume is bootable" do
+          let(:bootable) { true }
+
+          it "sets the boot flag" do
+            partition = creator.create_partitions(distribution).partitions.first
+            expect(partition.boot?).to eq true
+          end
+
+          it "does not set the legacy boot flag" do
+            partition = creator.create_partitions(distribution).partitions.first
+            expect(partition.legacy_boot?).to eq false
+          end
+        end
+
+        context "if the volume is not bootable" do
+          it "does not set the boot flag" do
+            partition = creator.create_partitions(distribution).partitions.first
+            expect(partition.boot?).to eq false
+          end
+
+          it "does not set the legacy boot flag" do
+            partition = creator.create_partitions(distribution).partitions.first
+            expect(partition.legacy_boot?).to eq false
+          end
+        end
+      end
+
+      context "with a GPT partition table" do
+        let(:scenario) { "empty_hard_disk_gpt_50GiB" }
+
+        context "if the volume is bootable" do
+          let(:bootable) { true }
+
+          it "does not set the boot flag" do
+            partition = creator.create_partitions(distribution).partitions.first
+            expect(partition.boot?).to eq false
+          end
+
+          it "does not set the legacy boot flag" do
+            partition = creator.create_partitions(distribution).partitions.first
+            expect(partition.legacy_boot?).to eq false
+          end
+        end
+
+        context "if the volume is not bootable" do
+          it "does not set the boot flag" do
+            partition = creator.create_partitions(distribution).partitions.first
+            expect(partition.boot?).to eq false
+          end
+
+          it "does not set the legacy boot flag" do
+            partition = creator.create_partitions(distribution).partitions.first
+            expect(partition.legacy_boot?).to eq false
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Part of https://trello.com/c/okn67JXC/465-5-proposalng-be-able-to-make-a-proposal-when-gpt-part-table-exists

It also includes some extra tests to check the "fix the wrong GUID..." task.

Travis will probably fail in a first attempt. This depends on https://github.com/openSUSE/libstorage-ng/pull/176