### PR TITLE
DiskAnalyzer: no MBR gap != MBR gap not applicable

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan  5 15:27:02 UTC 2017 - ancor@suse.com
+
+- Y2Storage::DiskAnalyzer - distinguish disks with no MBR gap
+  (0 bytes gap) from cases where the MBR gap is not applicable.
+  This fixes the proposal for some LVM scenarios with legacy boot.
+
+-------------------------------------------------------------------
 Fri Dec 23 12:44:24 UTC 2016 - ancor@suse.com
 
 - Removed unused ProposalDemo client (kind of obsoleted by

--- a/src/lib/y2storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/legacy.rb
@@ -34,7 +34,7 @@ module Y2Storage
       def needed_partitions
         volumes = super
         volumes << grub_volume if grub_partition_needed? && grub_partition_missing?
-        raise Error if grub_in_mbr? && mbr_gap < GRUB_SIZE
+        raise Error if grub_in_mbr? && mbr_gap && mbr_gap < GRUB_SIZE
 
         volumes
       end
@@ -62,7 +62,7 @@ module Y2Storage
       end
 
       def boot_partition_needed?
-        grub_in_mbr? && settings.use_lvm && mbr_gap < GRUB_SIZE + GRUBENV_SIZE
+        grub_in_mbr? && settings.use_lvm && mbr_gap && mbr_gap < GRUB_SIZE + GRUBENV_SIZE
       end
 
       def mbr_gap

--- a/src/lib/y2storage/disk_analyzer.rb
+++ b/src/lib/y2storage/disk_analyzer.rb
@@ -192,15 +192,14 @@ module Y2Storage
 
     # MBR gap (size between MBR and first partition) for every disk.
     #
-    # Note: the gap sizes on non-DOS partition tables are 0 (by definition).
-    #
-    # FIXME: sizes in Region are more or less useless atm, Arvin will fix this.
-    # If that's done switch from kb to byte units.
+    # If there are no partitions or if the existing partition table is not
+    # MBR-based the MBR gap is nil, meaning "gap not applicable" which is
+    # different from "no gap" (i.e. a 0 bytes gap).
     #
     # @see #scope
     #
-    # @return [Hash{String => Y2Storage::DiskSize}] each key is the name of a
-    # disk, the value is the DiskSize of the MBR gap.
+    # @return [Hash{String => (Y2Storage::DiskSize, nil)}] each key is the name
+    # of a disk, the value is the DiskSize of the MBR gap (or nil)
     def mbr_gap
       @mbr_gap ||= begin
         result = find_mbr_gap
@@ -306,7 +305,7 @@ module Y2Storage
       gaps = {}
       scoped_disks.each do |name|
         disk = device_by_name(name)
-        gap = DiskSize.KiB(0)
+        gap = nil
         if disk.partition_table? && disk.partition_table.type == ::Storage::PtType_MSDOS
           region1 = disk.partition_table.partitions.to_a.min do |x, y|
             x.region.start <=> y.region.start

--- a/test/data/devicegraphs/gpt_and_msdos.yml
+++ b/test/data/devicegraphs/gpt_and_msdos.yml
@@ -37,3 +37,16 @@
 - disk:
     name: /dev/sde
     size: 500 GiB
+
+- disk:
+    name: /dev/sdf
+    size: 100 GiB
+    partition_table:  ms-dos
+    mbr_gap: 0
+    partitions:
+
+    - partition:
+        start:        0
+        size:         unlimited
+        name:         /dev/sdf1
+        file_system:  xfs

--- a/test/data/devicegraphs/output/empty_hard_disk_50GiB-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_50GiB-lvm-sep-home.yml
@@ -1,0 +1,35 @@
+---
+- disk:
+    name: /dev/sda
+    size: 50 GiB
+    partition_table: ms-dos
+    partitions:
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda1
+        id:           lvm
+
+- lvm_vg:
+    vg_name: system
+
+    lvm_pvs:
+    - lvm_pv:
+        blk_device: "/dev/sda1"
+
+    lvm_lvs:
+    - lvm_lv:
+        lv_name:      home
+        size:         26212 MiB
+        file_system:  xfs
+        mount_point:  "/home"
+    - lvm_lv:
+        lv_name:      root
+        size:         22936 MiB
+        file_system:  btrfs
+        mount_point:  "/"
+    - lvm_lv:
+        lv_name:      swap
+        size:         2 GiB
+        file_system:  swap
+        mount_point:  swap

--- a/test/data/devicegraphs/output/empty_hard_disk_50GiB-lvm.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_50GiB-lvm.yml
@@ -1,0 +1,30 @@
+---
+- disk:
+    name: /dev/sda
+    size: 50 GiB
+    partition_table: ms-dos
+    partitions:
+
+    - partition:
+        size:         43009 MiB
+        name:         /dev/sda1
+        id:           lvm
+
+- lvm_vg:
+    vg_name: system
+
+    lvm_pvs:
+    - lvm_pv:
+        blk_device: "/dev/sda1"
+
+    lvm_lvs:
+    - lvm_lv:
+        lv_name:      root
+        size:         40 GiB
+        file_system:  btrfs
+        mount_point:  "/"
+    - lvm_lv:
+        lv_name:      swap
+        size:         2 GiB
+        file_system:  swap
+        mount_point:  swap

--- a/test/data/devicegraphs/output/empty_hard_disk_50GiB-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_50GiB-sep-home.yml
@@ -1,0 +1,23 @@
+---
+- disk:
+    name: /dev/sda
+    size: 50 GiB
+    partition_table: ms-dos
+    partitions:
+
+    - partition:
+        size:         22938 MiB
+        name:         /dev/sda1
+        file_system:  btrfs
+        mount_point:  "/"
+    - partition:
+        size:         2 GiB
+        name:         /dev/sda2
+        id:           swap
+        file_system:  swap
+        mount_point:  swap
+    - partition:
+        size:         26213 MiB
+        name:         /dev/sda3
+        file_system:  xfs
+        mount_point:  "/home"

--- a/test/data/devicegraphs/output/empty_hard_disk_50GiB.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_50GiB.yml
@@ -1,0 +1,18 @@
+---
+- disk:
+    name: /dev/sda
+    size: 50 GiB
+    partition_table: ms-dos
+    partitions:
+
+    - partition:
+        size:         40 GiB
+        name:         /dev/sda1
+        file_system:  btrfs
+        mount_point:  "/"
+    - partition:
+        size:         2 GiB
+        name:         /dev/sda2
+        id:           swap
+        file_system:  swap
+        mount_point:  swap

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-lvm-sep-home.yml
@@ -1,0 +1,44 @@
+---
+- disk:
+    name: /dev/sda
+    size: 50 GiB
+    partition_table: gpt
+    partitions:
+
+    - partition:
+        size: 1 MiB
+        name: /dev/sda1
+        id:   bios_boot
+
+    - partition:
+        size: 52426735.5 KiB
+        name: /dev/sda2
+        id:   lvm
+
+    # Reserved by GPT
+    - free:
+        size: 16.5 KiB
+
+- lvm_vg:
+    vg_name: system
+
+    lvm_pvs:
+    - lvm_pv:
+        blk_device: "/dev/sda2"
+
+    lvm_lvs:
+    - lvm_lv:
+        lv_name:      home
+        size:         26212 MiB
+        file_system:  xfs
+        mount_point:  "/home"
+    - lvm_lv:
+        lv_name:      root
+        size:         22936 MiB
+        file_system:  btrfs
+        mount_point:  "/"
+    - lvm_lv:
+        lv_name:      swap
+        size:         2 GiB
+        file_system:  swap
+        mount_point:  swap

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-lvm.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-lvm.yml
@@ -1,0 +1,35 @@
+---
+- disk:
+    name: /dev/sda
+    size: 50 GiB
+    partition_table: gpt
+    partitions:
+
+    - partition:
+        size: 1 MiB
+        name: /dev/sda1
+        id:   bios_boot
+
+    - partition:
+        size: 43009 MiB
+        name: /dev/sda2
+        id:   lvm
+
+- lvm_vg:
+    vg_name: system
+
+    lvm_pvs:
+    - lvm_pv:
+        blk_device: "/dev/sda2"
+
+    lvm_lvs:
+    - lvm_lv:
+        lv_name:      root
+        size:         40 GiB
+        file_system:  btrfs
+        mount_point:  "/"
+    - lvm_lv:
+        lv_name:      swap
+        size:         2 GiB
+        file_system:  swap
+        mount_point:  swap

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-sep-home.yml
@@ -1,0 +1,28 @@
+---
+- disk:
+    name: /dev/sda
+    size: 50 GiB
+    partition_table: gpt
+    partitions:
+
+    - partition:
+        size:         22937 MiB
+        name:         /dev/sda1
+        file_system:  btrfs
+        mount_point:  "/"
+    - partition:
+        size:         1 MiB
+        name:         /dev/sda2
+        id:           bios_boot
+    - partition:
+        size:         2 GiB
+        name:         /dev/sda3
+        id:           swap
+        file_system:  swap
+        mount_point:  swap
+    - partition:
+        # The final 16.5 KiB are reserved by GPT
+        size:         26842095.5 KiB
+        name:         /dev/sda4
+        file_system:  xfs
+        mount_point:  "/home"

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB.yml
@@ -1,0 +1,22 @@
+---
+- disk:
+    name: /dev/sda
+    size: 50 GiB
+    partition_table: gpt
+    partitions:
+
+    - partition:
+        size:         40 GiB
+        name:         /dev/sda1
+        file_system:  btrfs
+        mount_point:  "/"
+    - partition:
+        size:         1 MiB
+        name:         /dev/sda2
+        id:           bios_boot
+    - partition:
+        size:         2 GiB
+        name:         /dev/sda3
+        id:           swap
+        file_system:  swap
+        mount_point:  swap

--- a/test/data/devicegraphs/output/gpt_and_msdos-sda_root_device.yml
+++ b/test/data/devicegraphs/output/gpt_and_msdos-sda_root_device.yml
@@ -60,3 +60,16 @@
 - disk:
     name: /dev/sde
     size: 500 GiB
+
+- disk:
+    name: /dev/sdf
+    size: 100 GiB
+    partition_table:  ms-dos
+    mbr_gap: 0
+    partitions:
+
+    - partition:
+        start:        0
+        size:         unlimited
+        name:         /dev/sdf1
+        file_system:  xfs

--- a/test/data/devicegraphs/output/gpt_and_msdos-sdb_root_device.yml
+++ b/test/data/devicegraphs/output/gpt_and_msdos-sdb_root_device.yml
@@ -65,3 +65,16 @@
 - disk:
     name: /dev/sde
     size: 500 GiB
+
+- disk:
+    name: /dev/sdf
+    size: 100 GiB
+    partition_table:  ms-dos
+    mbr_gap: 0
+    partitions:
+
+    - partition:
+        start:        0
+        size:         unlimited
+        name:         /dev/sdf1
+        file_system:  xfs

--- a/test/disk_analyzer_test.rb
+++ b/test/disk_analyzer_test.rb
@@ -36,27 +36,30 @@ describe Y2Storage::DiskAnalyzer do
     let(:scenario) { "gpt_and_msdos" }
 
     it "returns the gap for every disk" do
-      expect(analyzer.mbr_gap.keys).to eq ["/dev/sda", "/dev/sdb", "/dev/sdc", "/dev/sdd", "/dev/sde"]
+      expect(analyzer.mbr_gap.keys).to eq(
+        ["/dev/sda", "/dev/sdb", "/dev/sdc", "/dev/sdd", "/dev/sde", "/dev/sdf"]
+      )
     end
 
-    it "returns 0 bytes for disks without partition table" do
-      expect(analyzer.mbr_gap["/dev/sde"]).to eq 0.KiB
+    it "returns nil for disks without partition table" do
+      expect(analyzer.mbr_gap["/dev/sde"]).to be_nil
     end
 
-    it "returns 0 bytes for GPT disks without partitions" do
-      expect(analyzer.mbr_gap["/dev/sdd"]).to eq 0.KiB
+    it "returns nil for GPT disks without partitions" do
+      expect(analyzer.mbr_gap["/dev/sdd"]).to be_nil
     end
 
-    it "returns 0 bytes for GPT disks with partitions" do
-      expect(analyzer.mbr_gap["/dev/sdb"]).to eq 0.KiB
+    it "returns nil for GPT disks with partitions" do
+      expect(analyzer.mbr_gap["/dev/sdb"]).to be_nil
     end
 
-    it "returns 0 bytes for MS-DOS disks without partitions" do
-      expect(analyzer.mbr_gap["/dev/sdc"]).to eq 0.KiB
+    it "returns nil for MS-DOS disks without partitions" do
+      expect(analyzer.mbr_gap["/dev/sdc"]).to be_nil
     end
 
     it "returns the gap for MS-DOS disks with partitions" do
       expect(analyzer.mbr_gap["/dev/sda"]).to eq 1.MiB
+      expect(analyzer.mbr_gap["/dev/sdf"]).to eq Y2Storage::DiskSize.zero
     end
   end
 

--- a/test/proposal_test.rb
+++ b/test/proposal_test.rb
@@ -150,6 +150,18 @@ describe Y2Storage::Proposal do
       include_examples "all proposed layouts"
     end
 
+    context "in a PC with an empty partition table" do
+      let(:scenario) { "empty_hard_disk_50GiB" }
+
+      include_examples "all proposed layouts"
+    end
+
+    context "in a PC with an empty GPT partition table" do
+      let(:scenario) { "empty_hard_disk_gpt_50GiB" }
+
+      include_examples "all proposed layouts"
+    end
+
     context "when forced to create a small partition" do
       let(:scenario) { "empty_hard_disk_gpt_25GiB" }
       let(:windows_partitions) { {} }


### PR DESCRIPTION
- `Y2Storage::DiskAnalyzer` - distinguish disks with no MBR gap (0 bytes gap) from cases where the MBR gap is not applicable.
- This fixes the proposal for some LVM scenarios with legacy boot (new tests included)