### PR TITLE
Partitioner: treat International System units as power of two

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jan 23 13:01:39 UTC 2018 - ancor@suse.com
+
+- Partitioner: consider all sizes entered by the user as base of 2
+  despite the units not being consistent with the International
+  System. Thus, 1KB (which in the IS actually means 1000 bytes)
+  becomes equivalent to 1KiB (which is 1024 bytes).
+
+-------------------------------------------------------------------
 Tue Jan 23 10:09:51 UTC 2018 - snwint@suse.com
 
 - fix proposal dialog error when there are no disks (bsc#1057430)

--- a/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "y2storage"
 require "y2partitioner/device_graphs"
+require "y2partitioner/size_parser"
 
 module Y2Partitioner
   module Actions
@@ -30,6 +31,7 @@ module Y2Partitioner
       # takes care of updating the devicegraph when needed
       class LvmVg
         include Yast::I18n
+        include SizeParser
 
         # @return [String] given volume group name
         attr_accessor :vg_name
@@ -60,12 +62,12 @@ module Y2Partitioner
         end
 
         # Stores the given extent size
-        # @note The value is internally stored as DiskSize (see {to_size}) when it can
-        #   be parsed; nil otherwise.
+        # @note The value is internally stored as DiskSize when it can be parsed;
+        #   nil otherwise.
         #
         # @param value [String]
         def extent_size=(value)
-          @extent_size = to_size(value)
+          @extent_size = parse_user_size(value)
         end
 
         # Effective size of the resulting LVM volume group
@@ -344,19 +346,6 @@ module Y2Partitioner
         # @return [Boolean] true if it is formatted; false otherwise
         def formatted?(device)
           !device.filesystem.nil?
-        end
-
-        # Converts a string to DiskSize, returning nil if the conversion
-        # it is not possible
-        #
-        # @see Y2Storage::DiskSize#from_human_string
-        #
-        # @return [Y2Storage::DiskSize, nil]
-        def to_size(value)
-          return nil if value.nil?
-          Y2Storage::DiskSize.from_human_string(value)
-        rescue TypeError
-          nil
         end
       end
     end

--- a/src/lib/y2partitioner/dialogs/blk_device_resize.rb
+++ b/src/lib/y2partitioner/dialogs/blk_device_resize.rb
@@ -5,6 +5,7 @@ require "cwm/custom_widget"
 require "cwm/common_widgets"
 require "y2partitioner/widgets/controller_radio_buttons"
 require "y2partitioner/device_graphs"
+require "y2partitioner/size_parser"
 
 Yast.import "Popup"
 
@@ -274,6 +275,8 @@ module Y2Partitioner
     class BlkDeviceResize
       # Widget to enter a human readable size
       class CustomSizeWidget < CWM::InputField
+        include SizeParser
+
         # @return [Y2Storage::DiskSize]
         attr_reader :min_size
 
@@ -313,9 +316,7 @@ module Y2Partitioner
 
         # @return [Y2Storage::DiskSize, nil] nil if the given size is not human readable.
         def value
-          Y2Storage::DiskSize.from_human_string(super)
-        rescue TypeError
-          nil
+          parse_user_size(super)
         end
 
         alias_method :size, :value

--- a/src/lib/y2partitioner/dialogs/lvm_lv_size.rb
+++ b/src/lib/y2partitioner/dialogs/lvm_lv_size.rb
@@ -23,6 +23,7 @@ require "yast"
 require "y2storage"
 require "cwm"
 require "y2partitioner/widgets/controller_radio_buttons"
+require "y2partitioner/size_parser"
 
 Yast.import "Popup"
 
@@ -130,6 +131,8 @@ module Y2Partitioner
 
       # Enter a human readable size
       class CustomSizeInput < CWM::InputField
+        include SizeParser
+
         # @param initial [Y2Storage::DiskSize]
         # @param min [Y2Storage::DiskSize]
         # @param max [Y2Storage::DiskSize]
@@ -167,9 +170,7 @@ module Y2Partitioner
 
         # @return [Y2Storage::DiskSize,nil]
         def value
-          Y2Storage::DiskSize.from_human_string(super)
-        rescue TypeError
-          nil
+          parse_user_size(super)
         end
 
         alias_method :size, :value

--- a/src/lib/y2partitioner/dialogs/partition_size.rb
+++ b/src/lib/y2partitioner/dialogs/partition_size.rb
@@ -4,6 +4,7 @@ require "cwm/dialog"
 require "cwm/common_widgets"
 require "cwm/custom_widget"
 require "y2partitioner/widgets/controller_radio_buttons"
+require "y2partitioner/size_parser"
 
 Yast.import "Popup"
 
@@ -133,6 +134,8 @@ module Y2Partitioner
 
       # Enter a human readable size
       class CustomSizeInput < CWM::InputField
+        include SizeParser
+
         # @return [Y2Storage::DiskSize]
         attr_reader :min_size, :max_size
 
@@ -214,9 +217,7 @@ module Y2Partitioner
 
         # @return [Y2Storage::DiskSize,nil]
         def value
-          Y2Storage::DiskSize.from_human_string(super)
-        rescue TypeError
-          nil
+          parse_user_size(super)
         end
 
         # @param v [Y2Storage::DiskSize]

--- a/src/lib/y2partitioner/size_parser.rb
+++ b/src/lib/y2partitioner/size_parser.rb
@@ -1,0 +1,46 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage"
+
+module Y2Partitioner
+  # Mixin for all those partitioner components that parse sizes entered by the
+  # user.
+  #
+  # Provided as a way to centralize the configuration of such parsing (e.g.
+  # considering International System units as base 2 units) and error handling
+  # (e.g. the user leaves the field empty or enters some crazy stuff).
+  module SizeParser
+    # Converts a string to DiskSize, returning nil if the conversion
+    # it is not possible
+    #
+    # @see Y2Storage::DiskSize#from_human_string
+    #
+    # @return [Y2Storage::DiskSize, nil]
+    def parse_user_size(string)
+      return nil if string.nil?
+      Y2Storage::DiskSize.from_human_string(string, legacy_units: true)
+    rescue TypeError
+      nil
+    end
+  end
+end

--- a/test/y2partitioner/actions/controllers/lvm_vg_test.rb
+++ b/test/y2partitioner/actions/controllers/lvm_vg_test.rb
@@ -67,6 +67,13 @@ describe Y2Partitioner::Actions::Controllers::LvmVg do
       end
     end
 
+    context "when the International System units are used" do
+      it "considers them as base 2 units" do
+        controller.extent_size = "4 mb"
+        expect(controller.extent_size).to eq(4.MiB)
+      end
+    end
+
     context "with an incorrect size representation" do
       it "sets nil" do
         controller.extent_size = "1 bad size"

--- a/test/y2partitioner/dialogs/blk_device_resize_test.rb
+++ b/test/y2partitioner/dialogs/blk_device_resize_test.rb
@@ -368,6 +368,67 @@ describe Y2Partitioner::Dialogs::BlkDeviceResize do
         end
       end
     end
+
+    describe "#value" do
+      let(:current_widget) { custom_size_widget }
+
+      before do
+        allow(Yast::UI).to receive(:QueryWidget).with(Id(current_widget.widget_id), :Value)
+          .and_return entered
+      end
+
+      context "when a valid size is entered" do
+        let(:entered) { "10 GiB" }
+
+        it "returns the corresponding DiskSize object" do
+          expect(current_widget.value).to eq 10.GiB
+        end
+      end
+
+      context "when no units are specified" do
+        let(:entered) { "10" }
+
+        it "returns a DiskSize object" do
+          expect(current_widget.value).to be_a Y2Storage::DiskSize
+        end
+
+        it "considers the units to be bytes" do
+          expect(current_widget.value.to_i).to eq 10
+        end
+      end
+
+      context "when International System units are used" do
+        let(:entered) { "10gb" }
+
+        it "considers them as base 2 units" do
+          expect(current_widget.value).to eq 10.GiB
+        end
+      end
+
+      context "when the units are only partially specified" do
+        let(:entered) { "10g" }
+
+        it "considers them as base 2 units" do
+          expect(current_widget.value).to eq 10.GiB
+        end
+      end
+
+      context "when nothing is entered" do
+        let(:entered) { "" }
+
+        it "returns nil" do
+          expect(current_widget.value).to be_nil
+        end
+      end
+
+      context "when an invalid string is entered" do
+        let(:entered) { "a big chunk" }
+
+        it "returns nil" do
+          expect(current_widget.value).to be_nil
+        end
+      end
+    end
   end
 
   describe Y2Partitioner::Dialogs::BlkDeviceResize::FixedSizeWidget do


### PR DESCRIPTION
This should make this test succeed, since "1Mb" will be considered equivalent to "1Mib" (we can't educate the whole world):

https://openqa.opensuse.org/tests/588406