### PR TITLE
Fall back to 3 GB /home if low disk space

### DIFF
--- a/src/lib/y2storage/proposal/devices_planner.rb
+++ b/src/lib/y2storage/proposal/devices_planner.rb
@@ -205,7 +205,12 @@ module Y2Storage
           home_vol.encryption_password = settings.encryption_password
         end
         home_vol.max_size = settings.home_max_size
-        home_vol.min_size = settings.home_min_size
+        home_vol.min_size =
+          if @target == :min
+            settings.root_base_size
+          else
+            settings.home_min_size
+          end
         home_vol.weight = 100.0 - settings.root_space_percent
         home_vol
       end

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -209,6 +209,10 @@ module Y2Storage
       @subvolumes                    = SubvolSpecification.fallback_list
 
       # Not yet in control.xml
+      #
+      # @home_min_size is only used when calculating the :desired size for
+      # the proposal. If space is tight (i.e. using :min), @root_base_size is
+      # used instead. See also DevicesPlanner::home_device.
       @home_min_size            = DiskSize.GiB(10)
       @home_max_size            = DiskSize.unlimited
     end

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-lvm-sep-home.yml
@@ -25,16 +25,16 @@
     lvm_lvs:
     - lvm_lv:
         lv_name:      home
-        size:         11004 MiB
+        size:         7984 MiB (7.80 GiB)
         file_system:  xfs
         mount_point:  "/home"
     - lvm_lv:
         lv_name:      root
-        size:         12.5 GiB
+        size:         15565 MiB (15.20 GiB)
         file_system:  btrfs
         mount_point:  "/"
     - lvm_lv:
         lv_name:      swap
-        size:         1792 MiB
+        size:         2 GiB
         file_system:  swap
         mount_point:  swap

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size:         12.5 GiB
+        size:         15565 MiB (15.20 GiB)
         name:         /dev/sda1
         file_system:  btrfs
         mount_point:  "/"
@@ -15,13 +15,13 @@
         name:         /dev/sda2
         id:           bios_boot
     - partition:
-        size:         1791 MiB 
+        size:         2 GiB
         name:         /dev/sda3
         id:           swap
         file_system:  swap
         mount_point:  swap
     - partition:
-        size:         11271151.5 KiB
+        size:         8176623.5 KiB (7.80 GiB)
         name:         /dev/sda4
         file_system:  xfs
         mount_point:  "/home"

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc-lvm-sep-home.yml
@@ -33,12 +33,12 @@
     lvm_lvs:
     - lvm_lv:
         lv_name:      home
-        size:         26208 MiB
+        size:         23340 MiB (22.79 GiB)
         file_system:  xfs
         mount_point:  "/home"
     - lvm_lv:
         lv_name:      root
-        size:         22936 MiB
+        size:         25804 MiB
         file_system:  btrfs
         mount_point:  "/"
     - lvm_lv:

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size:         22937 MiB
+        size:         25805 MiB (25.20 GiB)
         name:         /dev/sda1
         file_system:  btrfs
         mount_point:  "/"
@@ -29,7 +29,7 @@
           name: "/dev/mapper/cr_sda3"
           password: '12345678'
     - partition:
-        size:         26842095.5 KiB
+        size:         23905263.5 KiB (22.80 GiB)
         name:         /dev/sda4
         file_system:  xfs
         mount_point:  "/home"

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-lvm-sep-home.yml
@@ -29,12 +29,12 @@
     lvm_lvs:
     - lvm_lv:
         lv_name:      home
-        size:         26212 MiB
+        size:         23344 MiB
         file_system:  xfs
         mount_point:  "/home"
     - lvm_lv:
         lv_name:      root
-        size:         22936 MiB
+        size:         25804 MiB
         file_system:  btrfs
         mount_point:  "/"
     - lvm_lv:

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size:         22937 MiB
+        size:         25805 MiB (25.20 GiB)
         name:         /dev/sda1
         file_system:  btrfs
         mount_point:  "/"
@@ -22,7 +22,7 @@
         mount_point:  swap
     - partition:
         # The final 16.5 KiB are reserved by GPT
-        size:         26842095.5 KiB
+        size:         23905263.5 KiB (22.80 GiB)
         name:         /dev/sda4
         file_system:  xfs
         mount_point:  "/home"

--- a/test/data/devicegraphs/output/empty_hard_disk_mbr_50GiB-enc-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_mbr_50GiB-enc-lvm-sep-home.yml
@@ -24,12 +24,12 @@
     lvm_lvs:
     - lvm_lv:
         lv_name:      home
-        size:         26212 MiB
+        size:         23344 MiB
         file_system:  xfs
         mount_point:  "/home"
     - lvm_lv:
         lv_name:      root
-        size:         22936 MiB
+        size:         25804 MiB
         file_system:  btrfs
         mount_point:  "/"
     - lvm_lv:

--- a/test/data/devicegraphs/output/empty_hard_disk_mbr_50GiB-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_mbr_50GiB-enc-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size:         22938 MiB
+        size:         25805 MiB (25.20 GiB)
         name:         /dev/sda1
         file_system:  btrfs
         mount_point:  "/"
@@ -25,7 +25,7 @@
           name: "/dev/mapper/cr_sda2"
           password: '12345678'
     - partition:
-        size:         26213 MiB
+        size:         23346 MiB (22.80 GiB)
         name:         /dev/sda3
         file_system:  xfs
         mount_point:  "/home"

--- a/test/data/devicegraphs/output/empty_hard_disk_mbr_50GiB-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_mbr_50GiB-lvm-sep-home.yml
@@ -20,12 +20,12 @@
     lvm_lvs:
     - lvm_lv:
         lv_name:      home
-        size:         26212 MiB
+        size:         23344 MiB
         file_system:  xfs
         mount_point:  "/home"
     - lvm_lv:
         lv_name:      root
-        size:         22936 MiB
+        size:         25804 MiB
         file_system:  btrfs
         mount_point:  "/"
     - lvm_lv:

--- a/test/data/devicegraphs/output/empty_hard_disk_mbr_50GiB-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_mbr_50GiB-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size:         22938 MiB
+        size:         25805 MiB (25.20 GiB)
         name:         /dev/sda1
         file_system:  btrfs
         mount_point:  "/"
@@ -17,7 +17,7 @@
         file_system:  swap
         mount_point:  swap
     - partition:
-        size:         26213 MiB
+        size:         23346 MiB (22.80 GiB)
         name:         /dev/sda3
         file_system:  xfs
         mount_point:  "/home"

--- a/test/data/devicegraphs/output/s390_dasd_zipl-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl-lvm-sep-home.yml
@@ -19,12 +19,12 @@
     lvm_lvs:
     - lvm_lv:
         lv_name: home
-        size: 26148 MiB (25.54 GiB)
+        size: 23280 MiB (22.73 GiB)
         file_system: xfs
         mount_point: "/home"
     - lvm_lv:
         lv_name: root
-        size: 22896 MiB (22.36 GiB)
+        size: 25764 MiB (25.16 GiB) 
         file_system: btrfs
         mount_point: "/"
     - lvm_lv:


### PR DESCRIPTION
https://trello.com/c/B2Qv7y6d/639-5-storageng-proposal-adapt-to-the-situation

Now using `root_base_size` if disk space is low, i.e. when using `:min` instead of `:desired` to calculate a proposal. Continuing using `settings.home_min_size` for `:desired` which hopefully some day will be read from `control.xml` (but right now is initialized with a hard-code value of 10 GiB).