### PR TITLE
 Not longer trust any sorting coming from libstorage-ng 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec  5 06:46:00 UTC 2017 - ancor@suse.com
+
+- Don't trust any longer the order of any collection coming from
+  libstorage-ng (related to bsc#1049901 and part of fate#31896).
+- 4.0.50
+
+-------------------------------------------------------------------
 Mon Dec  4 09:02:09 UTC 2017 - jlopez@suse.com
 
 - Partitoner: added support for resizing partitions (bsc#1057586).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.49
+Version:        4.0.50
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -135,7 +135,7 @@ module Y2Partitioner
 
       def disk_items(disk)
         page = Pages::Disk.new(disk, self)
-        children = disk.partitions.map { |p| partition_items(p) }
+        children = disk.partitions.sort_by(&:number).map { |p| partition_items(p) }
         CWM::PagerTreeItem.new(page, children: children)
       end
 
@@ -165,7 +165,7 @@ module Y2Partitioner
 
       def lvm_vg_items(vg)
         page = Pages::LvmVg.new(vg, self)
-        children = vg.lvm_lvs.map { |l| lvm_lv_items(l) }
+        children = vg.lvm_lvs.sort_by(&:lv_name).map { |l| lvm_lv_items(l) }
         CWM::PagerTreeItem.new(page, children: children)
       end
 

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -209,7 +209,7 @@ module Y2Storage
       end
 
       def partitions_from_disk(disk)
-        disk.partitions.each_with_object([]) do |storage_partition, result|
+        disk.partitions.sort_by(&:number).each_with_object([]) do |storage_partition, result|
           next if skip_partition?(storage_partition)
 
           partition = PartitionSection.new_from_storage(storage_partition)

--- a/src/lib/y2storage/devicegraph.rb
+++ b/src/lib/y2storage/devicegraph.rb
@@ -235,9 +235,11 @@ module Y2Storage
       devices.sort { |a, b| a.compare_by_name(b) }
     end
 
+    # All partitions in the devicegraph, sorted by name
+    #
     # @return [Array<Partition>]
     def partitions
-      Partition.all(self)
+      Partition.sorted_by_name(self)
     end
 
     # @return [Array<Filesystems::Base>]
@@ -263,9 +265,11 @@ module Y2Storage
       Filesystems::Nfs.all(self)
     end
 
+    # All the LVM volume groups in the devicegraph, sorted by name
+    #
     # @return [Array<LvmVg>]
     def lvm_vgs
-      LvmVg.all(self)
+      LvmVg.sorted_by_name(self)
     end
 
     # @return [Array<LvmPv>]
@@ -273,9 +277,11 @@ module Y2Storage
       LvmPv.all(self)
     end
 
+    # All the LVM logical volumes in the devicegraph, sorted by name
+    #
     # @return [Array<LvmLv>]
     def lvm_lvs
-      LvmLv.all(self)
+      LvmLv.sorted_by_name(self)
     end
 
     # @return [Array<FreeDiskSpace>]

--- a/src/lib/y2storage/lvm_vg.rb
+++ b/src/lib/y2storage/lvm_vg.rb
@@ -99,7 +99,7 @@ module Y2Storage
     storage_forward :remove_lvm_pv
 
     # @!method lvm_lvs
-    #   @return [Array<LvmLv>] logical volumes in the VG
+    #   @return [Array<LvmLv>] logical volumes in the VG, in no particular order
     storage_forward :lvm_lvs, as: "LvmLv"
 
     # @!method create_lvm_lv(lv_name, size)

--- a/src/lib/y2storage/partition_tables/base.rb
+++ b/src/lib/y2storage/partition_tables/base.rb
@@ -58,7 +58,7 @@ module Y2Storage
       storage_forward :delete_partition
 
       # @!method partitions
-      #   All the partitions, sorted by partition number
+      #   All the partitions, in no particular order
       #   @return [Array<Partition>]
       storage_forward :partitions, as: "Partition"
 

--- a/src/lib/y2storage/partitionable.rb
+++ b/src/lib/y2storage/partitionable.rb
@@ -263,7 +263,7 @@ module Y2Storage
     def partitions_with_id(*ids)
       # Sorting is not mandatory, but keeping the output stable looks like a
       # sane practice.
-      partitions.sort_by(&:number).reject { |p| p.type.is?(:extended) }.select { |p| p.id.is?(*ids) }
+      partitions.reject { |p| p.type.is?(:extended) }.select { |p| p.id.is?(*ids) }.sort_by(&:number)
     end
   end
 end

--- a/src/lib/y2storage/partitionable.rb
+++ b/src/lib/y2storage/partitionable.rb
@@ -164,7 +164,9 @@ module Y2Storage
     #
     # @return [Array<Partition>]
     def possible_windows_partitions
-      partitions.select { |p| p.type.is?(:primary) && p.id.is?(:windows_system) }
+      # Sorting is not mandatory, but keeping the output stable looks like a
+      # sane practice.
+      partitions.select { |p| p.type.is?(:primary) && p.id.is?(:windows_system) }.sort_by(&:number)
     end
 
     # Size between MBR and first partition.
@@ -259,7 +261,9 @@ module Y2Storage
     #
     # @return [Array<Partition>}]
     def partitions_with_id(*ids)
-      partitions.reject { |p| p.type.is?(:extended) }.select { |p| p.id.is?(*ids) }
+      # Sorting is not mandatory, but keeping the output stable looks like a
+      # sane practice.
+      partitions.sort_by(&:number).reject { |p| p.type.is?(:extended) }.select { |p| p.id.is?(*ids) }
     end
   end
 end

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -272,7 +272,7 @@ module Y2Storage
     # @return [Array<Hash>]
     #
     def yaml_lvm_vg_lvm_lvs(lvm_vg)
-      lvm_vg.lvm_lvs.map { |lvm_lv| yaml_lvm_lv(lvm_lv) }
+      lvm_vg.lvm_lvs.sort_by(&:lv_name).map { |lvm_lv| yaml_lvm_lv(lvm_lv) }
     end
 
     # Return the YAML counterpart of a Y2Storage::LvmLv.

--- a/test/y2storage/autoinst_profile/drive_section_test.rb
+++ b/test/y2storage/autoinst_profile/drive_section_test.rb
@@ -239,7 +239,7 @@ describe Y2Storage::AutoinstProfile::DriveSection do
 
       before do
         # SWIG makes very hard to use proper mocking. See comment above.
-        win = dev.partitions.first
+        win = dev.partitions.sort_by(&:number).first
         win.boot = true if bootable
         win.filesystem.mountpoint = mountpoint if mountpoint
       end

--- a/test/y2storage/planned/lvm_vg_test.rb
+++ b/test/y2storage/planned/lvm_vg_test.rb
@@ -59,7 +59,7 @@ describe Y2Storage::Planned::LvmVg do
     end
 
     it "sets lvs" do
-      expect(planned_vg.lvs.map(&:logical_volume_name)).to eq(["lv1", "lv2"])
+      expect(planned_vg.lvs.map(&:logical_volume_name)).to contain_exactly("lv1", "lv2")
     end
   end
 

--- a/test/y2storage/proposal/lvm_creator_test.rb
+++ b/test/y2storage/proposal/lvm_creator_test.rb
@@ -174,7 +174,7 @@ describe Y2Storage::Proposal::LvmCreator do
             devicegraph = creator.create_volumes(vg, pv_partitions).devicegraph
             reused_vg = devicegraph.lvm_vgs.first
             lv_names = reused_vg.lvm_lvs.map(&:lv_name)
-            expect(lv_names).to eq(["one", "two"])
+            expect(lv_names).to contain_exactly("one", "two")
           end
         end
 
@@ -188,7 +188,7 @@ describe Y2Storage::Proposal::LvmCreator do
             devicegraph = creator.create_volumes(vg, pv_partitions).devicegraph
             reused_vg = devicegraph.lvm_vgs.first
             lv_names = reused_vg.lvm_lvs.map(&:lv_name)
-            expect(lv_names).to eq(["lv1", "two"])
+            expect(lv_names).to contain_exactly("lv1", "two")
           end
         end
       end


### PR DESCRIPTION
Last steps to implement https://trello.com/c/T8B7oRJs/769-yast2-storage-ng-do-not-rely-on-libstorage-ng-sorting-anymore

@aschnell announced its intention to drop any sorting from libstorage here https://lists.opensuse.org/yast-devel/2017-11/msg00009.html

As discussed in #454, that affects not only the collection of devices that used to be sorted by name (`Disks.all`, `Dasd.all`, etc.) but also collections within an object that used to be sorted by other criteria (partitions within a partition table will not be longer sorted by number, LVs within an VG will not be longer sorted by name, etc.)

This should prepare yast-storage-ng for such change. Manually tested by removing all the calls to `sort` in `DevicegraphImpl.h` in libstorage-ng. 