### PR TITLE
Show properly readable diff upon failure for proposal unit tests

### DIFF
--- a/src/lib/y2storage/devicegraph.rb
+++ b/src/lib/y2storage/devicegraph.rb
@@ -19,6 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "pp"
 require "y2storage/actiongraph"
 require "y2storage/blk_device"
 require "y2storage/disk"
@@ -209,7 +210,7 @@ module Y2Storage
     #
     # @return [String]
     def to_str
-      recursive_to_a(device_tree).to_s
+      PP.pp(recursive_to_a(device_tree),"")
     end
 
   private


### PR DESCRIPTION
No longer just showing two 3000+ character long strings for _expected_ and _actual_ for the proposal unit tests, but a proper diff that actually shows the problem:

``````
  77) Y2Storage::GuidedProposal#propose in a PC with an empty GPT partition table not using LVM but using encryption with a separate home proposes the expected layout
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected: "[[[\"disk\",\n   [[\"align_ofs\", \"0 B\"],\n    [\"block_size\", \"0.5 KiB\"],\n    [\"io_size\", \... \"16.5 KiB\"], [\"start\", \"52428783.5 KiB (50.00 GiB)\"]]]]]],\n    [\"size\", \"50 GiB\"]]]]]\n"
             got: "[[[\"disk\",\n   [[\"align_ofs\", \"0 B\"],\n    [\"block_size\", \"0.5 KiB\"],\n    [\"io_size\", \... \"16.5 KiB\"], [\"start\", \"52428783.5 KiB (50.00 GiB)\"]]]]]],\n    [\"size\", \"50 GiB\"]]]]]\n"
      
        (compared using ==)
      
        Diff:
        
        @@ -17,14 +17,14 @@
                  ["id", "linux"],
                  ["mount_point", "/"],
                  ["name", "/dev/sda1"],
        -         ["size", "22937 MiB (22.40 GiB)"],
        +         ["size", "23 GiB"],
                  ["start", "1 MiB"],
                  ["type", "primary"]]]],
               [["partition",
                 [["id", "bios_boot"],
                  ["name", "/dev/sda2"],
                  ["size", "1 MiB"],
        -         ["start", "22938 MiB (22.40 GiB)"],
        +         ["start", "23553 MiB (23.00 GiB)"],
                  ["type", "primary"]]]],
               [["partition",
                 [["encryption",
        @@ -35,8 +35,8 @@
                  ["id", "swap"],
                  ["mount_point", "swap"],
                  ["name", "/dev/sda3"],
        -         ["size", "2 GiB"],
        -         ["start", "22939 MiB (22.40 GiB)"],
        +         ["size", "0.5 GiB"],
        +         ["start", "23554 MiB (23.00 GiB)"],
                  ["type", "primary"]]]],
               [["partition",
                 [["encryption",
        @@ -47,8 +47,8 @@
                  ["id", "linux"],
                  ["mount_point", "/home"],
                  ["name", "/dev/sda4"],
        -         ["size", "26842095.5 KiB (25.60 GiB)"],
        -         ["start", "24987 MiB (24.40 GiB)"],
        +         ["size", "27785199.5 KiB (26.50 GiB)"],
        +         ["start", "24066 MiB (23.50 GiB)"],
                  ["type", "primary"]]]],
               [["free",
                 [["size", "16.5 KiB"], ["start", "52428783.5 KiB (50.00 GiB)"]]]]]],
        
      Shared Example Group: "proposed layout" called from ./support/proposal_examples.rb:89
      Shared Example Group: "Encrypted partition-based proposed layouts" called from ./support/proposal_examples.rb:103
      Shared Example Group: "all proposed layouts" called from ./proposal_scenarios_x86_test.rb:131
      # ./support/proposal_examples.rb:28:in `block (2 levels) in <top (required)>'
