### PR TITLE
Avoid to reuse small efi partitions

### DIFF
--- a/doc/boot-requirements.md
+++ b/doc/boot-requirements.md
@@ -2,101 +2,31 @@
 [//]: # (document was automatically created using 'rake doc:bootspecs')
 
 # Y2Storage::BootRequirementsChecker
-## needed partitions in a x86 system
-- using UEFI
-	- with a partitions-based proposal
-		- if there are no EFI partitions
-			- **requires only a new /boot/efi partition**
-		- if there is already an EFI partition
-			- **only requires to use the existing EFI partition**
-	- with a LVM-based proposal
-		- if there are no EFI partitions
-			- **requires only a new /boot/efi partition**
-		- if there is already an EFI partition
-			- **only requires to use the existing EFI partition**
-	- with an encrypted proposal
-		- if there are no EFI partitions
-			- **requires only a new /boot/efi partition**
-		- if there is already an EFI partition
-			- **only requires to use the existing EFI partition**
-- not using UEFI (legacy PC)
-	- with GPT partition table
-		- in a partitions-based proposal
-			- if there is no GRUB partition
-				- **requires a new GRUB partition**
-			- if there is already a GRUB partition
-				- **does not require any particular volume**
-		- in a LVM-based proposal
-			- if there is no GRUB partition
-				- **requires a new GRUB partition**
-			- if there is already a GRUB partition
-				- **does not require any particular volume**
-		- in an encrypted proposal
-			- if there is no GRUB partition
-				- **requires a new GRUB partition**
-			- if there is already a GRUB partition
-				- **does not require any particular volume**
-	- with a MS-DOS partition table
-		- if the MBR gap is big enough to embed Grub
-			- in a partitions-based proposal
-				- **does not require any particular volume**
-			- in a LVM-based proposal
-				- if the MBR gap has additional space for grubenv
-					- **does not require any particular volume**
-				- if the MBR gap has no additional space
-					- **requires only a /boot partition**
-			- in an encrypted proposal
-				- if the MBR gap has additional space for grubenv
-					- **does not require any particular volume**
-				- if the MBR gap has no additional space
-					- **requires only a /boot partition**
-		- with too small MBR gap
-			- in a partitions-based proposal
-				- if proposing root (/) as Btrfs
-					- **does not require any particular volume**
-				- if proposing root (/) as non-Btrfs
-					- **raises an exception**
-			- in a LVM-based proposal
-				- **raises an exception**
-			- in an encrypted proposal
-				- **raises an exception**
-	- when proposing a boot partition
-		- **requires /boot to be a non-encrypted ext4 partition in the booting disk**
-		- when aiming for the recommended size
-			- **requires /boot to be at least 200 MiB large**
-		- when aiming for the minimal size
-			- **requires /boot to be at least 100 MiB large**
-	- when proposing an new GRUB partition
-		- **requires it to have the correct id**
-		- **requires it to be a non-encrypted partition**
-		- when aiming for the recommended size
-			- **requires it to be between 1 and 8MiB, despite the alignment**
-		- when aiming for the minimal size
-			- **requires it to be between 256KiB and 8MiB, despite the alignment**
-	- when proposing an new EFI partition
-		- **requires /boot/efi to be a non-encrypted vfat partition**
-		- **requires /boot/efi to be close enough to the beginning of disk**
-		- when aiming for the recommended size
-			- **requires /boot/efi to be at least 500 MiB large**
-		- when aiming for the minimal size
-			- **requires /boot/efi to be at least 33 MiB large**
-
 ## needed partitions in an aarch64 system
 - with a partitions-based proposal
 	- if there are no EFI partitions
 		- **requires only a new /boot/efi partition**
 	- if there is already an EFI partition
-		- **only requires to use the existing EFI partition**
+		- and it does not have enough size
+			- **requires only a new /boot/efi partition**
+		- and it has enough size
+			- **only requires to use the existing EFI partition**
 - with a LVM-based proposal
 	- if there are no EFI partitions
 		- **requires only a new /boot/efi partition**
 	- if there is already an EFI partition
-		- **only requires to use the existing EFI partition**
+		- and it does not have enough size
+			- **requires only a new /boot/efi partition**
+		- and it has enough size
+			- **only requires to use the existing EFI partition**
 - with an encrypted proposal
 	- if there are no EFI partitions
 		- **requires only a new /boot/efi partition**
 	- if there is already an EFI partition
-		- **only requires to use the existing EFI partition**
+		- and it does not have enough size
+			- **requires only a new /boot/efi partition**
+		- and it has enough size
+			- **only requires to use the existing EFI partition**
 
 ## needed partitions in a PPC64 system
 - in a non-PowerNV system (KVM/LPAR)
@@ -163,3 +93,91 @@
 		- **requires /boot/zipl to be at least 200 MiB large**
 	- when aiming for the minimal size
 		- **requires /boot/zipl to be at least 100 MiB large**
+
+## needed partitions in a x86 system
+- using UEFI
+	- with a partitions-based proposal
+		- if there are no EFI partitions
+			- **requires only a new /boot/efi partition**
+		- if there is already an EFI partition
+			- and it does not have enough size
+				- **requires only a new /boot/efi partition**
+			- and it has enough size
+				- **only requires to use the existing EFI partition**
+	- with a LVM-based proposal
+		- if there are no EFI partitions
+			- **requires only a new /boot/efi partition**
+		- if there is already an EFI partition
+			- and it does not have enough size
+				- **requires only a new /boot/efi partition**
+			- and it has enough size
+				- **only requires to use the existing EFI partition**
+	- with an encrypted proposal
+		- if there are no EFI partitions
+			- **requires only a new /boot/efi partition**
+		- if there is already an EFI partition
+			- and it does not have enough size
+				- **requires only a new /boot/efi partition**
+			- and it has enough size
+				- **only requires to use the existing EFI partition**
+- not using UEFI (legacy PC)
+	- with GPT partition table
+		- in a partitions-based proposal
+			- if there is no GRUB partition
+				- **requires a new GRUB partition**
+			- if there is already a GRUB partition
+				- **does not require any particular volume**
+		- in a LVM-based proposal
+			- if there is no GRUB partition
+				- **requires a new GRUB partition**
+			- if there is already a GRUB partition
+				- **does not require any particular volume**
+		- in an encrypted proposal
+			- if there is no GRUB partition
+				- **requires a new GRUB partition**
+			- if there is already a GRUB partition
+				- **does not require any particular volume**
+	- with a MS-DOS partition table
+		- if the MBR gap is big enough to embed Grub
+			- in a partitions-based proposal
+				- **does not require any particular volume**
+			- in a LVM-based proposal
+				- if the MBR gap has additional space for grubenv
+					- **does not require any particular volume**
+				- if the MBR gap has no additional space
+					- **requires only a /boot partition**
+			- in an encrypted proposal
+				- if the MBR gap has additional space for grubenv
+					- **does not require any particular volume**
+				- if the MBR gap has no additional space
+					- **requires only a /boot partition**
+		- with too small MBR gap
+			- in a partitions-based proposal
+				- if proposing root (/) as Btrfs
+					- **does not require any particular volume**
+				- if proposing root (/) as non-Btrfs
+					- **raises an exception**
+			- in a LVM-based proposal
+				- **raises an exception**
+			- in an encrypted proposal
+				- **raises an exception**
+	- when proposing a boot partition
+		- **requires /boot to be a non-encrypted ext4 partition in the booting disk**
+		- when aiming for the recommended size
+			- **requires /boot to be at least 200 MiB large**
+		- when aiming for the minimal size
+			- **requires /boot to be at least 100 MiB large**
+	- when proposing an new GRUB partition
+		- **requires it to have the correct id**
+		- **requires it to be a non-encrypted partition**
+		- when aiming for the recommended size
+			- **requires it to be between 1 and 8MiB, despite the alignment**
+		- when aiming for the minimal size
+			- **requires it to be between 256KiB and 8MiB, despite the alignment**
+	- when proposing an new EFI partition
+		- **requires /boot/efi to be a non-encrypted vfat partition**
+		- **requires /boot/efi to be close enough to the beginning of disk**
+		- when aiming for the recommended size
+			- **requires /boot/efi to be at least 500 MiB large**
+		- when aiming for the minimal size
+			- **requires /boot/efi to be at least 33 MiB large**

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep 22 15:20:51 UTC 2017 - jlopez@suse.com
+
+- Avoid to reuse small efi partitions (bsc#1056640).
+- 3.3.19
+
+-------------------------------------------------------------------
 Thu Sep 21 14:54:28 UTC 2017 - ancor@suse.com
 
 - More backwards-compatible behavior when formatting partitions in

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        3.3.18
+Version:        3.3.19
 Release:	0
 BuildArch:	noarch
 

--- a/rakelib/doc_bootspecs.rake
+++ b/rakelib/doc_bootspecs.rake
@@ -20,7 +20,7 @@
 namespace :doc do
   desc "Build boot requirements spec."
   task :bootspecs do
-    files = Dir["**/test/boot_requirements_checker_*_test.rb"]
+    files = Dir["**/test/y2storage/boot_requirements_checker_*_test.rb"]
     sh "rspec" \
       " --require ./src/tools/md_formatter.rb" \
       " --format MdFormatter" \

--- a/src/lib/y2storage/boot_requirements_strategies/uefi.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/uefi.rb
@@ -37,6 +37,9 @@ module Y2Storage
 
     protected
 
+      MIN_SIZE = DiskSize.MiB(33).freeze
+      DESIRED_SIZE = DiskSize.MiB(500).freeze
+
       def efi_missing?
         free_mountpoint?("/boot/efi")
       end
@@ -47,7 +50,7 @@ module Y2Storage
           vol.reuse = reusable_efi.name
         else
           vol.partition_id = PartitionId::ESP
-          vol.min_size = target == :min ? DiskSize.MiB(33) : DiskSize.MiB(500)
+          vol.min_size = target == :min ? MIN_SIZE : DESIRED_SIZE
           vol.max_size = DiskSize.unlimited
           vol.max_start_offset = DiskSize.TiB(2)
         end
@@ -55,7 +58,9 @@ module Y2Storage
       end
 
       def reusable_efi
-        @reusable_efi = biggest_efi_in_boot_device || biggest_efi
+        efi = biggest_efi_in_boot_device || biggest_efi
+        efi = nil if !efi.nil? && efi.size < MIN_SIZE
+        @reusable_efi = efi
       end
 
       def biggest_efi_in_boot_device

--- a/test/y2storage/boot_requirements_duplicate_test.rb
+++ b/test/y2storage/boot_requirements_duplicate_test.rb
@@ -26,6 +26,8 @@ require_relative "#{TEST_PATH}/support/boot_requirements_context"
 require "y2storage"
 
 describe Y2Storage::BootRequirementsChecker do
+  using Y2Storage::Refinements::SizeCasts
+
   describe "planning of partitions that are already there" do
     include_context "boot requirements"
 
@@ -76,7 +78,7 @@ describe Y2Storage::BootRequirementsChecker do
           let(:missing_efi) { true }
 
           context "if there is suitable EFI partition in the devicegraph" do
-            let(:efi_partitions) { [partition_double("/dev/sda1")] }
+            let(:efi_partitions) { [partition_double("/dev/sda1", 50.MiB)] }
 
             it "proposes to use the existing EFI partition" do
               expect(checker.needed_partitions).to contain_exactly(


### PR DESCRIPTION
Bug: https://bugzilla.suse.com/show_bug.cgi?id=1056640.

https://trello.com/c/ppQwBqN0/726-sles15-p1-1056640-build-1738-installation-with-uefi-fails-due-to-boot-efi-partition-too-small