### PR TITLE
Add test that all class wrapper properly specify downcast_to

### DIFF
--- a/test/storage_class_wrapper_test.rb
+++ b/test/storage_class_wrapper_test.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+# load whole namespace, to check all classes
+require "y2storage"
+
+describe Y2Storage::StorageClassWrapper do
+  describe "wrap_class" do
+    all_wrappers = ObjectSpace.each_object(Class).select { |c| c < described_class }
+    all_wrappers.each do |wrapper|
+      describe wrapper do
+        all_children = ObjectSpace.each_object(Class).select { |c| c < wrapper }
+        direct_children = all_children.select do |child|
+          ancestors_classes = child.ancestors[1..-1].select { |c| c.is_a?(Class) }
+          ancestors_classes.first == wrapper
+        end
+
+        downcast_values = direct_children.map { |c| c.to_s[/Y2Storage::(.*)/, 1] }
+
+        message = if direct_children.empty?
+          "does not specify any downcastable class as it does not have a direct child"
+        else
+          "specifies its direct children #{direct_children.inspect} as downcastable"
+        end
+
+        it message do
+          expect(wrapper.instance_variable_get(:@downcast_class_names)).to match_array(downcast_values),
+            "Y2Storage::#{wrapper} specifies #{wrapper.instance_variable_get(:@downcast_class_names)} " \
+            " but direct children are #{direct_children}."
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It cannot be obtained automatic, as ancestor should not know about its
children, but for test it is fine to load whole namespace and all its
objects.


how output will look like:

```
Y2Storage::StorageClassWrapper
  wrap_class
    Y2Storage::Filesystems::Base
      specifies its direct children [Y2Storage::Filesystems::BlkFilesystem, Y2Storage::Filesystems::Nfs] as downcastable
    Y2Storage::Mountable
      specifies its direct children [Y2Storage::Filesystems::Base, Y2Storage::BtrfsSubvolume] as downcastable
    Y2Storage::Filesystems::BlkFilesystem
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::BtrfsSubvolume
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::LvmLv
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::Filesystems::Nfs
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::Dasd
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::ResizeInfo
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::Region
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::CompoundAction
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::Devicegraph
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::LvmVg
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::LvmPv
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::Disk
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::Partitionable
      specifies its direct children [Y2Storage::Dasd, Y2Storage::Disk, Y2Storage::Md] as downcastable
    Y2Storage::Md
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::PartitionTables::PartitionSlot
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::PartitionTables::Dasd
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::PartitionTables::Gpt
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::PartitionTables::Msdos
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::PartitionTables::Base
      specifies its direct children [Y2Storage::PartitionTables::Dasd, Y2Storage::PartitionTables::Gpt, Y2Storage::PartitionTables::Msdos] as downcastable
    Y2Storage::Partition
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::BlkDevice
      specifies its direct children [Y2Storage::LvmLv, Y2Storage::Partitionable, Y2Storage::Partition, Y2Storage::Encryption] as downcastable
    Y2Storage::Device
      specifies its direct children [Y2Storage::Mountable, Y2Storage::LvmVg, Y2Storage::LvmPv, Y2Storage::PartitionTables::Base, Y2Storage::BlkDevice] as downcastable
    Y2Storage::Actiongraph
      does not specify any downcastable class as it does not have a direct child
    Y2Storage::Encryption
      does not specify any downcastable class as it does not have a direct child

Finished in 0.01156 seconds (files took 1.03 seconds to load)
26 examples, 0 failures
```

so as you can see it will catch problem with Md as it is now tested.