### PR TITLE
Use new API in yaml-writer unit test

### DIFF
--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -48,6 +48,12 @@ module Y2Storage
 
     storage_forward :create_blk_filesystem, as: "Filesystems::BlkFilesystem", raise_errors: true
 
+    # @!method create_filesystem
+    #   Alias for create_blk_filesystem
+    #
+    #   @return [Filesystems::BlkFilesystem]
+    alias_method :create_filesystem, :create_blk_filesystem
+
     storage_forward :create_encryption, as: "Encryption", raise_errors: true
 
     # @!method direct_blk_filesystem


### PR DESCRIPTION
- Use new API in yaml-writer unit test

- Added alias for create_filesystem() which is more natural to use than create_blk_filesystem()