### PR TITLE
Subvol proposal

### DIFF
--- a/src/lib/y2storage/planned_subvol.rb
+++ b/src/lib/y2storage/planned_subvol.rb
@@ -127,9 +127,26 @@ module Y2Storage
       use_subvol
     end
 
+    # Create the subvolume as child of 'parent_subvol'.
+    #
+    # @param parent_subvol [::Storage::BtrfsSubvol]
+    # @param default_subvol [String] "@" or ""
+    # @param mount_prefix [String]
+    #
+    # @return [::Storage::BtrfsSubvol]
+    #
+    def create_subvol(parent_subvol, default_subvol, mount_prefix)
+      name = @path
+      name = default_subvol + "/" + path unless default_subvol.empty?
+      subvol = parent_subvol.create_btrfs_subvolume(name)
+      subvol.nocow = true if no_cow?
+      subvol.add_mountpoint(mount_prefix + @path)
+      subvol
+    end
+
     # Factory method: Create one PlannedSubvol from XML data stored as a map.
     #
-    # @return PlannedSubvol or nil if error
+    # @return [PlannedSubvol] or nil if error
     #
     def self.create_from_xml(xml)
       return nil unless xml && xml.key?("path")

--- a/src/lib/y2storage/planned_volume.rb
+++ b/src/lib/y2storage/planned_volume.rb
@@ -205,7 +205,9 @@ module Y2Storage
       @subvolumes.each do |planned_subvol|
         # Notice that subvolumes not matching the current architecture are
         # already removed
-        subvol = parent.create_btrfs_subvolume(planned_subvol.path)
+        path = planned_subvol.path
+        path = @default_subvolume + "/" + path unless @default_subvolume.empty?
+        subvol = parent.create_btrfs_subvolume(path)
         subvol.nocow = true if planned_subvol.no_cow?
         subvol.add_mountpoint(mount_point + planned_subvol.path)
       end

--- a/src/lib/y2storage/planned_volume.rb
+++ b/src/lib/y2storage/planned_volume.rb
@@ -2,7 +2,7 @@
 #
 # encoding: utf-8
 
-# Copyright (c) [2015] SUSE LLC
+# Copyright (c) [2015-2017] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2storage/planned_volume.rb
+++ b/src/lib/y2storage/planned_volume.rb
@@ -237,6 +237,8 @@ module Y2Storage
     # @param mount_point [String] mount point to check
     # @param other_mount_points [Array<String>]
     #
+    # @return [Boolean]
+    #
     def shadows?(mount_point, other_mount_points)
       # Just checking with start_with? is not sufficient:
       # "/bootinger/schlonz".start_with?("/boot") -> true

--- a/src/lib/y2storage/planned_volume.rb
+++ b/src/lib/y2storage/planned_volume.rb
@@ -200,7 +200,7 @@ module Y2Storage
       @subvolumes.each do |planned_subvol|
         # Notice that subvolumes not matching the current architecture are
         # already removed
-        next if shadows?(prefix + planned_subvol.path, other_mount_points)
+        next if PlannedVolume::shadows?(prefix + planned_subvol.path, other_mount_points)
         planned_subvol.create_subvol(parent_subvol, @default_subvolume, prefix)
       end
       nil
@@ -239,7 +239,8 @@ module Y2Storage
     #
     # @return [Boolean]
     #
-    def shadows?(mount_point, other_mount_points)
+    def self.shadows?(mount_point, other_mount_points)
+      return false if mount_point.nil? || other_mount_points.nil?
       # Just checking with start_with? is not sufficient:
       # "/bootinger/schlonz".start_with?("/boot") -> true
       # So append "/" to make sure only complete subpaths are compared:

--- a/src/lib/y2storage/proposal/lvm_helper.rb
+++ b/src/lib/y2storage/proposal/lvm_helper.rb
@@ -280,7 +280,12 @@ module Y2Storage
         name = volume.logical_volume_name || DEFAULT_LV_NAME
         name = available_name(name, volume_group)
         lv = volume_group.create_lvm_lv(name, volume.disk_size.to_i)
-        volume.create_filesystem(lv)
+        filesystem = volume.create_filesystem(lv)
+        if volume.subvolumes?
+          other_mount_points = @planned_volumes.map { |v| v.mount_point }
+          other_mount_points.delete_if { |mp| mp == volume.mount_point }
+          volume.create_subvolumes(filesystem, other_mount_points)
+        end
       end
 
       # Best logical volume to delete next while trying to make space for the

--- a/src/lib/y2storage/proposal/partition_creator.rb
+++ b/src/lib/y2storage/proposal/partition_creator.rb
@@ -123,7 +123,11 @@ module Y2Storage
             partition = create_partition(vol, partition_id, space, primary)
             final_device = encrypter.device_for(vol, partition)
             filesystem = vol.create_filesystem(final_device)
-            vol.create_subvolumes(filesystem) if vol.subvolumes?
+            if vol.subvolumes?
+              other_mount_points = volumes.map { |v| v.mount_point }
+              other_mount_points.delete_if { |mp| mp == vol.mount_point }
+              vol.create_subvolumes(filesystem, other_mount_points)
+            end
             devicegraph.check
           rescue ::Storage::Exception => error
             raise Error, "Error allocating #{vol}. Details: #{error}"

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -88,7 +88,7 @@ module Y2Storage
       @btrfs_increase_percentage     = 300.0
       @btrfs_default_subvolume       = "@"
       @root_subvolume_read_only      = false
-      @subvolumes                    = nil
+      @subvolumes                    = PlannedSubvol.fallback_list
 
       # Not yet in control.xml
       @home_min_disk_size            = DiskSize.GiB(10)

--- a/test/planned_volume_test.rb
+++ b/test/planned_volume_test.rb
@@ -40,7 +40,7 @@ describe Y2Storage::PlannedVolume do
       expect(Y2Storage::PlannedVolume.shadows?("/booting/xy", other)).to be false
     end
 
-    it "does not report a false positive /var/log with a /var subvolume" do
+    it "does not report a false positive for shadowing /var/log with a /var subvolume" do
       expect(Y2Storage::PlannedVolume.shadows?("/var", other)).to be false
     end
 

--- a/test/planned_volume_test.rb
+++ b/test/planned_volume_test.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2016-2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "storage"
+require "y2storage"
+
+describe Y2Storage::PlannedVolume do
+  describe "#shadows?" do
+    let(:other) { ["/home", "/boot", "/opt", "/var/log"] }
+
+    it "detects shadowing /home with a /home subvolume" do
+      expect(Y2Storage::PlannedVolume.shadows?("/home", other)).to be true
+    end
+
+    it "detects shadowing /boot with a /boot/something/else subvolume" do
+      expect(Y2Storage::PlannedVolume.shadows?("/boot/xy/myarch", other)).to be true
+    end
+
+    it "does not report a false positive for shadowing /boot with a /booting/xy subvolume" do
+      expect(Y2Storage::PlannedVolume.shadows?("/booting/xy", other)).to be false
+    end
+
+    it "does not report a false positive /var/log with a /var subvolume" do
+      expect(Y2Storage::PlannedVolume.shadows?("/var", other)).to be false
+    end
+
+    it "handles a nonexistent mount point well" do
+      expect(Y2Storage::PlannedVolume.shadows?("/wrglbrmpf", other)).to be false
+    end
+
+    it "handles an empty mount point well" do
+      expect(Y2Storage::PlannedVolume.shadows?("", other)).to be false
+    end
+
+    it "handles an empty mount points list well" do
+      expect(Y2Storage::PlannedVolume.shadows?("/xy", [])).to be false
+    end
+
+    it "handles a nil mount point well" do
+      expect(Y2Storage::PlannedVolume.shadows?(nil, other)).to be false
+    end
+
+    it "handles a nil mount points list well" do
+      expect(Y2Storage::PlannedVolume.shadows?("/xy", nil)).to be false
+    end
+  end
+end

--- a/test/proposal/volumes_generator_test.rb
+++ b/test/proposal/volumes_generator_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2016] SUSE LLC
+# Copyright (c) [2016-2017] SUSE LLC
 #
 # All Rights Reserved.
 #


### PR DESCRIPTION
- Prepend the default subvolume name to the subvol name upon creation: `var/log` -> `@/var/log`

- Don't shadow other volumes with a subvolume: Don't propose a `@/home` subvol to be mounted at `/home` when another dedicated volume (partition, LVM LV) is created for `/home´

- More unit tests