### PR TITLE
Log graph

### DIFF
--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -52,6 +52,9 @@ module Y2Storage
 
       # Commits the actions to disk
       def commit
+        manager.y2storage_probed.save(Yast::Directory.logdir + "/inst-probed_devicegraph.xml")
+        manager.y2storage_staging.save(Yast::Directory.logdir + "/inst-staging_devicegraph.xml")
+
         manager.rootprefix = Yast::Installation.destdir
         manager.commit
 

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -144,8 +144,6 @@ module Y2Storage
     #
     # Beware: this method can cause data loss
     def commit
-      storage.probed.save(Yast::Directory.logdir + "/probed-devicegraph.xml")
-      storage.staging.save(Yast::Directory.logdir + "/staging-devicegraph.xml")
       storage.calculate_actiongraph
       storage.commit
     end

--- a/test/clients/inst_prepdisk_test.rb
+++ b/test/clients/inst_prepdisk_test.rb
@@ -34,6 +34,7 @@ describe Y2Storage::Clients::InstPrepdisk do
       allow(Yast::Installation).to receive(:destdir).and_return "/dest"
       allow(Yast::SCR).to receive(:Execute).and_return(true)
       allow(Yast::Mode).to receive(:update).and_return(mode == :update)
+      allow_any_instance_of(Y2Storage::Devicegraph).to receive(:save)
     end
 
     let(:storage_manager) { Y2Storage::StorageManager.instance }
@@ -48,6 +49,16 @@ describe Y2Storage::Clients::InstPrepdisk do
 
       it "commits all libstorage pending changes" do
         expect(storage_manager).to receive(:commit)
+        client.run
+      end
+
+      it "saves probed devicegraph to a xml log file" do
+        expect(storage_manager.y2storage_probed).to receive(:save).with(/.*probed.*.xml/)
+        client.run
+      end
+
+      it "saves staging devicegraph to a xml log file" do
+        expect(storage_manager.y2storage_staging).to receive(:save).with(/.*staging.*.xml/)
         client.run
       end
     end


### PR DESCRIPTION
* Save devicegraphs xml only when **inst_prepdisk** does a commit.
* Avoid creation lo xml files in tests.
* Add tests.