### PR TITLE
Honor 'use' and 'initialize' even when no partitions are specified

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec  1 12:27:34 UTC 2017 - igonzalezsosa@suse.com
+
+- AutoYaST honors 'use' and 'initialize' elements even if the
+  list of partitions is missing (related to bsc#1065061).
+- 4.0.45
+
+-------------------------------------------------------------------
 Thu Nov 30 16:14:49 UTC 2017 - ancor@suse.com
 
 - Partitioner: added buttons to sort the devices being added to

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.44
+Version:        4.0.45
 Release:	0
 BuildArch:	noarch
 


### PR DESCRIPTION
AutoYaST did not run the space maker before falling back to using the original DevicesPlanner: https://bugzilla.suse.com/show_bug.cgi?id=1065061. So if you had a profile with an empty (or missing) `partitions` element, `use` and `initialize` would be ignored.
