### PR TITLE
DisksList#with_name_or_partition

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 21 12:01:32 UTC 2016 - ancor@suse.com
+
+- Improvements in the devicegraph query interface
+  (DisksLists#with_name_or_partition)
+- 0.1.6
+
+-------------------------------------------------------------------
 Tue Dec 20 06:39:28 UTC 2016 - ancor@suse.com
 
 - Fixed partitioning proposal to not fail when trying to create

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        0.1.5
+Version:        0.1.6
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/devices_lists/disks_list.rb
+++ b/src/lib/y2storage/devices_lists/disks_list.rb
@@ -63,6 +63,21 @@ module Y2Storage
         spaces_list = list.reduce([]) { |sum, disk| sum + disk.free_spaces }
         FreeDiskSpacesList.new(devicegraph, list: spaces_list)
       end
+
+      # Subset of the list filtered by both the name of the disks and the name
+      # of any of its partitions.
+      #
+      # Very similar to the old Yast::Storage.GetDisk
+      #
+      # @see #with
+      #
+      # @param [String, Array<String>] device name(s)
+      # @return [DisksList]
+      def with_name_or_partition(value)
+        disks = with(name: value).to_a
+        disks += partitions.with(name: value).disks.to_a
+        DisksList.new(devicegraph, list: disks.uniq { |d| d.sid })
+      end
     end
   end
 end

--- a/test/devices_list_test.rb
+++ b/test/devices_list_test.rb
@@ -234,6 +234,36 @@ describe "devices lists" do
         expect(spaces_sdc.size).to eq 1
       end
     end
+
+    describe "#with_name_or_partition" do
+      it "returns a list of disks" do
+        result = disks.with_name_or_partition("/dev/sda2")
+        expect(result).to be_a(Y2Storage::DevicesLists::DisksList)
+      end
+
+      it "filters by a single disk name" do
+        list = disks.with_name_or_partition("/dev/sda")
+        expect(list.size).to eq 1
+        expect(list.first.name).to eq "/dev/sda"
+      end
+
+      it "filters by a single partition name" do
+        list = disks.with_name_or_partition("/dev/sda2")
+        expect(list.size).to eq 1
+        expect(list.first.name).to eq "/dev/sda"
+      end
+
+      it "filters by a set of names" do
+        list = disks.with_name_or_partition(["/dev/sda1", "/dev/sda2", "/dev/sdb", "/dev/sdb1"])
+        expect(list.size).to eq 2
+        expect(list.map(&:name)).to contain_exactly("/dev/sda", "/dev/sdb")
+      end
+
+      it "returns an empty list if nothing matches" do
+        list = disks.with_name_or_partition("non_existent")
+        expect(list).to be_empty
+      end
+    end
   end
 
   describe Y2Storage::DevicesLists::PartitionsList do


### PR DESCRIPTION
New method very similar to the old `Yast::Storage.GetDisk`, added to avoid repeating the same pattern in yast2-bootloader all over the code.