### PR TITLE
Partitioner: checkbox to enable snapshots

### DIFF
--- a/doc/dont-format-in-expert-partitioner.md
+++ b/doc/dont-format-in-expert-partitioner.md
@@ -1,0 +1,76 @@
+# Implementing 'do not format' in the expert partitioner
+
+## About this document
+
+This should be a short-lived document just to explain a difference in behavior
+introduced in the expert partitioner by storage-ng when compared to the old
+storage stack. The current API and philosophy of `libstorage-ng` and the expert
+partitioner make it impossible to keep the traditional behavior. This document
+describes why and sketches a possible solution. After fixing the problem
+(hopefully sooner than later) this document will become obsolete and should be
+deleted.
+
+## The problem
+
+When editing a partition (the same applies to any other block device that can
+hold a filesystem), the expert partitioner displays a form with two options:
+"format partition" and "do not format partition". Now imagine the following
+situation.
+
+* Everything starts with `/dev/sda2` containing an ext2 filesystem
+* (Step 1) The user edits this partition and select to format it as ext4
+* (Step 2) The user then performs several other actions in other partitions
+* (Step 3) The user opens again the edit form for `/dev/sda2`, selects "do
+  not format partition" and clicks "next"
+
+The result should be that the original ext2 filesystem is back in the general
+view and applying the changes with the partitioner should not alter it or
+destroy it.
+
+With the current implementation of the storage-ng partitioner, which performs
+the changes in a devicegraph in memory, that cannot be implemented because it
+would imply copying (or restoring, to be precise) a device from the system
+devicegraph to the working devicegraph without copying the whole devicegraph,
+something that is currently no possible.
+
+## The obvious solution
+
+The problem can be fixed with a new functionality in the libstorage-ng API and
+some work in the expert partitioner. The library should allow to copy a device
+to another devicegraph keeping the `sid` and all its attributes. Then the expert
+partitioner could use that and some common sense to really restore the original
+filesystem while not breaking anything else in the devicegraph. Not rocket
+science, but not something to program in 10 minutes.
+
+## The alternatives/workarounds
+
+### The second 'edit' cleanups the filesystem
+
+The result with the current implementation is that after the third step
+`/dev/sda2` will look empty, with no filesystem. That is, the "do not format"
+option turns into "leave unformatted" when entering edit for the second time.
+It only changes from the behavior point of view, the label still says "do not
+format partition".
+
+This was the chosen alternative, despite being quite inconsistent from the user
+point of view, because all other scenarios work exactly like in the old
+partitioner except the one explained about, which is relatively hard to reach.
+
+### Consider the current devicegraph as the one to respect
+
+This is another alternative that would have been more consistent but too
+different to the old one and rather confusing during installation. In short,
+when clicking in 'edit', the user would be modifying the current state of
+`/dev/sda2` as displayed in the expert partitioner, not its state in the disk.
+
+From that point of view, selecting "do not format partition" would not mean
+respecting the original ext2 filesystem, but the _current_ ext4 one. In other
+words, the "do not format" option would mean "do not change what is
+configured now". Changing that without actually changing the label is confusing.
+Using the expert partitioner to modify the proposal makes everything even more
+confusing, since "do not format" means "do what the proposal suggested".
+
+### Others
+
+Some other behaviors were tested or considered, but the result was usually
+tricky in one way or another and is not worth describing them all here.

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Sep 21 14:54:28 UTC 2017 - ancor@suse.com
+
+- More backwards-compatible behavior when formatting partitions in
+  the expert partitioner.
+- Checkbox to enable snapshots for "/" in the expert partitioner.
+- Both part of fate#318196
+- 3.3.18
+
+-------------------------------------------------------------------
 Tue Sep 19 07:26:06 UTC 2017 - ancor@suse.com
 
 - Improved creation and modification of partitions in the Expert

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        3.3.17
+Version:        3.3.18
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/dialogs/format_and_mount.rb
+++ b/src/lib/y2partitioner/dialogs/format_and_mount.rb
@@ -12,8 +12,7 @@ module Y2Partitioner
         textdomain "storage"
 
         @controller = controller
-        @mount_options = Widgets::MountOptions.new(controller)
-        @format_options = Widgets::FormatOptions.new(controller, @mount_options)
+        @format_and_mount = FormatMountOptions.new(controller)
       end
 
       def title
@@ -21,13 +20,44 @@ module Y2Partitioner
       end
 
       def contents
-        HVSquash(
+        HVSquash(@format_and_mount)
+      end
+
+      # Simple container widget to allow the format options and the mount
+      # options widgets to refresh each other.
+      class FormatMountOptions < CWM::CustomWidget
+        def initialize(controller)
+          textdomain "storage"
+
+          @controller = controller
+          @format_options = Widgets::FormatOptions.new(controller, self)
+          @mount_options = Widgets::MountOptions.new(controller, self)
+
+          self.handle_all_events = true
+        end
+
+        # @macro seeAbstractWidget
+        def contents
           HBox(
             @format_options,
             HSpacing(5),
             @mount_options
           )
-        )
+        end
+
+        # Used by the children widgets to notify they have changed the status of
+        # the controller and, thus, some of its sibling widgets may need a
+        # refresh.
+        #
+        # @param exclude [CWM::AbstractWidget] widget originating the change,
+        #   and thus not needing a forced refresh
+        def refresh_others(exclude)
+          if exclude == @format_options
+            @mount_options.refresh
+          else
+            @format_options.refresh
+          end
+        end
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/btrfs_subvolumes.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_subvolumes.rb
@@ -37,9 +37,6 @@ module Y2Partitioner
         table = Widgets::BtrfsSubvolumesTable.new(filesystem)
 
         VBox(
-          # TODO: libstorage must manage snapshots
-          HBox(HSpacing(1), Left(CheckBox(_("Enable snapshots"), false))),
-          VSpacing(1),
           table,
           HBox(
             Widgets::BtrfsSubvolumesAddButton.new(table),
@@ -49,21 +46,7 @@ module Y2Partitioner
       end
 
       def help
-        text = _(
-          "<p>Create and remove subvolumes from a Btrfs filesystem.</p>\n"
-        )
-
-        if Yast::Mode.installation
-          text += _(
-            "<p>Enable automatic snapshots for a Btrfs filesystem with snapper.</p>"
-          )
-        end
-
-        # TODO: widget for enabale snapshot is not implemented yet. Waiting for snapshots
-        # support in libstorage-ng
-        text += "TODO enable snapshots help"
-
-        text
+        _("<p>Create and remove subvolumes from a Btrfs filesystem.</p>\n")
       end
 
     private

--- a/test/y2partitioner/dialogs/format_and_mount_test.rb
+++ b/test/y2partitioner/dialogs/format_and_mount_test.rb
@@ -25,17 +25,32 @@ describe Y2Partitioner::Dialogs::FormatAndMount::FormatMountOptions do
     before do
       allow(Y2Partitioner::Widgets::FormatOptions).to receive(:new).and_return format_widget
       allow(Y2Partitioner::Widgets::MountOptions).to receive(:new).and_return mount_widget
+      allow(format_widget).to receive(:refresh)
       allow(mount_widget).to receive(:refresh)
     end
 
-    it "does not call #refresh for the widget triggering the update" do
-      expect(format_widget).to_not receive(:refresh)
-      widget.refresh_others(format_widget)
+    context "when the FormatOptions widget triggers an update" do
+      it "does not call #refresh for the widget triggering the update" do
+        expect(format_widget).to_not receive(:refresh)
+        widget.refresh_others(format_widget)
+      end
+
+      it "calls #refresh for the widget not triggering the update" do
+        expect(mount_widget).to receive(:refresh)
+        widget.refresh_others(format_widget)
+      end
     end
 
-    it "calls #refresh for the widget not triggering the update" do
-      expect(mount_widget).to receive(:refresh)
-      widget.refresh_others(format_widget)
+    context "when the MountOptions widget triggers an update" do
+      it "does not call #refresh for the widget triggering the update" do
+        expect(mount_widget).to_not receive(:refresh)
+        widget.refresh_others(mount_widget)
+      end
+
+      it "calls #refresh for the widget not triggering the update" do
+        expect(format_widget).to receive(:refresh)
+        widget.refresh_others(mount_widget)
+      end
     end
   end
 end

--- a/test/y2partitioner/dialogs/format_and_mount_test.rb
+++ b/test/y2partitioner/dialogs/format_and_mount_test.rb
@@ -11,3 +11,31 @@ describe Y2Partitioner::Dialogs::FormatAndMount do
 
   include_examples "CWM::Dialog"
 end
+
+describe Y2Partitioner::Dialogs::FormatAndMount::FormatMountOptions do
+  let(:controller) { double("FilesystemController", filesystem: nil) }
+  subject(:widget) { described_class.new(controller) }
+
+  include_examples "CWM::CustomWidget"
+
+  describe "#refresh_others" do
+    let(:format_widget) { double("FormatOptions") }
+    let(:mount_widget) { double("MountOptions") }
+
+    before do
+      allow(Y2Partitioner::Widgets::FormatOptions).to receive(:new).and_return format_widget
+      allow(Y2Partitioner::Widgets::MountOptions).to receive(:new).and_return mount_widget
+      allow(mount_widget).to receive(:refresh)
+    end
+
+    it "does not call #refresh for the widget triggering the update" do
+      expect(format_widget).to_not receive(:refresh)
+      widget.refresh_others(format_widget)
+    end
+
+    it "calls #refresh for the widget not triggering the update" do
+      expect(mount_widget).to receive(:refresh)
+      widget.refresh_others(format_widget)
+    end
+  end
+end

--- a/test/y2partitioner/widgets/format_and_mount_test.rb
+++ b/test/y2partitioner/widgets/format_and_mount_test.rb
@@ -165,3 +165,77 @@ describe Y2Partitioner::Widgets::PartitionId do
 
   include_examples "CWM::AbstractWidget"
 end
+
+describe Y2Partitioner::Widgets::Snapshots do
+  let(:controller) { double("FilesystemController", filesystem: nil) }
+  subject { described_class.new(controller) }
+
+  include_examples "CWM::AbstractWidget"
+end
+
+describe Y2Partitioner::Widgets::FormatOptionsArea do
+  let(:controller) { double("FilesystemController", filesystem: nil) }
+  subject(:widget) { described_class.new(controller) }
+
+  include_examples "CWM::AbstractWidget"
+
+  describe "#refresh" do
+    let(:options_button) { double("FormatOptionsButton", enable: nil, disable: nil) }
+    let(:snapshots_checkbox) { double("Snapshots", refresh: nil) }
+
+    before do
+      allow(Y2Partitioner::Widgets::FormatOptionsButton).to receive(:new).and_return options_button
+      allow(Y2Partitioner::Widgets::Snapshots).to receive(:new).and_return snapshots_checkbox
+      allow(controller).to receive(:snapshots_supported?).and_return snapshots_supported
+      allow(controller).to receive(:format_options_supported?).and_return options_supported
+    end
+
+    context "if snapshots are supported for the current block device" do
+      let(:snapshots_supported) { true }
+
+      context "and format options are also supported" do
+        let(:options_supported) { true }
+
+        it "shows the snapshot checkbox in sync with the value from the controller" do
+          expect(widget).to receive(:show).with(snapshots_checkbox).ordered
+          expect(snapshots_checkbox).to receive(:refresh).ordered
+          widget.refresh
+        end
+      end
+
+      context "and format options are not supported" do
+        let(:options_supported) { false }
+
+        it "shows the snapshot checkbox in sync with the value from the controller" do
+          expect(widget).to receive(:show).with(snapshots_checkbox).ordered
+          expect(snapshots_checkbox).to receive(:refresh).ordered
+          widget.refresh
+        end
+      end
+    end
+
+    context "if snapshots are not supported for the current block device" do
+      let(:snapshots_supported) { false }
+
+      context "and format options are supported" do
+        let(:options_supported) { true }
+
+        it "shows the enabled options button" do
+          expect(widget).to receive(:show).with(options_button).ordered
+          expect(options_button).to receive(:enable).ordered
+          widget.refresh
+        end
+      end
+
+      context "and format options are not supported either" do
+        let(:options_supported) { false }
+
+        it "shows the disabled options button" do
+          expect(widget).to receive(:show).with(options_button).ordered
+          expect(options_button).to receive(:disable).ordered
+          widget.refresh
+        end
+      end
+    end
+  end
+end

--- a/test/y2partitioner/widgets/format_and_mount_test.rb
+++ b/test/y2partitioner/widgets/format_and_mount_test.rb
@@ -5,15 +5,16 @@ require "y2partitioner/widgets/format_and_mount"
 
 describe Y2Partitioner::Widgets::FormatOptions do
   let(:controller) { double("FilesystemController", filesystem: nil) }
-  let(:widget) { double("MountOptionsWidget") }
-  subject { described_class.new(controller, widget) }
+  let(:parent) { double("FormatMountOptions") }
+  subject { described_class.new(controller, parent) }
 
   include_examples "CWM::CustomWidget"
 end
 
 describe Y2Partitioner::Widgets::MountOptions do
   let(:controller) { double("FilesystemController", filesystem: nil) }
-  subject { described_class.new(controller) }
+  let(:parent) { double("FormatMountOptions") }
+  subject { described_class.new(controller, parent) }
 
   include_examples "CWM::CustomWidget"
 end


### PR DESCRIPTION
It also adjusts (and documents) some behavior when editing partitions.

Snapshots checkbox functionality manually tested with full installation.

Last step for https://trello.com/c/ytK5Yoe4/554-5-storageng-installation-to-root-subvolume