### PR TITLE
add test for reading of stripes

### DIFF
--- a/test/fake_device_factory_test.rb
+++ b/test/fake_device_factory_test.rb
@@ -112,6 +112,8 @@ describe Y2Storage::FakeDeviceFactory do
              '        lv_name: root',
              '        size: 16 GiB',
              '        file_system: ext4',
+             '        stripes: 2',
+             '        stripe_size: 8 GiB',
              '        mount_point: "/"',
              '    lvm_pvs:',
              '    - lvm_pv:',


### PR DESCRIPTION
it is demonstration of current failure.

Let me also a bit complain about logic in DiskSize[1], which expect that anything that is not DiskSize or String will have method round, which is not much helpful for debugging and also robust. It will be much nicer to simply raise ArgumentError with description what it actually get ( in this case it looks like `nil` ).

https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2storage/disk_size.rb#L98