### PR TITLE
Partitioner: fix custom size validation

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 29 10:54:54 UTC 2017 - jlopez@suse.com
+
+- Fix validation when trying to create a partition with custom
+  size (bsc#1060864).
+- 3.3.21
+
+-------------------------------------------------------------------
 Tue Sep 26 16:47:44 CEST 2017 - shundhammer@suse.de
 
 - Implemented simple proposal for CASP (bsc#1058736)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        3.3.20
+Version:        3.3.21
 Release:	0
 BuildArch:	noarch
 

--- a/test/y2partitioner/dialogs/partition_size_test.rb
+++ b/test/y2partitioner/dialogs/partition_size_test.rb
@@ -5,6 +5,8 @@ require "y2partitioner/dialogs/partition_size"
 require "y2partitioner/sequences/add_partition"
 
 describe "Partition Size widgets" do
+  using Y2Storage::Refinements::SizeCasts
+
   let(:controller) do
     pt = Y2Partitioner::Sequences::PartitionController.new("/dev/sda")
     pt.region = region
@@ -50,14 +52,57 @@ describe "Partition Size widgets" do
 
     describe "#validate" do
       before do
-        allow(subject).to receive(:value)
-          .and_return Y2Storage::DiskSize.new(2_000_000)
+        allow(subject).to receive(:value).and_return size
       end
 
-      it "pops up an error when the size is too big" do
-        expect(Yast::Popup).to receive(:Error)
-        expect(Yast::UI).to receive(:SetFocus)
-        expect(subject.validate).to eq false
+      context "when the entered size is too big" do
+        let(:size) { 2.TiB }
+
+        it "returns false" do
+          expect(subject.validate).to eq false
+        end
+
+        it "pops up an error" do
+          expect(Yast::Popup).to receive(:Error)
+          expect(Yast::UI).to receive(:SetFocus)
+          subject.validate
+        end
+      end
+
+      context "when the entered size is too small" do
+        let(:size) { 0.1.KiB }
+
+        it "returns false" do
+          expect(subject.validate).to eq false
+        end
+
+        it "pops up an error" do
+          expect(Yast::Popup).to receive(:Error)
+          expect(Yast::UI).to receive(:SetFocus)
+          subject.validate
+        end
+      end
+
+      context "when the entered value is not a correct size" do
+        let(:size) { nil }
+
+        it "returns false" do
+          expect(subject.validate).to eq false
+        end
+
+        it "pops up an error" do
+          expect(Yast::Popup).to receive(:Error)
+          expect(Yast::UI).to receive(:SetFocus)
+          subject.validate
+        end
+      end
+
+      context "when the entered value is a correct size" do
+        let(:size) { 1.MiB }
+
+        it "returns true" do
+          expect(subject.validate).to eq true
+        end
       end
     end
   end


### PR DESCRIPTION
Bug: https://bugzilla.suse.com/show_bug.cgi?id=1060864

https://trello.com/c/t5RCEg1L/729-sles15-p5-1060864-alpha-5-add-partition-with-empty-size-results-in-error-client-call-failed-with-not-a-number-typeerror