### PR TITLE
Fall back to less swap (min 512 MB) if not enough disk space for 2 GB

### DIFF
--- a/src/lib/y2storage/proposal/planned_devices_generator.rb
+++ b/src/lib/y2storage/proposal/planned_devices_generator.rb
@@ -37,8 +37,9 @@ module Y2Storage
 
       attr_accessor :settings
 
-      DEFAULT_SWAP_SIZE = DiskSize.GiB(2)
       MIN_SWAP_SIZE = DiskSize.MiB(512)
+      MAX_SWAP_SIZE = DiskSize.GiB(2) # This is also DEFAULT_SWAP_SIZE
+      SWAP_WEIGHT = 100 # Importance of swap if low free disk space
 
       def initialize(settings, devicegraph)
         @settings = settings
@@ -99,40 +100,44 @@ module Y2Storage
 
       # Device to host the swap space according to the settings.
       def swap_device
-        swap_size = DEFAULT_SWAP_SIZE
+        min_size = max_size = MAX_SWAP_SIZE
         if settings.enlarge_swap_for_suspend
-          swap_size = [ram_size, swap_size].max
+          min_size = max_size = [ram_size, max_size].max
         elsif @target == :min
-          swap_size = MIN_SWAP_SIZE
+          min_size = MIN_SWAP_SIZE
+          # leave max_size alone so any leftover free space can be distributed
+          # to swap, too according to SWAP_WEIGHT
         end
         if settings.use_lvm
-          swap_lv(swap_size)
+          swap_lv(min_size, max_size)
         else
-          swap_partition(swap_size)
+          swap_partition(min_size, max_size)
         end
       end
 
-      def swap_lv(size)
+      def swap_lv(min_size, max_size)
         lv = Planned::LvmLv.new("swap", Filesystems::Type::SWAP)
         lv.logical_volume_name = "swap"
-        lv.min_size = size
-        lv.max_size = size
+        lv.min_size = min_size
+        lv.max_size = max_size
+        lv.weight = SWAP_WEIGHT
         lv
       end
 
-      def swap_partition(size)
+      def swap_partition(min_size, max_size)
         part = Planned::Partition.new("swap", Filesystems::Type::SWAP)
         part.encryption_password = settings.encryption_password
         # NOTE: Enforcing the re-use of an existing partition limits the options
         # to propose a valid distribution of the planned partitions. For swap we
         # already have mechanisms to reuse UUIDs and labels, so maybe is smarter
         # to never reuse partitions as-is.
-        reuse = reusable_swap(size)
+        reuse = reusable_swap(max_size)
         if reuse
           part.reuse = reuse.name
         else
-          part.min_size  = size
-          part.max_size  = size
+          part.min_size = min_size
+          part.max_size = max_size
+          part.weight = SWAP_WEIGHT
         end
         part
       end

--- a/src/lib/y2storage/proposal/planned_devices_generator.rb
+++ b/src/lib/y2storage/proposal/planned_devices_generator.rb
@@ -38,6 +38,7 @@ module Y2Storage
       attr_accessor :settings
 
       DEFAULT_SWAP_SIZE = DiskSize.GiB(2)
+      MIN_SWAP_SIZE = DiskSize.MiB(512)
 
       def initialize(settings, devicegraph)
         @settings = settings
@@ -101,6 +102,8 @@ module Y2Storage
         swap_size = DEFAULT_SWAP_SIZE
         if settings.enlarge_swap_for_suspend
           swap_size = [ram_size, swap_size].max
+        elsif @target == :min
+          swap_size = MIN_SWAP_SIZE
         end
         if settings.use_lvm
           swap_lv(swap_size)

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-lvm-sep-home.yml
@@ -1,0 +1,40 @@
+---
+- disk:
+    name: /dev/sda
+    size: 25 GiB
+    partition_table: gpt
+    partitions:
+
+    - partition:
+        size: 1 MiB
+        name: /dev/sda1
+        id:   bios_boot
+
+    - partition:
+        size: 26212335.5 KiB
+        name: /dev/sda2
+        id:   lvm
+
+- lvm_vg:
+    vg_name: system
+
+    lvm_pvs:
+    - lvm_pv:
+        blk_device: "/dev/sda2"
+
+    lvm_lvs:
+    - lvm_lv:
+        lv_name:      home
+        size:         11004 MiB
+        file_system:  xfs
+        mount_point:  "/home"
+    - lvm_lv:
+        lv_name:      root
+        size:         12.5 GiB
+        file_system:  btrfs
+        mount_point:  "/"
+    - lvm_lv:
+        lv_name:      swap
+        size:         1792 MiB
+        file_system:  swap
+        mount_point:  swap

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-lvm.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-lvm.yml
@@ -1,0 +1,35 @@
+---
+- disk:
+    name: /dev/sda
+    size: 25 GiB
+    partition_table: gpt
+    partitions:
+
+    - partition:
+        size: 1 MiB
+        name: /dev/sda1
+        id:   bios_boot
+
+    - partition:
+        size: 26212335.5 KiB
+        name: /dev/sda2
+        id:   lvm
+
+- lvm_vg:
+    vg_name: system
+
+    lvm_pvs:
+    - lvm_pv:
+        blk_device: "/dev/sda2"
+
+    lvm_lvs:
+    - lvm_lv:
+        lv_name:      root
+        size:         23548 MiB
+        file_system:  btrfs
+        mount_point:  "/"
+    - lvm_lv:
+        lv_name:      swap
+        size:         2 GiB
+        file_system:  swap
+        mount_point:  swap

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-sep-home.yml
@@ -1,0 +1,27 @@
+---
+- disk:
+    name: /dev/sda
+    size: 25 GiB
+    partition_table: gpt
+    partitions:
+
+    - partition:
+        size:         12.5 GiB
+        name:         /dev/sda1
+        file_system:  btrfs
+        mount_point:  "/"
+    - partition:
+        size:         1 MiB
+        name:         /dev/sda2
+        id:           bios_boot
+    - partition:
+        size:         1791 MiB 
+        name:         /dev/sda3
+        id:           swap
+        file_system:  swap
+        mount_point:  swap
+    - partition:
+        size:         11271151.5 KiB
+        name:         /dev/sda4
+        file_system:  xfs
+        mount_point:  "/home"

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB.yml
@@ -1,0 +1,22 @@
+---
+- disk:
+    name: /dev/sda
+    size: 25 GiB
+    partition_table: gpt
+    partitions:
+
+    - partition:
+        size:         23549 MiB
+        name:         /dev/sda1
+        file_system:  btrfs
+        mount_point:  "/"
+    - partition:
+        size:         1 MiB
+        name:         /dev/sda2
+        id:           bios_boot
+    - partition:
+        size:         2098159.5 KiB
+        name:         /dev/sda3
+        id:           swap
+        file_system:  swap
+        mount_point:  swap

--- a/test/proposal_low_space_test.rb
+++ b/test/proposal_low_space_test.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "storage"
+require "y2storage"
+require_relative "support/proposal_examples"
+require_relative "support/proposal_context"
+
+describe Y2Storage::GuidedProposal do
+  describe "#propose" do
+    include_context "proposal"
+
+    subject(:proposal) { described_class.new(settings: settings) }
+    let(:architecture) { :x86 }
+
+    context "in a PC with a small (25GiB) disk" do
+      let(:scenario) { "empty_hard_disk_gpt_25GiB" }
+      let(:expected_scenario) { "empty_hard_disk_gpt_25GiB" }
+      include_examples "partition-based proposed layouts"
+      include_examples "LVM-based proposed layouts"
+    end
+  end
+end


### PR DESCRIPTION
If there is not enough disk space to satisfy all desired partition / volume sizes, now falling back to a minimum of 512 MB for swap, but keeping the maximum (by default - unless "enlarge for swap" is set) of 2 GB. It now uses a weight to get some disk space beyond the minimum: Any disk space above the cumulated minimum sizes of all planned partitions / volumes is distributed among those that have a weight set.

Right now, swap gets a weight of 100, i.e. it gets as much extra disk space as root and home together. The value is hard-coded right now. We might make it configurable some day, but right now this would just add to the complexity.

In practice all this means that while swap no longer gets its full 2 GB if disk space is low, it at least typically gets more than the minimum 512 MB; in the unit test added in this PR it usually gets ~1.7 GB which seems to be a reasonable compromise.