### PR TITLE
Legacy boot flag in proposal

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 11 06:21:36 UTC 2017 - ancor@suse.com
+
+- In the partitioning proposal, manage the legacy_boot flag in GPT
+  partition tables in the same way than the boot flag in MBR ones.
+
+-------------------------------------------------------------------
 Thu Jul  6 08:11:59 UTC 2017 - gsouza@suse.com
 
 - Added verifications for disk in network.

--- a/src/lib/y2storage/proposal/partition_creator.rb
+++ b/src/lib/y2storage/proposal/partition_creator.rb
@@ -158,7 +158,7 @@ module Y2Storage
         region = new_region_with_size(free_space.region, planned_partition.size)
         partition = ptable.create_partition(dev_name, region, partition_type)
         partition.id = partition_id(ptable, planned_partition)
-        partition.boot = !!planned_partition.bootable if ptable.partition_boot_flag_supported?
+        set_boot_flag(partition, planned_partition)
         partition
       end
 
@@ -250,6 +250,22 @@ module Y2Storage
         end
 
         ptable.partition_id_for(partition_id)
+      end
+
+      # Sets the boot or legacy_boot flag of the partition according to the type
+      # of partition and the value of PlannedPartition#bootable
+      #
+      # @param partition [Partition]
+      # @param planned_partition [Planned::Partition]
+      def set_boot_flag(partition, planned_partition)
+        ptable = partition.partition_table
+        value = !!planned_partition.bootable
+
+        if ptable.partition_boot_flag_supported?
+          partition.boot = value
+        elsif ptable.partition_legacy_boot_flag_supported?
+          partition.legacy_boot = value
+        end
       end
     end
   end

--- a/test/proposal/partition_creator_test.rb
+++ b/test/proposal/partition_creator_test.rb
@@ -392,7 +392,7 @@ describe Y2Storage::Proposal::PartitionCreator do
           it "does not set the legacy boot flag" do
             result = creator.create_partitions(distribution)
             partition = result.devicegraph.partitions.first
-            expect(partition.legacy_boot?).to eq false
+            expect(partition.legacy_boot?).to eq true
           end
         end
 


### PR DESCRIPTION
Depends on the discussion at https://trello.com/c/RAPZuM0j/640-3-storageng-bootloader-bootloader-does-not-detect-prep-boot-partition

If we conclude that the legacy boot must be set for PReP, this PR should do it. Otherwise, this can be closed right away.