### PR TITLE
raise exception properly when there are no disks (bsc#1057430)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan 23 10:09:51 UTC 2018 - snwint@suse.com
+
+- fix proposal dialog error when there are no disks (bsc#1057430)
+
+-------------------------------------------------------------------
 Mon Jan 22 19:33:46 UTC 2018 - jlopez@suse.com
 
 - Avoid partitioning checks error when using old settings format.

--- a/src/lib/y2storage/guided_proposal.rb
+++ b/src/lib/y2storage/guided_proposal.rb
@@ -113,7 +113,7 @@ module Y2Storage
 
     # Calculates the proposal
     #
-    # @raise [NoDiskSpaceError] if there is no enough space to perform the installation
+    # @raise [Error, NoDiskSpaceError] if there is no enough space to perform the installation
     def calculate_proposal
       settings.freeze
 
@@ -143,7 +143,7 @@ module Y2Storage
         end
       end
 
-      raise exception
+      raise exception || NoDiskSpaceError.new("No usable disks detected")
     end
 
     # @return [Array<Planned::Device>]

--- a/test/y2storage/guided_proposal_no_disks.rb
+++ b/test/y2storage/guided_proposal_no_disks.rb
@@ -23,9 +23,6 @@
 require_relative "spec_helper"
 require "y2storage"
 
-# stop rspec warning
-RSpec::Expectations.configuration.on_potential_false_positives = :nothing
-
 describe Y2Storage::GuidedProposal do
   # Regression test (bsc#1057430)
   describe ".initial" do

--- a/test/y2storage/guided_proposal_no_disks.rb
+++ b/test/y2storage/guided_proposal_no_disks.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+# stop rspec warning
+RSpec::Expectations.configuration.on_potential_false_positives = :nothing
+
+describe Y2Storage::GuidedProposal do
+  # Regression test (bsc#1057430)
+  describe ".initial" do
+    before do
+      Y2Storage::StorageManager.create_test_instance
+    end
+
+    let(:devicegraph) { Y2Storage::StorageManager.instance.probe_from_yaml(nil) }
+
+    context "with no disks at all" do
+      it "raises no Error" do
+        expect { described_class.initial } .to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Actually the description of #calculate_proposal is wrong. The space
calculator doesn't raise NoDiskSpaceError but Error if things fail.

Anyway, sticking to the docs and raising NoDiskSpaceError if disks are missing.