### PR TITLE
Partitioner: align created and resized partitions

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,18 @@
 -------------------------------------------------------------------
+Fri Jan 19 09:50:54 UTC 2018 - ancor@suse.com
+
+- Partitioner: when creating partitions they are now aligned to
+  hardware requirements (indispensable for DASD) and when possible
+  also for optimal performance (bsc#1069860 and bsc#1072011).
+- Partitioner: adjusted alignment logic during resizing to match
+  the new logic used during creation.
+- Partitioner: skip validation of disabled widgets in the dialog
+  to select the size of a new partition.
+- Partitioner: fixed a crash and one inconsistency in the dialog
+  to resize an existing partition.
+- 4.0.71
+
+-------------------------------------------------------------------
 Fri Jan 19 09:41:52 UTC 2018 - ancor@suse.com
 
 - Correctly open the expert partitioner when called from the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.70
+Version:        4.0.71
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/actions/controllers/partition.rb
+++ b/src/lib/y2partitioner/actions/controllers/partition.rb
@@ -72,19 +72,51 @@ module Y2Partitioner
           Y2Storage::BlkDevice.find_by_name(dg, disk_name)
         end
 
-        # Available slots to create the partition
+        # Available slots to create the partition in which the start is aligned
+        # according to AlignType::OPTIMAL (the end is not aligned)
+        #
+        # @see unused_slots
+        #
+        # @return [Array<Y2Storage::PartitionTables::PartitionSlot>]
+        def unused_optimal_slots
+          # Caching seems to be important for the current dialogs to work
+          @unused_optimal_slots ||= disk.ensure_partition_table.unused_partition_slots
+        end
+
+        # All available slots to create the partition, honoring just the
+        # required alignment
+        #
+        # @see optimal_unused_slots
+        #
         # @return [Array<Y2Storage::PartitionTables::PartitionSlot>]
         def unused_slots
           # Caching seems to be important for the current dialogs to work
-          @unused_slots ||= disk.ensure_partition_table.unused_partition_slots
+          @unused_slots ||= disk.ensure_partition_table.unused_partition_slots(
+            Y2Storage::AlignPolicy::KEEP_END, Y2Storage::AlignType::REQUIRED
+          )
+        end
+
+        # Grain to use in order to keep the optimal alignment
+        #
+        # @return [Y2Storage::DiskSize]
+        def optimal_grain
+          disk.ensure_partition_table.align_grain
+        end
+
+        # Grain to use in order to keep the required alignment
+        #
+        # @return [Y2Storage::DiskSize]
+        def required_grain
+          disk.ensure_partition_table.align_grain(Y2Storage::AlignType::REQUIRED)
         end
 
         # Creates the partition in the disk according to the controller
         # attributes (#type, #region, etc.)
         def create_partition
           ptable = disk.ensure_partition_table
-          slot = ptable.unused_slot_for(region)
-          @partition = ptable.create_partition(slot.name, region, type)
+          slot = slot_for(region)
+          aligned = align(region, slot, ptable)
+          @partition = ptable.create_partition(slot.name, aligned, type)
           UIState.instance.select_row(@partition)
         end
 
@@ -123,7 +155,7 @@ module Y2Partitioner
         #
         # @return [Boolean]
         def new_partition_possible?
-          unused_slots.any?(&:available?)
+          unused_optimal_slots.any?(&:available?)
         end
 
         # Title to display in the dialogs during the process
@@ -131,6 +163,138 @@ module Y2Partitioner
         def wizard_title
           # TRANSLATORS: dialog title. %s is a device name like /dev/sda
           _("Add Partition on %s") % disk_name
+        end
+
+        # Error to display to the user if the blocks selected to define a
+        # custom region are not valid.
+        #
+        # The string, if any, is already internationalized.
+        #
+        # @return [String, nil] nil if the blocks are valid (no error)
+        def error_for_custom_region(start_block, end_block)
+          parent = unused_slots.map(&:region).find { |r| r.cover?(start_block) }
+
+          if !parent
+            # starting block must be in a region,
+
+            # TRANSLATORS: text for an error popup
+            _("The block entered as start is not available.")
+          elsif end_block < start_block
+            # TRANSLATORS: text for an error popup
+            _("The end block cannot be before the start.")
+          elsif !parent.cover?(end_block)
+            # ending block must be in the same region than the start
+
+            # TRANSLATORS: text for an error popup
+            _("The region entered collides with the existing partitions.")
+          elsif too_small_custom_region?(start_block, end_block)
+            # It's so small that we already know that we can't align both
+            # start and end
+
+            # TRANSLATORS: text for an error popup
+            _("The region entered is too small, not supported by this device.")
+          elsif !alignable_custom_region?(start_block, end_block)
+            # Almost pathological case, but still can happen if the user tries
+            # to break stuff
+
+            # TRANSLATORS: text for an error popup
+            _("Invalid region entered, increase the size or align the start.")
+          end
+        end
+
+      protected
+
+        # Partition slot containing the given region
+        #
+        # @param region [Y2Storage::Region] region for the new partition
+        # @return [Y2Storage::PartitionTables::PartitionSlot, nil] nil if the
+        #   region is not contained in any of the relevant slots
+        def slot_for(region)
+          slots = align_only_to_required? ? unused_slots : unused_optimal_slots
+          slots.find { |slot| region.inside?(slot.region) }
+        end
+
+        # Aligns the region that will be used to create a new partition,
+        # according to the following partitioner logic:
+        #
+        #   * If the user specified a size, region.start is already granted to
+        #     be aligned according to OPTIMAL and this method:
+        #     * Leaves region.end untouched if it's equal to the end of the
+        #       slot, because that means the user wants to use the whole space
+        #       until the next "barrier" (the end of the disk or the start of an
+        #       existing partition) with no gap.
+        #     * Aligns region.end to OPTIMAL if it's smaller then the end of the
+        #       slot, because that means the user wants to leave some space and
+        #       we want that remaining space to start in an optimal block.
+        #   * If the user specified a custom region, region.start and region.end
+        #     are aligned according only to REQUIRED, not taking the optimal
+        #     performance into consideration. In most cases that implies no
+        #     changes but in some devices (like DASD) that small alignment makes
+        #     the creation possible.
+        #
+        # @param region [Y2Storage::Region] a region describing the intended
+        #   location of the new partition
+        # @param slot [Y2Storage::PartitionTables::PartitionSlot] the slot
+        #   to be used as base for the partition creation
+        # @param ptable [Y2Storage::PartitionTables::Base]
+        # @return [Y2Storage::Region] aligned according to the description above
+        def align(region, slot, ptable)
+          if align_only_to_required?
+            ptable.align(
+              region, Y2Storage::AlignPolicy::ALIGN_START_AND_END, Y2Storage::AlignType::REQUIRED
+            )
+          else
+            # Let's aim for optimal alignment or for usage of the whole space
+            ptable.align_end(region, max_end: slot.region.end)
+          end
+        rescue Storage::AlignError
+          # If something goes wrong during alignment, just try to create the
+          # smallest (thus, safer) possible partition with a valid start.
+          # Anyway, the validations in the dialog should prevent any possible
+          # alignment error, so this should never be reached.
+          grain = ptable.align_grain(Y2Storage::AlignType::REQUIRED)
+          blk_size = region.block_size.to_i
+          Y2Storage::Region.create(slot.region.start, grain.to_i / blk_size, blk_size)
+        end
+
+        # Whether the resulting partition should be aligned only to mandatory
+        # requirements (Y2Storage::AlignType::REQUIRED) ignoring any performance
+        # consideration.
+        #
+        # @return [Boolean] false if the partition should be aligned for optimal
+        #   performance (i.e. honoring Y2Storage::AlignType::OPTIMAL)
+        def align_only_to_required?
+          # If the user defined a custom region, let's respect it as much as
+          # possible, so only the REQUIRED alignment is enforced.
+          size_choice == :custom_region
+        end
+
+        # @return [Y2Storage::DiskSize]
+        def block_size
+          unused_slots.first.region.block_size
+        end
+
+        # Whether the given custom region can be aligned to hardware
+        # requirements without disappearing in the process.
+        #
+        # @return [Boolean]
+        def alignable_custom_region?(start_blk, end_blk)
+          region = Y2Storage::Region.create(start_blk, end_blk - start_blk + 1, block_size)
+          disk.ensure_partition_table.align(
+            region, Y2Storage::AlignPolicy::ALIGN_START_AND_END, Y2Storage::AlignType::REQUIRED
+          )
+          true
+        rescue Storage::AlignError
+          false
+        end
+
+        # Whether the given custom region is too small to be aligned to hardware
+        # requirements.
+        #
+        # @return [Boolean]
+        def too_small_custom_region?(start_blk, end_blk)
+          size = block_size * (end_blk - start_blk + 1)
+          size < required_grain
         end
       end
     end

--- a/src/lib/y2partitioner/actions/controllers/partition.rb
+++ b/src/lib/y2partitioner/actions/controllers/partition.rb
@@ -92,7 +92,7 @@ module Y2Partitioner
         def unused_slots
           # Caching seems to be important for the current dialogs to work
           @unused_slots ||= disk.ensure_partition_table.unused_partition_slots(
-            Y2Storage::AlignPolicy::KEEP_END, Y2Storage::AlignType::REQUIRED
+            Y2Storage::AlignPolicy::ALIGN_START_KEEP_END, Y2Storage::AlignType::REQUIRED
           )
         end
 

--- a/src/lib/y2partitioner/dialogs/partition_resize.rb
+++ b/src/lib/y2partitioner/dialogs/partition_resize.rb
@@ -85,7 +85,7 @@ module Y2Partitioner
       #
       # @return [Boolean]
       def swap_partition?
-        partition.id.is?(:swap)
+        partition.id.is?(:swap) || partition.formatted_as?(:swap)
       end
 
       # Disk size in use
@@ -314,7 +314,7 @@ module Y2Partitioner
 
         # @param v [Y2Storage::DiskSize]
         def value=(v)
-          super(v.human_floor)
+          super(v.to_human_string)
         end
       end
     end

--- a/src/lib/y2partitioner/dialogs/partition_resize.rb
+++ b/src/lib/y2partitioner/dialogs/partition_resize.rb
@@ -224,7 +224,7 @@ module Y2Partitioner
         #
         # @return [Y2Partition::DiskSize]
         def min_size
-          resize_info.min_size
+          [partition.aligned_min_size, partition.size].min
         end
 
         # Max possible size

--- a/src/lib/y2partitioner/dialogs/partition_size.rb
+++ b/src/lib/y2partitioner/dialogs/partition_size.rb
@@ -173,6 +173,7 @@ module Y2Partitioner
 
         # @macro seeAbstractWidget
         def validate
+          return true unless enabled?
           v = value
           return true unless v.nil? || v < min_size || v > max_size
 
@@ -255,6 +256,8 @@ module Y2Partitioner
 
         # @macro seeAbstractWidget
         def validate
+          return true unless enabled?
+
           start_block, end_block = query_widgets
           # starting block must be in a region,
           # ending block must be in the same region

--- a/src/lib/y2partitioner/dialogs/partition_size.rb
+++ b/src/lib/y2partitioner/dialogs/partition_size.rb
@@ -20,9 +20,11 @@ module Y2Partitioner
         textdomain "storage"
         @disk_name = controller.disk_name
         @controller = controller
+        # FIXME: the available regions should be filtered based on controller.type
         @regions = controller.unused_slots.map(&:region)
+        @optimal_regions = controller.unused_optimal_slots.map(&:region)
 
-        raise ArgumentError, "No region to make a partition in" if @regions.empty?
+        raise ArgumentError, "No region to make a partition in" if @optimal_regions.empty?
       end
 
       # @macro seeDialog
@@ -32,7 +34,7 @@ module Y2Partitioner
 
       # @macro seeDialog
       def contents
-        HVSquash(SizeWidget.new(@controller, @regions))
+        HVSquash(SizeWidget.new(@controller, @regions, @optimal_regions))
       end
 
       # return finish for extended partition, as it can set only type and its size
@@ -49,11 +51,15 @@ module Y2Partitioner
         #   a controller collecting data for a partition to be created
         # @param regions [Array<Y2Storage::Region>]
         #   regions available to create a partition in
-        def initialize(controller, regions)
+        # @param optimal_regions [Array<Y2Storage::Region>]
+        #   regions with an optimally aligned start available to create
+        #   a partition in
+        def initialize(controller, regions, optimal_regions)
           textdomain "storage"
           @controller = controller
           @regions = regions
-          @largest_region = @regions.max_by(&:size)
+          @optimal_regions = optimal_regions
+          @largest_region = @optimal_regions.max_by(&:size)
         end
 
         # @macro seeAbstractWidget
@@ -74,8 +80,8 @@ module Y2Partitioner
         def widgets
           @widgets ||= [
             MaxSizeDummy.new(@largest_region),
-            CustomSizeInput.new(@controller, @regions),
-            CustomRegion.new(@controller, @regions)
+            CustomSizeInput.new(@controller, @optimal_regions),
+            CustomRegion.new(@controller, @regions, @largest_region)
           ]
         end
 
@@ -92,6 +98,21 @@ module Y2Partitioner
           w.store
           @controller.region = w.region
           @controller.size_choice = value
+        end
+
+        # @macro seeAbstractWidget
+        def help
+          # helptext
+          _(
+            "<p>Choose the size for the new partition.</p>\n" \
+            "<p>If a size is specified (any of the two first options in the form),\n" \
+            "the start and end of the partition will be aligned to ensure optimal\n" \
+            "performance and to minimize gaps. That may result in a slightly\n" \
+            "smaller partition.</p>\n" \
+            "<p>If a custom region is specified, the start and end will be honored\n" \
+            "as closely as possible, with no performance optimizations. This is the\n" \
+            "best option to create very small partitions.</p>"
+          )
         end
       end
 
@@ -125,7 +146,7 @@ module Y2Partitioner
           @regions = regions
           largest_region = @regions.max_by(&:size)
           @max_size = largest_region.size
-          @min_size = largest_region.block_size
+          @min_size = controller.optimal_grain
         end
 
         # Forward to controller
@@ -212,11 +233,14 @@ module Y2Partitioner
         #   a controller collecting data for a partition to be created
         # @param regions [Array<Y2Storage::Region>]
         #   regions available to create a partition in
-        def initialize(controller, regions)
+        # @param default_region [Y2Storage::Region]
+        #   region suggested initially if there is none, used to suggest an
+        #   optimally aligned region (i.e. one not included in regions)
+        def initialize(controller, regions, default_region)
           textdomain "storage"
           @controller = controller
           @regions = regions
-          @region = @controller.region || @regions.max_by(&:size)
+          @region = @controller.region || default_region
         end
 
         # @macro seeCustomWidget
@@ -259,13 +283,11 @@ module Y2Partitioner
           return true unless enabled?
 
           start_block, end_block = query_widgets
-          # starting block must be in a region,
-          # ending block must be in the same region
-          parent = @regions.find { |r| r.cover?(start_block) }
-          return true if parent && parent.cover?(end_block)
-          # TODO: a better description why
-          # error popup
-          Yast::Popup.Error(_("The region entered is invalid."))
+          error = @controller.error_for_custom_region(start_block, end_block)
+
+          return true unless error
+
+          Yast::Popup.Error(error)
           Yast::UI.SetFocus(Id(:start_block))
           false
         end

--- a/src/lib/y2partitioner/dialogs/partition_type.rb
+++ b/src/lib/y2partitioner/dialogs/partition_type.rb
@@ -15,7 +15,7 @@ module Y2Partitioner
         def initialize(controller)
           textdomain "storage"
           @controller = controller
-          @slots = controller.unused_slots
+          @slots = controller.unused_optimal_slots
         end
 
         # @macro seeAbstractWidget

--- a/src/lib/y2storage/align_policy.rb
+++ b/src/lib/y2storage/align_policy.rb
@@ -24,6 +24,15 @@ require "y2storage/storage_enum_wrapper"
 module Y2Storage
   # Class to represent all the possible align policies implemented by libstorage
   #
+  #   * AlignPolicy::ALIGN_START_AND_END to align both start and end
+  #   * AlignPolicy::ALIGN_END is a deprecated equivalent to ALIGN_START_AND_END
+  #   * AlignPolicy::ALIGN_START_KEEP_END to align the start and keep the end
+  #   * AlignPolicy::KEEP_END is a deprecated equivalent to ALIGN_START_KEEP_END
+  #   * AlignPolicy::ALIGN_START_KEEP_SIZE to align the start and keep the exact size
+  #   * AlignPolicy::KEEP_SIZE is a deprecated equivalent to ALIGN_START_KEEP_SIZE
+  #   * AlignPolicy::KEEP_START_ALIGN_END to align only the end, leaving the
+  #     start untouched
+  #
   # This is a wrapper for the Storage::AlignPolicy enum
   class AlignPolicy
     include StorageEnumWrapper

--- a/src/lib/y2storage/align_type.rb
+++ b/src/lib/y2storage/align_type.rb
@@ -24,9 +24,9 @@ require "y2storage/storage_enum_wrapper"
 module Y2Storage
   # Class to represent all the possible align types implemented by libstorage
   #
-  # AlignType::REQUIRED can be used to align only to hard requirements.
-  # AlignType::OPTIMAL implies aligning to both hard requirements and topology
-  #   information, which optimizes performance.
+  #   * AlignType::REQUIRED can be used to align only to hard requirements.
+  #   * AlignType::OPTIMAL implies aligning to both hard requirements and topology
+  #     information, which optimizes performance.
   #
   # This is a wrapper for the Storage::AlignType enum
   class AlignType

--- a/src/lib/y2storage/partition.rb
+++ b/src/lib/y2storage/partition.rb
@@ -259,20 +259,20 @@ module Y2Storage
 
     # Aligns the end of a region, leaving the start untouched.
     #
-    # FIXME: This is a temporary method since, in theory, libstorage-ng should
-    # provide this functionality, but it's buggy right now.
-    #
     # @param region [Region] original region to align
     # @param align_type [AlignType]
     # @return [Region] a copy of region with the same start but the end aligned
     #   according to align_type
     def align_region_end(region, align_type)
+      # Currently, there is no way to use PartitionTable#align without
+      # enforcing the alignment of the start. Despite what the ALIGN_END name
+      # may suggest, that policy alters both start and end. So the following
+      # line is not enough to implement this method.
       # partition_table.align(region, AlignPolicy::ALIGN_END, align_type)
 
-      # This whole method could be implemented just by the commented line above.
-      # But there is a bug in libstorage-ng that causes it to alter the start of
-      # the region, even with the policy ALIGN_END.
-      # So here it comes the workaround
+      # This could be turned into a simple call to PartitionTable#align in the
+      # future if a KEEP_START_ALIGN_END (or similar) policy is provided by
+      # libstorage-ng in the future.
       if region.end_aligned?(align_grain(align_type))
         Region.create(region.start, region.length, region.block_size)
       else

--- a/src/lib/y2storage/partition.rb
+++ b/src/lib/y2storage/partition.rb
@@ -159,24 +159,30 @@ module Y2Storage
     # Resizes the partition by moving its end, taking alignment and resizing
     # limits into account.
     #
-    # This method never moves the partition start. If possible, the new end
-    # will always be aligned.
-    #
-    # The new end will always be within the min and max provided by
-    # #{#resize_info}, even if the requested size is bigger or smaller than
-    # those limits or if that means giving up on alignment.
+    # This method never moves the partition start.
     #
     # It does nothing if resizing is not possible (see {ResizeInfo#resize_ok?}).
     #
+    # If the requested size is greater or equal than the max provided by
+    # {#resize_info}, the end will be adjusted to reach exactly that max size.
+    # See {PartitionTables::Base#align_end} for the rationale.
+    #
+    # In any other case, the new end will always be within the min and max
+    # provided by #{#resize_info} (even if the requested size is smaller than
+    # that min). The end will be aligned according to align_type if possible.
+    #
     # @param new_size [DiskSize] temptative new size of the partition, take into
     #   account that the result may differ a bit due to alignment or limits
-    # @param align_type [AlignType] type of alignment
+    # @param align_type [AlignType, nil] type of alignment. Nil to avoid alignment.
     def resize(new_size, align_type: AlignType::OPTIMAL)
       log.info "Trying to resize #{name} (#{size}) to #{new_size} (align: #{align_type})"
       return unless can_resize?
 
+      initial_region = region.dup
       max = resize_info.max_size
-      min = resize_info.min_size
+      min = align_type.nil? ? resize_info.min_size : aligned_min_size(align_type)
+      min = [min, size].min
+
       self.size =
         if new_size > max
           max
@@ -187,10 +193,8 @@ module Y2Storage
         end
       log.info "Partition #{name} size initially set to #{size}"
 
-      # NOTE: maybe it also makes sense to skip aligning if the new region ends
-      # at the end of the disk
       return if align_type.nil?
-      self.region = aligned_region(align_type)
+      self.region = aligned_region(align_type, initial_region)
       log.info "Partition #{name} finally adjusted to #{size}"
     end
 
@@ -224,6 +228,22 @@ module Y2Storage
       self.id = fallback_id
     end
 
+    # Minimal size the partition could have while keeping its end aligned,
+    # according to {#resize_info} and {#align_grain}
+    #
+    # @param align_type [AlignType, nil] see #align_grain
+    def aligned_min_size(align_type = nil)
+      min = resize_info.min_size
+
+      length = min.to_i / region.block_size.to_i
+      min_region = Region.create(region.start, length, region.block_size)
+      grain = align_grain(align_type)
+      overhead = min_region.end_overhead(grain)
+
+      min += grain - overhead unless overhead.zero?
+      min
+    end
+
   protected
 
     # Values for volume specification matching
@@ -238,68 +258,25 @@ module Y2Storage
     end
 
     # Region resulting from aligning and applying limits to the current
-    # partition region.
-    #
-    # It may be the original region if a new region couldn't be calculated (i.e.
-    # it's not possible to honor alignment and limits at the same time).
-    #
-    # @see #resize
+    # partition region during the {#resize} operation.
     #
     # @param align_type [AlignType] type of alignment
-    def aligned_region(align_type)
-      new_region = align_region_end(region, align_type)
-      fix_region_end(new_region, align_type)
+    # @param fallback [Region] region to return if aligning is not possible
+    # @return [Region]
+    def aligned_region(align_type, fallback)
+      max_length = resize_info.max_size.to_i / region.block_size.to_i
+      max_end = region.start + max_length - 1
+      new_region =
+        begin
+          partition_table.align_end(region, align_type, max_end: max_end)
+        rescue Storage::AlignError
+          nil
+        end
 
-      if new_region.size > resize_info.max_size || new_region.size < resize_info.min_size
-        region
+      if new_region.nil? || new_region.size < resize_info.min_size
+        fallback
       else
         new_region
-      end
-    end
-
-    # Aligns the end of a region, leaving the start untouched.
-    #
-    # @param region [Region] original region to align
-    # @param align_type [AlignType]
-    # @return [Region] a copy of region with the same start but the end aligned
-    #   according to align_type
-    def align_region_end(region, align_type)
-      # Currently, there is no way to use PartitionTable#align without
-      # enforcing the alignment of the start. Despite what the ALIGN_END name
-      # may suggest, that policy alters both start and end. So the following
-      # line is not enough to implement this method.
-      # partition_table.align(region, AlignPolicy::ALIGN_END, align_type)
-
-      # This could be turned into a simple call to PartitionTable#align in the
-      # future if a KEEP_START_ALIGN_END (or similar) policy is provided by
-      # libstorage-ng in the future.
-      if region.end_aligned?(align_grain(align_type))
-        Region.create(region.start, region.length, region.block_size)
-      else
-        region_end = partition_table.align(region, AlignPolicy::ALIGN_END, align_type).end
-        Region.create(region.start, region_end - region.start + 1, region.block_size)
-      end
-    end
-
-    # Ensures the end of the given region is within the resizing limits of the
-    # partition and keeps the same alignment.
-    #
-    # @note This modifies the region parameter
-    #
-    # @param region [Region] region to adjust, can be modified
-    # @param align_type [AlignType]
-    def fix_region_end(region, align_type)
-      block_size = region.block_size.to_i
-      length     = region.length
-
-      min_blks   = resize_info.min_size.to_i / block_size
-      max_blks   = resize_info.max_size.to_i / block_size
-      grain_blks = align_grain(align_type).to_i / block_size
-
-      if length < min_blks
-        region.adjust_length(grain_blks * ((min_blks.to_f - length) / grain_blks).ceil)
-      elsif length > max_blks
-        region.adjust_length(grain_blks * ((max_blks.to_f - length) / grain_blks).floor)
       end
     end
   end

--- a/src/lib/y2storage/partition_tables/base.rb
+++ b/src/lib/y2storage/partition_tables/base.rb
@@ -91,15 +91,17 @@ module Y2Storage
       #   @return [Boolean] whether an extended partition exists in the table
       storage_forward :has_extended?, to: :has_extended
 
-      # @!method unused_partition_slots(policy = AlignPolicy::KEEP_END, align_type = AlignType::OPTIMAL)
+      # rubocop: disable Metrics/LineLength
+      # @!method unused_partition_slots(policy = AlignPolicy::ALIGN_START_KEEP_END, type = AlignType::OPTIMAL)
       #
       #   Slots that could be used to create new partitions following the
       #   given align policy.
       #
       #   @param policy [AlignPolicy] policy to consider while looking for slots
-      #   @param align_type [AlignType] type of alignment to use
+      #   @param type [AlignType] type of alignment to use
       #   @return [Array<PartitionTables::PartitionSlot>]
       storage_forward :unused_partition_slots, as: "PartitionTables::PartitionSlot"
+      # rubocop: enable all
 
       # @!method partition_boot_flag_supported?
       #   @return [Boolean] whether the partitions in the table can have the
@@ -118,8 +120,8 @@ module Y2Storage
       #   @return [Boolean] whether a partition can have this partition id.
       storage_forward :partition_id_supported?
 
-      # @!method align(region, align_policy = AlignPolicy::ALIGN_END, align_type = AlignType::OPTIMAL)
-      #   Align the region according to align policy and align type.
+      # @!method align(region, policy = AlignPolicy::ALIGN_START_AND_END, type = AlignType::OPTIMAL)
+      #   Aligns the region according to align policy and align type.
       #
       #   @param region [Region] region to align
       #   @param align_policy [AlignPolicy] policy to consider while aligning
@@ -151,7 +153,9 @@ module Y2Storage
       # @param align_type [AlignType] type used to detect the slot
       # @return [PartitionTables::PartitionSlot, nil] nil when region is not
       #   inside to any unused slot.
-      def unused_slot_for(region, align_policy: AlignPolicy::KEEP_END, align_type: AlignType::OPTIMAL)
+      def unused_slot_for(
+        region, align_policy: AlignPolicy::ALIGN_START_KEEP_END, align_type: AlignType::OPTIMAL
+      )
         unused_partition_slots(align_policy, align_type).detect { |s| region.inside?(s.region) }
       end
 

--- a/src/lib/y2storage/partition_tables/base.rb
+++ b/src/lib/y2storage/partition_tables/base.rb
@@ -124,8 +124,8 @@ module Y2Storage
       #   Aligns the region according to align policy and align type.
       #
       #   @param region [Region] region to align
-      #   @param align_policy [AlignPolicy] policy to consider while aligning
-      #   @param align_type [AlignType]
+      #   @param policy [AlignPolicy] policy to consider while aligning
+      #   @param type [AlignType]
       #
       #   @return [Region] always returns a new object
       storage_forward :align, as: "Region"

--- a/src/lib/y2storage/region.rb
+++ b/src/lib/y2storage/region.rb
@@ -157,6 +157,11 @@ module Y2Storage
       new(Storage::Region.new(start, length, block_size.to_i))
     end
 
+    # @return [Region]
+    def dup
+      self.class.create(start, length, block_size)
+    end
+
     # Whether the first block of the region is aligned according to
     # the given grain
     #

--- a/src/lib/y2storage/region.rb
+++ b/src/lib/y2storage/region.rb
@@ -178,8 +178,16 @@ module Y2Storage
     # @param grain [DiskSize]
     # @return [Boolean]
     def end_aligned?(grain)
-      overhead = (block_size * self.end + block_size) % grain
-      overhead.zero?
+      end_overhead(grain).zero?
+    end
+
+    # Distance between the end of the region and the latest aligned block,
+    # according to the given grain. Zero if the end of the block is aligned.
+    #
+    # @param grain [DiskSize]
+    # @return [DiskSize]
+    def end_overhead(grain)
+      (block_size * self.end + block_size) % grain
     end
   end
 end

--- a/test/y2partitioner/actions/controllers/partition_test.rb
+++ b/test/y2partitioner/actions/controllers/partition_test.rb
@@ -55,7 +55,7 @@ describe Y2Partitioner::Actions::Controllers::Partition do
       expect(slots).to all(be_a(Y2Storage::PartitionTables::PartitionSlot))
     end
 
-    it "returns the unused slots for the currently editing disk" do
+    it "returns the unused optimally aligned slots for the currently editing disk" do
       expect(subject.unused_optimal_slots.inspect)
         .to eq(subject.disk.partition_table.unused_partition_slots.inspect)
     end

--- a/test/y2partitioner/actions/controllers/partition_test.rb
+++ b/test/y2partitioner/actions/controllers/partition_test.rb
@@ -46,17 +46,17 @@ describe Y2Partitioner::Actions::Controllers::Partition do
     end
   end
 
-  describe "#unused_slots" do
+  describe "#unused_optimal_slots" do
     let(:disk_name) { "/dev/sdb" }
 
     it "returns a list of PartitionSlot" do
-      slots = subject.unused_slots
+      slots = subject.unused_optimal_slots
       expect(slots).to be_a(Array)
       expect(slots).to all(be_a(Y2Storage::PartitionTables::PartitionSlot))
     end
 
     it "returns the unused slots for the currently editing disk" do
-      expect(subject.unused_slots.inspect)
+      expect(subject.unused_optimal_slots.inspect)
         .to eq(subject.disk.partition_table.unused_partition_slots.inspect)
     end
   end
@@ -79,6 +79,18 @@ describe Y2Partitioner::Actions::Controllers::Partition do
       expect(subject.partition).to be_nil
       subject.create_partition
       expect(subject.partition).to eq(subject.disk.partitions.first)
+    end
+
+    describe "alignment" do
+      let(:scenario) { "dasd1.xml" }
+      let(:disk_name) { "/dev/dasda" }
+
+      before do
+        allow(subject).to receive(:region).and_return(subject.unused_slots.first.region)
+      end
+
+      # TODO: Test new arguments
+      # End if disk in DASD? end of disk in GPT?
     end
   end
 
@@ -244,7 +256,7 @@ describe Y2Partitioner::Actions::Controllers::Partition do
     let(:disk_name) { "/dev/sda" }
 
     before do
-      allow(subject).to receive(:unused_slots).and_return(slots)
+      allow(subject).to receive(:unused_optimal_slots).and_return(slots)
     end
 
     context "when there is not free space in the currently editing disk" do

--- a/test/y2partitioner/dialogs/partition_resize_test.rb
+++ b/test/y2partitioner/dialogs/partition_resize_test.rb
@@ -120,8 +120,8 @@ describe Y2Partitioner::Dialogs::PartitionResize do
           allow(partition).to receive(:filesystem).and_return(filesystem)
         end
 
-        let(:filesystem) { instance_double(Y2Storage::Filesystems::Base, detect_space_info: space_info) }
-
+        let(:ext3) { Y2Storage::Filesystems::Type::EXT3 }
+        let(:filesystem) { instance_double("Filesystem", detect_space_info: space_info, type: ext3) }
         let(:space_info) { instance_double(Y2Storage::SpaceInfo, used: 10.GiB) }
 
         it "shows the used size" do
@@ -179,11 +179,10 @@ describe Y2Partitioner::Dialogs::PartitionResize do
           context "and the max size causes a not end-aligned partition" do
             let(:max_size) { not_aligned_max_size }
 
-            it "updates the partition with the max aligned size" do
+            it "updates the partition with the max size" do
               subject.store
-              expect(partition.size).to eq adjusted_size
-              expect(partition.end_aligned?).to eq(true)
-              expect(partition.size).to be <= max_size
+              expect(partition.size).to eq max_size
+              expect(partition.end_aligned?).to eq(false)
             end
           end
         end

--- a/test/y2partitioner/dialogs/partition_size_test.rb
+++ b/test/y2partitioner/dialogs/partition_size_test.rb
@@ -8,18 +8,14 @@ describe "Partition Size widgets" do
   using Y2Storage::Refinements::SizeCasts
 
   let(:controller) do
-    pt = Y2Partitioner::Actions::Controllers::Partition.new("/dev/sda")
+    pt = Y2Partitioner::Actions::Controllers::Partition.new(disk)
     pt.region = region
     pt.custom_size = Y2Storage::DiskSize.MiB(1)
     pt
   end
+  let(:disk) { "/dev/sda" }
   let(:region) { Y2Storage::Region.create(2000, 1000, Y2Storage::DiskSize.new(1500)) }
   let(:slot) { double("PartitionSlot", region: region) }
-  before do
-    allow(controller).to receive(:unused_slots).and_return [slot]
-    allow(controller).to receive(:unused_optimal_slots).and_return [slot]
-    allow(controller).to receive(:optimal_grain).and_return Y2Storage::DiskSize.MiB(1)
-  end
   let(:regions) { [region] }
   let(:optimal_regions) { [region] }
 
@@ -29,12 +25,18 @@ describe "Partition Size widgets" do
     before do
       allow(Y2Partitioner::Dialogs::PartitionSize::SizeWidget)
         .to receive(:new).and_return(term(:Empty))
+      allow(controller).to receive(:unused_slots).and_return [slot]
+      allow(controller).to receive(:unused_optimal_slots).and_return [slot]
     end
     include_examples "CWM::Dialog"
   end
 
   describe Y2Partitioner::Dialogs::PartitionSize::SizeWidget do
     subject { described_class.new(controller, regions, optimal_regions) }
+
+    before do
+      allow(controller).to receive(:optimal_grain).and_return Y2Storage::DiskSize.MiB(1)
+    end
 
     include_examples "CWM::CustomWidget"
   end
@@ -43,6 +45,7 @@ describe "Partition Size widgets" do
     subject { described_class.new(controller, regions) }
 
     before do
+      allow(controller).to receive(:optimal_grain).and_return Y2Storage::DiskSize.MiB(1)
       allow(subject).to receive(:value).and_return nil
     end
 
@@ -140,8 +143,10 @@ describe "Partition Size widgets" do
 
   describe Y2Partitioner::Dialogs::PartitionSize::CustomRegion do
     before do
-      allow(subject).to receive(:query_widgets).and_return [2200, 2500]
+      allow(subject).to receive(:query_widgets).and_return [entered_start, entered_end]
     end
+    let(:entered_start) { 2200 }
+    let(:entered_end) { 2500 }
 
     subject { described_class.new(controller, regions, region) }
 
@@ -160,6 +165,168 @@ describe "Partition Size widgets" do
 
         expect(controller.region).to_not eq(subject.region)
         expect(controller.region).to eq(controller_before.region)
+      end
+    end
+
+    describe "#validate" do
+      before do
+        devicegraph_stub("dasd1.xml")
+        allow(subject).to receive(:enabled?).and_return enabled
+        graph = Y2Partitioner::DeviceGraphs.instance.current
+
+        # Let's create a couple of slots at beginning and end
+        dasd = graph.find_by_name(disk)
+        dasd.partition_table.delete_partition("/dev/dasda3")
+        dasd.partition_table.delete_partition("/dev/dasda1")
+      end
+      let(:disk) { "/dev/dasda" }
+      let(:enabled) { true }
+
+      context "when the entered start is not in one available region" do
+        let(:entered_start) { 52000 }
+        let(:entered_end) { 60000 }
+
+        it "returns false" do
+          expect(subject.validate).to eq false
+        end
+
+        it "pops up an error about wrong start block" do
+          expect(Yast::Popup).to receive(:Error).with(/entered as start/)
+          expect(Yast::UI).to receive(:SetFocus)
+          subject.validate
+        end
+
+        context "but the widget is disabled" do
+          let(:enabled) { false }
+
+          it "returns true" do
+            expect(subject.validate).to eq true
+          end
+        end
+      end
+
+      context "when the entered end is smaller than the start" do
+        let(:entered_start) { 2600 }
+        let(:entered_end) { 2200 }
+
+        it "returns false" do
+          expect(subject.validate).to eq false
+        end
+
+        it "pops up an error about wrong end block" do
+          expect(Yast::Popup).to receive(:Error).with(/end block/)
+          expect(Yast::UI).to receive(:SetFocus)
+          subject.validate
+        end
+
+        context "but the widget is disabled" do
+          let(:enabled) { false }
+
+          it "returns true" do
+            expect(subject.validate).to eq true
+          end
+        end
+      end
+
+      context "when the entered region overflows one of the available regions " do
+        let(:entered_start) { 2600 }
+        let(:entered_end) { 305000 }
+
+        it "returns false" do
+          expect(subject.validate).to eq false
+        end
+
+        it "pops up an error about collision with partitions" do
+          expect(Yast::Popup).to receive(:Error).with(/collides/)
+          expect(Yast::UI).to receive(:SetFocus)
+          subject.validate
+        end
+
+        context "but the widget is disabled" do
+          let(:enabled) { false }
+
+          it "returns true" do
+            expect(subject.validate).to eq true
+          end
+        end
+      end
+
+      context "when the entered end is not in an available region" do
+        let(:entered_start) { 2600 }
+        let(:entered_end) { 52000 }
+
+        it "returns false" do
+          expect(subject.validate).to eq false
+        end
+
+        it "pops up an error about collision with partitions" do
+          expect(Yast::Popup).to receive(:Error).with(/collides/)
+          expect(Yast::UI).to receive(:SetFocus)
+          subject.validate
+        end
+
+        context "but the widget is disabled" do
+          let(:enabled) { false }
+
+          it "returns true" do
+            expect(subject.validate).to eq true
+          end
+        end
+      end
+
+      context "when the entered region is too small for the alignment requirements" do
+        let(:entered_start) { 2600 }
+        let(:entered_end) { 2610 }
+
+        it "returns false" do
+          expect(subject.validate).to eq false
+        end
+
+        it "pops up an error about the region size" do
+          expect(Yast::Popup).to receive(:Error).with(/too small/)
+          expect(Yast::UI).to receive(:SetFocus)
+          subject.validate
+        end
+
+        context "but the widget is disabled" do
+          let(:enabled) { false }
+
+          it "returns true" do
+            expect(subject.validate).to eq true
+          end
+        end
+      end
+
+      context "when the entered region cannot be aligned despite having a valid size" do
+        let(:entered_start) { 2000 }
+        let(:entered_end) { 2014 }
+
+        it "returns false" do
+          expect(subject.validate).to eq false
+        end
+
+        it "pops up an error about the region being invalid" do
+          expect(Yast::Popup).to receive(:Error).with(/Invalid region/)
+          expect(Yast::UI).to receive(:SetFocus)
+          subject.validate
+        end
+
+        context "but the widget is disabled" do
+          let(:enabled) { false }
+
+          it "returns true" do
+            expect(subject.validate).to eq true
+          end
+        end
+      end
+
+      context "when the entered region is valid" do
+        let(:entered_start) { 2048 }
+        let(:entered_end) { 4096 }
+
+        it "returns false" do
+          expect(subject.validate).to eq true
+        end
       end
     end
   end

--- a/test/y2partitioner/dialogs/partition_type_test.rb
+++ b/test/y2partitioner/dialogs/partition_type_test.rb
@@ -5,7 +5,10 @@ require "y2partitioner/dialogs/partition_type"
 
 describe Y2Partitioner::Dialogs::PartitionType do
   let(:controller) do
-    double("PartitionController", unused_slots: slots, disk_name: "/dev/sda", wizard_title: "")
+    double(
+      "PartitionController",
+      unused_slots: slots, unused_optimal_slots: slots, disk_name: "/dev/sda", wizard_title: ""
+    )
   end
   let(:slots) { [] }
 
@@ -18,7 +21,11 @@ describe Y2Partitioner::Dialogs::PartitionType do
 end
 
 describe Y2Partitioner::Dialogs::PartitionType::TypeChoice do
-  let(:controller) { double("PartitionController", unused_slots: slots, disk_name: "/dev/sda") }
+  let(:controller) do
+    double(
+      "PartitionController", unused_slots: slots, unused_optimal_slots: slots, disk_name: "/dev/sda"
+    )
+  end
   let(:slots) { [double("Slot", :"possible?" => true)] }
 
   subject { described_class.new(controller) }


### PR DESCRIPTION
During partition creation and also when resizing partitions, this implements the alignment described at https://lists.opensuse.org/yast-devel/2018-01/msg00018.html . That is, new partitions are aligned to optimal requirements (in most cases) or at least to the mandatory alignment (when region start/end are explicitly specified). This alignment is specially relevant for DASD. Same alignment logic is also applied to partitions resizing.

Thus, this fixes
  * https://trello.com/c/PKzPu7mb/227-sles15-p2-1069860-sles15-beta3-yast-create-partition-failed-when-wanting-two-partitions
  * https://trello.com/c/xjvk3Pdv/232-sles15-p1-1072011-build-3811-storage-ng-calculates-incorrect-values-for-parted-command-for-eckd-dasd

Done as previous work to https://trello.com/c/ymdimYtb/91-3-lvm-expert-partitioner-resize-an-lv

It also includes some bonuses:

 * Small fixes in the dialog to resize partitions
 * Skip validation of disabled widgets in the dialog to select the size of a new partition

Note: this includes only very basic unit tests, but due to the time constraints I think it's reasonable. Specially if the situation is not worst than before by any means (coverage even increased since this area of the partitioner was not properly tested to start with).