### PR TITLE
Consider all spaces

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -2,7 +2,7 @@
 Mon Jan 22 13:11:32 UTC 2018 - igonzalezsosa@suse.com
 
 - Consider all free spaces when deciding which partitions
-  distribution is better (bsc#1077051) 
+  distribution is better (bsc#1077051).
 
 -------------------------------------------------------------------
 Thu Jan 19 12:10:29 UTC 2018 - jlopez@suse.com

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 22 13:11:32 UTC 2018 - igonzalezsosa@suse.com
+
+- Consider all free spaces when deciding which partitions
+  distribution is better (bsc#1077051) 
+
+-------------------------------------------------------------------
 Thu Jan 19 12:10:29 UTC 2018 - jlopez@suse.com
 
 - Fix TODOs labels in partitioner (bsc#1058652).

--- a/src/lib/y2storage/planned/partitions_distribution.rb
+++ b/src/lib/y2storage/planned/partitions_distribution.rb
@@ -97,7 +97,14 @@ module Y2Storage
         DiskSize.sum(spaces.map(&:unused) + unassigned_spaces.map(&:disk_size))
       end
 
-      # Number of gaps (unused disk portions) introduced by the distribution
+      # Number of gaps (unused disk portions)
+      #
+      # In the past, a free disk space which was not used at all was not considered
+      # a gap. Now the reasons of such a decision are not clear, so all free disk spaces
+      # are counted as gaps.
+      #
+      # Check https://github.com/yast/yast-storage-ng/blob/c2c164ae6148649f72a29c623dd2eae107bd4083/src/lib/y2storage/planned/partitions_distribution.rb#L91 for further details.
+      #
       # @return [Integer]
       def gaps_count
         spaces.reject { |s| s.unused.zero? }.size + unassigned_spaces.size

--- a/src/lib/y2storage/planned/partitions_distribution.rb
+++ b/src/lib/y2storage/planned/partitions_distribution.rb
@@ -103,7 +103,8 @@ module Y2Storage
       # a gap. Now the reasons of such a decision are not clear, so all free disk spaces
       # are counted as gaps.
       #
-      # Check https://github.com/yast/yast-storage-ng/blob/c2c164ae6148649f72a29c623dd2eae107bd4083/src/lib/y2storage/planned/partitions_distribution.rb#L91 for further details.
+      # Check https://github.com/yast/yast-storage-ng/blob/c2c164ae6148649f72a29c623dd2eae107bd4083/src/lib/y2storage/planned/partitions_distribution.rb#L91
+      # for further details.
       #
       # @return [Integer]
       def gaps_count

--- a/src/lib/y2storage/proposal/partitions_distribution_calculator.rb
+++ b/src/lib/y2storage/proposal/partitions_distribution_calculator.rb
@@ -65,6 +65,8 @@ module Y2Storage
 
         log.info "Calculate all the possible distributions of planned partitions into spaces"
         dist_hashes = distribution_hashes(disk_spaces_by_part)
+        add_unused_spaces(dist_hashes, spaces)
+
         candidates = distributions_from_hashes(dist_hashes)
 
         if lvm_helper.missing_space > DiskSize.zero
@@ -295,6 +297,18 @@ module Y2Storage
         result = candidates.sort { |a, b| a.better_than(b) }.first
         log.info "best_for result: #{result}"
         result
+      end
+
+      # Add unused spaces to a distributions hash
+      #
+      # @param dist_hashes [Array<Hash{FreeDiskSpace => <Planned::Partition>}>]
+      #   Distribution hashes
+      # @param spaces      [Array<FreeDiskSpace>] Free spaces
+      # @return [Array<Hash{FreeDiskSpace => <Planned::Partition>}>]
+      #   Distribution hashes considering all free disk spaces.
+      def add_unused_spaces(dist_hashes, spaces)
+        spaces_hash = Hash[spaces.product([[]])]
+        dist_hashes.map! { |d| spaces_hash.merge(d) }
       end
     end
   end

--- a/test/data/devicegraphs/output/kvm_role_scenario.yml
+++ b/test/data/devicegraphs/output/kvm_role_scenario.yml
@@ -6,13 +6,13 @@
     partitions:
     - partition:
         size: 16212 MiB (15.83 GiB)
-        name: "/dev/sda2"
+        name: "/dev/sda1"
         id: linux
         file_system: xfs
         mount_point: "/var/lib/libvirt"
     - partition:
         size: 2 GiB
-        name: "/dev/sda4"
+        name: "/dev/sda2"
         id: swap
         file_system: swap
         mount_point: swap
@@ -22,7 +22,7 @@
         id: bios_boot
     - partition:
         size: 8562671.5 KiB (8.17 GiB)
-        name: "/dev/sda1"
+        name: "/dev/sda4"
         id: linux
         file_system: xfs
         mount_point: "/"

--- a/test/y2storage/guided_proposal_test.rb
+++ b/test/y2storage/guided_proposal_test.rb
@@ -136,7 +136,7 @@ describe Y2Storage::GuidedProposal do
         multipath0, multipath1 = proposal.devices.multipaths
         expect(multipath0.partitions).to contain_exactly(
           an_object_having_attributes(filesystem_mountpoint: "/"),
-          an_object_having_attributes(filesystem_mountpoint: "/home"),
+          an_object_having_attributes(filesystem_mountpoint: "/home")
         )
         expect(multipath1.partitions).to contain_exactly(
           an_object_having_attributes(filesystem_mountpoint: "swap"),
@@ -149,12 +149,12 @@ describe Y2Storage::GuidedProposal do
         multipath0, multipath1 = proposal.devices.multipaths
         expect(multipath0.partitions.map(&:name)).to contain_exactly(
           "#{multipath0.name}-part1",
-          "#{multipath0.name}-part2",
+          "#{multipath0.name}-part2"
         )
 
         expect(multipath1.partitions.map(&:name)).to contain_exactly(
           "#{multipath1.name}-part1",
-          "#{multipath1.name}-part2",
+          "#{multipath1.name}-part2"
         )
       end
     end
@@ -185,7 +185,7 @@ describe Y2Storage::GuidedProposal do
         raid0, raid1 = proposal.devices.dm_raids
         expect(raid0.partitions.map(&:name)).to contain_exactly(
           "#{raid0.name}-part1",
-          "#{raid0.name}-part2",
+          "#{raid0.name}-part2"
         )
         expect(raid1.partitions.map(&:name)).to contain_exactly(
           "#{raid1.name}-part1"

--- a/test/y2storage/guided_proposal_test.rb
+++ b/test/y2storage/guided_proposal_test.rb
@@ -132,24 +132,29 @@ describe Y2Storage::GuidedProposal do
 
       it "creates the needed partitions in the multipath device" do
         proposal.propose
-        multipath = proposal.devices.multipaths.first
-        expect(multipath.partitions).to contain_exactly(
-          an_object_having_attributes(id: Y2Storage::PartitionId::BIOS_BOOT),
+
+        multipath0, multipath1 = proposal.devices.multipaths
+        expect(multipath0.partitions).to contain_exactly(
           an_object_having_attributes(filesystem_mountpoint: "/"),
           an_object_having_attributes(filesystem_mountpoint: "/home"),
-          an_object_having_attributes(filesystem_mountpoint: "swap")
+        )
+        expect(multipath1.partitions).to contain_exactly(
+          an_object_having_attributes(filesystem_mountpoint: "swap"),
+          an_object_having_attributes(id: Y2Storage::PartitionId::BIOS_BOOT)
         )
       end
 
       it "creates the needed partitions with correct device names" do
         proposal.propose
-        multipath = proposal.devices.multipaths.first
-        multipath_name = multipath.name
-        expect(multipath.partitions.map(&:name)).to contain_exactly(
-          "#{multipath_name}-part1",
-          "#{multipath_name}-part2",
-          "#{multipath_name}-part3",
-          "#{multipath_name}-part4"
+        multipath0, multipath1 = proposal.devices.multipaths
+        expect(multipath0.partitions.map(&:name)).to contain_exactly(
+          "#{multipath0.name}-part1",
+          "#{multipath0.name}-part2",
+        )
+
+        expect(multipath1.partitions.map(&:name)).to contain_exactly(
+          "#{multipath1.name}-part1",
+          "#{multipath1.name}-part2",
         )
       end
     end
@@ -176,13 +181,14 @@ describe Y2Storage::GuidedProposal do
 
       it "creates the needed partitions with correct device names" do
         proposal.propose
-        # note: potentially order dependent; thera are two raids defined
-        raid = proposal.devices.dm_raids.last
-        raid_name = raid.name
-        expect(raid.partitions.map(&:name)).to contain_exactly(
-          "#{raid_name}-part1",
-          "#{raid_name}-part2",
-          "#{raid_name}-part3"
+        # note: potentially order dependent; there are two raids defined
+        raid0, raid1 = proposal.devices.dm_raids
+        expect(raid0.partitions.map(&:name)).to contain_exactly(
+          "#{raid0.name}-part1",
+          "#{raid0.name}-part2",
+        )
+        expect(raid1.partitions.map(&:name)).to contain_exactly(
+          "#{raid1.name}-part1"
         )
       end
     end


### PR DESCRIPTION
Unused spaces are taken into account when deciding which partitions distribution is better. Somehow definition of `gap` is changed. Previously, it was meant to be a space produced by the partitioning algorithm (for instance, putting a partition into a free space but leaving some space at the end). Now, any free space is considered a gap (no matter how it was created).