### PR TITLE
Do not try to convert setter result in the wrapper

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jun  1 10:27:25 UTC 2017 - ancor@suse.com
+
+- Fixed a bug in LvmLv#stripe_size=
+
+-------------------------------------------------------------------
 Mon May 22 10:58:24 UTC 2017 - ancor@suse.com
 
 - Refactored the proposal code in preparation for the AutoYaST

--- a/src/lib/y2storage/disk_size.rb
+++ b/src/lib/y2storage/disk_size.rb
@@ -71,6 +71,7 @@ module Y2Storage
     # @!scope class
     #
     # Accepts +Numeric+, +Strings+, or {DiskSize} objects as initializers.
+    # @raise [ArgumentError] if anything else is used as initializer
     #
     # @see initialize
     # @see parse
@@ -91,13 +92,15 @@ module Y2Storage
 
     # @see new
     def initialize(size = 0)
-      @size = if size.is_a?(Y2Storage::DiskSize)
-        size.to_i
-      elsif size.is_a?(::String)
-        Y2Storage::DiskSize.parse(size).size
-      else
-        size.round
-      end
+      @size =
+        if size.is_a?(Y2Storage::DiskSize)
+          size.to_i
+        elsif size.is_a?(::String)
+          Y2Storage::DiskSize.parse(size).size
+        elsif size.respond_to?(:round)
+          size.round
+        end
+      raise(ArgumentError, "Cannot get the bytes count for #{size.inspect}") unless @size
     end
 
     #

--- a/src/lib/y2storage/lvm_lv.rb
+++ b/src/lib/y2storage/lvm_lv.rb
@@ -48,7 +48,7 @@ module Y2Storage
     #   Size of a stripe. DiskSize.zero if the LV is not striped.
     #   @return [DiskSize]
     storage_forward :stripe_size, as: "DiskSize"
-    storage_forward :stripe_size=, as: "DiskSize"
+    storage_forward :stripe_size=
 
     # @!method self.all(devicegraph)
     #   @param devicegraph [Devicegraph]

--- a/test/fake_device_factory_test.rb
+++ b/test/fake_device_factory_test.rb
@@ -112,6 +112,8 @@ describe Y2Storage::FakeDeviceFactory do
              '        lv_name: root',
              '        size: 16 GiB',
              '        file_system: ext4',
+             '        stripes: 2',
+             '        stripe_size: 8 GiB',
              '        mount_point: "/"',
              '    lvm_pvs:',
              '    - lvm_pv:',


### PR DESCRIPTION
Converting the result of the setter is not a good idea. Assignations should always return the left part of the expression, with no additional conversion.