### PR TITLE
Avoid RAID chunk size below 64 kiB

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 22 17:11:41 UTC 2017 - shundhammer@suse.com
+
+- No RAID chunk size below 64 kiB for most types of RAID
+  (bsc#1065381)
+- 4.0.33
+
+-------------------------------------------------------------------
 Mon Nov 20 15:40:58 UTC 2017 - shundhammer@suse.com
 
 - Added "Create New Partition Table" in partitioner

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.32
+Version:        4.0.33
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/actions/controllers/md.rb
+++ b/src/lib/y2partitioner/actions/controllers/md.rb
@@ -157,6 +157,20 @@ module Y2Partitioner
           md.minimal_number_of_devices
         end
 
+        # Possible chunk sizes for the Md object depending on its md_level.
+        #
+        # @return [Array<Y2Storage::DiskSize>]
+        def chunk_sizes
+          sizes = []
+          size = min_chunk_size
+
+          while size <= max_chunk_size
+            sizes << Y2Storage::DiskSize.new(size)
+            size *= 2
+          end
+          sizes
+        end
+
       private
 
         def working_graph
@@ -173,18 +187,26 @@ module Y2Partitioner
           mount.nil? || mount.empty?
         end
 
+        def min_chunk_size
+          [default_chunk_size, Y2Storage::DiskSize.KiB(64)].min
+        end
+
+        def max_chunk_size
+          Y2Storage::DiskSize.MiB(64)
+        end
+
         def default_chunk_size
           case md.md_level.to_sym
           when :raid0
-            Y2Storage::DiskSize.KiB(32)
+            Y2Storage::DiskSize.KiB(64)
           when :raid1
             Y2Storage::DiskSize.KiB(4)
           when :raid5, :raid6
             Y2Storage::DiskSize.KiB(128)
           when :raid10
-            Y2Storage::DiskSize.KiB(32)
+            Y2Storage::DiskSize.KiB(64)
           else
-            Y2Storage::DiskSize.KiB(4)
+            Y2Storage::DiskSize.KiB(64)
           end
         end
 

--- a/src/lib/y2partitioner/dialogs/md_options.rb
+++ b/src/lib/y2partitioner/dialogs/md_options.rb
@@ -54,7 +54,7 @@ module Y2Partitioner
         end
 
         def items
-          SIZES.map { |s| [Y2Storage::DiskSize.new(s).to_s, s] }
+          @controller.chunk_sizes.map { |s| [s.to_s, s.to_s] }
         end
 
         # @macro seeAbstractWidget
@@ -66,11 +66,6 @@ module Y2Partitioner
         def store
           @controller.chunk_size = Y2Storage::DiskSize.new(value)
         end
-
-        SIZES = ["4 KiB", "8 KiB", "16 KiB", "32 KiB", "128 KiB",
-                 "256 KiB", "512 KiB", "1 MiB", "2 MiB", "4 MiB"].freeze
-
-        private_constant :SIZES
       end
 
       # Widget to select the md parity

--- a/src/lib/y2storage/disk_size.rb
+++ b/src/lib/y2storage/disk_size.rb
@@ -743,7 +743,7 @@ module Y2Storage
       return [UNLIMITED, ""] if @size == -1
 
       unit_index = 0
-      # prefer, 0.50 MiB over 512 KiB
+      # prefer 0.50 MiB over 512 KiB
       size2 = @size * 2
 
       while size2.abs >= 1024.0 && unit_index < UNITS.size - 1

--- a/test/y2partitioner/actions/controllers/md_test.rb
+++ b/test/y2partitioner/actions/controllers/md_test.rb
@@ -359,9 +359,9 @@ describe Y2Partitioner::Actions::Controllers::Md do
     context "when the Md device is a RAID0" do
       let(:md_level) { Y2Storage::MdLevel::RAID0 }
 
-      it "sets chunk size to 32 KiB" do
+      it "sets chunk size to 64 KiB" do
         controller.apply_default_options
-        expect(controller.md.chunk_size).to eq(32.KiB)
+        expect(controller.md.chunk_size).to eq(64.KiB)
       end
 
       it "does not set the parity" do
@@ -415,9 +415,9 @@ describe Y2Partitioner::Actions::Controllers::Md do
     context "when the Md device is a RAID10" do
       let(:md_level) { Y2Storage::MdLevel::RAID10 }
 
-      it "sets chunk size to 32 KiB" do
+      it "sets chunk size to 64 KiB" do
         controller.apply_default_options
-        expect(controller.md.chunk_size).to eq(32.KiB)
+        expect(controller.md.chunk_size).to eq(64.KiB)
       end
 
       it "sets parity to default" do
@@ -429,9 +429,9 @@ describe Y2Partitioner::Actions::Controllers::Md do
     context "when the Md device has unknown level" do
       let(:md_level) { Y2Storage::MdLevel::UNKNOWN }
 
-      it "sets chunk size to 4 KiB" do
+      it "sets chunk size to 64 KiB" do
         controller.apply_default_options
-        expect(controller.md.chunk_size).to eq(4.KiB)
+        expect(controller.md.chunk_size).to eq(64.KiB)
       end
 
       it "does not set the parity" do
@@ -443,9 +443,9 @@ describe Y2Partitioner::Actions::Controllers::Md do
     context "when the Md device is a container" do
       let(:md_level) { Y2Storage::MdLevel::CONTAINER }
 
-      it "sets chunk size to 4 KiB" do
+      it "sets chunk size to 64 KiB" do
         controller.apply_default_options
-        expect(controller.md.chunk_size).to eq(4.KiB)
+        expect(controller.md.chunk_size).to eq(64.KiB)
       end
 
       it "does not set the parity" do


### PR DESCRIPTION
https://trello.com/c/8mxdS9qy/765-1-sles15-p2-1065381-build-3215ppc64-openqa-test-fails-in-to-create-raid10-stderrmdadm-runarray-failed-invalid-argument

https://bugzilla.suse.com/show_bug.cgi?id=1065381

For most RAID levels now use a chunk size of 64 kiB except for some where the page size is irrelevant. 

Now no longer using a fixed list of chunk sizes, but calculating it on the fly, depending on the default chunk size. If that is less than 64 kiB, use it as the starting point.

Also, after discussing this with Arvin extended the list of chunk sizes to up to 64 MiB since this might be more efficient and thus desired by many customers.

Caveat: It turned out that DiskSize.to_s likes to use fractional numbers in some cases, so the list contains `0.5 MiB` instead of `512 MiB`. This is just another way of presenting the same information, yet it might look a bit odd to some users. Let's see if users actually dislike this.

## RAID 0
![raid0-chunks](https://user-images.githubusercontent.com/11538225/33141152-8df09c4c-cfb2-11e7-81ed-4f6c2c1b5be7.png)

-------------------------

## RAID 1

![raid1-chunks](https://user-images.githubusercontent.com/11538225/33141170-9c2dda4a-cfb2-11e7-92f2-76ba48e8af42.png)

