### PR TITLE
Allow IS units for disk size and without spaces

### DIFF
--- a/src/lib/y2storage/disk_size.rb
+++ b/src/lib/y2storage/disk_size.rb
@@ -37,6 +37,7 @@ module Y2Storage
     include Comparable
 
     UNITS = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]
+    # International System units
     IS_UNITS = ["KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
     UNLIMITED = "unlimited"
 
@@ -80,8 +81,8 @@ module Y2Storage
 
       # Create a DiskSize from a parsed string.
       # @param str [String]
-      # @param legacy_units [Boolean] if true, IS units are considered
-      # base 2 units, that is MB is the same than MiB.
+      # @param legacy_units [Boolean] if true, International System units
+      # are considered as base 2 units, that is, MB is the same than MiB.
       #
       # Valid format:
       #
@@ -106,7 +107,8 @@ module Y2Storage
       def parse(str, legacy_units: false)
         str = sanitize(str)
         return DiskSize.unlimited if str == UNLIMITED
-        DiskSize.new str_to_bytes(str, legacy_units: legacy_units)
+        bytes = str_to_bytes(str, legacy_units: legacy_units)
+        DiskSize.new(bytes)
       end
 
       alias_method :from_s, :parse

--- a/src/lib/y2storage/disk_size.rb
+++ b/src/lib/y2storage/disk_size.rb
@@ -37,6 +37,7 @@ module Y2Storage
     include Comparable
 
     UNITS = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]
+    IS_UNITS = ["KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
     UNLIMITED = "unlimited"
 
     attr_reader :size
@@ -58,43 +59,16 @@ module Y2Storage
     # Factory methods
     #
     class << self
-      # rubocop:disable Style/MethodName
-      def B(size)
-        DiskSize.new(size)
+      # Define an initializer method for each unit:
+      # @see DiskSize::UNITS and DiskSize::IS_UNITS.
+      #
+      # Examples:
+      #
+      # DiskSize.MiB(10)  #=> new DiskSize of 10 MiB
+      # DiskSize.MB(10)   #=> new DiskSize of 10 MB
+      (UNITS + IS_UNITS).each do |unit|
+        define_method(unit) { |v| DiskSize.new(calculate_bytes(v, unit)) }
       end
-
-      def KiB(size)
-        DiskSize.new(size * 1024)
-      end
-
-      def MiB(size)
-        DiskSize.new(size * (1024**2))
-      end
-
-      def GiB(size)
-        DiskSize.new(size * (1024**3))
-      end
-
-      def TiB(size)
-        DiskSize.new(size * (1024**4))
-      end
-
-      def PiB(size)
-        DiskSize.new(size * (1024**5))
-      end
-
-      def EiB(size)
-        DiskSize.new(size * (1024**6))
-      end
-
-      def ZiB(size)
-        DiskSize.new(size * (1024**7))
-      end
-
-      def YiB(size)
-        DiskSize.new(size * (1024**8))
-      end
-      # rubocop:enable Style/MethodName
 
       def unlimited
         DiskSize.new(-1)
@@ -118,40 +92,61 @@ module Y2Storage
       # Examples:
       #   42 GiB
       #   42.00  GiB
+      #   42 GB
+      #   42GB
       #   512
       #   0.5 YiB (512 ZiB)
+      #   1024MiB(1 GiB)
       #   unlimited
       #
-      # Invalid:
-      #   42 GB    (supporting binary units only)
-      #
       def parse(str)
-        # ignore everything added in parentheses, so we can also parse the output of #to_s
-        str.gsub!(/\(.*/, "")
-        str.strip!
+        str = sanitize(str)
         return DiskSize.unlimited if str == UNLIMITED
-        size_str, unit = str.split(/\s+/)
-        raise ArgumentError, "Bad number: #{size_str}" if size_str !~ /^\d+\.?\d*$/
-        size = size_str.to_f
-        return DiskSize.new(size) if unit.nil?
-        DiskSize.new(size * unit_multiplier(unit))
+        DiskSize.new str_to_B(str)
       end
 
       alias_method :from_s, :parse
       alias_method :from_human_string, :parse
 
-      # Return the unit exponent for any of the known binary units ("KiB",
-      # "MiB", ...). The base of this exponent is 1024. The base unit is KiB.
-      #
-      def unit_exponent(unit)
-        UNITS.index(unit) or raise ArgumentError, "expected one of #{UNITS}"
+    private
+
+      # Ignore everything added in parentheses, so we can also parse the output of #to_s
+      def sanitize(str)
+        str.gsub(/\(.*/, "").strip
       end
 
-      # Return the unit multiplier for any of the known binary units ("KiB",
-      # "MiB", ...). The base unit is KiB.
-      #
-      def unit_multiplier(unit)
-        1024**unit_exponent(unit)
+      def str_to_B(str)
+        number = number(str).to_f
+        unit = unit(str)
+        return number if unit.empty?
+        to_B(number, unit)
+      end
+
+      def number(str)
+        number = str.scan(/^\d+\.?\d*/).first
+        raise ArgumentError, "Bad number: #{str}" if number.nil?
+        number
+      end
+
+      def unit(str)
+        unit = str.gsub(number(str), "").strip
+        if !unit.empty? && !(UNITS + IS_UNITS).include?(unit)
+          raise ArgumentError, "Bad unit: #{str}" 
+        end
+        unit
+      end
+
+      def to_B(number, unit)
+        if UNITS.include?(unit)
+          base = 1024
+          exp = UNITS.index(unit)
+        elsif IS_UNITS.include?(unit)
+          base = 1000
+          exp = IS_UNITS.index(unit) + 1
+        else
+          raise ArgumentError, "Bad unit: #{str}"
+        end
+        number * base**exp
       end
     end
 

--- a/src/lib/y2storage/refinements/size_casts.rb
+++ b/src/lib/y2storage/refinements/size_casts.rb
@@ -37,7 +37,10 @@ module Y2Storage
     #   12.5.MiB == Y2Storage::DiskSize.MiB(12.5)
     module SizeCasts
       REFINED_CLASSES = [::Fixnum, ::Float]
-      ADDED_METHODS = [:KiB, :MiB, :GiB, :TiB, :PiB, :EiB, :ZiB, :YiB]
+      ADDED_METHODS = [
+        :KiB, :MiB, :GiB, :TiB, :PiB, :EiB, :ZiB, :YiB,
+        :KB, :MB, :GB, :TB, :PB, :EB, :ZB, :YB
+      ]
 
       REFINED_CLASSES.each do |klass|
         refine klass do

--- a/test/disk_size_test.rb
+++ b/test/disk_size_test.rb
@@ -208,78 +208,63 @@ describe Y2Storage::DiskSize do
     end
   end
 
-  describe "unit exponent" do
-    it "should be correct for KiB" do
-      expect(Y2Storage::DiskSize.unit_exponent("KiB")).to be == 1
-    end
-    it "should be correct for MiB" do
-      expect(Y2Storage::DiskSize.unit_exponent("MiB")).to be == 2
-    end
-    it "should be correct for GiB" do
-      expect(Y2Storage::DiskSize.unit_exponent("GiB")).to be == 3
-    end
-    it "should be correct for TiB" do
-      expect(Y2Storage::DiskSize.unit_exponent("TiB")).to be == 4
-    end
-    it "should be correct for PiB" do
-      expect(Y2Storage::DiskSize.unit_exponent("PiB")).to be == 5
-    end
-    it "should be correct for EiB" do
-      expect(Y2Storage::DiskSize.unit_exponent("EiB")).to be == 6
-    end
-    it "should be correct for ZiB" do
-      expect(Y2Storage::DiskSize.unit_exponent("ZiB")).to be == 7
-    end
-    it "should be correct for YiB" do
-      expect(Y2Storage::DiskSize.unit_exponent("YiB")).to be == 8
-    end
-    it "should raise an exception for invalid units" do
-      expect { Y2Storage::DiskSize.unit_exponent("WTF") }.to raise_error(ArgumentError)
-      expect { Y2Storage::DiskSize.unit_exponent("MB") }.to raise_error(ArgumentError)
-      expect { Y2Storage::DiskSize.unit_exponent("GB") }.to raise_error(ArgumentError)
-      expect { Y2Storage::DiskSize.unit_exponent("TB") }.to raise_error(ArgumentError)
-    end
-  end
-
   describe "parsing from string" do
     it "should work with just an integer" do
       expect(described_class.parse("0").to_i).to be == 0
       expect(described_class.parse("7").to_i).to be == 7
     end
+
     it "should work with integer and unit" do
       expect(described_class.parse("42 GiB").to_i).to be == 42 * 1024**3
     end
+
     it "should work with float and unit" do
       expect(described_class.parse("43.00 GiB").to_i).to be == 43 * 1024**3
     end
+
     it "should work with just an integer" do
       expect(described_class.parse("0").to_i).to be == 0
     end
+
+    it "should work without spaces" do
+      expect(described_class.parse("10MiB").to_i).to eq(10 * 1024**2)
+    end
+
     it "should tolerate more embedded whitespace" do
       expect(described_class.parse("44   MiB").to_i).to be == 44 * 1024**2
     end
+
     it "should tolerate more surrounding whitespace" do
       expect(described_class.parse("   45   TiB  ").to_i).to be == 45 * 1024**4
       expect(described_class.parse("  46   ").to_i).to be == 46
     end
+
     it "should accept \"unlimited\"" do
       expect(described_class.parse("unlimited").to_i).to be == -1
     end
+
     it "should accept \"unlimited\" with surrounding whitespace" do
       expect(described_class.parse("  unlimited ").to_i).to be == -1
     end
+
+    it "should accept IS units" do
+      expect(described_class.parse("10 MB").to_i).to eq(10 * 1000**2)
+    end
+
     it "should accept #to_s output" do
       expect(described_class.parse(described_class.GiB(42).to_s).to_i).to be == 42 * 1024**3
       expect(described_class.parse(described_class.new(43).to_s).to_i).to be == 43
       expect(described_class.parse(described_class.zero.to_s).to_i).to be == 0
       expect(described_class.parse(described_class.unlimited.to_s).to_i).to be == -1
     end
+
     it "should accept #to_human_string output" do
       expect(described_class.parse(described_class.GiB(42).to_human_string).to_i).to be == 42 * 1024**3
       expect(described_class.parse(described_class.new(43).to_human_string).to_i).to be == 43
       expect(described_class.parse(described_class.zero.to_human_string).to_i).to be == 0
       expect(described_class.parse(described_class.unlimited.to_human_string).to_i).to be == -1
     end
+
     it "should reject invalid input" do
       expect { described_class.parse("wrglbrmpf") }.to raise_error(ArgumentError)
       expect { described_class.parse("47 00 GiB") }.to raise_error(ArgumentError)

--- a/test/disk_size_test.rb
+++ b/test/disk_size_test.rb
@@ -29,90 +29,156 @@ describe Y2Storage::DiskSize do
   let(:unlimited) { Y2Storage::DiskSize.unlimited }
   let(:one_byte) { Y2Storage::DiskSize.new(1) }
 
-  describe "constructed empty" do
-    it "should have a to_i of 0" do
-      disk_size = Y2Storage::DiskSize.new
-      expect(disk_size.to_i).to be == 0
+  describe ".new" do
+    context "when no param is passed" do
+      it "creates a disk size of 0 bytes" do
+        expect(described_class.new.size).to eq(0)
+      end
+    end
+
+    context "when a number is passed" do
+      context "and is a natural number" do
+        it "creates a disk size with this number of bytes" do
+          expect(described_class.new(5).size).to eq(5)
+        end
+      end
+
+      context "and is a floating point number" do
+        it "creates a disk size with a rounded number of bytes" do
+          expect(described_class.new(5.6).size).to eq(6)
+          expect(described_class.new(5.4).size).to eq(5)
+        end
+      end
+    end
+
+    context "when a string is passed" do
+      it "creates a disk size with the number of bytes represented by the string" do
+        expect(described_class.new("5").size).to eq(5)
+        expect(described_class.new("15 KB").size).to eq(15 * 1000)
+        expect(described_class.new("15 MiB").size).to eq(15 * 1024**2)
+        expect(described_class.new("23 TiB").size).to eq(23 * 1024**4)
+        expect(described_class.new("23.2 KiB").size).to eq((23.2 * 1024).round)
+      end
     end
   end
 
-  describe "created with 42 KiB" do
-    disk_size = Y2Storage::DiskSize.KiB(42)
-    it "should return the correct human readable string" do
-      expect(disk_size.to_human_string).to be == "42.00 KiB"
-    end
-    it "should have the correct numeric value internally" do
-      expect(disk_size.to_i).to be == 42 * 1024
+  describe ".B" do
+    it "creates a disk size from a number of bytes" do
+      expect(described_class.B(5).size).to eq(5)
     end
   end
 
-  describe "created with 43 MiB" do
-    disk_size = Y2Storage::DiskSize.MiB(43)
-    it "should return the correct human readable string" do
-      expect(disk_size.to_human_string).to be == "43.00 MiB"
-    end
-    it "should have the correct numeric value internally" do
-      expect(disk_size.to_i).to be == 43 * 1024**2
+  describe ".KiB" do
+    it "creates a disk size from a number of KiB" do
+      expect(described_class.KiB(5).size).to eq(5 * 1024)
     end
   end
 
-  describe "created with 44 GiB" do
-    disk_size = Y2Storage::DiskSize.GiB(44)
-    it "should return the correct human readable string" do
-      expect(disk_size.to_human_string).to be == "44.00 GiB"
-    end
-    it "should have the correct numeric value internally" do
-      expect(disk_size.to_i).to be == 44 * 1024**3
+  describe ".MiB" do
+    it "creates a disk size from a number of MiB" do
+      expect(described_class.MiB(5).size).to eq(5 * 1024**2)
     end
   end
 
-  describe "created with 45 TiB" do
-    disk_size = Y2Storage::DiskSize.TiB(45)
-    it "should return the correct human readable string" do
-      expect(disk_size.to_human_string).to be == "45.00 TiB"
-    end
-    it "should have the correct numeric value internally" do
-      expect(disk_size.to_i).to be == 45 * 1024**4
+  describe ".GiB" do
+    it "creates a disk size from a number of GiB" do
+      expect(described_class.GiB(5).size).to eq(5 * 1024**3)
     end
   end
 
-  describe "created with 46 PiB" do
-    disk_size = Y2Storage::DiskSize.PiB(46)
-    it "should return the correct human readable string" do
-      expect(disk_size.to_human_string).to be == "46.00 PiB"
-    end
-    it "should have the correct numeric value internally" do
-      expect(disk_size.to_i).to be == 46 * 1024**5
+  describe ".TiB" do
+    it "creates a disk size from a number of TiB" do
+      expect(described_class.TiB(5).size).to eq(5 * 1024**4)
     end
   end
 
-  describe "created with 47 EiB" do
-    disk_size = Y2Storage::DiskSize.EiB(47)
-    it "should return the correct human readable string" do
-      expect(disk_size.to_human_string).to be == "47.00 EiB"
-    end
-    it "should not overflow and have the correct numeric value internally" do
-      expect(disk_size.to_i).to be == 47 * 1024**6
+  describe ".PiB" do
+    it "creates a disk size from a number of PiB" do
+      expect(described_class.PiB(5).size).to eq(5 * 1024**5)
     end
   end
 
-  describe "created with a huge number" do
-    disk_size = Y2Storage::DiskSize.TiB(48 * 1024**5)
-    it "should return the correct human readable string" do
-      expect(disk_size.to_human_string).to be == "49152.00 YiB"
-    end
-    it "should not overflow" do
-      expect(disk_size.to_i).to be > 0
-    end
-    it "should have the correct numeric value internally" do
-      expect(disk_size.to_i).to be == 48 * 1024**9
+  describe ".EiB" do
+    it "creates a disk size from a number of EiB" do
+      expect(described_class.EiB(5).size).to eq(5 * 1024**6)
     end
   end
 
-  describe "created with 1024 GiB" do
-    disk_size = Y2Storage::DiskSize.GiB(1024)
-    it "should use the next higher unit (TiB) from 1024 on" do
-      expect(disk_size.to_human_string).to be == "1.00 TiB"
+  describe ".ZiB" do
+    it "creates a disk size from a number of ZiB" do
+      expect(described_class.ZiB(5).size).to eq(5 * 1024**7)
+    end
+  end
+
+  describe ".YiB" do
+    it "creates a disk size from a number of YiB" do
+      expect(described_class.YiB(5).size).to eq(5 * 1024**8)
+    end
+  end
+
+  describe ".KB" do
+    it "creates a disk size from a number of KB" do
+      expect(described_class.KB(5).size).to eq(5 * 1000)
+    end
+  end
+
+  describe ".MB" do
+    it "creates a disk size from a number of MB" do
+      expect(described_class.MB(5).size).to eq(5 * 1000**2)
+    end
+  end
+
+  describe ".GB" do
+    it "creates a disk size from a number of GB" do
+      expect(described_class.GB(5).size).to eq(5 * 1000**3)
+    end
+  end
+
+  describe ".TB" do
+    it "creates a disk size from a number of TB" do
+      expect(described_class.TB(5).size).to eq(5 * 1000**4)
+    end
+  end
+
+  describe ".PB" do
+    it "creates a disk size from a number of PB" do
+      expect(described_class.PB(5).size).to eq(5 * 1000**5)
+    end
+  end
+
+  describe ".EB" do
+    it "creates a disk size from a number of EB" do
+      expect(described_class.EB(5).size).to eq(5 * 1000**6)
+    end
+  end
+
+  describe ".ZB" do
+    it "creates a disk size from a number of ZB" do
+      expect(described_class.ZB(5).size).to eq(5 * 1000**7)
+    end
+  end
+
+  describe ".YB" do
+    it "creates a disk size from a number of YB" do
+      expect(described_class.YB(5).size).to eq(5 * 1000**8)
+    end
+  end
+
+  describe ".to_human_string" do
+    context "when has a specific size" do
+      it("returns human-readable string represented in the biggest possible unit") do
+        expect(described_class.B(5 * 1024**0).to_human_string).to eq("5.00 B")
+        expect(described_class.B(5 * 1024**1).to_human_string).to eq("5.00 KiB")
+        expect(described_class.B(5 * 1024**3).to_human_string).to eq("5.00 GiB")
+        expect(described_class.B(5 * 1024**4).to_human_string).to eq("5.00 TiB")
+        expect(described_class.B(5 * 1024**7).to_human_string).to eq("5.00 ZiB")
+      end
+    end
+
+    context "when has unlimited size" do
+      it "returns 'unlimited'" do
+        expect(described_class.unlimited.to_human_string).to eq("unlimited")
+      end
     end
   end
 
@@ -208,65 +274,75 @@ describe Y2Storage::DiskSize do
     end
   end
 
-  describe "parsing from string" do
-    it "should work with just an integer" do
-      expect(described_class.parse("0").to_i).to be == 0
-      expect(described_class.parse("7").to_i).to be == 7
+  describe ".parse" do
+    it "should work with just a number" do
+      expect(described_class.parse("0").to_i).to eq(0)
+      expect(described_class.parse("7").to_i).to eq(7)
+      expect(described_class.parse("7.00").to_i).to eq(7)
     end
 
     it "should work with integer and unit" do
-      expect(described_class.parse("42 GiB").to_i).to be == 42 * 1024**3
+      expect(described_class.parse("42 GiB").to_i).to eq(42 * 1024**3)
     end
 
     it "should work with float and unit" do
       expect(described_class.parse("43.00 GiB").to_i).to be == 43 * 1024**3
     end
 
-    it "should work with just an integer" do
-      expect(described_class.parse("0").to_i).to be == 0
-    end
-
-    it "should work without spaces" do
+    it "should work with integer and unit without space between them" do
       expect(described_class.parse("10MiB").to_i).to eq(10 * 1024**2)
     end
 
+    it "should work with float and unit without space between them" do
+      expect(described_class.parse("10.00MiB").to_i).to eq(10 * 1024**2)
+    end
+
     it "should tolerate more embedded whitespace" do
-      expect(described_class.parse("44   MiB").to_i).to be == 44 * 1024**2
+      expect(described_class.parse("44   MiB").to_i).to eq(44 * 1024**2)
     end
 
     it "should tolerate more surrounding whitespace" do
-      expect(described_class.parse("   45   TiB  ").to_i).to be == 45 * 1024**4
-      expect(described_class.parse("  46   ").to_i).to be == 46
+      expect(described_class.parse("   45   TiB  ").to_i).to eq(45 * 1024**4)
+      expect(described_class.parse("  46   ").to_i).to eq(46)
     end
 
     it "should accept \"unlimited\"" do
-      expect(described_class.parse("unlimited").to_i).to be == -1
+      expect(described_class.parse("unlimited").to_i).to eq(-1)
     end
 
     it "should accept \"unlimited\" with surrounding whitespace" do
-      expect(described_class.parse("  unlimited ").to_i).to be == -1
+      expect(described_class.parse("  unlimited ").to_i).to eq(-1)
     end
 
-    it "should accept IS units" do
+    it "should accept International System units" do
+      expect(described_class.parse("10 KB").to_i).to eq(10 * 1000)
       expect(described_class.parse("10 MB").to_i).to eq(10 * 1000**2)
     end
 
-    it "should work with legacy units" do
-      expect(described_class.parse("10MB", legacy_units: true).to_i).to eq(10 * 1024**2)
+    context "when using the legacy_unit flag" do
+      let(:legacy) { true }
+
+      it "considers international system units to be power of two" do
+        expect(described_class.parse("10 MB", legacy_units: legacy).size).to eq(10 * 1024**2)
+      end
+
+      it "reads units that are power of two in the usual way" do
+        expect(described_class.parse("10 MiB", legacy_units: legacy).size).to eq(10 * 1024**2)
+      end
     end
 
     it "should accept #to_s output" do
-      expect(described_class.parse(described_class.GiB(42).to_s).to_i).to be == 42 * 1024**3
-      expect(described_class.parse(described_class.new(43).to_s).to_i).to be == 43
-      expect(described_class.parse(described_class.zero.to_s).to_i).to be == 0
-      expect(described_class.parse(described_class.unlimited.to_s).to_i).to be == -1
+      expect(described_class.parse(described_class.GiB(42).to_s).to_i).to eq(42 * 1024**3)
+      expect(described_class.parse(described_class.new(43).to_s).to_i).to eq(43)
+      expect(described_class.parse(described_class.zero.to_s).to_i).to eq(0)
+      expect(described_class.parse(described_class.unlimited.to_s).to_i).to eq(-1)
     end
 
     it "should accept #to_human_string output" do
-      expect(described_class.parse(described_class.GiB(42).to_human_string).to_i).to be == 42 * 1024**3
-      expect(described_class.parse(described_class.new(43).to_human_string).to_i).to be == 43
-      expect(described_class.parse(described_class.zero.to_human_string).to_i).to be == 0
-      expect(described_class.parse(described_class.unlimited.to_human_string).to_i).to be == -1
+      expect(described_class.parse(described_class.GiB(42).to_human_string).to_i).to eq(42 * 1024**3)
+      expect(described_class.parse(described_class.new(43).to_human_string).to_i).to eq(43)
+      expect(described_class.parse(described_class.zero.to_human_string).to_i).to eq(0)
+      expect(described_class.parse(described_class.unlimited.to_human_string).to_i).to eq(-1)
     end
 
     it "should reject invalid input" do

--- a/test/disk_size_test.rb
+++ b/test/disk_size_test.rb
@@ -251,6 +251,10 @@ describe Y2Storage::DiskSize do
       expect(described_class.parse("10 MB").to_i).to eq(10 * 1000**2)
     end
 
+    it "should work with legacy units" do
+      expect(described_class.parse("10MB", legacy_units: true).to_i).to eq(10 * 1024**2)
+    end
+
     it "should accept #to_s output" do
       expect(described_class.parse(described_class.GiB(42).to_s).to_i).to be == 42 * 1024**3
       expect(described_class.parse(described_class.new(43).to_s).to_i).to be == 43


### PR DESCRIPTION
PBI https://trello.com/c/o9LkrKGc/525-3-read-setting-from-control-file

Disk size values read from control file can be formatted as "10MB". 

This PR extends DiskSize#parse to allow IS units and without spaces.