### PR TITLE
Fix alignment bug

### DIFF
--- a/src/lib/y2storage/planned/has_size.rb
+++ b/src/lib/y2storage/planned/has_size.rb
@@ -160,10 +160,10 @@ module Y2Storage
           extra_size = extra_size.ceil(rounding)
           extra_size = available_size.floor(rounding) if extra_size > available_size
 
-          new_size = extra_size + device.size
+          new_size = device.size + extra_size
           if new_size > device.max_size
-            # Increase just until reaching the max size
-            device.max_size - device.size
+            # Increase just until reaching the max size, ensuring rounding
+            (device.max_size - device.size).floor(rounding)
           else
             extra_size
           end

--- a/test/data/devicegraphs/empty_dasd_50GiB.yml
+++ b/test/data/devicegraphs/empty_dasd_50GiB.yml
@@ -2,4 +2,4 @@
 - dasd:
     name: /dev/sda
     type: eckd
-    size: 50 GiB
+    size: 23 GiB

--- a/test/data/devicegraphs/output/s390_dasd_zipl-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl-lvm-sep-home.yml
@@ -2,7 +2,7 @@
 - dasd:
     name: "/dev/sda"
     type: eckd
-    size: 50 GiB
+    size: 23 GiB
     partition_table: dasd
     partitions:
     - partition:
@@ -12,7 +12,7 @@
         file_system: ext2
         mount_point: /boot/zipl
     - partition:
-        size: 52326240 KiB (49.90 GiB)
+        size: 24014688 KiB (22.90 GiB)
         name: "/dev/sda2"
         id: lvm
 - lvm_vg:
@@ -20,12 +20,12 @@
     lvm_lvs:
     - lvm_lv:
         lv_name: home
-        size: 23280 MiB (22.73 GiB)
+        size: 6696 MiB (6.54 GiB)
         file_system: xfs
         mount_point: "/home"
     - lvm_lv:
         lv_name: root
-        size: 25768 MiB (25.16 GiB)
+        size: 14704 MiB (14.36 GiB)
         file_system: btrfs
         mount_point: "/"
     - lvm_lv:

--- a/test/data/devicegraphs/output/s390_dasd_zipl-lvm.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl-lvm.yml
@@ -2,17 +2,17 @@
 - dasd:
     name: "/dev/sda"
     type: eckd
-    size: 50 GiB
+    size: 23 GiB
     partition_table: dasd
     partitions:
     - partition:
-        size: 204816 KiB (200.02 MiB)
+        size: 102432 KiB (100.03 MiB)
         name: "/dev/sda1"
         id: linux
         file_system: ext2
         mount_point: "/boot/zipl"
     - partition:
-        size: 44041248 KiB (42.00 GiB)
+        size: 24014688 KiB (22.90 GiB)
         name: "/dev/sda2"
         id: lvm
 - lvm_vg:
@@ -20,7 +20,7 @@
     lvm_lvs:
     - lvm_lv:
         lv_name: root
-        size: 40 GiB
+        size: 21400 MiB (20.90 GiB)
         file_system: btrfs
         mount_point: "/"
         btrfs:

--- a/test/data/devicegraphs/output/s390_dasd_zipl.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl.yml
@@ -2,23 +2,23 @@
 - dasd:
     name: "/dev/sda"
     type: eckd
-    size: 50 GiB
+    size: 23 GiB
     partition_table: dasd
     partitions:
     - partition:
-        size: 204816 KiB (200.02 MiB)
+        size: 102432 KiB (100.03 MiB)
         name: "/dev/sda1"
         id: linux
         file_system: ext2
         mount_point: "/boot/zipl"
     - partition:
-        size: 41943072 KiB (40.00 GiB)
+        size: 21917568 KiB (20.90 GiB)
         name: "/dev/sda2"
         id: linux
         file_system: btrfs
         mount_point: "/"
     - partition:
-        size: 2097168 KiB (2.00 GiB)
+        size: 2097120 KiB (2.00 GiB)
         name: "/dev/sda3"
         id: linux
         file_system: swap


### PR DESCRIPTION
Ensure end-alignment when distributing extra space.

This should solve alignment problem detected in s380 openQA test: https://yast-openqa.suse.cz/tests/12374#step/start_install/5.

Part of PBI: https://trello.com/c/UBCLA6Qo/651-2-storageng-and-s-390-partitions-not-aligned.