### PR TITLE
- pass storage object when creating devicegraph objects

### DIFF
--- a/src/lib/y2storage/devicegraph.rb
+++ b/src/lib/y2storage/devicegraph.rb
@@ -85,7 +85,8 @@ module Y2Storage
     # @param filename [String]
     # @return [Devicegraph]
     def self.new_from_file(filename)
-      devicegraph = ::Storage::Devicegraph.new
+      storage = Y2Storage::StorageManager.instance.storage
+      devicegraph = ::Storage::Devicegraph.new(storage)
       Y2Storage::FakeDeviceFactory.load_yaml_file(devicegraph, filename)
       new(devicegraph)
     end

--- a/test/storage_manager_test.rb
+++ b/test/storage_manager_test.rb
@@ -24,7 +24,8 @@ require_relative "spec_helper"
 require "y2storage"
 
 def devicegraph_from(file_name)
-  st_graph = Storage::Devicegraph.new
+  storage = Y2Storage::StorageManager.instance.storage
+  st_graph = Storage::Devicegraph.new(storage)
   graph = Y2Storage::Devicegraph.new(st_graph)
   yaml_file = input_file_for(file_name)
   Y2Storage::FakeDeviceFactory.load_yaml_file(graph, yaml_file)


### PR DESCRIPTION
Needed for https://trello.com/c/WAGRJLgv/542-5-libstorage-ng-support-of-alternative-device-naming-schemes.