### PR TITLE
AutoYaST: Improve disklabel handling

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 18 12:59:02 UTC 2017 - igonzalezsosa@suse.com
+
+- AutoYaST: Improve disklabel element handling (bsc#1073307).
+- 4.0.57
+
+-------------------------------------------------------------------
 Thu Dec 14 12:01:48 UTC 2017 - ancor@suse.com
 
 - Fixed a recently added unit test to not rely on libstorage-ng

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.56
+Version:        4.0.57
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/autoinst_proposal.rb
+++ b/src/lib/y2storage/autoinst_proposal.rb
@@ -129,7 +129,7 @@ module Y2Storage
       end
 
       disk_ptable_type = disk.partition_table ? disk.partition_table.type : nil
-      ptable_type || disk_ptable_type || Y2Storage::PartitionTables::Type::MSDOS
+      ptable_type || disk_ptable_type || disk.preferred_ptable_type
     end
 
     # Update partition table

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -921,11 +921,11 @@ describe Y2Storage::AutoinstProposal do
             [{ "use" => "all", "partitions" => [swap, root] }]
           end
 
-          it "creates a 'msdos' partition" do
+          it "creates a partition table of the preferred type" do
             proposal.propose
             devicegraph = proposal.devices
             disk = Y2Storage::BlkDevice.find_by_name(devicegraph, "/dev/sda")
-            expect(disk.partition_table.type).to eq(Y2Storage::PartitionTables::Type::MSDOS)
+            expect(disk.partition_table.type).to eq(disk.preferred_ptable_type)
           end
         end
 


### PR DESCRIPTION
* Fixes [bsc#1073307](https://bugzilla.suse.com/show_bug.cgi?id=1073307)

## Expected behavior

* When the disk does not have a partition table:
  * If disklabel is defined in the profile -> it will use the given value.
  * If disklabel is not defined in the profile -> it will fallback to "msdos" (like in the past).

* When the disk has a partition table:
  * If the type defined in the profile (disklabel) is different -> change only if there are no partitions.
  * If the type matches -> do nothing.
  * If initialize is set to true -> always wipe the partition table