### PR TITLE
Added Devicegraph#find_by_any_name (needed for bsc#1073254)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan  8 22:16:30 UTC 2018 - ancor@suse.com
+
+- Added Devicegraph#find_by_any_name (needed for bsc#1073254)
+- 4.0.67
+
+-------------------------------------------------------------------
 Mon Jan  8 12:46:38 UTC 2018 - ancor@suse.com
 
 - Do not try to reuse UUID and label from unformatted swap

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.66
+Version:        4.0.67
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -187,6 +187,19 @@ module Y2Storage
       staging_revision != staging_revision_after_probing
     end
 
+    # Checks whether the staging devicegraph has been committed to the system.
+    #
+    # @see #commit
+    #
+    # If this is false, the probed devicegraph (see {#probed}) should perfectly
+    # match the real current system... as long as the system has not been
+    # modified externally to YaST, which is impossible to control.
+    #
+    # @return [Boolean]
+    def committed?
+      @committed
+    end
+
     # Performs in the system all the necessary operations to make it match the
     # staging devicegraph.
     #
@@ -202,6 +215,7 @@ module Y2Storage
       log.info("Committed devicegraph\n#{staging.to_xml}")
 
       storage.commit(commit_options, callbacks)
+      @committed = true
     end
 
     # Probes from a yml file instead of doing real probing
@@ -248,6 +262,7 @@ module Y2Storage
     def reset_probed
       @probed_graph = nil
       @probed_disk_analyzer = nil
+      @committed = false
       Y2Storage::HWInfoReader.instance.reset
     end
 

--- a/test/data/devicegraphs/complex-lvm-encrypt.yml
+++ b/test/data/devicegraphs/complex-lvm-encrypt.yml
@@ -134,5 +134,6 @@
             size:         5 GiB
             lv_name:      lv2
             file_system:  ext4
+            uuid:         "abcdefgh-ijkl-mnop-qrst-uvwxyzzz"
             encryption:
               name: /dev/mapper/cr_vg1_lv2


### PR DESCRIPTION
See https://bugzilla.suse.com/show_bug.cgi?id=1073254

yast2-bootloader and yast2-update wouldn't need any of this if libstorage-ng would save the discarded ids of each device.

I manually tested the 13.1 -> TW upgrade including the three patches (this, https://github.com/yast/yast-update/pull/91 and https://github.com/yast/yast-bootloader/pull/476) and it worked. :+1: