### PR TITLE
Fix disklabel

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Nov  8 05:54:04 UTC 2017 - igonzalezsosa@suse.com
+
+- AutoYaST: fix space distribution when partition table does not
+  exist (bsc#1065061)
+- AutoYaST: set partition tables type according to the profile
+- 4.0.24
+
+-------------------------------------------------------------------
 Tue Nov  7 13:18:35 UTC 2017 - igonzalezsosa@suse.com
 
 - AutoYaST: adjust the list of allowed keys in skip lists

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.23
+Version:        4.0.24
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/proposal/autoinst_devices_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_planner.rb
@@ -69,7 +69,6 @@ module Y2Storage
           end
         end
 
-        add_boot(result)
         remove_shadowed_subvols(result)
 
         result
@@ -434,23 +433,6 @@ module Y2Storage
       # @see AutoinstSizeParser
       def parse_size(section, min, max)
         AutoinstSizeParser.new(proposal_settings).parse(section.size, section.mount, min, max)
-      end
-
-      # Add devices to make the system bootable
-      #
-      # @return [Array<Planned::Device>] List of planned devices
-      def add_boot(devices)
-        return unless root?(devices)
-        checker = BootRequirementsChecker.new(devicegraph, planned_devices: devices)
-        devices.concat(checker.needed_partitions)
-      end
-
-      # Determines whether the list of devices includes a root partition
-      #
-      # @return [Boolean] true if there is a root partition; false otherwise.
-      def root?(devices)
-        return true if devices.any? { |d| d.respond_to?(:mount_point) && d.mount_point == "/" }
-        issues_list.add(:missing_root)
       end
     end
   end

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -643,7 +643,6 @@ describe Y2Storage::AutoinstProposal do
         allow(Y2Storage::BootRequirementsChecker).to receive(:new).and_return(boot_checker)
       end
 
-
       let(:partitioning) do
         [{ "use" => "all", "partitions" => [swap, root], "disklabel" => "gpt" }]
       end
@@ -662,7 +661,6 @@ describe Y2Storage::AutoinstProposal do
         it "creates the boot partition" do
           proposal.propose
           devicegraph = proposal.devices
-          disk = devicegraph.disk_devices.first
           boot = devicegraph.partitions.find { |p| p.id == Y2Storage::PartitionId::BIOS_BOOT }
           expect(boot).to_not be_nil
         end
@@ -674,7 +672,6 @@ describe Y2Storage::AutoinstProposal do
         it "does not create a boot partition" do
           proposal.propose
           devicegraph = proposal.devices
-          disk = devicegraph.disk_devices.first
           boot = devicegraph.partitions.find { |p| p.id == Y2Storage::PartitionId::BIOS_BOOT }
           expect(boot).to be_nil
         end

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -630,35 +630,63 @@ describe Y2Storage::AutoinstProposal do
       end
     end
 
-    describe "when boot partition is required" do
+    describe "boot partition" do
       let(:scenario) { "empty_hard_disk_50GiB" }
 
-      let(:boot_checker) do
-        instance_double(Y2Storage::BootRequirementsChecker, needed_partitions: [planned_boot])
-      end
+      let(:planned_boots) { [] }
 
-      let(:planned_boot) do
-        Y2Storage::Planned::Partition.new(nil).tap do |part|
-          part.min_size = 1.MiB
-          part.max_size = 1.MiB
-          part.partition_id = Y2Storage::PartitionId::BIOS_BOOT
-        end
+      let(:boot_checker) do
+        instance_double(Y2Storage::BootRequirementsChecker, needed_partitions: planned_boots)
       end
 
       before do
         allow(Y2Storage::BootRequirementsChecker).to receive(:new).and_return(boot_checker)
       end
 
+
       let(:partitioning) do
         [{ "use" => "all", "partitions" => [swap, root], "disklabel" => "gpt" }]
       end
 
-      it "creates the boot partition" do
+      context "when a boot partition is required" do
+        let(:planned_boots) { [planned_boot] }
+
+        let(:planned_boot) do
+          Y2Storage::Planned::Partition.new(nil).tap do |part|
+            part.min_size = 1.MiB
+            part.max_size = 1.MiB
+            part.partition_id = Y2Storage::PartitionId::BIOS_BOOT
+          end
+        end
+
+        it "creates the boot partition" do
+          proposal.propose
+          devicegraph = proposal.devices
+          disk = devicegraph.disk_devices.first
+          boot = devicegraph.partitions.find { |p| p.id == Y2Storage::PartitionId::BIOS_BOOT }
+          expect(boot).to_not be_nil
+        end
+      end
+
+      context "when a boot partition is not required" do
+        let(:planned_boots) { [] }
+
+        it "does not create a boot partition" do
+          proposal.propose
+          devicegraph = proposal.devices
+          disk = devicegraph.disk_devices.first
+          boot = devicegraph.partitions.find { |p| p.id == Y2Storage::PartitionId::BIOS_BOOT }
+          expect(boot).to be_nil
+        end
+      end
+
+      it "checks for boot partition after partition tables have been created" do
+        expect(Y2Storage::BootRequirementsChecker).to receive(:new) do |devicegraph, _planned|
+          disk = devicegraph.disks.first
+          expect(disk.partition_table).to_not be_nil
+          boot_checker
+        end
         proposal.propose
-        devicegraph = proposal.devices
-        disk = devicegraph.disk_devices.first
-        expect(disk.name).to eq("/dev/sda")
-        expect(disk.partition_table.type).to eq(Y2Storage::PartitionTables::Type::GPT)
       end
     end
 
@@ -701,25 +729,38 @@ describe Y2Storage::AutoinstProposal do
         end
       end
 
-      context "when partition table exist" do
+      context "when does exist" do
         let(:scenario) { "windows-linux-free-pc" }
+        let(:partitioning) do
+          [
+            {
+              "use" => "all", "partitions" => [swap, root], "disklabel" => "gpt",
+              "initialize" => initialize_value
+            }
+          ]
+        end
 
-        context "and a different type is requested" do
-          let(:partitioning) do
-            [
-              {
-                "use" => "all", "partitions" => [swap, root], "disklabel" => "gpt",
-                "initialize" => true
-              }
-            ]
-          end
+        context "and a different type is requested and 'initialize' element is set to 'true'" do
+          let(:initialize_value) { true }
 
-          it "creates a partition of the given type" do
+          it "creates a partition table of the given type" do
             proposal.propose
             devicegraph = proposal.devices
             disk = devicegraph.disk_devices.first
             expect(disk.name).to eq("/dev/sda")
             expect(disk.partition_table.type).to eq(Y2Storage::PartitionTables::Type::GPT)
+          end
+        end
+
+        context "and a different type is requested but 'initialize' element is set to 'false'" do
+          let(:initialize_value) { false }
+
+          it "does not change the partition table" do
+            proposal.propose
+            devicegraph = proposal.devices
+            disk = devicegraph.disk_devices.first
+            expect(disk.name).to eq("/dev/sda")
+            expect(disk.partition_table.type).to eq(Y2Storage::PartitionTables::Type::MSDOS)
           end
         end
       end

--- a/test/y2storage/proposal/autoinst_devices_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_planner_test.rb
@@ -65,17 +65,6 @@ describe Y2Storage::Proposal::AutoinstDevicesPlanner do
   end
 
   describe "#planned_devices" do
-    context "when a boot partition is required" do
-      let(:boot) { Y2Storage::Planned::Partition.new("/boot", Y2Storage::Filesystems::Type::EXT4) }
-
-      it "adds the boot partition" do
-        expect(Y2Storage::BootRequirementsChecker).to receive(:new)
-          .and_return(boot_checker)
-        expect(boot_checker).to receive(:needed_partitions).and_return([boot])
-        expect(planner.planned_devices(drives_map).map(&:mount_point)).to include("/boot")
-      end
-    end
-
     context "reusing partitions" do
       context "when a partition number is specified" do
         let(:root_spec) do


### PR DESCRIPTION
This PR fixes partition table creation in AutoYaST (now is set to the right type). But, even more important, it also fixes space distribution in the following situation:

* no partition table exists (or profile sets `<initialize>` element to `true`)
* any partition size is set to `max` (or not set at all)

In such a scenario, the storage proposal runs out of space. There is a possible workaround: setting all partition sizes, but the user would need to take the partitions table size into account.

For the records, the problem was that the partition table was created too late (not explicitly created at all), so calculations about space distribution were just wrong.