### PR TITLE
fix miscalculation of sizes when resizing a Windows partition (bsc#1066386)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 22 14:40:04 UTC 2017 - snwint@suse.com
+
+- fix unnecessary Windows partition deletion (bsc #1066386)
+- 4.0.63
+
+-------------------------------------------------------------------
 Fri Dec 22 12:35:29 UTC 2017 - snwint@suse.com
 
 - fix logic in GuidedProposal::calculate_proposal (bsc#1058027)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.62
+Version:        4.0.63
 Release:	0
 BuildArch:	noarch
 

--- a/test/data/devicegraphs/output/windows-pc-50GiB-gpt-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-50GiB-gpt-sep-home.yml
@@ -1,0 +1,45 @@
+---
+- disk:
+    name: "/dev/sda"
+    size: 50 GiB
+    block_size: 0.5 KiB
+    io_size: 0 B
+    min_grain: 1 MiB
+    align_ofs: 0 B
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 36172783.5 KiB (34.50 GiB)
+        name: "/dev/sda1"
+        type: primary
+        id: windows_basic_data
+        file_system: ntfs
+        label: windows
+    - partition:
+        size: 12 GiB
+        name: "/dev/sda2"
+        type: primary
+        id: linux
+        file_system: btrfs
+        mount_point: "/"
+        btrfs:
+          subvolumes: []
+    - partition:
+        size: 1 MiB
+        name: "/dev/sda3"
+        type: primary
+        id: bios_boot
+    - partition:
+        size: 0.5 GiB
+        name: "/dev/sda4"
+        type: primary
+        id: swap
+        file_system: swap
+        mount_point: swap
+    - partition:
+        size: 3146735.5 KiB (3.00 GiB)
+        name: "/dev/sda5"
+        type: primary
+        id: linux
+        file_system: xfs
+        mount_point: "/home"

--- a/test/data/devicegraphs/output/windows-pc-50GiB-gpt.yml
+++ b/test/data/devicegraphs/output/windows-pc-50GiB-gpt.yml
@@ -1,0 +1,40 @@
+---
+- disk:
+    name: "/dev/sda"
+    size: 50 GiB
+    block_size: 0.5 KiB
+    io_size: 0 B
+    min_grain: 1 MiB
+    align_ofs: 0 B
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 8385519.5 KiB (8.00 GiB)
+        name: "/dev/sda1"
+        type: primary
+        id: windows_basic_data
+        file_system: ntfs
+        label: windows
+    - partition:
+        size: 40 GiB
+        name: "/dev/sda2"
+        type: primary
+        id: linux
+        file_system: btrfs
+        mount_point: "/"
+        btrfs:
+          subvolumes: []
+    - partition:
+        size: 1 MiB
+        name: "/dev/sda3"
+        type: primary
+        id: bios_boot
+    - partition:
+        size: 2098159.5 KiB (2.00 GiB)
+        name: "/dev/sda4"
+        type: primary
+        id: swap
+        file_system: swap
+        mount_point: swap
+    - free:
+        size: 16.5 KiB

--- a/test/data/devicegraphs/output/windows-pc-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-enc-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 745470 MiB
+        size: 745469 MiB
         name: /dev/sda1
         id: 0x7
         file_system: ntfs
@@ -25,7 +25,7 @@
           password: '12345678'
 
     - partition:
-        size: 12290 MiB
+        size: 12291 MiB
         name: "/dev/sda4"
         type: extended
         id: extended
@@ -43,7 +43,7 @@
           password: '12345678'
 
     - partition:
-        size: 10 GiB
+        size: 10241 MiB
         name: "/dev/sda6"
         type: logical
         id: linux

--- a/test/data/devicegraphs/output/windows-pc-enc.yml
+++ b/test/data/devicegraphs/output/windows-pc-enc.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 738.00 GiB
+        size: 755711 MiB
         name: /dev/sda1
         id: 0x7
         file_system: ntfs
@@ -34,6 +34,9 @@
           type: luks
           name: "/dev/mapper/cr_sda4"
           password: '12345678'
+
+    - free:
+        size: 1 MiB
 
     - partition:
         size: unlimited

--- a/test/data/devicegraphs/output/windows-pc-gpt-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-enc-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 745471 MiB
+        size: 745470 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
@@ -40,7 +40,7 @@
           password: '12345678'
 
     - partition:
-        size: 10.00 GiB
+        size: 10241 MiB
         name: "/dev/sda6"
         id: linux
         file_system: xfs

--- a/test/data/devicegraphs/output/windows-pc-gpt-enc.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-enc.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 755711 MiB
+        size: 755710 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
@@ -38,6 +38,9 @@
           type: luks
           name: "/dev/mapper/cr_sda5"
           password: '12345678'
+
+    - free:
+        size: 1 MiB
 
     - partition:
         size: unlimited

--- a/test/data/devicegraphs/output/windows-pc-gpt-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 745471 MiB
+        size: 745470 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
@@ -32,7 +32,7 @@
         mount_point: swap
 
     - partition:
-        size: 10.00 GiB
+        size: 10241 MiB
         name: "/dev/sda6"
         id: linux
         file_system: xfs

--- a/test/data/devicegraphs/output/windows-pc-gpt.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 755711 MiB
+        size: 755710 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
@@ -30,6 +30,9 @@
         id: swap
         file_system: swap
         mount_point: swap
+
+    - free:
+        size: 1 MiB
 
     - partition:
         size: unlimited

--- a/test/data/devicegraphs/output/windows-pc-mbr128-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-mbr128-sep-home.yml
@@ -7,7 +7,7 @@
     partitions:
 
     - partition:
-        size: 745470 MiB
+        size: 745469 MiB
         start: 128 KiB
         name: /dev/sda1
         id: 0x7
@@ -23,7 +23,7 @@
         mount_point: "/"
 
     - partition:
-        size: 12290 MiB
+        size: 12291 MiB
         name: "/dev/sda4"
         type: extended
         id: extended
@@ -37,7 +37,7 @@
         mount_point: swap
 
     - partition:
-        size: 10 GiB
+        size: 10241 MiB
         name: "/dev/sda6"
         type: logical
         id: linux

--- a/test/data/devicegraphs/output/windows-pc-mbr128.yml
+++ b/test/data/devicegraphs/output/windows-pc-mbr128.yml
@@ -7,7 +7,7 @@
     partitions:
 
     - partition:
-        size: 738.00 GiB
+        size: 755711 MiB
         start: 128 KiB
         name: /dev/sda1
         id: 0x7
@@ -28,6 +28,9 @@
         id: swap
         file_system: swap
         mount_point: swap
+
+    - free:
+        size: 1 MiB
 
     - partition:
         size: unlimited

--- a/test/data/devicegraphs/output/windows-pc-mbr256-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-mbr256-sep-home.yml
@@ -7,7 +7,7 @@
     partitions:
 
     - partition:
-        size: 745470 MiB
+        size: 745469 MiB
         start: 256 KiB
         name: /dev/sda1
         id: 0x7
@@ -23,7 +23,7 @@
         mount_point: "/"
 
     - partition:
-        size: 12290 MiB
+        size: 12291 MiB
         name: "/dev/sda4"
         type: extended
         id: extended
@@ -37,7 +37,7 @@
         mount_point: swap
 
     - partition:
-        size: 10 GiB
+        size: 10241 MiB
         name: "/dev/sda6"
         type: logical
         id: linux

--- a/test/data/devicegraphs/output/windows-pc-mbr256.yml
+++ b/test/data/devicegraphs/output/windows-pc-mbr256.yml
@@ -7,7 +7,7 @@
     partitions:
 
     - partition:
-        size: 738.00 GiB
+        size: 755711 MiB
         start: 256 KiB
         name: /dev/sda1
         id: 0x7
@@ -28,6 +28,9 @@
         id: swap
         file_system: swap
         mount_point: swap
+
+    - free:
+        size: 1 MiB
 
     - partition:
         size: unlimited

--- a/test/data/devicegraphs/output/windows-pc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 745470 MiB
+        size: 745469 MiB
         name: /dev/sda1
         id: 0x7
         file_system: ntfs
@@ -21,7 +21,7 @@
         mount_point: "/"
 
     - partition:
-        size: 12290 MiB
+        size: 12291 MiB
         name: "/dev/sda4"
         type: extended
         id: extended
@@ -35,7 +35,7 @@
         mount_point: swap
 
     - partition:
-        size: 10 GiB
+        size: 10241 MiB
         name: "/dev/sda6"
         type: logical
         id: linux

--- a/test/data/devicegraphs/output/windows-pc.yml
+++ b/test/data/devicegraphs/output/windows-pc.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 738.00 GiB
+        size: 755711 MiB
         name: /dev/sda1
         id: 0x7
         file_system: ntfs
@@ -26,6 +26,9 @@
         id: swap
         file_system: swap
         mount_point: swap
+
+    - free:
+       size: 1 MiB
 
     - partition:
         size: unlimited

--- a/test/data/devicegraphs/windows-pc-50GiB-gpt.yml
+++ b/test/data/devicegraphs/windows-pc-50GiB-gpt.yml
@@ -1,0 +1,13 @@
+---
+- disk:
+    name: /dev/sda
+    size: 50 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size:         51198 MiB
+        name:         /dev/sda1
+        id:           windows_basic_data
+        file_system:  ntfs
+        label:        windows

--- a/test/y2storage/proposal/space_maker_test.rb
+++ b/test/y2storage/proposal/space_maker_test.rb
@@ -296,7 +296,7 @@ describe Y2Storage::Proposal::SpaceMaker do
             it "resizes Windows partitions to free additional needed space" do
               result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
               expect(result[:devicegraph].partitions).to contain_exactly(
-                an_object_having_attributes(filesystem_label: "windows", size: 200.GiB - 1.MiB)
+                an_object_having_attributes(filesystem_label: "windows", size: 200.GiB - 2.MiB)
               )
             end
           end

--- a/test/y2storage/proposal_scenarios_x86_test.rb
+++ b/test/y2storage/proposal_scenarios_x86_test.rb
@@ -101,6 +101,17 @@ describe Y2Storage::GuidedProposal do
       include_examples "all proposed layouts"
     end
 
+    context "in a 50 GiB Windows-only PC with GPT partition table" do
+      let(:scenario) { "windows-pc-50GiB-gpt" }
+      let(:windows_partitions) { [partition_double("/dev/sda1")] }
+      let(:resize_info) do
+        instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 1.GiB)
+      end
+
+      # essential part of the example: Windows partition has been resized
+      include_examples "partition-based proposed layouts"
+    end
+
     context "in a windows/linux multiboot PC with GPT partition table" do
       let(:scenario) { "windows-linux-multiboot-pc-gpt" }
 


### PR DESCRIPTION
What otherwise happens is this: our planning strategy will typically resize
an existing Windows partition *twice*. First for the root partition, then
again for the rest.

Without this patch, after the first (correct) resize, the Windows partition
will leave a free space block that appears to be bigger than can actually be
used (due to the alignment issue). As a result, the second resize would be
planned too small.