### PR TITLE
README - enable autorefresh for the storage-ng repo

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,16 @@
+engines:
+  # disable Rubocop at CodeClimate, it cannot read the shared config from
+  # the /usr/share/YaST2/data/devtools/data/rubocop_yast_style.yml file
+  rubocop:
+    enabled: false
+
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+
+ratings:
+  paths:
+  - "**.rb"
+  - Rakefile

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the following steps (as root):
 
 ```bash
 # Repository for Tumbleweed/Factory, adjust this line if using other distribution
-zypper ar http://download.opensuse.org/repositories/YaST:/storage-ng/openSUSE_Tumbleweed/ libstorage-ng
+zypper ar -f http://download.opensuse.org/repositories/YaST:/storage-ng/openSUSE_Tumbleweed/ libstorage-ng
 zypper ref
 rpm -e --nodeps libstorage7 libstorage-ruby libstorage-python libstorage-devel libstorage-testsuite
 # There might be reported file conflicts between yast2-storage-ng and yast2-storage,


### PR DESCRIPTION
- The packages can be easily updated without manual refresh
- Added `.codeclimate.yml` - disable Rubocop check, the shared config file cannot be read by CodeClimate (we run Rubocop at Travis anyway), this will fix the CC errors in the pull requests