### PR TITLE
Don't insist on installing filesystem support packages that are not available in any repo (bsc#1039830)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun  6 17:57:16 CEST 2017 - shundhammer@suse.de
+
+- Don't insist on installing filesystem support packages that
+  are not available in any repo (bsc#1039830)
+- 0.1.16
+
+-------------------------------------------------------------------
 Thu Jun  1 10:27:25 UTC 2017 - ancor@suse.com
 
 - Fixed a bug in LvmLv#stripe_size=

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        0.1.15
+Version:        0.1.16
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/package_handler.rb
+++ b/src/lib/y2storage/package_handler.rb
@@ -73,7 +73,22 @@ module Y2Storage
     #
     def add_feature_packages(devicegraph)
       used_features = UsedStorageFeatures.new(devicegraph)
-      add_packages(used_features.feature_packages)
+      packages = used_features.feature_packages
+      packages = packages.delete_if { |pkg| unavailable_optional_package?(pkg) }
+      add_packages(packages)
+    end
+
+    # Check if a package is an optional package that is unavailable.
+    # See also bsc#1039830
+    #
+    # @param package [String] package name
+    # @return [Boolean] true if package is optional and unavailable,
+    #                   false if not optional or if available.
+    def unavailable_optional_package?(package)
+      return false unless UsedStorageFeatures::OPTIONAL_PACKAGES.include?(package)
+      return false if Yast::Package.Available(package)
+      log.warn("WARNING: Skipping unavailable filesystem support package #{package}")
+      true
     end
 
     # Start a package dependency resolver run

--- a/src/lib/y2storage/used_storage_features.rb
+++ b/src/lib/y2storage/used_storage_features.rb
@@ -209,6 +209,16 @@ module Y2Storage
     def bitmask(feature)
       ::Storage.const_get(feature)
     end
+
+    # Check if a storage-related package is an optional one, i.e. installation
+    # can safely continue without it.
+    #
+    # @param package [String] package name
+    # @return [Boolean] true if this is an optional package, false otherwise
+    #
+    def self.optional_package?(package)
+      UsedStorageFeatures::OPTIONAL_PACKAGES.include?(package)
+    end
   end
 end
 

--- a/src/lib/y2storage/used_storage_features.rb
+++ b/src/lib/y2storage/used_storage_features.rb
@@ -100,6 +100,16 @@ module Y2Storage
         # partition to it is handled by yast-bootloader in the inst-sys.
         UF_EFIBOOT:       "efibootmgr"
       }
+    
+      # Storage-related packages that are nice to have, but not absolutely
+      # required.
+      #
+      # SLES-12 for example (unlike SLED-12) does not come with NTFS packages,
+      # so they cannot be installed. But there might already be an existing
+      # NTFS Windows partition on the disk; don't throw an error pop-up in that
+      # case, just log a warning (bsc#1039830).
+      #
+      OPTIONAL_PACKAGES = [ "ntfs-3g", "ntfsprogs" ]
     # configurable part ends here
     #======================================================================
 

--- a/src/lib/y2storage/used_storage_features.rb
+++ b/src/lib/y2storage/used_storage_features.rb
@@ -100,16 +100,16 @@ module Y2Storage
         # partition to it is handled by yast-bootloader in the inst-sys.
         UF_EFIBOOT:       "efibootmgr"
       }
-    
-      # Storage-related packages that are nice to have, but not absolutely
-      # required.
-      #
-      # SLES-12 for example (unlike SLED-12) does not come with NTFS packages,
-      # so they cannot be installed. But there might already be an existing
-      # NTFS Windows partition on the disk; don't throw an error pop-up in that
-      # case, just log a warning (bsc#1039830).
-      #
-      OPTIONAL_PACKAGES = [ "ntfs-3g", "ntfsprogs" ]
+
+    # Storage-related packages that are nice to have, but not absolutely
+    # required.
+    #
+    # SLES-12 for example (unlike SLED-12) does not come with NTFS packages,
+    # so they cannot be installed. But there might already be an existing
+    # NTFS Windows partition on the disk; don't throw an error pop-up in that
+    # case, just log a warning (bsc#1039830).
+    #
+    OPTIONAL_PACKAGES = ["ntfs-3g", "ntfsprogs"]
     # configurable part ends here
     #======================================================================
 

--- a/test/package_handler_test.rb
+++ b/test/package_handler_test.rb
@@ -118,12 +118,12 @@ describe Y2Storage::PackageHandler do
       allow(Yast::Package).to receive(:Available).with("ntfsprogs").and_return(false)
       expect(subject.pkg_list).to contain_exactly("e2fsprogs")
     end
-    
+
     it "still installs optional packages when available and needed" do
       allow(Yast::Package).to receive(:Available).with("ntfs-3g").and_return(true)
       allow(Yast::Package).to receive(:Available).with("ntfsprogs").and_return(true)
       expect(subject.pkg_list).to contain_exactly("e2fsprogs", "ntfs-3g", "ntfsprogs")
     end
   end
-  
+
 end


### PR DESCRIPTION
Port to Storage-NG:

https://trello.com/c/yqdIek3N/606-2-handle-optional-fs-packages-correctly

https://bugzilla.suse.com/show_bug.cgi?id=1039830
