### PR TITLE
Add DASD type and format to YAML reader and writer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 script:
   # the "storage-ng-travis-ruby" script is included in the base yastdevel/storage-ng image
   # see https://github.com/yast/docker-storage-ng/blob/master/storage-ng-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-storage-ng-image storage-ng-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-storage-ng-image storage-ng-travis-ruby rpm -qa | sort

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ services:
 
 before_install:
   - docker build -t yast-storage-ng-image .
+    # list the installed packages (just for easier debugging)
+  - docker run --rm -it yast-storage-ng-image rpm -qa | sort
+
 script:
   # the "storage-ng-travis-ruby" script is included in the base yastdevel/storage-ng image
   # see https://github.com/yast/docker-storage-ng/blob/master/storage-ng-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-storage-ng-image storage-ng-travis-ruby rpm -qa | sort
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-storage-ng-image storage-ng-travis-ruby

--- a/doc/fake-devicegraphs-yaml-format.md
+++ b/doc/fake-devicegraphs-yaml-format.md
@@ -88,6 +88,12 @@ or
 	lvm_pvs:
 	- lvm_pv:
 
+or
+
+    - dasd
+
+Very much like "disk" with some additional parameters.
+
 
 ### For Future Use
 
@@ -140,6 +146,22 @@ Example:
 - mount_point: mount point for a filesystem directly on the disk.
   Notice that partition_table and mount_point (filesystem) are mutually
   exclusive; a disk can only have either of them, never both.
+
+
+### dasd
+
+"dasd" is very similar to "disk", but S/390 specific. In addition to the
+parameters that "disk" offers, it can also have:
+
+- type: Type of the DASD to create.
+  Permitted values (case-insensitive):
+  - eckd
+  - fba
+
+- format: Format of the DASD to create.
+  Permitted values (case-insensitive):
+  - ldl
+  - cdl
 
 
 ### partition

--- a/src/lib/storage/patches.rb
+++ b/src/lib/storage/patches.rb
@@ -40,12 +40,12 @@ module Storage
 
     # FIXME: The libstorage API for DASD is still not defined, let's assume it
     # will look like this (for mocking purposes)
-    def dasd_type
+    def type
       ::Storage::DasdType_UNKNOWN
     end
 
     # FIXME: see above
-    def dasd_format
+    def format
       ::Storage::DasdFormat_NONE
     end
   end

--- a/src/lib/y2storage/boot_requirements_strategies/zipl.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/zipl.rb
@@ -37,8 +37,8 @@ module Y2Storage
       def supported_boot_disk?
         return false unless boot_disk
         if boot_disk.is?(:dasd)
-          return false if boot_disk.dasd_type.is?(:fba)
-          return false if boot_disk.dasd_format.is?(:ldl)
+          return false if boot_disk.type.is?(:fba)
+          return false if boot_disk.format.is?(:ldl)
           # TODO: DIAG disks (whatever they are) are not supported either
         end
         true

--- a/src/lib/y2storage/dasd.rb
+++ b/src/lib/y2storage/dasd.rb
@@ -33,15 +33,15 @@ module Y2Storage
     #   @return [Boolean] whether this is a rotational device
     storage_forward :rotational?
 
-    # @!method dasd_type
+    # @!method type
     #   @return [DasdType]
-    storage_forward :dasd_type, as: "DasdType"
-    storage_forward :dasd_type=
+    storage_forward :type, as: "DasdType"
+    storage_forward :type=
 
-    # @!method dasd_format
+    # @!method format
     #   @return [DasdFormat]
-    storage_forward :dasd_format, as: "DasdFormat"
-    storage_forward :dasd_format=
+    storage_forward :format, as: "DasdFormat"
+    storage_forward :format=
 
     # @!method self.create(devicegraph, name, region_or_size = nil)
     #   @param devicegraph [Devicegraph]

--- a/src/lib/y2storage/dasd.rb
+++ b/src/lib/y2storage/dasd.rb
@@ -36,10 +36,12 @@ module Y2Storage
     # @!method dasd_type
     #   @return [DasdType]
     storage_forward :dasd_type, as: "DasdType"
+    storage_forward :dasd_type=
 
     # @!method dasd_format
     #   @return [DasdFormat]
     storage_forward :dasd_format, as: "DasdFormat"
+    storage_forward :dasd_format=
 
     # @!method self.create(devicegraph, name, region_or_size = nil)
     #   @param devicegraph [Devicegraph]

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -63,7 +63,7 @@ module Y2Storage
     VALID_PARAM =
       {
         "dasd"            => [
-          "name", "size", "block_size", "io_size", "min_grain", "align_ofs"
+          "name", "size", "block_size", "io_size", "min_grain", "align_ofs", "type", "format"
         ].concat(FILE_SYSTEM_PARAM),
         "disk"            => [
           "name", "size", "block_size", "io_size", "min_grain", "align_ofs", "mbr_gap"
@@ -204,10 +204,20 @@ module Y2Storage
     #   "io_size"    optimal io size
     #   "min_grain"  minimal grain
     #   "align_ofs"  alignment offset
+    #   "type"       DASD type ("eckd", "fba")
+    #   "format"     DASD format ("ldl", "cdl")
     #
     # @return [String] device name of the new DASD disk ("/dev/sda" etc.)
     def create_dasd(_parent, args)
-      new_partitionable(Dasd, args)
+      name   = args["name"] || "/dev/dasda"
+      type   = args["type"] || "unknown"
+      format = args["format"] || "none"
+      type   = fetch(DasdType, type, "dasd type", name)
+      format = fetch(DasdFormat, format, "dasd format", name)
+      dasd = new_partitionable(Dasd, args)
+      dasd.dasd_type = type unless type.is?(:unknown)
+      dasd.dasd_format = format unless format.is?(:none)
+      dasd
     end
 
     # Factory method to create a disk.

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -85,6 +85,7 @@ module Y2Storage
     # @return [Hash]
     def yaml_disk_device(device)
       content = basic_disk_device_attributes(device)
+      content.merge!(dasd_additional_attributes(device)) if device.is?(:dasd)
       if device.partition_table
         ptable = device.partition_table
         content["partition_table"] = ptable.type.to_s
@@ -114,6 +115,17 @@ module Y2Storage
         "min_grain"  => device.min_grain.to_s,
         "align_ofs"  => DiskSize.B(device.topology.alignment_offset).to_s
       }
+    end
+
+    # Additional attributes for a DASD device
+    #
+    # @param  device [Dasd]
+    # @return [Hash{String => Object}]
+    def dasd_additional_attributes(device)
+      content = {}
+      content["type"] = device.dasd_type.to_s unless device.dasd_type.is?(:unknown)
+      content["format"] = device.dasd_format.to_s unless device.dasd_format.is?(:none)
+      content
     end
 
     # Returns a YAML representation of the partitions and free slots in a

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -123,8 +123,8 @@ module Y2Storage
     # @return [Hash{String => Object}]
     def dasd_additional_attributes(device)
       content = {}
-      content["type"] = device.dasd_type.to_s unless device.dasd_type.is?(:unknown)
-      content["format"] = device.dasd_format.to_s unless device.dasd_format.is?(:none)
+      content["type"] = device.type.to_s unless device.type.is?(:unknown)
+      content["format"] = device.format.to_s unless device.format.is?(:none)
       content
     end
 

--- a/test/boot_requirements_checker_s390_test.rb
+++ b/test/boot_requirements_checker_s390_test.rb
@@ -36,14 +36,14 @@ describe Y2Storage::BootRequirementsChecker do
 
     before do
       allow(dev_sda).to receive(:is?).with(:dasd).and_return(dasd)
-      allow(dev_sda).to receive(:dasd_type).and_return(dasd_type)
-      allow(dev_sda).to receive(:dasd_format).and_return(dasd_format)
+      allow(dev_sda).to receive(:type).and_return(type)
+      allow(dev_sda).to receive(:format).and_return(format)
     end
 
     context "trying to install in a zfcp disk" do
       let(:dasd) { false }
-      let(:dasd_type) { Y2Storage::DasdType::UNKNOWN }
-      let(:dasd_format) { Y2Storage::DasdFormat::NONE }
+      let(:type) { Y2Storage::DasdType::UNKNOWN }
+      let(:format) { Y2Storage::DasdFormat::NONE }
 
       context "with a partitions-based proposal" do
         let(:use_lvm) { false }
@@ -79,9 +79,9 @@ describe Y2Storage::BootRequirementsChecker do
 
     context "trying to install in a FBA DASD disk" do
       let(:dasd) { true }
-      let(:dasd_type) { Y2Storage::DasdType::FBA }
+      let(:type) { Y2Storage::DasdType::FBA }
       # Format and LVM are irrelevant
-      let(:dasd_format) { Y2Storage::DasdFormat::NONE }
+      let(:format) { Y2Storage::DasdFormat::NONE }
       let(:use_lvm) { false }
 
       it "raises an error" do
@@ -92,10 +92,10 @@ describe Y2Storage::BootRequirementsChecker do
 
     context "trying to install in a (E)CKD DASD disk" do
       let(:dasd) { true }
-      let(:dasd_type) { Y2Storage::DasdType::ECKD }
+      let(:type) { Y2Storage::DasdType::ECKD }
 
       context "if the disk is formatted as LDL" do
-        let(:dasd_format) { Y2Storage::DasdFormat::LDL }
+        let(:format) { Y2Storage::DasdFormat::LDL }
         # LVM is irrelevant
         let(:use_lvm) { false }
 
@@ -106,7 +106,7 @@ describe Y2Storage::BootRequirementsChecker do
       end
 
       context "if the disk is formatted as CDL" do
-        let(:dasd_format) { Y2Storage::DasdFormat::CDL }
+        let(:format) { Y2Storage::DasdFormat::CDL }
 
         context "with a partitions-based proposal" do
           let(:use_lvm) { false }
@@ -145,8 +145,8 @@ describe Y2Storage::BootRequirementsChecker do
       let(:zipl_part) { find_vol("/boot/zipl", checker.needed_partitions(target)) }
       # Default values to ensure the partition is proposed
       let(:dasd) { false }
-      let(:dasd_type) { Y2Storage::DasdType::UNKNOWN }
-      let(:dasd_format) { Y2Storage::DasdFormat::NONE }
+      let(:type) { Y2Storage::DasdType::UNKNOWN }
+      let(:format) { Y2Storage::DasdFormat::NONE }
       let(:use_lvm) { false }
 
       include_examples "proposed /boot/zipl partition"

--- a/test/boot_requirements_duplicate_test.rb
+++ b/test/boot_requirements_duplicate_test.rb
@@ -184,14 +184,14 @@ describe Y2Storage::BootRequirementsChecker do
       # Default values to ensure the partition is needed
       let(:architecture) { :s390 }
       let(:dasd) { false }
-      let(:dasd_type) { Y2Storage::DasdType::UNKNOWN }
-      let(:dasd_format) { Y2Storage::DasdFormat::NONE }
+      let(:type) { Y2Storage::DasdType::UNKNOWN }
+      let(:format) { Y2Storage::DasdFormat::NONE }
       let(:use_lvm) { false }
 
       before do
         allow(dev_sda).to receive(:is?).with(:dasd).and_return(dasd)
-        allow(dev_sda).to receive(:dasd_type).and_return(dasd_type)
-        allow(dev_sda).to receive(:dasd_format).and_return(dasd_format)
+        allow(dev_sda).to receive(:type).and_return(type)
+        allow(dev_sda).to receive(:format).and_return(format)
         allow(analyzer).to receive(:free_mountpoint?).with("/boot/zipl")
           .and_return missing_zipl
       end

--- a/test/proposal_scenarios_s390_test.rb
+++ b/test/proposal_scenarios_s390_test.rb
@@ -32,12 +32,12 @@ describe Y2Storage::GuidedProposal do
 
   describe "#propose" do
     before do
-      allow_any_instance_of(Y2Storage::Dasd).to receive(:dasd_type).and_return(dasd_type)
-      allow_any_instance_of(Y2Storage::Dasd).to receive(:dasd_format).and_return(dasd_format)
+      allow_any_instance_of(Y2Storage::Dasd).to receive(:type).and_return(type)
+      allow_any_instance_of(Y2Storage::Dasd).to receive(:format).and_return(format)
     end
 
-    let(:dasd_type) { Y2Storage::DasdType::UNKNOWN }
-    let(:dasd_format) { Y2Storage::DasdFormat::NONE }
+    let(:type) { Y2Storage::DasdType::UNKNOWN }
+    let(:format) { Y2Storage::DasdFormat::NONE }
 
     context "with a zfcp disk" do
       let(:scenario) { "empty_hard_disk_50GiB" }
@@ -48,7 +48,7 @@ describe Y2Storage::GuidedProposal do
 
     context "with a FBA DASD disk" do
       let(:scenario) { "empty_dasd_50GiB" }
-      let(:dasd_type) { Y2Storage::DasdType::FBA }
+      let(:type) { Y2Storage::DasdType::FBA }
 
       it "fails to make a proposal" do
         expect { proposal.propose }.to raise_error Y2Storage::Error
@@ -59,10 +59,10 @@ describe Y2Storage::GuidedProposal do
       let(:scenario) { "empty_dasd_50GiB" }
       let(:expected_scenario) { "s390_dasd_zipl" }
 
-      let(:dasd_type) { Y2Storage::DasdType::ECKD }
+      let(:type) { Y2Storage::DasdType::ECKD }
 
       context "formated as LDL" do
-        let(:dasd_format) { Y2Storage::DasdFormat::LDL }
+        let(:format) { Y2Storage::DasdFormat::LDL }
 
         it "fails to make a proposal" do
           expect { proposal.propose }.to raise_error Y2Storage::Error
@@ -70,7 +70,7 @@ describe Y2Storage::GuidedProposal do
       end
 
       context "formated as CDL" do
-        let(:dasd_format) { Y2Storage::DasdFormat::CDL }
+        let(:format) { Y2Storage::DasdFormat::CDL }
 
         context "not using LVM" do
           let(:lvm) { false }

--- a/test/yaml_writer_test.rb
+++ b/test/yaml_writer_test.rb
@@ -33,6 +33,8 @@ describe Y2Storage::YamlWriter do
 
     sda = Y2Storage::Dasd.create(staging, "/dev/sda")
     sda.size = 256 * Storage.GiB
+    sda.dasd_type = Y2Storage::DasdType::ECKD
+    sda.dasd_format = Y2Storage::DasdFormat::LDL
 
     sda.create_partition_table(Y2Storage::PartitionTables::Type::DASD)
 
@@ -46,6 +48,8 @@ describe Y2Storage::YamlWriter do
               '    io_size: 0 B',
               '    min_grain: 1 MiB',
               '    align_ofs: 0 B',
+              '    type: eckd',
+              '    format: ldl',
               '    partition_table: dasd',
               '    partitions:',
               '    - free:',

--- a/test/yaml_writer_test.rb
+++ b/test/yaml_writer_test.rb
@@ -33,8 +33,8 @@ describe Y2Storage::YamlWriter do
 
     sda = Y2Storage::Dasd.create(staging, "/dev/sda")
     sda.size = 256 * Storage.GiB
-    sda.dasd_type = Y2Storage::DasdType::ECKD
-    sda.dasd_format = Y2Storage::DasdFormat::LDL
+    sda.type = Y2Storage::DasdType::ECKD
+    sda.format = Y2Storage::DasdFormat::LDL
 
     sda.create_partition_table(Y2Storage::PartitionTables::Type::DASD)
 


### PR DESCRIPTION
- Add support for DASD type and DASD format to the YAML reader and writer
  https://trello.com/c/m7N8jeE6/506-2-storageng-make-proposal-work-with-dasd

- Adapt Y2Storage API to renamed (in libstorage-ng) method/attribute names _dasd_type_ -> _type_, _dasd_format_ -> _format_

- DASD type and format are now writable (both in libstorage-ng and in the Y2Storage API)