### PR TITLE
Manage small partitions and GPT final space

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Dec 20 06:39:28 UTC 2016 - ancor@suse.com
+
+- Fixed partitioning proposal to not fail when trying to create
+  very small partitions (like bios_boot), to work better with uneven
+  spaces (not divisible by the minimal grain) and to reduce the
+  gaps between partitions.
+
+-------------------------------------------------------------------
 Wed Dec 14 16:01:00 UTC 2016 - ancor@suse.com
 
 - Write more precise information in the logs (DiskSize#to_s)

--- a/src/lib/y2storage/devices_lists/base.rb
+++ b/src/lib/y2storage/devices_lists/base.rb
@@ -36,7 +36,7 @@ module Y2Storage
         end
       end
 
-      def_delegators :@list, :each, :empty?, :length, :size
+      def_delegators :@list, :each, :empty?, :length, :size, :last
 
       def initialize(devicegraph, list: nil)
         @devicegraph = devicegraph

--- a/src/lib/y2storage/disk_size.rb
+++ b/src/lib/y2storage/disk_size.rb
@@ -181,6 +181,17 @@ module Y2Storage
       end
     end
 
+    def %(other)
+      return DiskSize.unlimited if any_operand_unlimited?(other)
+      if other.is_a?(Numeric)
+        DiskSize.new(@size % other)
+      elsif other.respond_to?(:size)
+        DiskSize.new(@size % other.size)
+      else
+        raise TypeError, "Unexpected #{other.class}; expected Numeric value or DiskSize"
+      end
+    end
+
     def *(other)
       if !other.is_a?(Numeric)
         raise TypeError, "Unexpected #{other.class}; expected Numeric value"

--- a/src/lib/y2storage/proposal/assigned_space.rb
+++ b/src/lib/y2storage/proposal/assigned_space.rb
@@ -88,7 +88,7 @@ module Y2Storage
 
       # Space available in addition to the target
       #
-      # This method is slightly pesimistic. In a quite specific corner case, one
+      # This method is slightly pessimistic. In a quite specific corner case, one
       # of the volumes could be adjusted down to not be divisible by min_grain
       # and then the extra size would be actually sligthly bigger than reported.
       # But being pessimistic is good here because we don't want to enforce that

--- a/src/lib/y2storage/proposal/assigned_space.rb
+++ b/src/lib/y2storage/proposal/assigned_space.rb
@@ -22,12 +22,14 @@
 # find current contact information at www.suse.com.
 
 require "storage"
+require "y2storage/refinements"
 
 module Y2Storage
   class Proposal
     # Each one of the spaces contained in a SpaceDistribution
     class AssignedSpace
       extend Forwardable
+      using Y2Storage::Refinements::Disk
 
       # @return [FreeDiskSpace]
       attr_reader :disk_space
@@ -70,7 +72,10 @@ module Y2Storage
       #  - the chances of having 2 volumes with max_start_offset in the same
       #    free space are very low
       def valid?
-        usable_size >= volumes.target_disk_size
+        return true if usable_size >= volumes.target_disk_size(rounding: min_grain)
+        # At first sight, there is no enough space, but maybe enforcing some
+        # order...
+        !!volumes.enforced_last(usable_size, min_grain)
       end
 
       # Space that will remain unused (wasted) after creating the partitions
@@ -83,9 +88,16 @@ module Y2Storage
 
       # Space available in addition to the target
       #
+      # This method is slightly pesimistic. In a quite specific corner case, one
+      # of the volumes could be adjusted down to not be divisible by min_grain
+      # and then the extra size would be actually sligthly bigger than reported.
+      # But being pessimistic is good here because we don't want to enforce that
+      # situation.
+      # @see PlannedVolumesList#enforced_last
+      #
       # @return [DiskSize]
       def extra_size
-        disk_size - volumes.target_disk_size
+        disk_size - volumes.target_disk_size(rounding: min_grain)
       end
 
       # Usable space available in addition to the target, taking into account
@@ -145,6 +157,10 @@ module Y2Storage
         extended = partitions.detect { |p| p.type == Storage::PartitionType_EXTENDED }
         return false unless extended
         extended.region.start <= space_start && extended.region.end > space_start
+      end
+
+      def min_grain
+        disk_space.disk.min_grain
       end
     end
   end

--- a/src/lib/y2storage/refinements/disk.rb
+++ b/src/lib/y2storage/refinements/disk.rb
@@ -23,6 +23,7 @@
 
 require "storage"
 require "y2storage/free_disk_space"
+require "y2storage/disk_size"
 
 module Y2Storage
   module Refinements
@@ -62,6 +63,13 @@ module Y2Storage
           partition_table.unused_partition_slots.map do |slot|
             FreeDiskSpace.new(self, slot)
           end
+        end
+
+        # Minimal grain of the disk
+        #
+        # @return [DiskSize]
+        def min_grain
+          DiskSize.new(topology.minimal_grain)
         end
       end
     end

--- a/test/data/devicegraphs/empty_hard_disk_gpt_25GiB.yml
+++ b/test/data/devicegraphs/empty_hard_disk_gpt_25GiB.yml
@@ -1,0 +1,5 @@
+---
+- disk:
+    name: /dev/sda
+    size: 25 GiB
+    partition_table: gpt

--- a/test/data/devicegraphs/output/multi-linux-pc-gpt-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-gpt-lvm-sep-home.yml
@@ -41,8 +41,9 @@
         name:         /dev/sda6
         id: lvm
 
+    # The last 16.5 KiB of a GPT disk are not usable
     - free:
-        size:         unlimited
+        size:         16.5 KiB
 
 - lvm_vg:
     vg_name: system

--- a/test/data/devicegraphs/output/multi-linux-pc-gpt-sep-home.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-gpt-sep-home.yml
@@ -44,8 +44,12 @@
         id:           bios_boot
 
     - partition:
-        size:         unlimited
+        size:         587200495.5 KiB
         name:         /dev/sda7
         id:           linux
         file_system:  xfs
         mount_point:  "/home"
+
+    # The last 16.5 KiB of a GPT disk are not usable
+    - free:
+        size:         16.5 KiB

--- a/test/data/devicegraphs/output/windows-linux-lvm-pc-gpt-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-lvm-pc-gpt-lvm-sep-home.yml
@@ -23,9 +23,13 @@
         id: bios_boot
 
     - partition:
-        size: unlimited
+        size: 20969455.5 KiB
         name: /dev/sda4
         id: lvm
+
+    # The last 16.5 KiB of a GPT disk are not usable
+    - free:
+        size:         16.5 KiB
 
 - lvm_vg:
     vg_name: vg0

--- a/test/data/devicegraphs/output/windows-linux-lvm-pc-gpt-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-lvm-pc-gpt-sep-home.yml
@@ -32,8 +32,12 @@
         mount_point: swap
 
     - partition:
-        size: unlimited
+        size: 29358063.5 KiB
         name: /dev/sda5
         id: linux
         file_system: xfs
         mount_point: "/home"
+
+    - free:
+        size: 16.5 KiB
+        start: 838860783.5 KiB (0.78 TiB)

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-lvm-sep-home.yml
@@ -22,9 +22,13 @@
         name: "/dev/sda3"
         id: bios_boot
     - partition:
-        size: unlimited
+        size: 260044783.5 KiB
         name: "/dev/sda4"
         id: lvm
+
+    # The last 16.5 KiB of a GPT disk are not usable
+    - free:
+        size:         16.5 KiB
 
 - lvm_vg:
     vg_name: system

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-sep-home.yml
@@ -30,8 +30,11 @@
         name: "/dev/sda4"
         id: bios_boot
     - partition:
-        size: unlimited
+        size: 218101743.5 KiB
         name: "/dev/sda5"
         id: linux
         file_system: xfs
         mount_point: "/home"
+    # The last 16.5 KiB of a GPT disk are not usable
+    - free:
+        size:         16.5 KiB

--- a/test/planned_volumes_list_test.rb
+++ b/test/planned_volumes_list_test.rb
@@ -92,4 +92,36 @@ describe Y2Storage::PlannedVolumesList do
       )
     end
   end
+
+  describe "#enforced_last" do
+    let(:big_vol1) { planned_vol(type: :vfat, desired: 10.MiB) }
+    let(:big_vol2) { planned_vol(type: :vfat, desired: 10.MiB) }
+    let(:small_vol) { planned_vol(type: :vfat, desired: 1.MiB + 512.KiB) }
+
+    subject(:list) { described_class.new([big_vol1, small_vol, big_vol2]) }
+
+    it "returns nil if all the volumes are divisible by min_grain" do
+      size = 21.MiB + 512.KiB
+      min_grain = 512.KiB
+      expect(list.enforced_last(size, min_grain)).to be_nil
+    end
+
+    it "returns nil if the space is big enough for any order" do
+      size = 22.MiB
+      min_grain = 1.MiB
+      expect(list.enforced_last(size, min_grain)).to be_nil
+    end
+
+    it "returns nil if the volumes don't fit into the space" do
+      size = 21.MiB
+      min_grain = 1.MiB
+      expect(list.enforced_last(size, min_grain)).to be_nil
+    end
+
+    it "returns the volume that must be placed at the end" do
+      size = 21.MiB + 512.KiB
+      min_grain = 1.MiB
+      expect(list.enforced_last(size, min_grain)).to eq small_vol
+    end
+  end
 end

--- a/test/proposal/partition_creator_test.rb
+++ b/test/proposal/partition_creator_test.rb
@@ -134,7 +134,7 @@ describe Y2Storage::Proposal::PartitionCreator do
       end
 
       context "when the space is not divisible by the minimal grain" do
-        # The last 16.5KiB of GPT are not usable, what makes the space not
+        # The last 16.5KiB of GPT are not usable, which makes the space not
         # divisible by 1MiB
         let(:scenario) { "empty_hard_disk_gpt_25GiB" }
         let(:vol1) { planned_vol(mount_point: "/1", type: :vfat, desired: vol1_size, weight: 1) }

--- a/test/proposal_test.rb
+++ b/test/proposal_test.rb
@@ -150,6 +150,27 @@ describe Y2Storage::Proposal do
       include_examples "all proposed layouts"
     end
 
+    context "when forced to create a small partition" do
+      let(:scenario) { "empty_hard_disk_gpt_25GiB" }
+      let(:windows_partitions) { {} }
+      let(:separate_home) { true }
+      let(:lvm) { false }
+
+      it "does not fail to make a proposal" do
+        expect { proposal.propose }.to_not raise_error
+      end
+
+      it "creates all the needed partitions" do
+        proposal.propose
+        expect(proposal.devices.partitions).to contain_exactly(
+          an_object_with_fields(id: Storage::ID_BIOS_BOOT),
+          an_object_with_fields(mountpoint: "/"),
+          an_object_with_fields(mountpoint: "/home"),
+          an_object_with_fields(mountpoint: "swap")
+        )
+      end
+    end
+
     context "with pre-existing swap partitions" do
       before do
         allow(Y2Storage::Proposal::VolumesGenerator).to receive(:new).and_return volumes_generator


### PR DESCRIPTION
Correctly manage small partitions (like bios_boot) and the infamous 16.5KiB at the end of GPT partitions

Before this change, in GPT + legacy boot, the proposal wanted to create very small bios_boot but after creating other bigger partitions there was no suitable slot because we didn't round to min_grain. This prevent such situations (tests included).

This also reduce the number of produced gaps.