### PR TITLE
handle partition ids for different partition types (bsc #1060993)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov  8 16:03:31 UTC 2017 - snwint@suse.com
+
+- safer handling of partition ids (bsc#1060993
+- 4.0.28
+
+-------------------------------------------------------------------
 Wed Nov  8 14:45:22 UTC 2017 - igonzalezsosa@suse.com
 
 - AutoYaST: filter out old '@' entries when importing the list of

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.27
+Version:        4.0.28
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/partition.rb
+++ b/src/lib/y2storage/partition.rb
@@ -149,6 +149,11 @@ module Y2Storage
     # @param partition_id [PartitionId]
     def adapted_id=(partition_id)
       self.id = partition_table.partition_id_for(partition_id)
+    rescue ::Storage::Exception
+      # if we made some mistake, log an error but don't break completely
+      fallback_id = PartitionId::LINUX
+      log.error "Failed to set partition id #{partition_id}, falling back to #{fallback_id}"
+      self.id = fallback_id
     end
 
   protected

--- a/src/lib/y2storage/partition_tables/dasd.rb
+++ b/src/lib/y2storage/partition_tables/dasd.rb
@@ -40,13 +40,18 @@ module Y2Storage
       end
 
       # DASD partition table uses partition id LINUX for swap.
+      # In fact, it uses LINUX for everything except LVM and RAID.
       # @see PatitionTables::Base#partition_id_for
       #
       # @param partition_id [PartitionId]
       # @return [PartitionId]
       def partition_id_for(partition_id)
-        return PartitionId::LINUX if partition_id.is?(:swap)
-        super
+        case partition_id.to_sym
+          when :lvm, :raid
+            super
+          else
+            PartitionId::LINUX
+        end
       end
     end
   end

--- a/src/lib/y2storage/partition_tables/dasd.rb
+++ b/src/lib/y2storage/partition_tables/dasd.rb
@@ -47,10 +47,10 @@ module Y2Storage
       # @return [PartitionId]
       def partition_id_for(partition_id)
         case partition_id.to_sym
-          when :lvm, :raid
-            super
-          else
-            PartitionId::LINUX
+        when :lvm, :raid
+          super
+        else
+          PartitionId::LINUX
         end
       end
     end

--- a/src/lib/y2storage/partition_tables/gpt.rb
+++ b/src/lib/y2storage/partition_tables/gpt.rb
@@ -37,6 +37,20 @@ module Y2Storage
       # @!method pmbr_boot=(value)
       #   @attr value [Boolean] set/unset flag
       storage_forward :pmbr_boot=
+
+      # GPT partition table doesn't use that many different ids.
+      # @see PatitionTables::Base#partition_id_for
+      #
+      # @param partition_id [PartitionId]
+      # @return [PartitionId]
+      def partition_id_for(partition_id)
+        case partition_id.to_sym
+          when :ntfs, :dos32, :dos16, :dos12
+            PartitionId::WINDOWS_BASIC_DATA
+          else
+            super
+        end
+      end
     end
   end
 end

--- a/src/lib/y2storage/partition_tables/gpt.rb
+++ b/src/lib/y2storage/partition_tables/gpt.rb
@@ -45,10 +45,10 @@ module Y2Storage
       # @return [PartitionId]
       def partition_id_for(partition_id)
         case partition_id.to_sym
-          when :ntfs, :dos32, :dos16, :dos12
-            PartitionId::WINDOWS_BASIC_DATA
-          else
-            super
+        when :ntfs, :dos32, :dos16, :dos12
+          PartitionId::WINDOWS_BASIC_DATA
+        else
+          super
         end
       end
     end

--- a/test/y2storage/partition_tables/dasd_test.rb
+++ b/test/y2storage/partition_tables/dasd_test.rb
@@ -34,14 +34,24 @@ describe Y2Storage::PartitionTables::Dasd do
   subject { disk.create_partition_table(partition_table_type) }
 
   describe "#partition_id_for" do
-    it "returns LINUX partition id for swap" do
-      swap = Y2Storage::PartitionId::SWAP
-      expect(subject.partition_id_for(swap)).to eq Y2Storage::PartitionId::LINUX
+    it "uses the LVM partition id for LVM" do
+      p_id = Y2Storage::PartitionId::LVM
+      expect(subject.partition_id_for(p_id)).to eq p_id
     end
 
-    it "returns the same partition id in other cases" do
-      ntfs = Y2Storage::PartitionId::NTFS
-      expect(subject.partition_id_for(ntfs)).to eq ntfs
+    it "uses the RAID partition id for RAID" do
+      p_id = Y2Storage::PartitionId::RAID
+      expect(subject.partition_id_for(p_id)).to eq p_id
+    end
+
+    it "uses the LINUX partition id for swap" do
+      p_id = Y2Storage::PartitionId::SWAP
+      expect(subject.partition_id_for(p_id)).to eq Y2Storage::PartitionId::LINUX
+    end
+
+    it "maps other partition ids to LINUX" do
+      p_id = Y2Storage::PartitionId::NTFS
+      expect(subject.partition_id_for(p_id)).to eq Y2Storage::PartitionId::LINUX
     end
   end
 end

--- a/test/y2storage/partition_tables/gpt_test.rb
+++ b/test/y2storage/partition_tables/gpt_test.rb
@@ -1,0 +1,62 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::PartitionTables::Gpt do
+  before do
+    fake_scenario("empty_hard_disk_50GiB")
+  end
+
+  let(:disk) { Y2Storage::Disk.find_by_name(fake_devicegraph, "/dev/sda") }
+  let(:partition_table_type) { Y2Storage::PartitionTables::Type.find(:gpt) }
+
+  subject { disk.create_partition_table(partition_table_type) }
+
+  describe "#partition_id_for" do
+    it "uses the WINDOWS_BASIC_DATA partition id for WINDOWS_BASIC_DATA" do
+      p_id = Y2Storage::PartitionId::WINDOWS_BASIC_DATA
+      expect(subject.partition_id_for(p_id)).to eq p_id
+    end
+
+    it "uses the MICROSOFT_RESERVED partition id for MICROSOFT_RESERVED" do
+      p_id = Y2Storage::PartitionId::MICROSOFT_RESERVED
+      expect(subject.partition_id_for(p_id)).to eq p_id
+    end
+
+    it "uses the SWAP partition id for SWAP" do
+      p_id = Y2Storage::PartitionId::SWAP
+      expect(subject.partition_id_for(p_id)).to eq Y2Storage::PartitionId::SWAP
+    end
+
+    it "uses the WINDOWS_BASIC_DATA partition id for NTFS" do
+      p_id = Y2Storage::PartitionId::NTFS
+      expect(subject.partition_id_for(p_id)).to eq Y2Storage::PartitionId::WINDOWS_BASIC_DATA
+    end
+
+    it "uses the WINDOWS_BASIC_DATA partition id for DOS32" do
+      p_id = Y2Storage::PartitionId::DOS32
+      expect(subject.partition_id_for(p_id)).to eq Y2Storage::PartitionId::WINDOWS_BASIC_DATA
+    end
+  end
+end


### PR DESCRIPTION
- step 1: don't break if we messed up the ids - instead, log an error and continue with a reasonable default

- step 2: map partition ids to allowed values