### PR TITLE
Add default fstab options

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 25 16:00:29 UTC 2018 - shundhammer@suse.com
+
+- Add default mount options for /etc/fstab for ext2/3/4 and vfat
+  (bsc#1066076)
+- 4.0.77
+
+-------------------------------------------------------------------
 Wed Jan 24 12:28:19 UTC 2018 - igonzalezsosa@suse.com
 
 - Properly detect snapshots subvolumes (bsc#1076321 and

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.76
+Version:        4.0.77
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -184,7 +184,7 @@ module Y2Partitioner
           Yast::UI.ChangeWidget(Id(:mount_device), :Enabled, true)
 
           if filesystem.mountpoint.nil? || filesystem.mountpoint.empty?
-            Yast::UI.ChangeWidget(Id(:no_mount_device), :Value, true)
+            Yast::UI.ChangeWidget(Id(:dont_mount_device), :Value, true)
             @mount_point_widget.disable
             @fstab_options_widget.disable
           else
@@ -195,7 +195,7 @@ module Y2Partitioner
         else
           Yast::UI.ChangeWidget(Id(:mount_device), :Enabled, false)
 
-          Yast::UI.ChangeWidget(Id(:no_mount_device), :Value, true)
+          Yast::UI.ChangeWidget(Id(:dont_mount_device), :Value, true)
           @mount_point_widget.disable
           @fstab_options_widget.disable
         end
@@ -219,7 +219,7 @@ module Y2Partitioner
                       Left(@fstab_options_widget)
                     )
                   ),
-                  Left(RadioButton(Id(:no_mount_device), Opt(:notify), _("Do not mount device")))
+                  Left(RadioButton(Id(:dont_mount_device), Opt(:notify), _("Do not mount device")))
                 )
               ),
               HBox(Left(@btrfs_subvolumes_widget))
@@ -235,8 +235,8 @@ module Y2Partitioner
         case event["ID"]
         when :mount_device
           mount_device
-        when :no_mount_device
-          no_mount_device
+        when :dont_mount_device
+          dont_mount_device
         when @mount_point_widget.widget_id
           mount_point_change
         else
@@ -255,7 +255,7 @@ module Y2Partitioner
         @mount_point_widget.enable
       end
 
-      def no_mount_device
+      def dont_mount_device
         @controller.mount_point = ""
         @fstab_options_widget.disable
         @mount_point_widget.disable

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -362,7 +362,7 @@ module Y2Partitioner
       def widgets
         [
           Acl.new(@controller),
-          User_xattr.new(@controller)
+          UserXattr.new(@controller)
         ]
       end
     end
@@ -385,7 +385,7 @@ module Y2Partitioner
     end
 
     # CheckBox to enable extended user attributes (xattr)
-    class User_xattr < FstabCheckBox
+    class UserXattr < FstabCheckBox
       include FstabCommon
 
       VALUES = ["user_xattr", "nouser_xattr"].freeze

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -79,7 +79,7 @@ module Y2Partitioner
       include FstabCommon
 
       def label
-        _("Fstab options...")
+        _("Fstab Options...")
       end
 
       def handle

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -517,11 +517,17 @@ module Y2Partitioner
       VALUES = ["codepage="].freeze
       DEFAULT = "".freeze
 
+      def init
+        i = filesystem.fstab_options.index { |o| o =~ REGEXP }
+
+        self.value = i ? filesystem.fstab_options[i].gsub(REGEXP, "") : DEFAULT
+      end
+
       def store
         # The options can only be modified using BlkDevice#fstab_options=
         filesystem.fstab_options = filesystem.fstab_options.reject { |o| o =~ REGEXP }
 
-        return if value && !value.empty?
+        return if value.nil? || value.empty?
         filesystem.fstab_options = filesystem.fstab_options + ["codepage=#{value}"]
       end
 

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -5,7 +5,7 @@ require "y2storage"
 module Y2Partitioner
   module Widgets
     # The fstab options are mostly checkboxes and combo boxes that share some
-    # common methods, so this is a mixin for that share code.
+    # common methods, so this is a mixin for that shared code.
     module FstabCommon
       def initialize(controller)
         textdomain "storage"
@@ -21,9 +21,9 @@ module Y2Partitioner
         init_regexp if self.class.const_defined?("REGEXP")
       end
 
-      # No all the fstab options are supported by all the filesystem so each
-      # widget are able to check if the current filesystem is supported
-      # explicitely or checking if the values it is responsable of are
+      # No all the fstab options are supported by all the filesystems so each
+      # widget is able to check if the current filesystem is supported
+      # explicitely or checking if the values it is responsable for are
       # supported by the filesystem.
       def supported_by_filesystem?
         return false if filesystem.nil?
@@ -74,7 +74,7 @@ module Y2Partitioner
       end
     end
 
-    # Push button that launch a dialog for set the fstab options
+    # Push button that launch a dialog to set the fstab options
     class FstabOptionsButton < CWM::PushButton
       include FstabCommon
 
@@ -401,8 +401,8 @@ module Y2Partitioner
     # A input field that allows to set other options that are not handled by
     # specific widgets
     #
-    # TODO: FIXME: Pending implementation, currently it is only draw, all the options
-    # that it is responsable of should be defined, removing them if not set or
+    # TODO: FIXME: Pending implementation, currently it is only drawing; all the options
+    # that it is responsible for should be defined, removing them if not set or
     # supported by the current filesystem.
     class ArbitraryOptions < CWM::InputField
       def initialize(controller)

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -3,7 +3,10 @@ require "cwm"
 require "y2storage"
 
 module Y2Partitioner
+  # Partitioner widgets
   module Widgets
+    include Yast::Logger
+
     # The fstab options are mostly checkboxes and combo boxes that share some
     # common methods, so this is a mixin for that shared code.
     module FstabCommon
@@ -21,9 +24,9 @@ module Y2Partitioner
         init_regexp if self.class.const_defined?("REGEXP")
       end
 
-      # No all the fstab options are supported by all the filesystems so each
+      # Not all the fstab options are supported by all the filesystems so each
       # widget is able to check if the current filesystem is supported
-      # explicitely or checking if the values it is responsable for are
+      # explicitely or checking if the values it is responsible for are
       # supported by the filesystem.
       def supported_by_filesystem?
         return false if filesystem.nil?
@@ -31,10 +34,12 @@ module Y2Partitioner
         if self.class.const_defined?("SUPPORTED_FILESYSTEMS")
           self.class::SUPPORTED_FILESYSTEMS
             .include?(filesystem.type.to_sym)
-        else
+        elsif self.class.const_defined?("VALUES")
           self.class::VALUES.all? do |v|
             filesystem.type.supported_fstab_options.include?(v)
           end
+        else
+          false
         end
       end
 
@@ -54,10 +59,17 @@ module Y2Partitioner
         [Left(widget), VSpacing(1)]
       end
 
-      def delete_from_fstab!(option)
+      def delete_fstab_option!(option)
         # The options can only be modified using BlkDevice#fstab_options=
         filesystem.fstab_options = filesystem.fstab_options.reject { |o| o =~ option }
       end
+
+      def add_fstab_options(*options)
+        # The options can only be modified using BlkDevice#fstab_options=
+        filesystem.fstab_options = filesystem.fstab_options + options
+      end
+
+      alias_method :add_fstab_option, :add_fstab_options
 
     private
 
@@ -83,7 +95,9 @@ module Y2Partitioner
       end
 
       def handle
+        log.info("fstab_options before dialog: #{filesystem.fstab_options}")
         Dialogs::FstabOptions.new(@controller).run
+        log.info("fstab_options after dialog: #{filesystem.fstab_options}")
 
         nil
       end
@@ -243,11 +257,8 @@ module Y2Partitioner
 
       # FIXME: It is common to almost all regexp widgets not only for checkboxes
       def store
-        delete_from_fstab!(Regexp.union(options))
-
-        return unless value
-        # The options can only be modified using BlkDevice#fstab_options=
-        filesystem.fstab_options = filesystem.fstab_options + [checked_value]
+        delete_fstab_option!(Regexp.union(options))
+        add_fstab_option(checked_value) if value
       end
 
     private
@@ -335,31 +346,95 @@ module Y2Partitioner
       end
 
       def store
-        delete_from_fstab!(Regexp.union(VALUES))
+        delete_fstab_option!(Regexp.union(VALUES))
+        add_fstab_options("usrquota", "grpquota") if value
+      end
+    end
 
-        return unless value
-        # The options can only be modified using BlkDevice#fstab_options=
-        filesystem.fstab_options = filesystem.fstab_options + ["usrquota", "grpquota"]
+    # Generic ComboBox for fstab options.
+    #
+    # This uses some constants that each derived class should define:
+    #
+    # REGEXP [Regex] The regular expression describing the fstab option.
+    # If it ends with "=", the value will be appended to it.
+    #
+    # ITEMS [Array<String>] The items to choose from.
+    # The first one is used as the default (initial) value.
+    #
+    class FstabComboBox < CWM::ComboBox
+      include FstabCommon
+
+      # Set the combo box value to the current value matching REGEXP.
+      def init
+        i = filesystem.fstab_options.index { |o| o =~ self.class::REGEXP }
+        self.value = i ? filesystem.fstab_options[i].gsub(self.class::REGEXP, "") : default_value
+      end
+
+      # Convert REGEXP to the option string. This is a very basic
+      # implementation that just removes a "^" if the regexp contains it.
+      # For anything more sophisticated, reimplement this.
+      #
+      # @return [String]
+      def option_str
+        self.class::REGEXP.source.delete("^")
+      end
+
+      # Overriding FstabCommon::supported_by_filesystem? to make use of the
+      # REGEXP and to avoid having to duplicate it in VALUES
+      def supported_by_filesystem?
+        return false if filesystem.nil?
+        filesystem.type.supported_fstab_options.any? { |opt| opt =~ self.class::REGEXP }
+      end
+
+      # The default value for the option.
+      #
+      # @return [String]
+      def default_value
+        items.first.first
+      end
+
+      # Store the current value in the fstab_options.
+      # If the value is nil or empty, it will only remove the old value.
+      #
+      # If option_str (i.e. normally REGEXP) ends with "=", the value is
+      # appended to it, otherwise only the value is used.
+      # "codepage=" -> "codepage=value"
+      # "foo" -> "value"
+      def store
+        delete_fstab_option!(self.class::REGEXP)
+        return if value.nil? || value.empty?
+
+        opt = option_str
+        if opt.end_with?("=")
+          opt += value
+        else
+          opt = value
+        end
+        add_fstab_option(opt)
+      end
+
+      # Convert ITEMS to the format expected by the underlying
+      # CWM::ComboBox.
+      def items
+        self.class::ITEMS.map { |val| [val, val] }
+      end
+
+      # Widget options
+      def opt
+        %i(editable hstretch)
       end
     end
 
     # ComboBox to specify the journal mode to use by the filesystem
-    class JournalOptions < CWM::ComboBox
-      include FstabCommon
-
+    class JournalOptions < FstabComboBox
       REGEXP = /^data=/
-      VALUES = ["data="].freeze
-      DEFAULT = "journal".freeze
 
       def label
         _("Data &Journaling Mode")
       end
 
-      def store
-        delete_from_fstab!(REGEXP)
-
-        # The options can only be modified using BlkDevice#fstab_options=
-        filesystem.fstab_options = filesystem.fstab_options + ["data=#{value}"]
+      def default_value
+        "ordered"
       end
 
       def items
@@ -450,10 +525,8 @@ module Y2Partitioner
       end
 
       def store
-        delete_from_fstab!(REGEXP)
-
-        # The options can only be modified using BlkDevice#fstab_options=
-        filesystem.fstab_options = filesystem.fstab_options + ["pri=#{value}"]
+        delete_fstab_option!(REGEXP)
+        add_fstab_option("pri=#{value}") if value
       end
 
       def help
@@ -463,29 +536,22 @@ module Y2Partitioner
     end
 
     # VFAT IOCharset
-    class IOCharset < CWM::ComboBox
-      include FstabCommon
-
-      SUPPORTED_FILESYSTEMS = ["vfat"].freeze
+    class IOCharset < FstabComboBox
       REGEXP = /^iocharset=/
-      DEFAULT = "".freeze
-      AVAILABLE_VALUES = [
+      ITEMS = [
         "", "iso8859-1", "iso8859-15", "iso8859-2", "iso8859-5", "iso8859-7",
         "iso8859-9", "utf8", "koi8-r", "euc-jp", "sjis", "gb2312", "big5",
         "euc-kr"
       ].freeze
 
-      def init
-        i = filesystem.fstab_options.index { |o| o =~ REGEXP }
-
-        self.value = i ? filesystem.fstab_options[i].gsub(REGEXP, "") : DEFAULT
+      def store
+        delete_fstab_option!(/^utf8=.*/)
+        super
       end
 
-      def store
-        delete_from_fstab!(/^iocharset=/)
-
-        # The options can only be modified using BlkDevice#fstab_options=
-        filesystem.fstab_options = filesystem.fstab_options + ["iocharset=#{value}"]
+      def default_value
+        iocharset = filesystem.type.iocharset
+        ITEMS.include?(iocharset) ? iocharset : ITEMS.first
       end
 
       def label
@@ -496,39 +562,16 @@ module Y2Partitioner
         _("<p><b>Charset for File Names:</b>\nSet the charset used for display " \
         "of file names in Windows partitions.</p>\n")
       end
-
-      def opt
-        %i(editable hstretch)
-      end
-
-      def items
-        AVAILABLE_VALUES.map do |ch|
-          [ch, ch]
-        end
-      end
     end
 
     # VFAT Codepage
-    class Codepage < CWM::ComboBox
-      include FstabCommon
-
-      CODEPAGES = ["", "437", "852", "932", "936", "949", "950"].freeze
+    class Codepage < FstabComboBox
       REGEXP = /^codepage=/
-      VALUES = ["codepage="].freeze
-      DEFAULT = "".freeze
+      ITEMS = ["", "437", "852", "932", "936", "949", "950"].freeze
 
-      def init
-        i = filesystem.fstab_options.index { |o| o =~ REGEXP }
-
-        self.value = i ? filesystem.fstab_options[i].gsub(REGEXP, "") : DEFAULT
-      end
-
-      def store
-        # The options can only be modified using BlkDevice#fstab_options=
-        filesystem.fstab_options = filesystem.fstab_options.reject { |o| o =~ REGEXP }
-
-        return if value.nil? || value.empty?
-        filesystem.fstab_options = filesystem.fstab_options + ["codepage=#{value}"]
+      def default_value
+        cp = filesystem.type.codepage
+        ITEMS.include?(cp) ? cp : ITEMS.first
       end
 
       def label
@@ -538,14 +581,6 @@ module Y2Partitioner
       def help
         _("<p><b>Codepage for Short FAT Names:</b>\nThis codepage is used for " \
         "converting to shortname characters on FAT file systems.</p>\n")
-      end
-
-      def opt
-        %i(editable hstretch)
-      end
-
-      def items
-        CODEPAGES.map { |ch| [ch, ch] }
       end
     end
   end

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -34,6 +34,7 @@ module Y2Storage
 
       wrap_enum "FsType"
 
+      # See "man mount" for all those options.
       COMMON_FSTAB_OPTIONS = ["async", "atime", "noatime", "user", "nouser",
                               "auto", "noauto", "ro", "rw", "defaults"].freeze
       EXT_FSTAB_OPTIONS = ["dev", "nodev", "usrquota", "grpquota", "acl",
@@ -344,11 +345,7 @@ module Y2Storage
         fstab_options.map do |opt|
           next opt unless opt.start_with?("iocharset")
           iocharset = lang_typical_encoding
-          if iocharset == "utf8"
-            "utf8=true"
-          else
-            "iocharset=" + iocharset
-          end
+          "iocharset=" + iocharset
         end
       end
 

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -38,7 +38,7 @@ module Y2Storage
       COMMON_FSTAB_OPTIONS = ["async", "atime", "noatime", "user", "nouser",
                               "auto", "noauto", "ro", "rw", "defaults"].freeze
       EXT_FSTAB_OPTIONS = ["dev", "nodev", "usrquota", "grpquota", "acl",
-                           "noacl"].freeze
+                           "noacl", "user_xattr", "nouser_xattr"].freeze
       JOURNAL_OPTIONS = ["data=ordered"].freeze
       ACL_OPTIONS = ["acl", "user_xattr"].freeze
 

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -22,6 +22,8 @@
 require "y2storage/storage_enum_wrapper"
 require "y2storage/partition_id"
 
+Yast.import "Encoding"
+
 module Y2Storage
   module Filesystems
     # Class to represent all the possible filesystem types
@@ -36,12 +38,28 @@ module Y2Storage
                               "auto", "noauto", "ro", "rw", "defaults"].freeze
       EXT_FSTAB_OPTIONS = ["dev", "nodev", "usrquota", "grpquota", "acl",
                            "noacl"].freeze
+      JOURNAL_OPTIONS = ["data=ordered"].freeze
+      ACL_OPTIONS = ["acl", "user_xattr"].freeze
+
+      # For "iocharset" and "codepage" the value will be added on demand.
+      #
+      # Not doing it here to avoid always doing complicated locale lookups even
+      # if not needed because in many cases no such filesystem is used.
+      IOCHARSET_OPTIONS = ["iocharset="].freeze
+      CODEPAGE_OPTIONS = ["codepage="].freeze
+      DEFAULT_CODEPAGE = "437".freeze
 
       # Hash with the properties of several filesystem types.
+      #
       # Keys are the symbols representing the types and values are hashes that
-      # can contain `:name` for human string, `:fstab_options` for a list of
-      # supported /etc/fstab options and `:default_partition_id` for the partition
-      # id that fits better with the corresponding filesystem type.
+      # can contain:
+      # - `:name` for human string
+      # - `:fstab_options` for a list of supported /etc/fstab options
+      # - `:default_fstab_options` for the default /etc/fstab options
+      #   (do not include "defaults" here!)
+      # - `:default_partition_id` for the partition id that fits better with
+      #   the corresponding filesystem type.
+      #
       # Not all combinations of filesystem types and properties are represented,
       # default values are used for missing information.
       PROPERTIES = {
@@ -50,16 +68,19 @@ module Y2Storage
           name:          "BtrFS"
         },
         ext2:     {
-          fstab_options: COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS,
-          name:          "Ext2"
+          fstab_options:         COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS,
+          default_fstab_options: ACL_OPTIONS,
+          name:                  "Ext2"
         },
         ext3:     {
-          fstab_options: COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],
-          name:          "Ext3"
+          fstab_options:         COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],
+          default_fstab_options: JOURNAL_OPTIONS + ACL_OPTIONS,
+          name:                  "Ext3"
         },
         ext4:     {
-          fstab_options: COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],
-          name:          "Ext4"
+          fstab_options:         COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],
+          default_fstab_options: JOURNAL_OPTIONS + ACL_OPTIONS,
+          name:                  "Ext4"
         },
         hfs:      {
           name: "MacHFS"
@@ -69,9 +90,6 @@ module Y2Storage
         },
         jfs:      {
           name: "JFS"
-        },
-        msdos:    {
-          name: "FAT"
         },
         nfs:      {
           name: "NFS"
@@ -83,7 +101,8 @@ module Y2Storage
           name: "NilFS"
         },
         ntfs:     {
-          name: "NTFS"
+          default_fstab_options: ["fmask=133", "dmask=022"],
+          name:                  "NTFS"
         },
         reiserfs: {
           name: "ReiserFS"
@@ -94,9 +113,10 @@ module Y2Storage
           name:                 "Swap"
         },
         vfat:     {
-          fstab_options:        COMMON_FSTAB_OPTIONS + ["dev", "nodev", "iocharset=", "codepage="],
-          default_partition_id: PartitionId::DOS32,
-          name:                 "FAT"
+          fstab_options:         COMMON_FSTAB_OPTIONS + ["dev", "nodev", "iocharset=", "codepage="],
+          default_fstab_options: IOCHARSET_OPTIONS + CODEPAGE_OPTIONS,
+          default_partition_id:  PartitionId::DOS32,
+          name:                  "FAT"
         },
         xfs:      {
           fstab_options: COMMON_FSTAB_OPTIONS + ["usrquota", "grpquota"],
@@ -112,6 +132,22 @@ module Y2Storage
         }
       }
 
+      # Typical encodings for some languages used in a non-utf8 8 bit locale
+      # environment. This is mostly relevant for FAT filesystems.
+      LANG_ENCODINGS = {
+        "el" => "iso8859-7",
+        "hu" => "iso8859-2",
+        "cs" => "iso8859-2",
+        "hr" => "iso8859-2",
+        "sl" => "iso8859-2",
+        "sk" => "iso8859-2",
+        "en" => "iso8859-1",
+        "tr" => "iso8859-9",
+        "lt" => "iso8859-13",
+        "bg" => "iso8859-5",
+        "ru" => "iso8859-5"
+      }.freeze
+
       ROOT_FILESYSTEMS = [:ext2, :ext3, :ext4, :btrfs, :xfs]
 
       HOME_FILESYSTEMS = [:ext2, :ext3, :ext4, :btrfs, :xfs]
@@ -124,7 +160,8 @@ module Y2Storage
 
       private_constant :PROPERTIES, :ROOT_FILESYSTEMS, :HOME_FILESYSTEMS,
         :COMMON_FSTAB_OPTIONS, :EXT_FSTAB_OPTIONS, :LEGACY_ROOT_FILESYSTEMS,
-        :LEGACY_HOME_FILESYSTEMS, :ZIPL_FILESYSTEMS
+        :LEGACY_HOME_FILESYSTEMS, :ZIPL_FILESYSTEMS, :JOURNAL_OPTIONS,
+        :ACL_OPTIONS, :IOCHARSET_OPTIONS, :CODEPAGE_OPTIONS, :LANG_ENCODINGS
 
       # Allowed filesystems for root
       #
@@ -245,6 +282,26 @@ module Y2Storage
         properties[:fstab_options] || default
       end
 
+      # Default fstab options for filesystems of this type. These are used if
+      # the user does not explicitly select anything else in the partitioner
+      # for this filesystem.
+      #
+      # Notice that this will never include "defaults" which is only a
+      # placeholder for that field in /etc/fstab if there are no options. The
+      # EtcFstab class will handle that on its own. It also does not make any
+      # sense to include "defaults" if any other option is present.
+      #
+      # @return [Array<String>]
+      def default_fstab_options
+        properties = PROPERTIES[to_sym]
+        fallback = []
+        return fallback unless properties
+        opt = properties[:default_fstab_options] || fallback
+        opt = patch_codepage(opt)
+        opt = patch_iocharset(opt)
+        opt
+      end
+
       # Best fitting partition id for this filesystem type
       #
       # @note: Take into account that the default partition id can be inappropriate for some
@@ -258,6 +315,71 @@ module Y2Storage
         return default unless properties
         properties[:default_partition_id] || default
       end
+
+      # Add the required codepage number according to the current locale to
+      # fstab options if it contains a codepage specification.
+      #
+      # @param fstab_options [Array<String>]
+      # @return [Array<String>] changed fstab options
+      #
+      def patch_codepage(fstab_options)
+        fstab_options.map do |opt|
+          next opt unless opt.start_with?("codepage")
+          cp = codepage
+          if cp == "437" # Default according to "man mount"
+            nil
+          else
+            "codepage=" + cp
+          end
+        end.compact
+      end
+
+      # Add the required iocharset value according to the current locale to
+      # fstab options if it contains a iocharset specification.
+      #
+      # @param fstab_options [Array<String>]
+      # @return [Array<String>] changed fstab options
+      #
+      def patch_iocharset(fstab_options)
+        fstab_options.map do |opt|
+          next opt unless opt.start_with?("iocharset")
+          iocharset = lang_typical_encoding
+          if iocharset == "utf8"
+            "utf8=true"
+          else
+            "iocharset=" + iocharset
+          end
+        end
+      end
+
+      # Return the codepage for FAT filesystems. This is used to convert
+      # between long filenames and their short (8+3) equivalent.
+      #
+      # See also "man mount".
+      #
+      # @return [String]
+      #
+      def codepage
+        encoding = lang_typical_encoding
+        cp = Yast::Encoding.GetCodePage(encoding)
+        cp.empty? ? DEFAULT_CODEPAGE : cp
+      end
+
+      # Get the encoding that is typical for the current language environment
+      # as stored in the Encoding module (where it can be set by the
+      # installation workflow). In most cases, this is "utf8". Older FAT
+      # filesystems might still use one of the legacy encodings (iso8859-x).
+      #
+      # @return [String]
+      #
+      def lang_typical_encoding
+        return "utf8" if Yast::Encoding.GetUtf8Lang
+        lang = Yast::Encoding.GetEncLang # e.g. "de_DE.iso8859-15"
+        lang = lang.downcase[0, 2] # need only the language part
+        LANG_ENCODINGS[lang] || "iso8859-15"
+      end
+
+      alias_method :iocharset, :lang_typical_encoding
     end
   end
 end

--- a/src/lib/y2storage/mountable.rb
+++ b/src/lib/y2storage/mountable.rb
@@ -84,8 +84,15 @@ module Y2Storage
     def mountpoint=(path)
       to_storage_value.add_mountpoint(path.to_s)
       if fstab_options && !fstab_options.empty?
-        mp = to_storage_value.mountpoint # storage::Mountpoint, not string!
-        mp.mount_options = mp.mount_options.to_a + fstab_options
+        mp = to_storage_value.mount_point # storage::Mountpoint, not string!
+
+        # Append Mountable.fstab_options to the Mountpoint.mount_options.
+        # We can't just assign a Ruby string array because the SWIG bindings
+        # expect a std:vector<std::string> and won't automatically convert a
+        # Ruby array to it.
+        fstab_options.each do |opt|
+          mp.mount_options << opt unless fstab_options.include?(opt)
+        end
       end
       mountpoint
     end

--- a/src/lib/y2storage/mountable.rb
+++ b/src/lib/y2storage/mountable.rb
@@ -83,6 +83,10 @@ module Y2Storage
     # @return [String]
     def mountpoint=(path)
       to_storage_value.add_mountpoint(path.to_s)
+      if fstab_options && !fstab_options.empty?
+        mp = to_storage_value.mountpoint # storage::Mountpoint, not string!
+        mp.mount_options = mp.mount_options.to_a + fstab_options
+      end
       mountpoint
     end
 

--- a/src/lib/y2storage/planned/can_be_formatted.rb
+++ b/src/lib/y2storage/planned/can_be_formatted.rb
@@ -152,8 +152,11 @@ module Y2Storage
       # @param filesystem [Filesystems::BlkFilesystem]
       def setup_fstab_options(filesystem)
         return unless filesystem
-        return unless filesystem_type
-        filesystem.fstab_options = fstab_options || filesystem_type.default_fstab_options
+        if fstab_options
+          filesystem.fstab_options = fstab_options
+        elsif filesystem_type
+          filesystem.fstab_options = filesystem_type.default_fstab_options
+        end
       end
 
       # Creates subvolumes in the previously created filesystem that is placed

--- a/src/lib/y2storage/planned/can_be_formatted.rb
+++ b/src/lib/y2storage/planned/can_be_formatted.rb
@@ -142,8 +142,16 @@ module Y2Storage
         filesystem.label = label if label
         filesystem.uuid = uuid if uuid
         filesystem.mkfs_options = mkfs_options if mkfs_options
-        filesystem.fstab_options = fstab_options if fstab_options
         filesystem.mount_by = mount_by if mount_by
+        setup_fstab_options(filesystem)
+      end
+
+      # Set the fstab options, either those that were explicitly set, or the
+      # defaults for this filesystem type
+      #
+      # @param filesystem [Filesystems::BlkFilesystem]
+      def setup_fstab_options(filesystem)
+        filesystem.fstab_options = fstab_options || filesystem_type.default_fstab_options
       end
 
       # Creates subvolumes in the previously created filesystem that is placed
@@ -172,6 +180,7 @@ module Y2Storage
           format!(device)
         else
           filesystem = final_device!(device).filesystem
+          setup_fstab_options(filesystem)
           assign_mountpoint(filesystem)
         end
       end

--- a/src/lib/y2storage/planned/can_be_formatted.rb
+++ b/src/lib/y2storage/planned/can_be_formatted.rb
@@ -151,6 +151,8 @@ module Y2Storage
       #
       # @param filesystem [Filesystems::BlkFilesystem]
       def setup_fstab_options(filesystem)
+        return unless filesystem
+        return unless filesystem_type
         filesystem.fstab_options = fstab_options || filesystem_type.default_fstab_options
       end
 
@@ -180,8 +182,10 @@ module Y2Storage
           format!(device)
         else
           filesystem = final_device!(device).filesystem
-          setup_fstab_options(filesystem)
-          assign_mountpoint(filesystem)
+          if filesystem
+            setup_fstab_options(filesystem)
+            assign_mountpoint(filesystem)
+          end
         end
       end
 

--- a/src/lib/y2storage/proposal/base.rb
+++ b/src/lib/y2storage/proposal/base.rb
@@ -75,6 +75,7 @@ module Y2Storage
         raise UnexpectedCallError if proposed?
         @proposed = true
         result = calculate_proposal
+        return result if devices.nil? || devices.empty?
         log.info("Proposed devicegraph:\n\n#{devices.to_str}\n")
         result
       end

--- a/src/lib/y2storage/proposal/base.rb
+++ b/src/lib/y2storage/proposal/base.rb
@@ -74,7 +74,9 @@ module Y2Storage
       def propose
         raise UnexpectedCallError if proposed?
         @proposed = true
-        calculate_proposal
+        result = calculate_proposal
+        log.info("Proposed devicegraph:\n\n#{devices.to_str}\n")
+        result
       end
 
       # Checks whether the proposal has already being calculated

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-docker-lvm.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-docker-lvm.yml
@@ -23,6 +23,10 @@
         size: 30716 MiB (30.00 GiB)
         file_system: ext4
         mount_point: "/"
+        fstab_options:
+          - data=ordered
+          - acl
+          - user_xattr
     - lvm_lv:
         lv_name: var_lib_docker
         size: 20 GiB

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-swap.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-swap.yml
@@ -10,6 +10,10 @@
         id: linux
         file_system: ext4
         mount_point: "/"
+        fstab_options:
+          - data=ordered
+          - acl
+          - user_xattr
     - partition:
         size: 1 MiB
         name: "/dev/sda2"

--- a/test/data/devicegraphs/output/ppc_non_power_nv-lvm.yml
+++ b/test/data/devicegraphs/output/ppc_non_power_nv-lvm.yml
@@ -11,6 +11,10 @@
         id: linux
         file_system: ext4
         mount_point: "/boot"
+        fstab_options:
+          - data=ordered
+          - acl
+          - user_xattr
     - partition:
         size: 1 MiB
         name: "/dev/sda2"

--- a/test/data/devicegraphs/output/ppc_power_nv-lvm.yml
+++ b/test/data/devicegraphs/output/ppc_power_nv-lvm.yml
@@ -11,6 +11,10 @@
         id: linux
         file_system: ext4
         mount_point: "/boot"
+        fstab_options:
+          - data=ordered
+          - acl
+          - user_xattr
     - partition:
         size: 43009 MiB (42.00 GiB)
         name: "/dev/sda2"

--- a/test/data/devicegraphs/output/s390_dasd_zipl-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl-lvm-sep-home.yml
@@ -11,6 +11,9 @@
         id: linux
         file_system: ext2
         mount_point: /boot/zipl
+        fstab_options:
+          - acl
+          - user_xattr
     - partition:
         size: 24014688 KiB (22.90 GiB)
         name: "/dev/sda2"

--- a/test/data/devicegraphs/output/s390_dasd_zipl-lvm.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl-lvm.yml
@@ -11,6 +11,9 @@
         id: linux
         file_system: ext2
         mount_point: "/boot/zipl"
+        fstab_options:
+          - acl
+          - user_xattr
     - partition:
         size: 24014688 KiB (22.90 GiB)
         name: "/dev/sda2"

--- a/test/data/devicegraphs/output/s390_dasd_zipl.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl.yml
@@ -11,6 +11,9 @@
         id: linux
         file_system: ext2
         mount_point: "/boot/zipl"
+        fstab_options:
+          - acl
+          - user_xattr
     - partition:
         size: 21917568 KiB (20.90 GiB)
         name: "/dev/sda2"

--- a/test/data/devicegraphs/output/s390_zfcp_zipl.yml
+++ b/test/data/devicegraphs/output/s390_zfcp_zipl.yml
@@ -10,6 +10,9 @@
         id: linux
         file_system: ext2
         mount_point: "/boot/zipl"
+        fstab_options:
+          - acl
+          - user_xattr
     - partition:
         size: 40 GiB
         name: "/dev/sda2"

--- a/test/data/devicegraphs/output/windows-pc-mbr256-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-mbr256-lvm-sep-home.yml
@@ -20,6 +20,10 @@
         id: linux
         file_system: ext4
         mount_point: "/boot"
+        fstab_options:
+          - data=ordered
+          - acl
+          - user_xattr
 
     - partition:
         size: 53249 MiB

--- a/test/data/devicegraphs/output/windows-pc-mbr256-lvm.yml
+++ b/test/data/devicegraphs/output/windows-pc-mbr256-lvm.yml
@@ -20,6 +20,10 @@
         id: linux
         file_system: ext4
         mount_point: "/boot"
+        fstab_options:
+          - data=ordered
+          - acl
+          - user_xattr
 
     - partition:
         size: 43009 MiB

--- a/test/support/proposal_context.rb
+++ b/test/support/proposal_context.rb
@@ -21,6 +21,7 @@
 # find current contact information at www.suse.com.
 
 RSpec.shared_context "proposal" do
+  include Yast::Logger
   using Y2Storage::Refinements::SizeCasts
 
   before do
@@ -100,6 +101,9 @@ RSpec.shared_context "proposal" do
     file_name.concat("-enc") if encrypt
     file_name.concat("-lvm") if lvm
     file_name.concat("-sep-home") if separate_home
-    Y2Storage::Devicegraph.new_from_file(output_file_for(file_name))
+    full_path = output_file_for(file_name)
+    devicegraph = Y2Storage::Devicegraph.new_from_file(full_path)
+    log.info("Expected devicegraph from file\n#{full_path}:\n\n#{devicegraph.to_str}\n")
+    devicegraph
   end
 end

--- a/test/y2partitioner/widgets/fstab_options_test.rb
+++ b/test/y2partitioner/widgets/fstab_options_test.rb
@@ -46,6 +46,8 @@ describe Y2Partitioner::Widgets do
     allow(filesystem).to receive(:fstab_options=)
     allow(filesystem).to receive(:label=)
     allow(filesystem).to receive(:mount_by=)
+    allow(filesystem.type).to receive(:codepage).and_return("437")
+    allow(filesystem.type).to receive(:iocharset).and_return("utf8")
   end
 
   subject { described_class.new(controller) }

--- a/test/y2storage/filesystems/type_test.rb
+++ b/test/y2storage/filesystems/type_test.rb
@@ -23,6 +23,8 @@
 require_relative "../spec_helper"
 require "y2storage"
 
+Yast.import "Encoding"
+
 describe Y2Storage::Filesystems::Type do
   describe "#to_human_string" do
     it "returns the description of the type" do
@@ -102,6 +104,82 @@ describe Y2Storage::Filesystems::Type do
         Y2Storage::Filesystems::Type.legacy_home_filesystems.each do |filesystem|
           expect(filesystem.legacy_home?).to eq(true)
         end
+      end
+    end
+  end
+
+  describe "#iocharset and #codepage" do
+    it "return the correct values in a utf8 locale" do
+      Yast::Encoding.SetUtf8Lang(true)
+      Yast::Encoding.SetEncLang("cs_CZ")
+      expect(described_class::VFAT.iocharset).to eq "utf8"
+      expect(described_class::VFAT.codepage).to eq "437"
+    end
+
+    it "return the correct values in a legacy cs_CZ locale" do
+      Yast::Encoding.SetUtf8Lang(false)
+      Yast::Encoding.SetEncLang("cs_CZ")
+
+      expect(described_class::VFAT.iocharset).to eq "iso8859-2"
+      expect(described_class::VFAT.codepage).to eq "852"
+    end
+
+    it "return the correct values in a legacy de_DE locale" do
+      Yast::Encoding.SetUtf8Lang(false)
+      Yast::Encoding.SetEncLang("de_DE")
+      expect(described_class::VFAT.iocharset).to eq "iso8859-15"
+      expect(described_class::VFAT.codepage).to eq "437"
+    end
+
+    it "return the correct values in a utf8 ja_JP locale" do
+      Yast::Encoding.SetUtf8Lang(true)
+      Yast::Encoding.SetEncLang("ja_JP")
+      expect(described_class::VFAT.iocharset).to eq "utf8"
+      expect(described_class::VFAT.codepage).to eq "932"
+    end
+  end
+
+  describe "#default_fstab_options" do
+    context "for locale-independent filesystem types" do
+      it "ext2 has the correct fstab options" do
+        expect(described_class::EXT2.default_fstab_options).to eq ["acl", "user_xattr"]
+      end
+
+      it "ext3 has the correct fstab options" do
+        expect(described_class::EXT3.default_fstab_options).to eq ["data=ordered", "acl", "user_xattr"]
+      end
+
+      it "ext4 has the correct fstab options" do
+        expect(described_class::EXT4.default_fstab_options).to eq ["data=ordered", "acl", "user_xattr"]
+      end
+
+      it "xfs has the correct fstab options" do
+        expect(described_class::XFS.default_fstab_options).to eq []
+      end
+
+      it "ntfs has the correct fstab options" do
+        expect(described_class::NTFS.default_fstab_options).to eq ["fmask=133", "dmask=022"]
+      end
+    end
+
+    context "for locale-dependent filesystem types" do
+      it "vfat has the correct fstab options for a utf8 locale" do
+        Yast::Encoding.SetUtf8Lang(true)
+        Yast::Encoding.SetEncLang("de_DE")
+        expect(described_class::VFAT.default_fstab_options).to eq ["utf8=true"]
+      end
+
+      it "vfat has the correct fstab options for a non-utf8 cs_CZ locale" do
+        Yast::Encoding.SetUtf8Lang(false)
+        Yast::Encoding.SetEncLang("cs_CZ")
+        expect(described_class::VFAT.default_fstab_options).to eq ["iocharset=iso8859-2", "codepage=852"]
+      end
+
+      it "vfat has the correct fstab options for a non-utf8 de_DE locale" do
+        Yast::Encoding.SetUtf8Lang(false)
+        Yast::Encoding.SetEncLang("de_DE")
+        # "codepage=437" is default and thus omitted
+        expect(described_class::VFAT.default_fstab_options).to eq ["iocharset=iso8859-15"]
       end
     end
   end

--- a/test/y2storage/filesystems/type_test.rb
+++ b/test/y2storage/filesystems/type_test.rb
@@ -166,7 +166,7 @@ describe Y2Storage::Filesystems::Type do
       it "vfat has the correct fstab options for a utf8 locale" do
         Yast::Encoding.SetUtf8Lang(true)
         Yast::Encoding.SetEncLang("de_DE")
-        expect(described_class::VFAT.default_fstab_options).to eq ["utf8=true"]
+        expect(described_class::VFAT.default_fstab_options).to eq ["iocharset=utf8"]
       end
 
       it "vfat has the correct fstab options for a non-utf8 cs_CZ locale" do


### PR DESCRIPTION
https://trello.com/c/5zK5B9J6/94-5-betasles15-p2-1066076-installer-default-data-journaling-mode-in-ext34-differ-from-sles12


This adds fstab options (mount options to be written to /etc/fstab) to filesystems we create or mount, very much like in the old storage stack.

If the user or the application logic explicitly sets any fstab options, those are used, of course. If not, this now uses default fstab options which are different for each filesystem type: ext2/3/4, vfat, ntfs.

I extended the table that already existed for similar things that are different for each filesystem type.

In most cases it's a very simple list of strings, but there are also the Microsoft filesystems that need some locale-specific parameters such as `iocharset` and `codepage` where we need to figure out the appropriate values based on locale information. Those settings are used to convert filenames with special (non-ASCII) characters to and from Linux filenames.

This is not done in libstorage-ng for several reasons:

- Some day soon, this might have to become configurable for each product we make.
- It should be easily accessible and easy to change.
- It should be at one central place, not scattered over a dozen files.
- The locale information that is needed for `iocharset` and `codepage` has to be fetched from the `Encoding` Ruby module. We don't want to clutter the APIs to pass that information back and forth.

There is also the special case of the YAML reader (the FakeDeviceFactory): It should not implicitly set values that are not explicitly in the YAML file that is read.

------------------

After one very much failed approach that tried to overload `BlkDevice::create_blk_filesystem()` to fetch the default fstab options per filesystem type (and which had that problem that the YAML reader was then doing magic things without being asked to do them), now the default fstab options are explicitly added at the appropriate places.

This needs to cover:
- The proposal
- The guided setup (which is little more than the proposal)
- The expert partitioner

and it needs to cover both when we explicitly create a filesystem _and_ when we reuse an existing one and just add a new entry in /etc/fstab for it.

-------------------

## New fstab options in partitioner

![ext4-fstab-options](https://user-images.githubusercontent.com/11538225/35397497-f09931fa-01ef-11e8-9b19-a6e87cba1ade.png)

### Resulting /etc/fstab

![ext4-fstab](https://user-images.githubusercontent.com/11538225/35397511-fc705616-01ef-11e8-8f0a-d8cd6db42e1e.png)

Notice the last entry with _ext4_ that shows the new default options. They are now correctly initialized and passed to the expert partitioner (which the screenshot shows). If the user doesn't open that dialog, they are just used as they are; if he does, he can change them, of course.

The proposal uses those defaults as well; see the corresponding unit tests.
