### PR TITLE
Usability fixes

### DIFF
--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -32,11 +32,11 @@ module Y2Storage
       # Dialog to select partitioning scheme.
       class SelectScheme < Base
         # Handler for :encryption check box.
-        # @param allow_focus [Boolean] whether password field can be focused
-        def encryption_handler(allow_focus: true)
+        # @param focus [Boolean] whether password field should be focused
+        def encryption_handler(focus: true)
           widget_update(:password, using_encryption?, attr: :Enabled)
           widget_update(:repeat_password, using_encryption?, attr: :Enabled)
-          return unless allow_focus && using_encryption?
+          return unless focus && using_encryption?
           Yast::UI.SetFocus(Id(:password))
         end
 
@@ -77,7 +77,7 @@ module Y2Storage
         def initialize_widgets
           widget_update(:lvm, settings.use_lvm)
           widget_update(:encryption, settings.use_encryption)
-          encryption_handler(allow_focus: false)
+          encryption_handler(focus: false)
           if settings.use_encryption
             widget_update(:password, settings.encryption_password)
             widget_update(:repeat_password, settings.encryption_password)

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -31,9 +31,13 @@ module Y2Storage
     class GuidedSetup
       # Dialog to select partitioning scheme.
       class SelectScheme < Base
-        def encryption_handler
-          widget_update(:password, widget_value(:encryption), attr: :Enabled)
-          widget_update(:repeat_password, widget_value(:encryption), attr: :Enabled)
+        # Handler for :encryption check box.
+        # @param allow_focus [Boolean] whether password field can be focused
+        def encryption_handler(allow_focus: true)
+          widget_update(:password, using_encryption?, attr: :Enabled)
+          widget_update(:repeat_password, using_encryption?, attr: :Enabled)
+          return unless allow_focus && using_encryption?
+          Yast::UI.SetFocus(Id(:password))
         end
 
       protected
@@ -73,7 +77,7 @@ module Y2Storage
         def initialize_widgets
           widget_update(:lvm, settings.use_lvm)
           widget_update(:encryption, settings.use_encryption)
-          encryption_handler
+          encryption_handler(allow_focus: false)
           if settings.use_encryption
             widget_update(:password, settings.encryption_password)
             widget_update(:repeat_password, settings.encryption_password)

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -86,8 +86,8 @@ module Y2Storage
 
         def update_settings!
           settings.use_lvm = widget_value(:lvm)
-          password = widget_value(:password)
-          settings.encryption_password = password unless password.to_s.empty?
+          password = using_encryption? ? widget_value(:password) : nil
+          settings.encryption_password = password
         end
 
       private

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -24,6 +24,7 @@ require "y2storage"
 require "y2storage/dialogs/guided_setup/base"
 
 Yast.import "InstExtensionImage"
+Yast.import "Popup"
 
 module Y2Storage
   module Dialogs
@@ -141,11 +142,25 @@ module Y2Storage
         end
 
         # Password is considered strong when cracklib returns an empty message.
+        # User has the last word to decide whether to use a weak password.
         def password_strong?
           message = cracklib_message
           return true if message.empty?
-          Yast::Report.Warning(message)
-          false
+
+          popup_text = [
+            _("The password is too simple:"),
+            message,
+            "\n",
+            _("Really use this password?")
+          ].join("\n")
+
+          Yast::Popup.AnyQuestion(
+            "",
+            popup_text,
+            Yast::Label.YesButton,
+            Yast::Label.NoButton,
+            :focus_no
+          )
         end
 
         def password_min_size?

--- a/test/dialogs/guided_setup/select_scheme_test.rb
+++ b/test/dialogs/guided_setup/select_scheme_test.rb
@@ -90,6 +90,7 @@ describe Y2Storage::Dialogs::GuidedSetup::SelectScheme do
 
     context "when encryption is not selected" do
       before do
+        settings.encryption_password = "12345678"
         not_select_widget(:encryption)
       end
 
@@ -97,6 +98,11 @@ describe Y2Storage::Dialogs::GuidedSetup::SelectScheme do
         expect_disable(:password)
         expect_disable(:repeat_password)
         subject.run
+      end
+
+      it "sets password to nil" do
+        subject.run
+        expect(settings.encryption_password).to be_nil
       end
     end
 

--- a/test/dialogs/guided_setup/select_scheme_test.rb
+++ b/test/dialogs/guided_setup/select_scheme_test.rb
@@ -180,9 +180,22 @@ describe Y2Storage::Dialogs::GuidedSetup::SelectScheme do
 
           it "does not save password in settings" do
             subject.run
+            expect(subject.settings).not_to receive(:encryption_password=)
             expect(subject.settings.encryption_password).to eq(nil)
           end
         end
+      end
+    end
+
+    context "when encryption is clicked" do
+      before do
+        select_widget(:encryption)
+        allow(Yast::UI).to receive(:UserInput).and_return(:encryption, :abort)
+      end
+
+      it "focuses password field" do
+        expect(Yast::UI).to receive(:SetFocus)
+        subject.run
       end
     end
 


### PR DESCRIPTION
Related to PBI https://trello.com/c/b5DSHXf5/567-2-storageng-guided-set-up-disable-unneeded-widgets

* Focus password field when encryption is selected.
* Improve password error message and allow to use a simple password.