### PR TITLE
WIP: sorting of blk devices by name

### DIFF
--- a/src/lib/y2storage/dasd.rb
+++ b/src/lib/y2storage/dasd.rb
@@ -66,6 +66,10 @@ module Y2Storage
       "<Dasd #{name} #{size}>"
     end
 
+    def self.name_regexps
+      [/#{DEVDIR}dasd([[:alpha:]]+)/, /#{DEVDIR}vd([[:alpha:]]+)/]
+    end
+
     # DASD disks cannot be usb
     #
     # @return [Boolean]

--- a/src/lib/y2storage/disk.rb
+++ b/src/lib/y2storage/disk.rb
@@ -62,6 +62,13 @@ module Y2Storage
       "<Disk #{name} #{size}>"
     end
 
+    def self.name_regexps
+      [
+        /#{DEVDIR}sd([[:alpha:]]+)/, /#{DEVDIR}vd([[:alpha:]]+)/, /#{DEVDIR}pmem(\d+)/,
+        /#{DEVDIR}mmcblk(\d+)/, /#{DEVDIR}nvme(\d+)n(\d+)/
+      ]
+    end
+
     # Checks if it's an USB disk
     #
     # @return [Boolean]

--- a/src/lib/y2storage/partition.rb
+++ b/src/lib/y2storage/partition.rb
@@ -134,27 +134,17 @@ module Y2Storage
       Partitionable.all(devicegraph).map(&:partitions).flatten
     end
 
-    # All partitions in the given devicegraph, sorted by name
-    #
-    # See {Partitionable#compare_by_name} to know more about the sorting.
-    #
-    # @param devicegraph [Devicegraph]
-    # @return [Array<Partition>]
-    def self.sorted_by_name(devicegraph)
-      Partitionable.sorted_by_name(devicegraph).each_with_object([]) do |partitionable, result|
-        partitions = partitionable.partitions.sort do |a, b|
-          # Within the same partition table, the equivalent of Partitionable#compare_by_name
-          # is sorting by name size and then alphabetically
-          by_size = a.name.size <=> b.name.size
-          by_size.zero? ? a.name <=> b.name : by_size
-        end
-        result.concat(partitions)
-      end
-    end
-
     # @return [String]
     def inspect
       "<Partition #{name} #{size}, #{region.show_range}>"
+    end
+
+    def self.name_regexps
+      [
+        /#{DEVDIR}sd([[:alpha:]]+)(\d+)/, /#{DEVDIR}vd([[:alpha:]]+)(\d+)/,
+        /#{DEVDIR}dasd([[:alpha:]]+)(\d+)/, /#{DEVDIR}pmem(\d+)p(\d+)/,
+        /#{DEVDIR}mmcblk(\d+)p(\d+)/, /#{DEVDIR}nvme(\d+)n(\d+)p(\d+)/
+      ]
     end
 
     # Sets the id, ensuring its value is compatible with the partition table.

--- a/src/lib/y2storage/partitionable.rb
+++ b/src/lib/y2storage/partitionable.rb
@@ -83,56 +83,6 @@ module Y2Storage
     #     in no particular order
     storage_class_forward :all, as: "Partitionable"
 
-    # @!method self.compare_by_name(lhs, rhs)
-    #   Compare two devices by their name, used for sorting sets of
-    #   partitionable devices.
-    #
-    #   Using this method to compare and sort would result is something similar
-    #   to alphabetical order but with some desired exceptions like:
-    #
-    #   * /dev/sda, /dev/sdb, ..., /dev/sdaa
-    #   * /dev/md1, /dev/md2, ..., /dev/md10
-    #
-    #   @param lhs [Partitionable]
-    #   @param rhs [Partitionable]
-    #   @return [boolean] true if the first argument should appear first in a
-    #       sorted list (less than)
-    storage_class_forward :compare_by_name
-
-    # Compare to another device by name, used for sorting sets of
-    # partitionable devices.
-    #
-    # Using this method to compare and sort would result is something similar
-    # to alphabetical order but with some desired exceptions like:
-    #
-    # * /dev/sda, /dev/sdb, ..., /dev/sdaa
-    # * /dev/md1, /dev/md2, ..., /dev/md10
-    #
-    # Unlike the class method {Partitionable.compare_by_name}, which is boolean,
-    # this method follows the Ruby convention of returning -1 or 1 in the same
-    # cases than the <=> operator.
-    #
-    # @param other [Partitionable]
-    # @return [Integer] -1 if this object should appear before the one passed as
-    #   argument (less than). 1 otherwise.
-    def compare_by_name(other)
-      # In practice, two devices cannot have the same name. But let's take the
-      # case in consideration to ensure full compatibility with <=>
-      return 0 if name == other.name
-      Partitionable.compare_by_name(self, other) ? -1 : 1
-    end
-
-    # All the devices of the correspondig class found in the given devicegraph,
-    # sorted by name
-    #
-    # See {Partitionable#compare_by_name} to know more about the sorting.
-    #
-    # @param devicegraph [Devicegraph]
-    # @return [Array<#compare_by_name>]
-    def self.sorted_by_name(devicegraph)
-      all(devicegraph).sort { |a, b| a.compare_by_name(b) }
-    end
-
     # Partitions in the device
     #
     # @return [Array<Partition>]

--- a/test/data/devicegraphs/sorting/disks_and_dasds1.yml
+++ b/test/data/devicegraphs/sorting/disks_and_dasds1.yml
@@ -1,0 +1,171 @@
+---
+# This file includes many holes in the names of the devices. The goal is not to
+# represent a valid devicegraph but to present challenging combinations of names
+# to test the stable sorting
+- dasd:
+    name: /dev/dasda
+    size: 50 GiB
+    partition_table:  dasd
+    partitions:
+
+    - partition:
+        size:         1 GiB
+        name:         /dev/dasda1
+
+    - partition:
+        size:         6 GiB
+        name:         /dev/dasda2
+
+    - partition:
+        size:         unlimited
+        name:         /dev/dasda10
+
+- disk:
+    name: /dev/sda
+    size: 50 GiB
+
+- dasd:
+    name: /dev/dasdab
+    size: 50 GiB
+
+- disk:
+    name: /dev/sdb
+    size: 800 GiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        size:         780 GiB
+        name:         /dev/sdb1
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sdb2
+
+- dasd:
+    name: /dev/dasdb
+    size: 10 GiB
+    partition_table:  dasd
+    partitions:
+
+    - partition:
+        size:         1 GiB
+        name:         /dev/dasdb1
+
+    - partition:
+        size:         6 GiB
+        name:         /dev/dasdb2
+
+    - partition:
+        size:         unlimited
+        name:         /dev/dasdb3
+
+- disk:
+    size: 800 GiB
+    name: "/dev/nvme0n2"
+    partition_table: gpt
+    partitions:
+
+    - partition:
+        size: 75 GiB
+        name: /dev/nvme0n2p1
+
+    - partition:
+        size: 40 GiB
+        name: /dev/nvme0n2p2
+
+- disk:
+    name: /dev/sdc
+    size: 500 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size:         50 GiB
+        name:         /dev/sdc1
+
+    - partition:
+        size:         2 GiB
+        name:         /dev/sdc2
+
+    - partition:
+        size:         20 GiB
+        name:         /dev/sdc3
+
+    - partition:
+        size:         20 GiB
+        name:         /dev/sdc4
+
+    - partition:
+        size:         20 GiB
+        name:         /dev/sdc10
+
+    - partition:
+        size:         20 GiB
+        name:         /dev/sdc21
+
+- disk:
+    size: 800 GiB
+    name: "/dev/nvme1n1"
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size: 75 GiB
+        name: /dev/nvme1n1p2
+
+    - partition:
+        size: 40 GiB
+        name: /dev/nvme1n1p1
+
+- disk:
+    name: /dev/sdaa
+    size: 500 GiB
+    partition_table:  msdos
+    partitions:
+
+    - partition:
+        size:         250 GiB
+        name:         /dev/sdaa1
+
+    - partition:
+        size:         2 GiB
+        name:         /dev/sdaa2
+
+    - partition:
+        size:         20 GiB
+        name:         /dev/sdaa3
+
+- disk:
+    size: 800 GiB
+    name: "/dev/nvme0n1"
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size: 75 GiB
+        name: /dev/nvme0n1p1
+
+    - partition:
+        size: 40 GiB
+        name: /dev/nvme0n1p2
+
+    - partition:
+        size: 2 GiB
+        name: /dev/nvme0n1p3
+
+    - partition:
+        size: 2 GiB
+        name: /dev/nvme0n1p4
+
+    - partition:
+        size: 2 GiB
+        name: /dev/nvme0n1p10
+
+    - partition:
+        size: 2 GiB
+        name: /dev/nvme0n1p11
+
+    - partition:
+        size: 2 GiB
+        name: /dev/nvme0n1p40

--- a/test/data/devicegraphs/sorting/disks_and_dasds2.yml
+++ b/test/data/devicegraphs/sorting/disks_and_dasds2.yml
@@ -1,0 +1,15 @@
+---
+# This file includes many holes in the names of the devices. The goal is not to
+# represent a valid devicegraph but to present challenging combinations of names
+# to test the stable sorting
+- disk:
+    name: /dev/vda
+    size: 50 GiB
+
+- dasd:
+    name: /dev/vdaa
+    size: 50 GiB
+
+- disk:
+    name: /dev/vdb
+    size: 50 GiB

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -527,4 +527,34 @@ describe Y2Storage::BlkDevice do
       end
     end
   end
+
+  describe ".sorted_by_name" do
+    before { fake_scenario("sorting/disks_and_dasds1") }
+
+    it "returns all the blk devices sorted by name" do
+      devices = Y2Storage::BlkDevice.sorted_by_name(fake_devicegraph)
+      expect(devices.map(&:basename)).to eq %w(
+        dasda dasda1 dasda2 dasda10 dasdb dasdab dasdb1 dasdb2 dasdb3
+        nvme0n1 nvme0n1p1 nvme0n1p2 nvme0n1p3 nvme0n1p4 nvme0n1p10 nvme0n1p11 nvme0n1p40
+        nvme0n2 nvme0n2p1 nvme0n2p2 nvme1n1 nvme1n1p1 nvme1n1p2
+        sda sdb sdaa sdb1 sdb2 sdc sdc1 sdc2 sdc3 sdc4 sdc10 sdc21 sdaa1 sdaa2 sdaa3
+      )
+    end
+  end
+
+  describe "#compare_by_name" do
+    context "when devices of different types share a common name structure" do
+      before { fake_scenario("sorting/disks_and_dasds2") }
+
+      let(:vda) { Y2Storage::Disk.find_by_name(fake_devicegraph, "/dev/vda") }
+      let(:vdaa) { Y2Storage::Dasd.find_by_name(fake_devicegraph, "/dev/vdaa") }
+      let(:vdb) { Y2Storage::Disk.find_by_name(fake_devicegraph, "/dev/vdb") }
+
+      it "allows to sort them by name, no matter the input order" do
+        [vda, vdaa, vdb].permutation do |input|
+          expect(input.sort { |a, b| a.compare_by_name(b) }).to eq [vda, vdb, vdaa]
+        end
+      end
+    end
+  end
 end

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -191,7 +191,7 @@ describe Y2Storage::Devicegraph do
 
     def less_than_next(device, collection)
       next_dev = collection[collection.index(device) + 1]
-      next_dev.nil? || Y2Storage::Partitionable.compare_by_name(device, next_dev)
+      next_dev.nil? || device.compare_by_name(next_dev) < 0
     end
 
     context "if there are no multi-disk devices" do

--- a/test/y2storage/disk_test.rb
+++ b/test/y2storage/disk_test.rb
@@ -361,7 +361,7 @@ describe Y2Storage::Disk do
   end
 
   describe ".sorted_by_name" do
-    let(:scenario) { "autoyast_drive_examples" }
+    let(:scenario) { "sorting/disks_and_dasds1" }
 
     it "returns a list of Y2Storage::Disk objects" do
       disks = Y2Storage::Disk.sorted_by_name(fake_devicegraph)
@@ -372,7 +372,7 @@ describe Y2Storage::Disk do
     it "includes all disks in the devicegraph, sorted by name, and nothing else" do
       disks = Y2Storage::Disk.sorted_by_name(fake_devicegraph)
       expect(disks.map(&:basename)).to eq [
-        "nvme0n1", "sda", "sdb", "sdc", "sdd", "sdf", "sdh", "sdaa"
+        "nvme0n1", "nvme0n2", "nvme1n1", "sda", "sdb", "sdc", "sdaa"
       ]
     end
 
@@ -387,7 +387,7 @@ describe Y2Storage::Disk do
       it "returns an array sorted by name" do
         disks = Y2Storage::Disk.sorted_by_name(fake_devicegraph)
         expect(disks.map(&:basename)).to eq [
-          "nvme0n1", "sda", "sdb", "sdc", "sdd", "sdf", "sdh", "sdaa"
+          "nvme0n1", "nvme0n2", "nvme1n1", "sda", "sdb", "sdc", "sdaa"
         ]
       end
     end


### PR DESCRIPTION
@aschnell, @joseivanlopez please check.

This is a proof of concept of an alternative algorithm to the `compare_by_name` offered by libstorage-ng. It follows the same principle, that is, alphabetical-like order but dealing well with stuff like `sdb < sdaa` or `vda2 < vda10`.

There is no need to keep it in Ruby, I'm fine with moving it to the library if we agree this supports more cases than the current one in the library and introduces no regression (I just was more comfortable with Ruby for writing a POC).

Advantages:

 * It supports sorting all kind of blk devices, even those that include several variable parts in the name (like "/dev/nvmeXvYpZ")
 * It works correctly when sorting sets of devices with a common name structure but that belongs to different types. That is, is not affected by the problem demonstrated at http://paste.opensuse.org/64738254

Several unit tests included to probe it works in all situations (so far). The regular expression for several blk device types are still missing, but this should be enough to get the idea.