### PR TITLE
Added support for legacy filesystems (fate#323394)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 21 22:47:04 UTC 2017 - knut.anderssen@suse.com
+
+- Added support for legacy filesystems (fate#323394).
+- 3.3.4
+
+-------------------------------------------------------------------
 Mon Aug 21 13:40:03 CEST 2017 - snwint@suse.de
 
 - adjust package description in spec file

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        3.3.3
+Version:        3.3.4
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -116,8 +116,13 @@ module Y2Storage
 
       HOME_FILESYSTEMS = [:ext2, :ext3, :ext4, :btrfs, :xfs]
 
+      LEGACY_ROOT_FILESYSTEMS = [:jfs, :reiserfs]
+
+      LEGACY_HOME_FILESYSTEMS = [:jfs, :reiserfs]
+
       private_constant :PROPERTIES, :ROOT_FILESYSTEMS, :HOME_FILESYSTEMS,
-        :COMMON_FSTAB_OPTIONS, :EXT_FSTAB_OPTIONS
+        :COMMON_FSTAB_OPTIONS, :EXT_FSTAB_OPTIONS, :LEGACY_ROOT_FILESYSTEMS,
+        :LEGACY_HOME_FILESYSTEMS
 
       # Allowed filesystems for root
       #
@@ -126,11 +131,25 @@ module Y2Storage
         ROOT_FILESYSTEMS.map { |f| find(f) }
       end
 
+      # Legacy filesystems allowed for root
+      #
+      # @return [Array<Filesystems::Type>]
+      def self.legacy_root_filesystems
+        LEGACY_ROOT_FILESYSTEMS.map { |f| find(f) }
+      end
+
       # Allowed filesystems for home
       #
       # @return [Array<Filesystems::Type>]
       def self.home_filesystems
         HOME_FILESYSTEMS.map { |f| find(f) }
+      end
+
+      # Legacy filesystems allowed for home
+      #
+      # @return [Array<Filesystems::Type>]
+      def self.legacy_home_filesystems
+        LEGACY_HOME_FILESYSTEMS.map { |f| find(f) }
       end
 
       # Check if filesystem is usable as root (mountpoint "/") filesystem.
@@ -146,6 +165,19 @@ module Y2Storage
         return Type.root_filesystems.include?(self)
       end
 
+      # Check if filesystem was usable as root (mountpoint "/") filesystem.
+      #
+      # return [Boolean]
+      #
+      # @example
+      #   devicegraph.filesystems.each do |fs|
+      #     puts "#{fs.type}: #{fs.type.legacy_root?}"
+      #   end
+      #
+      def legacy_root?
+        Type.legacy_root_filesystems.include?(self)
+      end
+
       # Check if filesystem is usable as home (mountpoint "/home") filesystem.
       #
       # return [Boolean]
@@ -157,6 +189,19 @@ module Y2Storage
       #
       def home_ok?
         return Type.home_filesystems.include?(self)
+      end
+
+      # Check if filesystem was usable as home (mountpoint "/home") filesystem.
+      #
+      # return [Boolean]
+      #
+      # @example
+      #   devicegraph.filesystems.each do |fs|
+      #     puts "#{fs.type}: #{fs.type.legacy_home?}"
+      #   end
+      #
+      def legacy_home?
+        Type.legacy_home_filesystems.include?(self)
       end
 
       # Human readable text for a filesystem

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -116,9 +116,9 @@ module Y2Storage
 
       HOME_FILESYSTEMS = [:ext2, :ext3, :ext4, :btrfs, :xfs]
 
-      LEGACY_ROOT_FILESYSTEMS = [:jfs, :reiserfs]
+      LEGACY_ROOT_FILESYSTEMS = [:reiserfs]
 
-      LEGACY_HOME_FILESYSTEMS = [:jfs, :reiserfs]
+      LEGACY_HOME_FILESYSTEMS = [:reiserfs]
 
       private_constant :PROPERTIES, :ROOT_FILESYSTEMS, :HOME_FILESYSTEMS,
         :COMMON_FSTAB_OPTIONS, :EXT_FSTAB_OPTIONS, :LEGACY_ROOT_FILESYSTEMS,

--- a/test/y2storage/filesystems/type_test.rb
+++ b/test/y2storage/filesystems/type_test.rb
@@ -53,4 +53,56 @@ describe Y2Storage::Filesystems::Type do
       end
     end
   end
+
+  describe "#legacy_root_filesystems" do
+    let(:reiserfs) { Y2Storage::Filesystems::Type::REISERFS }
+
+    it "returns an array of filesystems that were valid for '/' mountpoint" do
+      expect(Y2Storage::Filesystems::Type.legacy_root_filesystems).to include(reiserfs)
+    end
+  end
+
+  describe "#legacy_home_filesystems" do
+    let(:reiserfs) { Y2Storage::Filesystems::Type::REISERFS }
+
+    it "returns an array of filesystems that were valid for '/home' mountpoint" do
+      expect(Y2Storage::Filesystems::Type.legacy_home_filesystems).to include(reiserfs)
+    end
+  end
+
+  describe "#legacy_root?" do
+    context "for a filesystem that is not legacy" do
+      it "returns false" do
+        Y2Storage::Filesystems::Type.root_filesystems.each do |filesystem|
+          expect(filesystem.legacy_root?).to eq(false)
+        end
+      end
+    end
+
+    context "for a legacy filesystem that was valid for '/' mountpoint" do
+      it "returns true" do
+        Y2Storage::Filesystems::Type.legacy_root_filesystems.each do |filesystem|
+          expect(filesystem.legacy_root?).to eq(true)
+        end
+      end
+    end
+  end
+
+  describe "#legacy_home?" do
+    context "for a filesystem that is not legacy" do
+      it "returns false" do
+        Y2Storage::Filesystems::Type.home_filesystems.each do |filesystem|
+          expect(filesystem.legacy_home?).to eq(false)
+        end
+      end
+    end
+
+    context "for a legacy filesystem that was valid for '/home' mount point" do
+      it "returns true" do
+        Y2Storage::Filesystems::Type.legacy_home_filesystems.each do |filesystem|
+          expect(filesystem.legacy_home?).to eq(true)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
With #335 reiserfs was dropped but it affected yast2-update not showing the legacy root partitions.

![screenshot_sles12sp3_2017-08-21_14 40 18](https://user-images.githubusercontent.com/7056681/29555758-836bcdb2-871b-11e7-9fb8-e8bc13f068b1.png)

With this PR we will add support for check legacy filesystems that were valid for '/' and '/home' mount points.