### PR TITLE
Set default btrfs subvolume

### DIFF
--- a/src/lib/y2storage/planned_volume.rb
+++ b/src/lib/y2storage/planned_volume.rb
@@ -195,6 +195,7 @@ module Y2Storage
       return unless filesystem.supports_btrfs_subvolumes?
       return unless subvolumes?
       parent_subvol = get_parent_subvol(filesystem)
+      parent_subvol.set_default_btrfs_subvolume
       prefix = filesystem.mountpoint
       prefix += "/" unless prefix == "/"
       @subvolumes.each do |planned_subvol|

--- a/src/lib/y2storage/proposal/volumes_generator.rb
+++ b/src/lib/y2storage/proposal/volumes_generator.rb
@@ -140,7 +140,7 @@ module Y2Storage
           multiplicator = 1.0 + @settings.btrfs_increase_percentage / 100.0
           root_vol.min_disk_size *= multiplicator
           root_vol.max_disk_size *= multiplicator
-          root_vol.default_subvolume = @settings.btrfs_default_subvolume
+          root_vol.default_subvolume = @settings.btrfs_default_subvolume || ""
           root_vol.subvolumes = @settings.subvolumes
           log.info "Adding Btrfs subvolumes: \n#{root_vol.subvolumes}"
         end

--- a/test/proposal_subvol_test.rb
+++ b/test/proposal_subvol_test.rb
@@ -21,100 +21,159 @@
 # find current contact information at www.suse.com.
 
 require_relative "spec_helper"
-require "storage"
-require "y2storage"
-require_relative "support/proposal_examples"
 require_relative "support/proposal_context"
 
 describe Y2Storage::Proposal do
-  describe "#propose subvolumes" do
-    include_context "proposal"
+  include_context "proposal"
 
-    let(:subvol) { true }
+  subject { described_class.new(settings: settings) }
 
-    let(:proposal_devicegraph_yaml) do
-      proposal.propose
-      yaml_writer = Y2Storage::YamlWriter.new
-      yaml_writer.yaml_device_tree(proposal.devices)
+  let(:test_with_subvolumes) { true }
+
+  describe "#propose" do
+    let(:scenario) { "empty_hard_disk_50GiB" }
+
+    def root_filesystem
+      subject.devices.filesystems.detect { |f| f.mount_point == "/" }
     end
 
-    let(:root_yaml) do
-      disk = proposal_devicegraph_yaml.first["disk"]
-      partitions = disk["partitions"]
-      partitions.map do |pslot|
-        part = pslot["partition"]
-        next nil unless part
-        part["mount_point"] == "/" ? part : nil
-      end.compact.first
+    context "when root filesystem is BtrFS" do
+      before do
+        settings.root_filesystem_type = Y2Storage::Filesystems::Type::BTRFS
+      end
+
+      let(:subvolumes) { root_filesystem.btrfs_subvolumes }
+      let(:x86_subvolumes) { ["@/boot/grub2/i386-pc", "@/boot/grub2/x86_64-efi"] }
+      let(:s390_subvolumes) { ["@/boot/grub2/s390x-emu"] }
+
+      it "proposes the top level subvolume" do
+        subject.propose
+        top_level_subvolume = subvolumes.detect { |s| s.id == 5 }
+
+        expect(top_level_subvolume).not_to be_nil
+        expect(top_level_subvolume.path).to eq("")
+      end
+
+      context "and there is not a default subvolume" do
+        before { settings.btrfs_default_subvolume = nil }
+
+        it "proposes top level subvolume as default subvolume" do
+          subject.propose
+          default_subvol = subvolumes.detect(&:default_btrfs_subvolume?)
+
+          expect(default_subvol).to eq(root_filesystem.top_level_btrfs_subvolume)
+        end
+      end
+
+      context "and there is a default subvolume" do
+        it "proposes as default the correct subvolume" do
+          settings.btrfs_default_subvolume = "@@@"
+
+          subject.propose
+          default_subvol = subvolumes.detect(&:default_btrfs_subvolume?)
+
+          expect(default_subvol).not_to be_nil
+          expect(default_subvol.path).to eq("@@@")
+        end
+      end
+
+      context "and there are planned subvolumes" do
+        before do
+          settings.subvolumes = [
+            Y2Storage::PlannedSubvol.new("myhome", copy_on_write: true),
+            Y2Storage::PlannedSubvol.new("myopt", copy_on_write: false)
+          ]
+        end
+
+        it "proposes planned subvolumes" do
+          subject.propose
+          expect(subvolumes.map(&:path)).to include("@/myhome", "@/myopt")
+          expect(subvolumes.detect { |s| s.path == "@/myhome" }.nocow?).to be(false)
+          expect(subvolumes.detect { |s| s.path == "@/myopt" }.nocow?).to be(true)
+        end
+
+        it "does not propose not planned subvolumes" do
+          subject.propose
+          expect(subvolumes.map(&:path)).not_to include("@/opt")
+        end
+      end
+
+      context "and there are not planned subvolumes" do
+        it "proposes correct COW subvolumes" do
+          expected_cow_subvolumes = [
+            "@/home",
+            "@/opt",
+            "@/srv",
+            "@/tmp",
+            "@/usr/local",
+            "@/var/cache",
+            "@/var/crash",
+            "@/var/lib/machines",
+            "@/var/lib/mailman",
+            "@/var/lib/named",
+            "@/var/log",
+            "@/var/opt",
+            "@/var/spool",
+            "@/var/tmp"
+          ]
+
+          subject.propose
+          cow_subvolumes = subvolumes.reject { |s| s.nocow? }
+
+          expect(cow_subvolumes.map(&:path)).to include(*expected_cow_subvolumes)
+        end
+
+        it "proposes correct NoCOW subvolumes" do
+          expected_nocow_subvolumes = [
+            "@/var/lib/libvirt/images",
+            "@/var/lib/mariadb",
+            "@/var/lib/mysql",
+            "@/var/lib/pgsql"
+          ]
+
+          subject.propose
+          nocow_subvolumes = subvolumes.select { |s| s.nocow? }
+
+          expect(nocow_subvolumes.map(&:path)).to contain_exactly(*expected_nocow_subvolumes)
+        end
+      end
+
+      context "when there is seperate home" do
+        let(:separate_home) { true }
+
+        it "does not propose a subvolume for home" do
+          subject.propose
+          expect(subvolumes.detect { |s| s.path == "@/home" }).to be_nil
+        end
+      end
+
+      context "when architecture is x86" do
+        let(:architecture) { :x86 }
+
+        it "proposes correct x86 specific subvolumes" do
+          subject.propose
+          expect(subvolumes.map(&:path)).to include(*x86_subvolumes)
+        end
+
+        it "does not propose other arch subvolumes" do
+          subject.propose
+          expect(subvolumes.map(&:path)).not_to include(*s390_subvolumes)
+        end
+      end
+
+      context "when architecture is s390" do
+        let(:architecture) { :s390 }
+
+        it "proposes correct s390 specific subvolumes" do
+          subject.propose
+          expect(subvolumes.map(&:path)).to include(*s390_subvolumes)
+        end
+
+        it "does not propose other arch subvolumes" do
+          subject.propose
+          expect(subvolumes.map(&:path)).not_to include(*x86_subvolumes)
+        end
+      end
     end
-
-    let(:subvol_yaml) do
-      root = root_yaml || {}
-      btrfs_yaml = root["btrfs"] || {}
-      btrfs_yaml["subvolumes"] || []
-    end
-
-    # rubocop:disable Metrics/LineLength
-    context "without separate /home on x86" do
-      let(:architecture) { :x86 }
-      let(:separate_home) { false }
-      let(:scenario) { "empty_hard_disk_50GiB" }
-      subject(:proposal) { described_class.new(settings: settings) }
-
-      it "proposes normal (COW) subvolumes" do
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/home" })
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/opt" })
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/srv" })
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/usr/local" })
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/var/log" })
-      end
-
-      it "proposes NoCOW subvolumes" do
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/var/lib/libvirt/images", "nocow" => "true" })
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/var/lib/mariadb", "nocow" => "true" })
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/var/lib/mysql", "nocow" => "true" })
-      end
-
-      it "proposes the correct architecture specific subvolumes" do
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/boot/grub2/i386-pc" })
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/boot/grub2/x86_64-efi" })
-        expect(subvol_yaml).not_to include("subvolume" => { "path" => "@/boot/grub2/s390x-emu" })
-      end
-    end
-
-    context "with separate /home" do
-      let(:architecture) { :x86 }
-      let(:separate_home) { true }
-      let(:scenario) { "empty_hard_disk_50GiB" }
-      subject(:proposal) { described_class.new(settings: settings) }
-
-      it "does not shadow /home with a subvolume" do
-        expect(subvol_yaml).not_to include("subvolume" => { "path" => "@/home" })
-      end
-
-      it "proposes normal (COW) subvolumes" do
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/opt" })
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/srv" })
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/usr/local" })
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/var/log" })
-      end
-    end
-
-    context "on s390" do
-      let(:architecture) { :s390 }
-      let(:separate_home) { false }
-      let(:scenario) { "empty_hard_disk_50GiB" }
-      subject(:proposal) { described_class.new(settings: settings) }
-
-      it "proposes the correct architecture specific subvolumes for s390" do
-        expect(subvol_yaml).to include("subvolume" => { "path" => "@/boot/grub2/s390x-emu" })
-      end
-
-      it "does not propose subvolumes for x86" do
-        expect(subvol_yaml).not_to include("subvolume" => { "path" => "@/boot/grub2/i386-pc" })
-        expect(subvol_yaml).not_to include("subvolume" => { "path" => "@/boot/grub2/x86_64-efi" })
-      end
-    end
-    # rubocop:enable all
   end
 end

--- a/test/support/proposal_context.rb
+++ b/test/support/proposal_context.rb
@@ -56,14 +56,14 @@ RSpec.shared_context "proposal" do
   let(:separate_home) { false }
   let(:lvm) { false }
   let(:encrypt) { false }
-  let(:subvol) { false }
+  let(:test_with_subvolumes) { false }
   let(:settings) do
     settings = Y2Storage::ProposalSettings.new
     settings.use_separate_home = separate_home
     settings.use_lvm = lvm
     settings.encryption_password = encrypt ? "12345678" : nil
     # If subvolumes are not tested, override the subvolume fallbacks list
-    settings.subvolumes = nil unless subvol
+    settings.subvolumes = nil unless test_with_subvolumes
     settings
   end
 


### PR DESCRIPTION
This solves current problem in openQA with BtrFS where parent subvolume was always set as default. 

With this patch, apparently all it is fine.

See https://trello.com/c/taJNub8F/576-fixes-to-do-openqa-passes