### PR TITLE
Make DiskSize#to_s precise

### DIFF
--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -103,7 +103,7 @@ module Y2Storage
         ptable = disk.partition_table # this will raise an exception if no partition table
         content["partition_table"] = @partition_table_types[ptable.type]
         if ::Storage.msdos?(ptable)
-          content["mbr_gap"] = DiskSize.B(::Storage.to_msdos(ptable).minimal_mbr_gap).to_s_ex
+          content["mbr_gap"] = DiskSize.B(::Storage.to_msdos(ptable).minimal_mbr_gap).to_s
         end
         partitions = yaml_disk_partitions(disk)
         content["partitions"] = partitions unless partitions.empty?
@@ -122,11 +122,11 @@ module Y2Storage
     def basic_disk_attributes(disk)
       {
         "name"       => disk.name,
-        "size"       => DiskSize.B(disk.size).to_s_ex,
-        "block_size" => DiskSize.B(disk.region.block_size).to_s_ex,
-        "io_size"    => DiskSize.B(disk.topology.optimal_io_size).to_s_ex,
-        "min_grain"  => DiskSize.B(disk.topology.minimal_grain).to_s_ex,
-        "align_ofs"  => DiskSize.B(disk.topology.alignment_offset).to_s_ex
+        "size"       => DiskSize.B(disk.size).to_s,
+        "block_size" => DiskSize.B(disk.region.block_size).to_s,
+        "io_size"    => DiskSize.B(disk.topology.optimal_io_size).to_s,
+        "min_grain"  => DiskSize.B(disk.topology.minimal_grain).to_s,
+        "align_ofs"  => DiskSize.B(disk.topology.alignment_offset).to_s
       }
     end
 
@@ -218,8 +218,8 @@ module Y2Storage
 
     def yaml_partition(partition)
       content = {
-        "size"  => DiskSize.B(partition.region.length * partition.region.block_size).to_s_ex,
-        "start" => DiskSize.B(partition.region.start * partition.region.block_size).to_s_ex,
+        "size"  => DiskSize.B(partition.region.length * partition.region.block_size).to_s,
+        "start" => DiskSize.B(partition.region.start * partition.region.block_size).to_s,
         "name"  => partition.name,
         "type"  => @partition_types[partition.type],
         "id"    => @partition_ids[partition.id] || "0x#{partition.id.to_s(16)}"
@@ -237,7 +237,7 @@ module Y2Storage
     # @return [Hash]
     #
     def yaml_free_slot(start, size)
-      { "free" => { "size" => size.to_s_ex, "start" => start.to_s_ex } }
+      { "free" => { "size" => size.to_s, "start" => start.to_s } }
     end
 
     # Return the YAML counterpart of a ::Storage::LvmVg.
@@ -265,7 +265,7 @@ module Y2Storage
     def basic_lvm_vg_attributes(lvm_vg)
       {
         "vg_name"     => lvm_vg.vg_name,
-        "extent_size" => DiskSize.B(lvm_vg.extent_size).to_s_ex
+        "extent_size" => DiskSize.B(lvm_vg.extent_size).to_s
       }
     end
 
@@ -286,11 +286,11 @@ module Y2Storage
     def yaml_lvm_lv(lvm_lv)
       content = {
         "lv_name" => lvm_lv.lv_name,
-        "size"    => DiskSize.B(lvm_lv.size).to_s_ex
+        "size"    => DiskSize.B(lvm_lv.size).to_s
       }
 
       content["stripes"] = lvm_lv.stripes if lvm_lv.stripes != 0
-      content["stripe_size"] = DiskSize.B(lvm_lv.stripe_size).to_s_ex if lvm_lv.stripe_size != 0
+      content["stripe_size"] = DiskSize.B(lvm_lv.stripe_size).to_s if lvm_lv.stripe_size != 0
 
       content.merge!(yaml_filesystem(lvm_lv.filesystem)) if lvm_lv.has_filesystem
 

--- a/test/disk_size_test.rb
+++ b/test/disk_size_test.rb
@@ -39,7 +39,7 @@ describe Y2Storage::DiskSize do
   describe "created with 42 KiB" do
     disk_size = Y2Storage::DiskSize.KiB(42)
     it "should return the correct human readable string" do
-      expect(disk_size.to_s).to be == "42.00 KiB"
+      expect(disk_size.to_human_string).to be == "42.00 KiB"
     end
     it "should have the correct numeric value internally" do
       expect(disk_size.to_i).to be == 42 * 1024
@@ -49,7 +49,7 @@ describe Y2Storage::DiskSize do
   describe "created with 43 MiB" do
     disk_size = Y2Storage::DiskSize.MiB(43)
     it "should return the correct human readable string" do
-      expect(disk_size.to_s).to be == "43.00 MiB"
+      expect(disk_size.to_human_string).to be == "43.00 MiB"
     end
     it "should have the correct numeric value internally" do
       expect(disk_size.to_i).to be == 43 * 1024**2
@@ -59,7 +59,7 @@ describe Y2Storage::DiskSize do
   describe "created with 44 GiB" do
     disk_size = Y2Storage::DiskSize.GiB(44)
     it "should return the correct human readable string" do
-      expect(disk_size.to_s).to be == "44.00 GiB"
+      expect(disk_size.to_human_string).to be == "44.00 GiB"
     end
     it "should have the correct numeric value internally" do
       expect(disk_size.to_i).to be == 44 * 1024**3
@@ -69,7 +69,7 @@ describe Y2Storage::DiskSize do
   describe "created with 45 TiB" do
     disk_size = Y2Storage::DiskSize.TiB(45)
     it "should return the correct human readable string" do
-      expect(disk_size.to_s).to be == "45.00 TiB"
+      expect(disk_size.to_human_string).to be == "45.00 TiB"
     end
     it "should have the correct numeric value internally" do
       expect(disk_size.to_i).to be == 45 * 1024**4
@@ -79,7 +79,7 @@ describe Y2Storage::DiskSize do
   describe "created with 46 PiB" do
     disk_size = Y2Storage::DiskSize.PiB(46)
     it "should return the correct human readable string" do
-      expect(disk_size.to_s).to be == "46.00 PiB"
+      expect(disk_size.to_human_string).to be == "46.00 PiB"
     end
     it "should have the correct numeric value internally" do
       expect(disk_size.to_i).to be == 46 * 1024**5
@@ -89,7 +89,7 @@ describe Y2Storage::DiskSize do
   describe "created with 47 EiB" do
     disk_size = Y2Storage::DiskSize.EiB(47)
     it "should return the correct human readable string" do
-      expect(disk_size.to_s).to be == "47.00 EiB"
+      expect(disk_size.to_human_string).to be == "47.00 EiB"
     end
     it "should not overflow and have the correct numeric value internally" do
       expect(disk_size.to_i).to be == 47 * 1024**6
@@ -99,7 +99,7 @@ describe Y2Storage::DiskSize do
   describe "created with a huge number" do
     disk_size = Y2Storage::DiskSize.TiB(48 * 1024**5)
     it "should return the correct human readable string" do
-      expect(disk_size.to_s).to be == "49152.00 YiB"
+      expect(disk_size.to_human_string).to be == "49152.00 YiB"
     end
     it "should not overflow" do
       expect(disk_size.to_i).to be > 0
@@ -112,7 +112,7 @@ describe Y2Storage::DiskSize do
   describe "created with 1024 GiB" do
     disk_size = Y2Storage::DiskSize.GiB(1024)
     it "should use the next higher unit (TiB) from 1024 on" do
-      expect(disk_size.to_s).to be == "1.00 TiB"
+      expect(disk_size.to_human_string).to be == "1.00 TiB"
     end
   end
 
@@ -268,11 +268,17 @@ describe Y2Storage::DiskSize do
     it "should accept \"unlimited\" with surrounding whitespace" do
       expect(described_class.parse("  unlimited ").to_i).to be == -1
     end
-    it "should accept its own output" do
+    it "should accept #to_s output" do
       expect(described_class.parse(described_class.GiB(42).to_s).to_i).to be == 42 * 1024**3
       expect(described_class.parse(described_class.new(43).to_s).to_i).to be == 43
       expect(described_class.parse(described_class.zero.to_s).to_i).to be == 0
       expect(described_class.parse(described_class.unlimited.to_s).to_i).to be == -1
+    end
+    it "should accept #to_human_string output" do
+      expect(described_class.parse(described_class.GiB(42).to_human_string).to_i).to be == 42 * 1024**3
+      expect(described_class.parse(described_class.new(43).to_human_string).to_i).to be == 43
+      expect(described_class.parse(described_class.zero.to_human_string).to_i).to be == 0
+      expect(described_class.parse(described_class.unlimited.to_human_string).to_i).to be == -1
     end
     it "should reject invalid input" do
       expect { described_class.parse("wrglbrmpf") }.to raise_error(ArgumentError)


### PR DESCRIPTION
The fact that `DiskSize#to_s` returned imprecise numbers is unexpected and can be a problem for log-based debugging. Lines like these were actually logging imprecise information:
```ruby
log.info "This is a size: #{disk_size}"
log.info "Content of the volume: #{volume}"
```

This PR aims to make `to_s` more "programmer friendly" (a.k.a. precise). We still have `to_human_string` for user friendliness (although is not much used so far).