### PR TITLE
- do not query end of region if region is empty (bsc#1066290)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 03 14:27:02 CET 2017 - aschnell@suse.com
+
+- do not query end of region if region is empty (bsc#1066290)
+- 4.0.19
+
+-------------------------------------------------------------------
 Thu Nov  2 17:58:28 UTC 2017 - igonzalezsosa@suse.com
 
 - AutoYaST: query hardware information on skip lists (bsc#1065668).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.18
+Version:        4.0.19
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -188,11 +188,13 @@ module Y2Partitioner
 
       def start_value(device)
         return "" unless device.respond_to?(:region)
+        return "" if device.region.empty?
         device.region.start
       end
 
       def end_value(device)
         return "" unless device.respond_to?(:region)
+        return "" if device.region.empty?
         device.region.end
       end
     end


### PR DESCRIPTION
Querying the end can result in wrap around so must be avoided.

Showing only start and no end is strange so also omit start.