### PR TITLE
Add some missing skip list keys

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov  7 13:18:35 UTC 2017 - igonzalezsosa@suse.com
+
+- AutoYaST: adjust the list of allowed keys in skip lists
+  (bsc#1065668)
+- 4.0.23
+
+-------------------------------------------------------------------
 Tue Nov  7 09:38:19 UTC 2017 - igonzalezsosa@suse.com
 
 - AutoYaST: add support for udev links in the <device/> element

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.22
+Version:        4.0.23
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/autoinst_profile/skip_list_value.rb
+++ b/src/lib/y2storage/autoinst_profile/skip_list_value.rb
@@ -110,13 +110,13 @@ module Y2Storage
       # @return [String,nil] DASD format or nil if not a DASD device
       #   backward compatibility
       def dasd_format
-        return nil unless disk.is_a?(Y2Storage::Dasd)
+        return nil unless disk.is?(:dasd)
         disk.format.to_s
       end
 
       # @return [String,nil] DASD type or nil if not a DASD device
       def dasd_type
-        return nil unless disk.is_a?(Y2Storage::Dasd)
+        return nil unless disk.is?(:dasd)
         disk.type.to_s
       end
 

--- a/src/lib/y2storage/autoinst_profile/skip_list_value.rb
+++ b/src/lib/y2storage/autoinst_profile/skip_list_value.rb
@@ -68,11 +68,62 @@ module Y2Storage
         disk.basename
       end
 
+      # @return [String,nil] DASD format or nil if not a DASD device
+      #   backward compatibility
+      def dasd_format
+        return nil unless disk.is_a?(Y2Storage::Dasd)
+        disk.format.to_s
+      end
+
+      # @return [String,nil] DASD type or nil if not a DASD device
+      def dasd_type
+        return nil unless disk.is_a?(Y2Storage::Dasd)
+        disk.type.to_s
+      end
+
+      # @return [String] Partition table type ("msdos", "gpt", etc.)
+      def label
+        return nil if disk.partition_table.nil?
+        disk.partition_table.type.to_s
+      end
+
+      # @return [Integer] Max number of primery partitions
+      def max_primary
+        return nil if disk.partition_table.nil?
+        disk.partition_table.max_primary
+      end
+
+      # @return [Integer] Max number of logical partitions
+      def max_logical
+        return nil if disk.partition_table.nil?
+        disk.partition_table.max_logical
+      end
+
+      # @return [String] Disk transport
+      def transport
+        disk.transport.to_s
+      end
+
+      # @return [Integer] Block size
+      def sector_size
+        disk.region.block_size.to_i
+      end
+
+      # @return [Array<String>] Device udev identifiers
+      def udev_id
+        disk.udev_ids
+      end
+
+      # @return [Array<String>] Device udev paths
+      def udev_path
+        disk.udev_paths
+      end
+
     private
 
       # Redefine method_missing in order to try to to get additional values from hardware info
       def method_missing(meth, *_args, &_block)
-        if disk.hwinfo && disk.hwinfo.respond_to?(meth)
+        if disk.hwinfo && HWINFO_KEYS.include?(meth) && disk.hwinfo.respond_to?(meth)
           disk.hwinfo.public_send(meth)
         else
           super

--- a/src/lib/y2storage/hwinfo_reader.rb
+++ b/src/lib/y2storage/hwinfo_reader.rb
@@ -103,7 +103,7 @@ module Y2Storage
       body.lines.map(&:strip).each_with_object(OpenStruct.new) do |line, data|
         key, value = line.split(":", 2)
         next if value.nil?
-        key = key.downcase.tr(" ", "_").tr("()", "")
+        key = key.downcase.tr(" ", "_").tr("()/", "")
         value = value.tr("\"()", "").strip
         parsed_value = MULTI_VALUED.include?(key) ? parse_multi(value) : parse_single(value)
         data.public_send("#{key}=", parsed_value)

--- a/test/data/hwinfo.txt
+++ b/test/data/hwinfo.txt
@@ -47,6 +47,7 @@
   Geometry (Logical): CHS 121601/255/63
   Size: 1953525168 sectors a 512 bytes
   Capacity: 931 GB (1000204886016 bytes)
+  I/O Ports: 0xe000-0xefff (rw)
   Config Status: cfg=no, avail=yes, need=no, active=unknown
   Attached to: #12 (RAID bus controller)
 

--- a/test/y2storage/autoinst_profile/skip_list_value_test.rb
+++ b/test/y2storage/autoinst_profile/skip_list_value_test.rb
@@ -73,4 +73,100 @@ describe Y2Storage::AutoinstProfile::SkipListValue do
       end
     end
   end
+
+  describe "#label" do
+    it "returns partitions table type" do
+      expect(value.label).to eq("msdos")
+    end
+
+    context "when there is no partition table"
+  end
+
+  describe "#max_primary" do
+    it "returns partitions table type" do
+      expect(value.max_primary).to eq(4)
+    end
+
+    context "when there is no partition table"
+  end
+
+  describe "#max_logical" do
+    it "returns partitions table type" do
+      expect(value.max_logical).to eq(256)
+    end
+
+    context "when there is no partition table"
+  end
+
+  describe "#dasd_format" do
+    let(:scenario) { "dasd_50GiB" }
+    let(:disk) { Y2Storage::Dasd.find_by_name(fake_devicegraph, "/dev/sda") }
+
+    it "returns format" do
+      expect(value.dasd_format).to eq("none")
+    end
+
+    context "when device is not dasd" do
+      let(:scenario) { "windows-linux-free-pc" }
+      let(:disk) { Y2Storage::Disk.find_by_name(fake_devicegraph, "/dev/sda") }
+
+      it "returns nil" do
+        expect(value.dasd_format).to be_nil
+      end
+    end
+  end
+
+  describe "#transport" do
+    it "returns transport" do
+      expect(value.transport).to eq("unknown")
+    end
+  end
+
+  describe "#sector_size" do
+    it "returns block size" do
+      expect(value.sector_size).to eq(512)
+    end
+  end
+
+  describe "#udev_id" do
+    let(:udev_ids) { ["ata-Micron_1100_SATA_512GB_170115619F17"] }
+
+    before do
+      allow(disk).to receive(:udev_ids).and_return(udev_ids)
+    end
+
+    it "returns udev path" do
+      expect(value.udev_id).to eq(udev_ids)
+    end
+  end
+
+  describe "#udev_path" do
+    let(:udev_paths) { ["pci-0000:00:17.0-ata-3"] }
+
+    before do
+      allow(disk).to receive(:udev_paths).and_return(udev_paths)
+    end
+
+    it "returns udev path" do
+      expect(value.udev_path).to eq(udev_paths)
+    end
+  end
+
+  describe "#dasd_type" do
+    let(:scenario) { "dasd_50GiB" }
+    let(:disk) { Y2Storage::Dasd.find_by_name(fake_devicegraph, "/dev/sda") }
+
+    it "returns type" do
+      expect(value.dasd_type).to eq("eckd")
+    end
+
+    context "when device is not dasd" do
+      let(:scenario) { "windows-linux-free-pc" }
+      let(:disk) { Y2Storage::Disk.find_by_name(fake_devicegraph, "/dev/sda") }
+
+      it "returns nil" do
+        expect(value.dasd_type).to be_nil
+      end
+    end
+  end
 end

--- a/test/y2storage/hwinfo_reader_test.rb
+++ b/test/y2storage/hwinfo_reader_test.rb
@@ -42,6 +42,7 @@ describe Y2Storage::HWInfoReader do
                     unique_id:        "3OOL.7kkY9irDFZ4",
                     driver_modules:   ["ahci"],
                     driver:           ["ahci", "sd"],
+                    io_ports:         "0xe000-0xefff rw",
                     geometry_logical: "CHS 121601/255/63")
     end
 


### PR DESCRIPTION
Here is the second part of #408, adding some missing keys that were available in SLE12. Check https://github.com/yast/yast-autoinstallation/pull/364 to see them in action.