### PR TITLE
rewrite SpaceMaker::resize_and_delete! to be more human-readable

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 22 15:17:35 UTC 2017 - snwint@suse.com
+
+- rewrite SpaceMaker::resize_and_delete! to be more human-readable
+- 4.0.64
+
+-------------------------------------------------------------------
 Fri Dec 22 14:40:04 UTC 2017 - snwint@suse.com
 
 - fix unnecessary Windows partition deletion (bsc #1066386)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.63
+Version:        4.0.64
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/proposal/space_maker.rb
+++ b/src/lib/y2storage/proposal/space_maker.rb
@@ -220,7 +220,7 @@ module Y2Storage
           #
           # ** Note **
           #
-          # There are two steps where we try to resize a Windows partition. 
+          # There are two steps where we try to resize a Windows partition.
           # Both should be mutually exclusive. But the 'force' argument
           # itself doesn't ensure this. However: when we did a resize in
           # Step 1 we either did a partial resize - in this case we don't


### PR DESCRIPTION
This also includes making the exit criterion explicit even if this makes the function code so long rubocop complains.