### PR TITLE
Remove rubocop SymbolProc exception

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,15 +16,6 @@ SingleLineBlockParams:
 Metrics/LineLength:
   Max: 105
 
-# This two are not equivalent if using refinements (and we use them to add
-# functionality to the classes coming from libstorage)
-#   using RefinementAddingFooToThing
-#   things.map { |s| s.foo } # it works
-#   things.map(&:foo) # it does not work
-# See https://github.com/bbatsov/rubocop/issues/2720
-Style/SymbolProc:
-  Enabled: false
-
 # Enforce if/unless at the end only for really short lines
 Style/IfUnlessModifier:
   MaxLineLength: 60

--- a/src/lib/y2storage/disk_analyzer.rb
+++ b/src/lib/y2storage/disk_analyzer.rb
@@ -78,7 +78,7 @@ module Y2Storage
     # @param disks [Disk, String] disks to analyze. All disks by default.
     # @return [Array<Partition>]
     def linux_partitions(*disks)
-      data_for(*disks, :linux_partitions) { |d| d.linux_system_partitions }
+      data_for(*disks, :linux_partitions, &:linux_system_partitions)
     end
 
     # Release names of installed systems for every disk.
@@ -223,7 +223,7 @@ module Y2Storage
     def find_candidate_disks
       @installation_disks = find_installation_disks
 
-      usb_disks, non_usb_disks = devicegraph.disk_devices.partition { |d| d.usb? }
+      usb_disks, non_usb_disks = devicegraph.disk_devices.partition(&:usb?)
 
       # Try with non-USB disks first.
       disks = remove_installation_disks(non_usb_disks)
@@ -255,7 +255,7 @@ module Y2Storage
     #
     # @return [Array<Disk>]
     def find_installation_disks
-      usb_disks, non_usb_disks = devicegraph.disk_devices.partition { |d| d.usb? }
+      usb_disks, non_usb_disks = devicegraph.disk_devices.partition(&:usb?)
       disks = usb_disks + non_usb_disks
       disks = disks.first(DEFAULT_CHECK_LIMIT)
       disks.select { |d| installation_disk?(d) }

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -673,7 +673,7 @@ module Y2Storage
     # @return [Object] default subvolume or nil if there is none
     #
     def find_default_subvolume(btrfs)
-      btrfs.btrfs_subvolumes.find { |s| s.default_btrfs_subvolume? }
+      btrfs.btrfs_subvolumes.find(&:default_btrfs_subvolume?)
     end
 
     # Factory method for a btrfs subvolume

--- a/src/lib/y2storage/planned/partitions_distribution.rb
+++ b/src/lib/y2storage/planned/partitions_distribution.rb
@@ -137,7 +137,7 @@ module Y2Storage
       end
 
       def to_s
-        spaces_str = spaces.map { |s| s.to_s }.join(", ")
+        spaces_str = spaces.map(&:to_s).join(", ")
         "#<PartitionsDistribution spaces=[#{spaces_str}]>"
       end
 
@@ -318,7 +318,7 @@ module Y2Storage
 
       # @see #comparable_string
       def partitions_comparable_string(partitions)
-        partitions_strings = partitions.map { |part| part.to_s }.sort
+        partitions_strings = partitions.map(&:to_s).sort
         "<partitions=#{partitions_strings.join}>"
       end
 

--- a/src/lib/y2storage/proposal/lvm_creator.rb
+++ b/src/lib/y2storage/proposal/lvm_creator.rb
@@ -207,9 +207,9 @@ module Y2Storage
         lvs = volume_group.lvm_lvs
         big_lvs = lvs.select { |lv| lv.size >= target_space }
         if big_lvs.empty?
-          lvs.max_by { |lv| lv.size }
+          lvs.max_by(&:size)
         else
-          big_lvs.min_by { |lv| lv.size }
+          big_lvs.min_by(&:size)
         end
       end
 

--- a/test/y2storage/proposal/lvm_creator_test.rb
+++ b/test/y2storage/proposal/lvm_creator_test.rb
@@ -139,7 +139,7 @@ describe Y2Storage::Proposal::LvmCreator do
       it "does not delete existing LVs if there is enough free space" do
         devicegraph = creator.create_volumes(vg, pv_partitions).devicegraph
         reused_vg = devicegraph.lvm_vgs.first
-        lv_names = reused_vg.lvm_lvs.map { |lv| lv.lv_name }
+        lv_names = reused_vg.lvm_lvs.map(&:lv_name)
         expect(lv_names).to include("lv1", "lv2")
       end
 
@@ -173,7 +173,7 @@ describe Y2Storage::Proposal::LvmCreator do
           it "deletes all existing LVs" do
             devicegraph = creator.create_volumes(vg, pv_partitions).devicegraph
             reused_vg = devicegraph.lvm_vgs.first
-            lv_names = reused_vg.lvm_lvs.map { |lv| lv.lv_name }
+            lv_names = reused_vg.lvm_lvs.map(&:lv_name)
             expect(lv_names).to eq(["one", "two"])
           end
         end
@@ -187,7 +187,7 @@ describe Y2Storage::Proposal::LvmCreator do
           it "deletes all existing LVs but the reusable one" do
             devicegraph = creator.create_volumes(vg, pv_partitions).devicegraph
             reused_vg = devicegraph.lvm_vgs.first
-            lv_names = reused_vg.lvm_lvs.map { |lv| lv.lv_name }
+            lv_names = reused_vg.lvm_lvs.map(&:lv_name)
             expect(lv_names).to eq(["lv1", "two"])
           end
         end

--- a/test/y2storage/proposal/partitions_distribution_calculator_test.rb
+++ b/test/y2storage/proposal/partitions_distribution_calculator_test.rb
@@ -197,7 +197,7 @@ describe Y2Storage::Proposal::PartitionsDistributionCalculator do
           let(:scenario) { "spaces_5_3_extended" }
 
           it "plans all partitions as logical" do
-            types = distribution.spaces.map { |s| s.partition_type }
+            types = distribution.spaces.map(&:partition_type)
             expect(types).to eq [:logical, :logical]
           end
         end
@@ -216,12 +216,12 @@ describe Y2Storage::Proposal::PartitionsDistributionCalculator do
               let(:scenario) { "spaces_5_3_used_extended" }
 
               it "sets the primary partition type for all the spaces" do
-                types = distribution.spaces.map { |s| s.partition_type }
+                types = distribution.spaces.map(&:partition_type)
                 expect(types).to eq [:primary, :primary]
               end
 
               it "plans all partitions as primary" do
-                logical = distribution.spaces.map { |s| s.num_logical }
+                logical = distribution.spaces.map(&:num_logical)
                 expect(logical).to eq [0, 0]
               end
             end
@@ -346,7 +346,7 @@ describe Y2Storage::Proposal::PartitionsDistributionCalculator do
       let(:lvm_max) { Y2Storage::DiskSize.unlimited }
 
       let(:pv_vols) do
-        volumes = distribution.spaces.map { |sp| sp.partitions }
+        volumes = distribution.spaces.map(&:partitions)
         volumes.map { |vols| vols.select(&:lvm_pv?) }.flatten
       end
 

--- a/test/y2storage/proposal_subvol_test.rb
+++ b/test/y2storage/proposal_subvol_test.rb
@@ -118,7 +118,7 @@ describe Y2Storage::GuidedProposal do
           ]
 
           subject.propose
-          cow_subvolumes = subvolumes.reject { |s| s.nocow? }
+          cow_subvolumes = subvolumes.reject(&:nocow?)
 
           expect(cow_subvolumes.map(&:path)).to include(*expected_cow_subvolumes)
         end
@@ -132,7 +132,7 @@ describe Y2Storage::GuidedProposal do
           ]
 
           subject.propose
-          nocow_subvolumes = subvolumes.select { |s| s.nocow? }
+          nocow_subvolumes = subvolumes.select(&:nocow?)
 
           expect(nocow_subvolumes.map(&:path)).to contain_exactly(*expected_nocow_subvolumes)
         end


### PR DESCRIPTION
Refinements are not used anymore.

PBI: https://trello.com/c/BWtX9ccg/548-2-remove-refinements-patches-extensions-etc-from-yast-storage-ng.