### PR TITLE
Do not crash when an unknown key is used

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov  1 08:23:17 UTC 2017 - igonzalezsosa@suse.com
+
+- AutoYaST: do not crash when an unknown key is used in a
+  skip list (bsc#1065670). 
+- 4.0.16
+
+-------------------------------------------------------------------
 Tue Oct 31 12:14:18 UTC 2017 - igonzalezsosa@suse.com
 
 - AutoYaST: fix reuse of partitions (bsc#1060637).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.15
+Version:        4.0.16
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/autoinst_issues/missing_value.rb
+++ b/src/lib/y2storage/autoinst_issues/missing_value.rb
@@ -30,9 +30,6 @@ module Y2Storage
     #   problem = MissingValue.new(section, :size)
     #   problem.attr #=> :size
     class MissingValue < Issue
-      # @return [String] Device affected by this error
-      attr_reader :device
-
       # @return [Symbol] Name of the missing attribute
       attr_reader :attr
 

--- a/src/lib/y2storage/autoinst_profile/skip_list_section.rb
+++ b/src/lib/y2storage/autoinst_profile/skip_list_section.rb
@@ -99,6 +99,13 @@ module Y2Storage
         rules.map(&:to_profile_rule)
       end
 
+      # Return section name
+      #
+      # @return [String] "skip_list"
+      def section_name
+        "skip_list"
+      end
+
     private
 
       # Log a list of rules as ignored

--- a/src/lib/y2storage/autoinst_profile/skip_list_value.rb
+++ b/src/lib/y2storage/autoinst_profile/skip_list_value.rb
@@ -35,6 +35,8 @@ module Y2Storage
       private :disk
 
       # Constructor
+      #
+      # @param disk [Y2Storage::Disk] Disk
       def initialize(disk)
         @disk = disk
       end

--- a/src/lib/y2storage/autoinst_profile/skip_rule.rb
+++ b/src/lib/y2storage/autoinst_profile/skip_rule.rb
@@ -37,6 +37,8 @@ module Y2Storage
     #   Proposal::SkipRule.from_profile_hash(hash)
     #
     class SkipRule
+      include Yast::Logger
+
       class NotValidSkipRule < StandardError; end
 
       # @return [String] Name of the attribute to check when applying the rule
@@ -123,7 +125,10 @@ module Y2Storage
       #
       # @see Proposal::SkipListValue
       def value(disk)
-        SkipListValue.new(disk).send(key)
+        SkipListValue.new(disk).public_send(key)
+      rescue NoMethodError
+        log.warn "Unknown skip list key: #{key}"
+        false
       end
 
       # Rule definition in the AutoYaST profile format used by the AutoYaST

--- a/src/lib/y2storage/proposal/autoinst_devices_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_planner.rb
@@ -80,7 +80,7 @@ module Y2Storage
 
       # @return [Devicegraph] Starting devicegraph
       attr_reader :devicegraph
-      # @return [AutoinstIssues::List] Starting devicegraph
+      # @return [AutoinstIssues::List] List of AutoYaST issues to register them
       attr_reader :issues_list
 
       # Returns an array of planned partitions for a given disk

--- a/test/y2storage/autoinst_profile/skip_list_section_test.rb
+++ b/test/y2storage/autoinst_profile/skip_list_section_test.rb
@@ -96,4 +96,10 @@ describe Y2Storage::AutoinstProfile::SkipListSection do
       expect(list.to_hashes).to eq([rule1_hash])
     end
   end
+
+  describe "#section_name" do
+    it "returns 'skip_list'" do
+      expect(list.section_name).to eq("skip_list")
+    end
+  end
 end

--- a/test/y2storage/autoinst_profile/skip_rule_test.rb
+++ b/test/y2storage/autoinst_profile/skip_rule_test.rb
@@ -263,6 +263,21 @@ describe Y2Storage::AutoinstProfile::SkipRule do
         end
       end
     end
+
+    context "when key is not supported" do
+      before do
+        allow(value).to receive(key).and_raise(NoMethodError)
+      end
+
+      it "returns false" do
+        expect(rule.matches?(disk)).to eq(false)
+      end
+
+      it "logs a warning" do
+        expect(rule.log).to receive(:warn).with("Unknown skip list key: size_k")
+        rule.matches?(disk)
+      end
+    end
   end
 
   describe "#valid?" do


### PR DESCRIPTION
Fixes [bsc#1065670](https://bugzilla.suse.com/show_bug.cgi?id=1065670) and logs a warning. This PR contains other minor fixes too.