### PR TITLE
WIP: make StorageManager a real singleton and add revision

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 17 12:07:18 UTC 2017 - ancor@suse.com
+
+- Improved StorageManager that complies to the Singleton pattern
+  and includes a revision counter for the staging devicegraph.
+- 0.1.8
+
+-------------------------------------------------------------------
 Mon Jan 16 12:27:03 UTC 2017 - ancor@suse.com
 
 - Added 'fstab_options' key to the YAML representation of the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        0.1.7
+Version:        0.1.8
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/expert_partitioner/main_dialog.rb
+++ b/src/lib/expert_partitioner/main_dialog.rb
@@ -152,7 +152,7 @@ module ExpertPartitioner
     end
 
     def storage
-      Y2Storage::StorageManager.instance
+      Y2Storage::StorageManager.instance.storage
     end
   end
 end

--- a/src/lib/expert_partitioner/tab_views/view.rb
+++ b/src/lib/expert_partitioner/tab_views/view.rb
@@ -43,7 +43,7 @@ module ExpertPartitioner
   protected
 
     def storage
-      Y2Storage::StorageManager.instance
+      Y2Storage::StorageManager.instance.storage
     end
   end
 end

--- a/src/lib/expert_partitioner/tree.rb
+++ b/src/lib/expert_partitioner/tree.rb
@@ -156,7 +156,7 @@ module ExpertPartitioner
     end
 
     def storage
-      Y2Storage::StorageManager.instance
+      Y2Storage::StorageManager.instance.storage
     end
   end
 end

--- a/src/lib/expert_partitioner/tree_views/view.rb
+++ b/src/lib/expert_partitioner/tree_views/view.rb
@@ -44,7 +44,7 @@ module ExpertPartitioner
   protected
 
     def storage
-      Y2Storage::StorageManager.instance
+      Y2Storage::StorageManager.instance.storage
     end
   end
 end

--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -49,7 +49,7 @@ module Y2Storage
 
       # Commits the actions to disk
       def commit
-        storage = Y2Storage::StorageManager.instance
+        storage = Y2Storage::StorageManager.instance.storage
         storage.rootprefix = Yast::Installation.destdir
         storage.calculate_actiongraph
         storage.commit
@@ -60,7 +60,7 @@ module Y2Storage
       end
 
       def mount_in_target(path, device, options)
-        storage = Y2Storage::StorageManager.instance
+        storage = Y2Storage::StorageManager.instance.storage
         target_path = storage.prepend_rootprefix(path)
 
         if !Yast::FileUtils.Exists(target_path)

--- a/src/lib/y2storage/dialogs/inst_disk_proposal.rb
+++ b/src/lib/y2storage/dialogs/inst_disk_proposal.rb
@@ -42,7 +42,7 @@ module Y2Storage
       def next_handler
         if devicegraph
           log.info "Setting the devicegraph as staging"
-          devicegraph.copy_to_staging
+          Y2Storage::StorageManager.instance.copy_to_staging(devicegraph)
           super
         else
           confirm = Yast::Popup.ContinueCancel(

--- a/src/lib/y2storage/refinements/devicegraph.rb
+++ b/src/lib/y2storage/refinements/devicegraph.rb
@@ -52,11 +52,6 @@ module Y2Storage
           copy(new_graph)
           new_graph
         end
-
-        # Sets this as the staging devicegraph
-        def copy_to_staging
-          copy(storage.staging)
-        end
       end
     end
   end

--- a/test/clients/inst_prepdisk_test.rb
+++ b/test/clients/inst_prepdisk_test.rb
@@ -29,25 +29,26 @@ describe Y2Storage::Clients::InstPrepdisk do
   subject(:client) { described_class.new }
 
   describe "#run" do
-    let(:storage_manager) { double("Y2Storage::StorageManager").as_null_object }
+    let(:storage) { double("Storage::Storage").as_null_object }
 
     before do
-      allow(Y2Storage::StorageManager).to receive(:instance).and_return storage_manager
+      Y2Storage::StorageManager.create_test_instance
+      allow(Y2Storage::StorageManager.instance).to receive(:storage).and_return storage
       allow(Yast::Installation).to receive(:destdir).and_return "/dest"
-      allow(storage_manager).to receive(:prepend_rootprefix).with("/dev").and_return "/dest/dev"
-      allow(storage_manager).to receive(:prepend_rootprefix).with("/proc").and_return "/dest/proc"
-      allow(storage_manager).to receive(:prepend_rootprefix).with("/sys").and_return "/dest/sys"
+      allow(storage).to receive(:prepend_rootprefix).with("/dev").and_return "/dest/dev"
+      allow(storage).to receive(:prepend_rootprefix).with("/proc").and_return "/dest/proc"
+      allow(storage).to receive(:prepend_rootprefix).with("/sys").and_return "/dest/sys"
       allow(Yast::SCR).to receive(:Execute).and_return(true)
     end
 
     it "uses the destination directory to mount and prepare the result" do
-      expect(storage_manager).to receive(:rootprefix=).with("/dest")
+      expect(storage).to receive(:rootprefix=).with("/dest")
       client.run
     end
 
     it "commits all libstorage pending changes" do
-      expect(storage_manager).to receive(:calculate_actiongraph)
-      expect(storage_manager).to receive(:commit)
+      expect(storage).to receive(:calculate_actiongraph)
+      expect(storage).to receive(:commit)
       client.run
     end
   end

--- a/test/proposal_test.rb
+++ b/test/proposal_test.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#r!/usr/bin/env rspec
 # encoding: utf-8
 
 # Copyright (c) [2016] SUSE LLC
@@ -43,7 +43,7 @@ describe Y2Storage::Proposal do
         .and_return(resize_info)
 
       allow(Yast::Arch).to receive(:x86_64).and_return true
-      allow(Y2Storage::StorageManager.instance).to receive(:arch).and_return(storage_arch)
+      allow(Y2Storage::StorageManager.instance.storage).to receive(:arch).and_return(storage_arch)
       allow(storage_arch).to receive(:efiboot?).and_return(false)
       allow(storage_arch).to receive(:x86?).and_return(true)
       allow(storage_arch).to receive(:ppc?).and_return(false)

--- a/test/storage_manager_test.rb
+++ b/test/storage_manager_test.rb
@@ -1,0 +1,107 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+describe Y2Storage::StorageManager do
+
+  subject(:manager) { described_class.instance }
+
+  describe ".new" do
+    it "cannot be used directly" do
+      expect { described_class.new }.to raise_error
+    end
+  end
+
+  describe ".create_test_instance" do
+    it "returns the singleton StorageManager object" do
+      expect(described_class.create_test_instance).to be_a described_class
+    end
+
+    it "initializes #storage with empty devicegraphs" do
+      manager = described_class.create_test_instance
+      expect(manager.storage).to be_a Storage::Storage
+      expect(manager.probed).to be_empty
+      expect(manager.staging).to be_empty
+    end
+
+    it "initializes #staging_revision" do
+      manager = described_class.create_test_instance
+      expect(manager.staging_revision).to be_zero
+    end
+  end
+
+  describe ".fake_from_yaml" do
+    it "returns the singleton StorageManager object" do
+      result = described_class.fake_from_yaml(input_file_for("gpt_and_msdos"))
+      expect(result).to be_a described_class
+    end
+
+    it "initializes #storage with the mocked devicegraphs" do
+      manager = described_class.fake_from_yaml(input_file_for("gpt_and_msdos"))
+      expect(manager.storage).to be_a Storage::Storage
+      expect(Storage::Disk.all(manager.probed).size).to eq 6
+      expect(Storage::Disk.all(manager.staging).size).to eq 6
+    end
+
+    it "initializes #staging_revision" do
+      manager = described_class.create_test_instance
+      expect(manager.staging_revision).to be_zero
+    end
+  end
+
+  describe ".instance" do
+    it "returns the singleton object in subsequent calls" do
+      initial = described_class.create_test_instance
+      second = described_class.instance
+      # Note using equal to ensure is actually the same object (same object_id)
+      expect(second).to equal initial
+      expect(described_class.instance).to equal initial
+    end
+  end
+
+  describe "#copy_to_staging" do
+    before do
+      described_class.create_test_instance
+    end
+
+    let(:new_graph) do
+      new_graph = Storage::Devicegraph.new
+      yaml_file = input_file_for("gpt_and_msdos")
+      Y2Storage::FakeDeviceFactory.load_yaml_file(new_graph, yaml_file)
+      new_graph
+    end
+
+    it "copies the devicegraph" do
+      expect(manager.staging).to be_empty
+      manager.copy_to_staging(new_graph)
+      expect(Storage::Disk.all(manager.staging).size).to eq 6
+    end
+
+    it "increments the staging revision" do
+      pre = manager.staging_revision
+      manager.copy_to_staging(new_graph)
+      expect(manager.staging_revision).to be > pre
+    end
+  end
+end


### PR DESCRIPTION
Pull request opened just for discussion.

I have never liked the fact that (in master)
```ruby
manager = Y2Storage::StorageManager.instance
manager.class != Y2Storage::StorageManager
manager.class == Storage::Storage
```
That's not how a singleton class should behave. It's highly unexpected.

With this proposed change:
```ruby
manager = Y2Storage::StorageManager.instance
manager.class == Y2Storage::StorageManager
manager.storage.class == Storage::Storage
```
Which is more consistent.

In addition, it makes sense to me to store the revision (see [1]) in the same singleton object used to (indirectly) contain the devicegraphs. So...
```ruby
manager = Y2Storage::StorageManager.instance
if manager.revision > 0
  puts "This devicegraph is not the original one #{manager.staging}"
end
```
Notice that, as explained in [1], the revision will be handled manually.

[1] https://github.com/yast/yast-storage-ng/blob/master/doc/software-requirements.md