### PR TITLE
 Add button to run partitioner from probed 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Oct 30 13:32:02 UTC 2017 - ancor@suse.com
+
+- Added an option in the installer to run the expert partitioner
+  with the current storage layout as starting point.
+- Possible fix for bsc#1055644 and part of fate#318196.
+- 4.0.14
+
+-------------------------------------------------------------------
 Fri Oct 27 11:33:55 UTC 2017 - jsrain@suse.cz
 
 - Limit maximal proposed size of EFI partition (bsc#1062775)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.13
+Version:        4.0.14
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/clients/inst_disk_proposal.rb
+++ b/src/lib/y2storage/clients/inst_disk_proposal.rb
@@ -101,7 +101,6 @@ module Y2Storage
         end
 
         case result
-        # NOTE: method Y2Partitioner::Dialogs::Main#run does not return :abort when aborting.
         when :abort
           @result = :abort
         when :next

--- a/src/lib/y2storage/clients/inst_disk_proposal.rb
+++ b/src/lib/y2storage/clients/inst_disk_proposal.rb
@@ -62,8 +62,10 @@ module Y2Storage
           when :guided
             settings = dialog.proposal ? dialog.proposal.settings : new_settings
             guided_setup(settings)
-          when :expert
-            expert_partitioner
+          when :expert_from_proposal
+            expert_partitioner(@devicegraph) if @devicegraph
+          when :expert_from_probed
+            expert_partitioner(storage_manager.probed)
           end
         end
 
@@ -94,10 +96,10 @@ module Y2Storage
         end
       end
 
-      def expert_partitioner
+      def expert_partitioner(initial_graph)
         dialog = Y2Partitioner::Dialogs::Main.new
         result = without_title_on_left do
-          dialog.run(storage_manager.probed, @devicegraph)
+          dialog.run(storage_manager.probed, initial_graph)
         end
 
         case result

--- a/src/lib/y2storage/clients/inst_disk_proposal.rb
+++ b/src/lib/y2storage/clients/inst_disk_proposal.rb
@@ -60,10 +60,9 @@ module Y2Storage
           when :next
             save_to_storage_manager
           when :guided
-            settings = dialog.proposal ? dialog.proposal.settings : new_settings
-            guided_setup(settings)
+            guided_setup
           when :expert_from_proposal
-            expert_partitioner(@devicegraph) if @devicegraph
+            expert_partitioner(@devicegraph)
           when :expert_from_probed
             expert_partitioner(storage_manager.probed)
           end
@@ -86,7 +85,8 @@ module Y2Storage
         add_storage_packages
       end
 
-      def guided_setup(settings)
+      def guided_setup
+        settings = @proposal ? @proposal.settings : new_settings
         dialog = Dialogs::GuidedSetup.new(settings, probed_analyzer)
         case dialog.run
         when :abort
@@ -97,6 +97,8 @@ module Y2Storage
       end
 
       def expert_partitioner(initial_graph)
+        return unless initial_graph
+
         dialog = Y2Partitioner::Dialogs::Main.new
         result = without_title_on_left do
           dialog.run(storage_manager.probed, initial_graph)

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -124,10 +124,10 @@ module Y2Storage
       def expert_partitioner
         items = []
         if devicegraph
-          items << Item(Id(:expert_from_proposal), _("Start with Current Proposal"))
+          items << Item(Id(:expert_from_proposal), _("Start with &Current Proposal"))
         end
-        items << Item(Id(:expert_from_probed), _("Start with Existing Partitions"))
-        MenuButton(_("Expert Partitioner"), items)
+        items << Item(Id(:expert_from_probed), _("Start with Existing &Partitions"))
+        MenuButton(_("&Expert Partitioner"), items)
       end
 
       def dialog_content
@@ -135,7 +135,7 @@ module Y2Storage
           2, 1,
           VBox(
             MinHeight(8, summary),
-            PushButton(Id(:guided), _("Guided Setup")),
+            PushButton(Id(:guided), _("&Guided Setup")),
             expert_partitioner
           )
         )

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -60,8 +60,12 @@ module Y2Storage
         finish_dialog(:guided)
       end
 
-      def expert_handler
-        finish_dialog(:expert)
+      def expert_from_proposal_handler
+        finish_dialog(:expert_from_proposal)
+      end
+
+      def expert_from_probed_handler
+        finish_dialog(:expert_from_probed)
       end
 
       def handle_event(input)
@@ -117,13 +121,22 @@ module Y2Storage
         _("Suggested Partitioning")
       end
 
+      def expert_partitioner
+        items = []
+        if devicegraph
+          items << Item(Id(:expert_from_proposal), _("Start with Current Proposal"))
+        end
+        items << Item(Id(:expert_from_probed), _("Start with Existing Partitions"))
+        MenuButton(_("Expert Partitioner"), items)
+      end
+
       def dialog_content
         MarginBox(
           2, 1,
           VBox(
             MinHeight(8, summary),
             PushButton(Id(:guided), _("Guided Setup")),
-            PushButton(Id(:expert), _("Expert partitioner"))
+            expert_partitioner
           )
         )
       end

--- a/test/y2storage/dialogs/proposal_test.rb
+++ b/test/y2storage/dialogs/proposal_test.rb
@@ -244,5 +244,29 @@ describe Y2Storage::Dialogs::Proposal do
         dialog.run
       end
     end
+
+    context "when the user decides to run the expert partitioner from the proposed devicegraph" do
+      let(:proposal) { double("Y2Storage::GuidedProposal", proposed?: true) }
+
+      before do
+        allow(Yast::UI).to receive(:UserInput).and_return(:expert_from_proposal)
+      end
+
+      it "returns :expert_from_proposal" do
+        expect(dialog.run).to eq :expert_from_proposal
+      end
+    end
+
+    context "when the user decides to run the expert partitioner from the probed devicegraph" do
+      let(:proposal) { double("Y2Storage::GuidedProposal", proposed?: true) }
+
+      before do
+        allow(Yast::UI).to receive(:UserInput).and_return(:expert_from_probed)
+      end
+
+      it "returns :expert_from_probed" do
+        expect(dialog.run).to eq :expert_from_probed
+      end
+    end
   end
 end


### PR DESCRIPTION
This implements https://trello.com/c/LvwStMCI/704-1-partitioner-start-from-scratch

Easier to review in a per-commit fashion.

Manually tested in the inst-sys, see screenshots.

![partitioner_from_scratch_qt](https://user-images.githubusercontent.com/3638289/32177501-c7fc2bfc-bd8a-11e7-8d19-a7d4ce35f93a.png)

![partitioner_from_scratch_ncurses](https://user-images.githubusercontent.com/3638289/32177499-c7d8e8ea-bd8a-11e7-9eb2-d5ac013d4af9.png)