### PR TITLE
Added .desktop file

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct  4 17:28:24 CEST 2017 - shundhammer@suse.de
+
+- Added disk.desktop file for partitioner (bsc#1059528)
+- 3.3.25
+
+-------------------------------------------------------------------
 Wed Oct  4 12:11:11 UTC 2017 - snwint@suse.com
 
 - separate planning strategies from DevicesPlanner into

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        3.3.24
+Version:        3.3.25
 Release:	0
 BuildArch:	noarch
 

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -61,6 +61,7 @@ rake install DESTDIR="%{buildroot}"
 %defattr(-,root,root)
 %{yast_dir}/clients/*.rb
 %{yast_dir}/lib
+%{yast_desktopdir}/*.desktop
 
 # agents-scr
 %{yast_scrconfdir}/*.scr

--- a/src/desktop/disk.desktop
+++ b/src/desktop/disk.desktop
@@ -1,0 +1,21 @@
+[Desktop Entry]
+Type=Application
+Categories=Settings;System;Qt;X-SuSE-YaST;X-SuSE-YaST-System;
+
+X-KDE-HasReadOnlyMode=true
+X-SuSE-YaST-Call=disk
+
+X-SuSE-YaST-Group=System
+X-SuSE-YaST-Argument=
+X-SuSE-YaST-RootOnly=true
+X-SuSE-YaST-AutoInst=
+X-SuSE-YaST-Geometry=
+X-SuSE-YaST-SortKey=
+X-SuSE-YaST-AutoInstResource=
+
+Icon=yast-disk
+Exec=xdg-su -c "/sbin/yast2 disk"
+
+Name=Partitioner
+GenericName=Partition hard disks (including RAID, LVM, and encrypted file systems)
+StartupNotify=true

--- a/src/desktop/disk.desktop
+++ b/src/desktop/disk.desktop
@@ -3,7 +3,7 @@ Type=Application
 Categories=Settings;System;Qt;X-SuSE-YaST;X-SuSE-YaST-System;
 
 X-KDE-HasReadOnlyMode=true
-X-SuSE-YaST-Call=disk
+X-SuSE-YaST-Call=partitioner
 
 X-SuSE-YaST-Group=System
 X-SuSE-YaST-Argument=

--- a/src/desktop/disk.desktop
+++ b/src/desktop/disk.desktop
@@ -14,7 +14,7 @@ X-SuSE-YaST-SortKey=
 X-SuSE-YaST-AutoInstResource=
 
 Icon=yast-disk
-Exec=xdg-su -c "/sbin/yast2 disk"
+Exec=xdg-su -c "/sbin/yast2 partitioner"
 
 Name=Partitioner
 GenericName=Partition hard disks (including RAID, LVM, and encrypted file systems)


### PR DESCRIPTION
https://trello.com/c/85gke1CE/745-0-storageng-missing-desktop-file-for-expert-partitioner

Directory structure and Rakefile changes taken from yast-packager, a package that does not also use the autotools. desktop files from src/desktop are automatically picked up and installed to /usr/share/applications/YaST by our default rake rules.

The .desktop file is copied verbatim from yast-storage-old.