### PR TITLE
Fix size=max for logical volumes

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 28 13:35:34 UTC 2017 - igonzalezsosa@suse.com
+
+- AutoYaST: honor size=max for logical volumes (bsc#1070131).
+- 4.0.41
+
+-------------------------------------------------------------------
 Mon Nov 27 17:49:38 UTC 2017 - jlopez@suse.com
 
 - Allow to work with BIOS RAIDs as regular disks (bsc#1067349).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.40
+Version:        4.0.41
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/proposal/autoinst_devices_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_planner.rb
@@ -395,6 +395,7 @@ module Y2Storage
           lv.min_size = size_info.min
           lv.max_size = size_info.max
         end
+        lv.weight = 1 if size_info.max == DiskSize.unlimited
 
         true
       end

--- a/src/lib/y2storage/proposal/autoinst_devices_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_planner.rb
@@ -371,7 +371,7 @@ module Y2Storage
 
         partition.min_size = size_info.min
         partition.max_size = size_info.max
-        partition.weight = 1 if size_info.max == DiskSize.unlimited
+        partition.weight = 1 if size_info.unlimited?
         true
       end
 
@@ -395,7 +395,7 @@ module Y2Storage
           lv.min_size = size_info.min
           lv.max_size = size_info.max
         end
-        lv.weight = 1 if size_info.max == DiskSize.unlimited
+        lv.weight = 1 if size_info.unlimited?
 
         true
       end

--- a/src/lib/y2storage/proposal/autoinst_size.rb
+++ b/src/lib/y2storage/proposal/autoinst_size.rb
@@ -42,6 +42,13 @@ module Y2Storage
         @weight = weight
         @percentage = percentage
       end
+
+      # Determines whether the size is unlimited
+      #
+      # @return [Boolean] +true+ if unlimited; +false+ otherwise.
+      def unlimited?
+        !!max && max.unlimited?
+      end
     end
   end
 end

--- a/test/y2storage/device_test.rb
+++ b/test/y2storage/device_test.rb
@@ -90,20 +90,20 @@ describe Y2Storage::Device do
   describe "#can_resize?" do
     subject(:device) { Y2Storage::Partition.find_by_name(fake_devicegraph, "/dev/sda1") }
     let(:resize_info) { double(Y2Storage::ResizeInfo, resize_ok?: resize_ok) }
- 
+
     before { allow(device).to receive(:detect_resize_info).and_return resize_info }
- 
+
     context "if libstorage-nd reports that resizing is possible" do
       let(:resize_ok) { true }
- 
+
       it "returns true" do
         expect(device.can_resize?).to eq true
       end
     end
- 
+
     context "if libstorage-ng reports that resizing is not possible" do
       let(:resize_ok) { false }
- 
+
       it "returns false" do
         expect(device.can_resize?).to eq false
       end

--- a/test/y2storage/proposal/autoinst_size_test.rb
+++ b/test/y2storage/proposal/autoinst_size_test.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage/proposal/autoinst_size"
+
+describe Y2Storage::Proposal::AutoinstSize do
+
+  subject(:autoinst_size) { described_class.new("10GB", max: max) }
+
+  describe "#unlimited?" do
+    context "when max size is unlimited" do
+      let(:max) { Y2Storage::DiskSize.unlimited }
+
+      it "returns true" do
+        expect(autoinst_size).to be_unlimited
+      end
+    end
+
+    context "when max size is nil" do
+      let(:max) { nil }
+
+      it "returns false" do
+        expect(autoinst_size).to_not be_unlimited
+      end
+    end
+
+    context "when max size is not unlimited" do
+      let(:max) { Y2Storage::DiskSize.GiB(10) }
+
+      it "returns false" do
+        expect(autoinst_size).to_not be_unlimited
+      end
+    end
+  end
+end


### PR DESCRIPTION
Set weight properly so the logical volume will grow when distributing space.