### PR TITLE
Fix use

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov  3 15:11:42 UTC 2017 - igonzalezsosa@suse.com
+
+- AutoYaST: do not remove partitions that are supposed to be reused
+  (bsc#1066398).
+- 4.0.20
+
+-------------------------------------------------------------------
 Fri Nov 03 14:27:02 CET 2017 - aschnell@suse.com
 
 - do not query end of region if region is empty (bsc#1066290)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.19
+Version:        4.0.20
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/autoinst_proposal.rb
+++ b/src/lib/y2storage/autoinst_proposal.rb
@@ -74,10 +74,7 @@ module Y2Storage
         return @devices
       end
 
-      space_maker = Proposal::AutoinstSpaceMaker.new(disk_analyzer, issues_list)
-      devicegraph = space_maker.cleaned_devicegraph(initial_devicegraph, drives)
-
-      @devices = propose_devicegraph(devicegraph, drives)
+      @devices = propose_devicegraph(initial_devicegraph, drives)
     end
 
     # Proposes a devicegraph based on given drives map
@@ -91,6 +88,10 @@ module Y2Storage
     def propose_devicegraph(devicegraph, drives)
       if drives.partitions?
         @planned_devices = plan_devices(devicegraph, drives)
+
+        space_maker = Proposal::AutoinstSpaceMaker.new(disk_analyzer, issues_list)
+        devicegraph = space_maker.cleaned_devicegraph(devicegraph, drives, @planned_devices)
+
         create_devices(devicegraph, @planned_devices, drives.disk_names)
       else
         log.info "No partitions were specified. Falling back to guided setup planning."

--- a/src/lib/y2storage/proposal/autoinst_space_maker.rb
+++ b/src/lib/y2storage/proposal/autoinst_space_maker.rb
@@ -187,7 +187,7 @@ module Y2Storage
             all << devicegraph.partitions.find { |p| device.reuse == p.name }
           when Y2Storage::Planned::LvmVg
             vg = devicegraph.lvm_vgs.find { |v| File.join("/dev", device.reuse) == v.name }
-            all.concat(vg.lvm_pvs.map(&:blk_device))
+            all.concat(vg.lvm_pvs)
           when Y2Storage::Planned::Md
             all << devicegraph.md_raids.find { |r| device.reuse == r.name }
           end

--- a/src/lib/y2storage/proposal/autoinst_space_maker.rb
+++ b/src/lib/y2storage/proposal/autoinst_space_maker.rb
@@ -22,6 +22,8 @@
 # find current contact information at www.suse.com.
 
 require "y2storage/disk"
+require "y2storage/planned/lvm_vg"
+require "y2storage/planned/lvm_lv"
 
 module Y2Storage
   module Proposal
@@ -45,17 +47,22 @@ module Y2Storage
       # Performs all the delete operations specified in the AutoYaST profile
       #
       # @param original_devicegraph [Devicegraph] initial devicegraph
-      # @param drives_map           [Array<Planned::Partition>] set of partitions
+      # @param drives_map           [AutoinstDrivesMap] drives map
+      # @param planned_devices      [Array<Planned::Partition>] set of partitions
       #   to make space for.
-      def cleaned_devicegraph(original_devicegraph, drives_map)
+      def cleaned_devicegraph(original_devicegraph, drives_map, planned_devices)
         devicegraph = original_devicegraph.dup
+
+        reused_partitions = reused_partitions_by_disk(devicegraph, planned_devices)
+        sid_map = partitions_sid_map(devicegraph)
 
         drives_map.each_pair do |disk_name, drive_spec|
           disk = BlkDevice.find_by_name(devicegraph, disk_name)
           next unless disk
-          delete_stuff(devicegraph, disk, drive_spec)
+          delete_stuff(devicegraph, disk, drive_spec, reused_partitions[disk.name])
         end
 
+        adjust_reuse_values(devicegraph, planned_devices, sid_map)
         devicegraph
       end
 
@@ -65,49 +72,57 @@ module Y2Storage
 
       # Deletes unwanted partitions for the given disk
       #
-      # @param devicegraph [Devicegraph]
-      # @param disk        [Disk]
-      # @param drive_spec  [AutoinstProfile::DriveSection]
-      def delete_stuff(devicegraph, disk, drive_spec)
-        if drive_spec.initialize_attr
+      # @param devicegraph  [Devicegraph]
+      # @param disk         [Disk]
+      # @param drive_spec   [AutoinstProfile::DriveSection]
+      # @param reused_parts [Array<String>] Reused partitions names
+      def delete_stuff(devicegraph, disk, drive_spec, reused_parts)
+        reused_parts ||= []
+        if drive_spec.initialize_attr && reused_parts.empty?
           disk.remove_descendants
           return
         end
 
         # TODO: resizing of partitions
 
-        delete_by_use(devicegraph, disk, drive_spec)
+        delete_by_use(devicegraph, disk, drive_spec, reused_parts)
       end
 
       # Deletes unwanted partition according to the "use" element
       #
-      # @param devicegraph [Devicegraph]
-      # @param disk        [Disk]
-      # @param drive_spec  [AutoinstProfile::DriveSection]
-      def delete_by_use(devicegraph, disk, drive_spec)
+      # @param devicegraph  [Devicegraph]
+      # @param disk         [Disk]
+      # @param drive_spec   [AutoinstProfile::DriveSection]
+      # @param reused_parts [Array<String>] Reused partitions names
+      def delete_by_use(devicegraph, disk, drive_spec, reused_parts)
         return if drive_spec.use == "free"
         case drive_spec.use
         when "all"
-          disk.partition_table.remove_descendants if disk.partition_table
+          delete_partitions(devicegraph, disk.partitions, reused_parts) if disk.partition_table
         when "linux"
-          delete_linux_partitions(devicegraph, disk)
+          delete_linux_partitions(devicegraph, disk, reused_parts)
         when Array
-          delete_partitions_by_number(devicegraph, disk, drive_spec.use)
+          delete_partitions_by_number(devicegraph, disk, drive_spec.use, reused_parts)
         else
           register_invalid_use_value(drive_spec)
         end
       end
 
+      # Search a partition by its sid
+      #
+      # @param devicegraph  [Devicegraph] Working devicegraph
+      def partition_by_sid(devicegraph, sid)
+        devicegraph.partitions.find { |p| p.sid == sid }
+      end
+
       # Deletes Linux partitions from a disk in the given devicegraph
       #
-      # @param devicegraph [Devicegraph] Working devicegraph
-      # @param disk        [Disk]        Disk to remove partitions from
-      def delete_linux_partitions(devicegraph, disk)
-        partition_killer = Proposal::PartitionKiller.new(devicegraph)
+      # @param devicegraph  [Devicegraph] Working devicegraph
+      # @param disk         [Disk]        Disk to remove partitions from
+      # @param reused_parts [Array<String>] Reused partitions names
+      def delete_linux_partitions(devicegraph, disk, reused_parts)
         parts = disk_analyzer.linux_partitions(disk)
-        # TODO: when introducing supporting for LVM, should we protect here
-        # the PVs of VGs that are going to be reused somehow?
-        parts.map(&:name).each { |n| partition_killer.delete(n) }
+        delete_partitions(devicegraph, parts, reused_parts)
       end
 
       # Deletes Linux partitions which number is included in a list
@@ -115,10 +130,22 @@ module Y2Storage
       # @param devicegraph [Devicegraph]    Working devicegraph
       # @param disk        [Disk]           Disk to remove partitions from
       # @param partition_nrs [Array<Integer>] List of partition numbers
-      def delete_partitions_by_number(devicegraph, disk, partition_nrs)
-        partition_killer = Proposal::PartitionKiller.new(devicegraph)
+      def delete_partitions_by_number(devicegraph, disk, partition_nrs, reused_partitions)
         parts = disk.partitions.select { |n| partition_nrs.include?(n.number) }
-        parts.map(&:name).each { |n| partition_killer.delete(n) }
+        delete_partitions(devicegraph, parts, reused_partitions)
+      end
+
+      # @param devicegraph     [Devicegraph]               devicegraph
+      # @param parts           [Array<Planned::Partition>] parts to delete
+      # @param reused_parts    [Array<String>]             reused partitions names
+      def delete_partitions(devicegraph, parts, reused_parts)
+        partition_killer = Proposal::PartitionKiller.new(devicegraph)
+        parts_to_delete = parts.reject { |p| reused_parts.include?(p.name) }
+        parts_to_delete.map(&:sid).each do |sid|
+          partition = partition_by_sid(devicegraph, sid)
+          next unless partition
+          partition_killer.delete(partition.name)
+        end
       end
 
       # Register an invalid/missing value for 'use'
@@ -129,6 +156,76 @@ module Y2Storage
           issues_list.add(:invalid_value, drive_spec, :use)
         else
           issues_list.add(:missing_value, drive_spec, :use)
+        end
+      end
+
+      # Return a map of reused partitions
+      #
+      # Calculates which partitions are meant to be reused and, as a consequence, should not
+      # be deleted.
+      #
+      # @param devicegraph     [Devicegraph]               devicegraph
+      # @param planned_devices [Array<Planned::Partition>] set of partitions
+      # @return [Hash<String,Array<String>>] disk name to list of reused partitions map
+      def reused_partitions_by_disk(devicegraph, planned_devices)
+        find_reused_partitions(devicegraph, planned_devices).each_with_object({}) do |part, map|
+          disk_name = part.disk.name
+          map[disk_name] ||= []
+          map[disk_name] << part.name
+        end
+      end
+
+      # Determine which partitions will be reused
+      #
+      # @param devicegraph     [Devicegraph]               devicegraph
+      # @param planned_devices [Array<Planned::Partition>] set of partitions
+      # @return [Hash<String,Array<String>>] disk name to list of reused partitions map
+      def find_reused_partitions(devicegraph, planned_devices)
+        reused_devices = planned_devices.select(&:reuse).each_with_object([]) do |device, all|
+          case device
+          when Y2Storage::Planned::Partition
+            all << devicegraph.partitions.find { |p| device.reuse == p.name }
+          when Y2Storage::Planned::LvmVg
+            vg = devicegraph.lvm_vgs.find { |v| File.join("/dev", device.reuse) == v.name }
+            all.concat(vg.lvm_pvs.map(&:blk_device))
+          when Y2Storage::Planned::Md
+            all << devicegraph.md_raids.find { |r| device.reuse == r.name }
+          end
+        end
+
+        ancestors = reused_devices.map(&:ancestors).flatten
+        (reused_devices + ancestors).select { |p| p.is_a?(Y2Storage::Partition) }
+      end
+
+      # Build a device name to sid map
+      #
+      # @param devicegraph [Devicegraph] devicegraph
+      # @return [Hash<String,Integer>] Map with device names as keys and sid as values.
+      #
+      # @see adjust_reuse_values
+      def partitions_sid_map(devicegraph)
+        devicegraph.partitions.each_with_object({}) { |p, m| m[p.name] = p.sid }
+      end
+
+      # Adjust reuse values
+      #
+      # When using logical partitions (ms-dos), removing a partition might cause the rest of
+      # logical partitions numbers to shift. In such a situation, 'reuse' properties of planned
+      # devices will break (they might point to a non-existent device).
+      #
+      # This method takes care of setting the correct value for every 'reuse' property (thus
+      # planned_devices are modified).
+      #
+      # @param devicegraph     [Devicegraph]               devicegraph
+      # @param planned_devices [Array<Planned::Partition>] set of partitions to make space for
+      # @param sid_map         [Hash<String,Integer>]      device name to sid map
+      #
+      # @see sid_map
+      def adjust_reuse_values(devicegraph, planned_devices, sid_map)
+        planned_devices.select { |d| d.is_a?(Y2Storage::Planned::Partition) && d.reuse }.each do |device|
+          sid = sid_map[device.reuse]
+          partition = partition_by_sid(devicegraph, sid)
+          device.reuse = partition.name
         end
       end
     end

--- a/test/y2storage/autoinst_issues/missing_reusable_device_test.rb
+++ b/test/y2storage/autoinst_issues/missing_reusable_device_test.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "y2storage/autoinst_issues/missing_reuse_info"
+require "y2storage/autoinst_profile/partition_section"
+
+describe Y2Storage::AutoinstIssues::MissingReusableDevice do
+  subject(:issue) { described_class.new(section) }
+
+  let(:section) do
+    instance_double(Y2Storage::AutoinstProfile::PartitionSection)
+  end
+
+  describe "#message" do
+    it "returns a description of the issue" do
+      expect(issue.message).to eq("Reusable device not found")
+    end
+  end
+
+  describe "#severity" do
+    it "returns :warn" do
+      expect(issue.severity).to eq(:warn)
+    end
+  end
+end

--- a/test/y2storage/autoinst_issues/missing_reuse_info_test.rb
+++ b/test/y2storage/autoinst_issues/missing_reuse_info_test.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "y2storage/autoinst_issues/missing_reuse_info"
+require "y2storage/autoinst_profile/partition_section"
+
+describe Y2Storage::AutoinstIssues::MissingReuseInfo do
+  subject(:issue) { described_class.new(section) }
+
+  let(:section) do
+    instance_double(Y2Storage::AutoinstProfile::PartitionSection)
+  end
+
+  describe "#message" do
+    it "returns a description of the issue" do
+      expect(issue.message).to include "Not enough information"
+    end
+  end
+
+  describe "#severity" do
+    it "returns :warn" do
+      expect(issue.severity).to eq(:warn)
+    end
+  end
+end

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -239,6 +239,37 @@ describe Y2Storage::AutoinstProposal do
       end
     end
 
+    describe "reusing logical volumes" do
+      let(:scenario) { "lvm-two-vgs" }
+
+      let(:lvm_group) { "vg0" }
+
+      let(:root) do
+        {
+          "create" => false, "mount" => "/", "filesystem" => "ext4", "lv_name" => "lv1",
+          "size" => "20G"
+        }
+      end
+
+      let(:partitioning) do
+        [
+          { "device" => "/dev/sda", "use" => "all", "partitions" => [pv] }, vg
+        ]
+      end
+
+      let(:vg) do
+        { "device" => "/dev/#{lvm_group}", "partitions" => [root], "type" => :CT_LVM }
+      end
+
+      let(:pv) do
+        { "create" => true, "lvm_group" => lvm_group, "size" => "max", "type" => :CT_LVM }
+      end
+
+      it "reuses the volume group" do
+        proposal.propose
+      end
+    end
+
     describe "skipping a disk" do
       let(:skip_list) do
         [{ "skip_key" => "name", "skip_value" => skip_device }]

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -511,6 +511,43 @@ describe Y2Storage::AutoinstProposal do
           )
         end
       end
+
+      context "reusing a RAID" do
+        let(:scenario) { "md_raid.xml" }
+        let(:md_device) { "/dev/md/md0" }
+
+        let(:partitioning) do
+          [
+            { "device" => "/dev/sda", "use" => "all", "partitions" => [root_spec, raid_spec] },
+            { "device" => "/dev/md", "partitions" => [home_spec] }
+          ]
+        end
+
+        let(:raid_options) { { "raid_name" => md_device, "raid_type" => "raid0" } }
+
+        let(:home_spec) do
+          {
+            "mount" => "/home", "filesystem" => "xfs", "size" => "max",
+            "raid_name" => md_device, "partition_nr" => 0, "raid_options" => raid_options,
+            "create" => false
+          }
+        end
+
+        let(:raid_spec) do
+          { "raid_name" => md_device, "create" => false }
+        end
+
+        it "reuses a RAID" do
+          proposal.propose
+          devicegraph = proposal.devices
+          expect(devicegraph.md_raids).to contain_exactly(
+            an_object_having_attributes(
+              "name"     => "/dev/md/md0",
+              "md_level" => Y2Storage::MdLevel::RAID0
+            )
+          )
+        end
+      end
     end
 
     describe "LVM on RAID" do

--- a/test/y2storage/proposal/autoinst_space_maker_test.rb
+++ b/test/y2storage/proposal/autoinst_space_maker_test.rb
@@ -237,7 +237,7 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
           Y2Storage::Planned::Partition.new("/").tap { |p| p.reuse = "/dev/sda1" }
         end
 
-        it "does not removes the partition table" do
+        it "does not remove the partition table" do
           devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
           devicegraph.partitions
           disk = Y2Storage::Disk.find_by_name(devicegraph, "/dev/sda")

--- a/test/y2storage/proposal/autoinst_space_maker_test.rb
+++ b/test/y2storage/proposal/autoinst_space_maker_test.rb
@@ -28,27 +28,68 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
   subject(:space_maker) { described_class.new(analyzer) }
 
   let(:analyzer) { Y2Storage::DiskAnalyzer.new(fake_devicegraph) }
-  let(:scenario) { "windows-linux-free-pc" }
+  let(:scenario) { "lvm-two-vgs" }
   let(:partitioning_array) { [{ "device" => "/dev/sda", "use" => "all" }] }
   let(:partitioning) do
     Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(partitioning_array)
   end
+
+  let(:planned_devices) { [] }
   let(:drives_map) { Y2Storage::Proposal::AutoinstDrivesMap.new(fake_devicegraph, partitioning) }
+  let(:planned_partition) do
+    Y2Storage::Planned::Partition.new("/").tap { |p| p.reuse = "/dev/sda8" }
+  end
+  let(:planned_vg) do
+    Y2Storage::Planned::LvmVg.new(volume_group_name: "vg0").tap { |p| p.reuse = "vg0" }
+  end
 
   before { fake_scenario(scenario) }
 
   describe "#cleaned_devicegraph" do
     context "when 'use' key is set to 'all'" do
       it "removes all partitions" do
-        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map)
+        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
         expect(devicegraph.partitions).to be_empty
       end
 
       it "does not remove the partition table" do
-        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map)
+        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
         devicegraph.partitions
         disk = Y2Storage::Disk.find_by_name(devicegraph, "/dev/sda")
         expect(disk.partition_table).to_not be_nil
+      end
+
+      context "and a partition will be reused" do
+        let(:scenario) { "lvm-two-vgs" }
+        let(:planned_devices) { [planned_partition] }
+
+        it "keeps reused partitions" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          expect(devicegraph.partitions).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/sda3"),
+            an_object_having_attributes("name" => planned_partition.reuse)
+          )
+        end
+      end
+
+      context "and a volume group will be reused" do
+        let(:scenario) { "lvm-two-vgs" }
+        let(:planned_devices) { [planned_vg] }
+
+        it "keeps the physical volumes" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          expect(devicegraph.partitions).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/sda3"),
+            an_object_having_attributes("name" => "/dev/sda5")
+          )
+          vg = devicegraph.lvm_vgs.first
+          pv = vg.lvm_pvs.first
+          expect(pv.blk_device.name).to eq("/dev/sda5")
+        end
+      end
+
+      context "and a RAID device will be reused" do
+        it "keeps the physical partition"
       end
     end
 
@@ -56,10 +97,44 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
       let(:partitioning_array) { [{ "device" => "/dev/sda", "use" => "linux" }] }
 
       it "removes only Linux partitions" do
-        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map)
+        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
         expect(devicegraph.partitions).to contain_exactly(
-          an_object_having_attributes(name: "/dev/sda1")
+          an_object_having_attributes(name: "/dev/sda1"),
+          an_object_having_attributes(name: "/dev/sda2")
         )
+      end
+
+      context "and a partition will be reused" do
+        let(:scenario) { "lvm-two-vgs" }
+        let(:planned_devices) { [planned_partition] }
+
+        it "keeps reused partitions" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          expect(devicegraph.partitions).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/sda1"),
+            an_object_having_attributes("name" => "/dev/sda2"),
+            an_object_having_attributes("name" => "/dev/sda3"),
+            an_object_having_attributes("name" => planned_partition.reuse)
+          )
+        end
+      end
+
+      context "and a volume group will be reused" do
+        let(:scenario) { "lvm-two-vgs" }
+        let(:planned_devices) { [planned_vg] }
+
+        it "keeps the physical volumes" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          expect(devicegraph.partitions).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/sda1"),
+            an_object_having_attributes("name" => "/dev/sda2"),
+            an_object_having_attributes("name" => "/dev/sda3"),
+            an_object_having_attributes("name" => "/dev/sda5")
+          )
+          vg = devicegraph.lvm_vgs.first
+          pv = vg.lvm_pvs.first
+          expect(pv.blk_device.name).to eq("/dev/sda5")
+        end
       end
     end
 
@@ -67,10 +142,43 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
       let(:partitioning_array) { [{ "device" => "/dev/sda", "use" => "2,3" }] }
 
       it "removes specified partitions" do
-        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map)
+        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
         expect(devicegraph.partitions).to contain_exactly(
           an_object_having_attributes(name: "/dev/sda1")
         )
+      end
+
+      context "and a partition will be reused" do
+        let(:scenario) { "lvm-two-vgs" }
+        let(:planned_devices) { [planned_partition] }
+        let(:partitioning_array) { [{ "device" => "/dev/sda", "use" => "2,3,4,5,6,7,8,9" }] }
+
+        it "keeps reused partitions" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          expect(devicegraph.partitions).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/sda1"),
+            an_object_having_attributes("name" => "/dev/sda3"),
+            an_object_having_attributes("name" => planned_partition.reuse)
+          )
+        end
+      end
+
+      context "and a volume group will be reused" do
+        let(:scenario) { "lvm-two-vgs" }
+        let(:planned_devices) { [planned_vg] }
+        let(:partitioning_array) { [{ "device" => "/dev/sda", "use" => "2,3,4,5,6,7,8,9" }] }
+
+        it "keeps the physical volumes" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          expect(devicegraph.partitions).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/sda1"),
+            an_object_having_attributes("name" => "/dev/sda3"),
+            an_object_having_attributes("name" => "/dev/sda5")
+          )
+          vg = devicegraph.lvm_vgs.first
+          pv = vg.lvm_pvs.first
+          expect(pv.blk_device.name).to eq("/dev/sda5")
+        end
       end
     end
 
@@ -78,12 +186,12 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
       let(:partitioning_array) { [{ "device" => "/dev/sda", "use" => "wrong-value" }] }
 
       it "does not remove any partition" do
-        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map)
-        expect(devicegraph.partitions.size).to eq(3)
+        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+        expect(devicegraph.partitions.size).to eq(8)
       end
 
       it "registers an issue" do
-        subject.cleaned_devicegraph(fake_devicegraph, drives_map)
+        subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
 
         issue = subject.issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::InvalidValue) }
         expect(issue.attr).to eq(:use)
@@ -95,12 +203,12 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
       let(:partitioning_array) { [{ "device" => "/dev/sda" }] }
 
       it "does not remove any partition" do
-        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map)
-        expect(devicegraph.partitions.size).to eq(3)
+        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+        expect(devicegraph.partitions.size).to eq(8)
       end
 
       it "registers an issue" do
-        subject.cleaned_devicegraph(fake_devicegraph, drives_map)
+        subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
 
         issue = subject.issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::MissingValue) }
         expect(issue.attr).to eq(:use)
@@ -111,15 +219,30 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
       let(:partitioning_array) { [{ "device" => "/dev/sda", "initialize" => true }] }
 
       it "remove all partitions" do
-        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map)
+        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
         expect(devicegraph.partitions).to be_empty
       end
 
       it "removes the partitions table" do
-        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map)
+        devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
         devicegraph.partitions
         disk = Y2Storage::Disk.find_by_name(devicegraph, "/dev/sda")
         expect(disk.partition_table).to be_nil
+      end
+
+      context "and some device will be used" do
+        let(:scenario) { "lvm-two-vgs" }
+        let(:planned_devices) { [planned_partition] }
+        let(:planned_partition) do
+          Y2Storage::Planned::Partition.new("/").tap { |p| p.reuse = "/dev/sda1" }
+        end
+
+        it "does not removes the partition table" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          devicegraph.partitions
+          disk = Y2Storage::Disk.find_by_name(devicegraph, "/dev/sda")
+          expect(disk.partition_table).to_not be_nil
+        end
       end
     end
 
@@ -127,7 +250,8 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
       let(:partitioning_array) { [{ "device" => "/dev/sdx", "use" => "all" }] }
 
       it "ignores the device" do
-        expect { subject.cleaned_devicegraph(fake_devicegraph, drives_map) }.to_not raise_error
+        expect { subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices) }
+          .to_not raise_error
       end
     end
   end


### PR DESCRIPTION
This fixes an important bug: [bsc#1066398](https://bugzilla.suse.com/show_bug.cgi?id=1066398).

Basically, AutoinstSpaceMaker kicks in when partitions have been planned and does not remove any partition that could be reused.

The tricky part is mapping the `sid` with the `device name` in order to reassign `reuse` properties after making space (as, for instance, removing a logical partition might cause other partitions to be renamed).