### PR TITLE
Don't rely on a previous swap partition being formatted (bsc#1071515)

### DIFF
--- a/src/lib/y2storage/proposal/devicegraph_generator.rb
+++ b/src/lib/y2storage/proposal/devicegraph_generator.rb
@@ -155,6 +155,7 @@ module Y2Storage
         new_swap_volumes.each_with_index do |swap_volume, idx|
           deleted_swap = deleted_swaps[idx]
           break unless deleted_swap
+          break unless deleted_swap.formatted_as?(:swap)
 
           swap_volume.uuid = deleted_swap.filesystem.uuid
           swap_volume.label = deleted_swap.filesystem.label


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1071515

Now checking if that previous swap partition actually did have a filesystem (in this case a swap signature) and if it is of type swap.

Not sure if in both cases it shouldn't rather be `next` rather than `break`; trying to be consistent here.

Please notice that this is untested as of now.