### PR TITLE
Implement "arbitrary options" in the partitioner's fstab options page

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 31 16:06:25 UTC 2018 - shundhammer@suse.com
+
+- Handle arbitrary mount options for /etc/fstab properly
+  (bsc#1066076)
+- 4.0.82
+
+-------------------------------------------------------------------
 Wed Jan 31 14:53:57 UTC 2018 - jlopez@suse.com
 
 - Partitioner: list all LVM thin volumes to delete when an LVM thin
@@ -525,7 +532,7 @@ Wed Nov  1 09:11:23 UTC 2017 - jlopez@suse.com
 Wed Nov  1 08:23:17 UTC 2017 - igonzalezsosa@suse.com
 
 - AutoYaST: do not crash when an unknown key is used in a
-  skip list (bsc#1065670). 
+  skip list (bsc#1065670).
 - 4.0.16
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.81
+Version:        4.0.82
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -315,7 +315,7 @@ module Y2Partitioner
       VALUES = ["user", "nouser"].freeze
 
       def label
-        _("Mountable by user")
+        _("Mountable by User")
       end
 
       def help

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -361,7 +361,7 @@ module Y2Partitioner
       def help
         _("<p><b>Enable Quota Support:</b>\n" \
           "The file system is mounted with user quotas enabled.\n" \
-          "Default is false.</p>\n")
+          "Default is false.</p>")
       end
 
       def init

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -66,7 +66,10 @@ module Y2Partitioner
 
       def add_fstab_options(*options)
         # The options can only be modified using BlkDevice#fstab_options=
-        filesystem.fstab_options = filesystem.fstab_options + options
+        # so we can't just append options with << or push
+        new_options = filesystem.fstab_options
+        options.each { |opt| new_options << opt }
+        filesystem.fstab_options = new_options
       end
 
       alias_method :add_fstab_option, :add_fstab_options
@@ -117,6 +120,9 @@ module Y2Partitioner
       end
 
       def init
+        @contents = nil
+        @values = nil
+        @regexps = nil
         disable if !supported_by_filesystem?
       end
 
@@ -136,17 +142,36 @@ module Y2Partitioner
       end
 
       def contents
-        VBox(
-          Left(MountBy.new(@controller)),
-          VSpacing(1),
-          Left(VolumeLabel.new(@controller)),
-          VSpacing(1),
-          Left(GeneralOptions.new(@controller)),
-          Left(FilesystemsOptions.new(@controller)),
-          Left(AclOptions.new(@controller)),
-          * ui_term_with_vspace(JournalOptions.new(@controller)),
-          Left(ArbitraryOptions.new(@controller))
-        )
+        @contents ||=
+          VBox(
+            Left(MountBy.new(@controller)),
+            VSpacing(1),
+            Left(VolumeLabel.new(@controller)),
+            VSpacing(1),
+            Left(GeneralOptions.new(@controller)),
+            Left(FilesystemsOptions.new(@controller)),
+            Left(AclOptions.new(@controller)),
+            * ui_term_with_vspace(JournalOptions.new(@controller)),
+            Left(ArbitraryOptions.new(@controller, self))
+          )
+      end
+
+      # Return an array of all VALUES of all widgets in this tree.
+      # @return [Array<String>]
+      def values
+        @values ||= widgets.each_with_object([]) do |widget, values|
+          next unless widget.class.const_defined?("VALUES")
+          values.concat(widget.class::VALUES)
+        end.uniq
+      end
+
+      # Return an array of all REGEXPs of all widgets in this tree.
+      # @return [Array<Regexp>]
+      def regexps
+        @regexps ||= widgets.each_with_object([]) do |widget, regexps|
+          next unless widget.class.const_defined?("REGEXP")
+          regexps << widget.class::REGEXP
+        end.uniq
       end
 
     private
@@ -335,8 +360,8 @@ module Y2Partitioner
 
       def help
         _("<p><b>Enable Quota Support:</b>\n" \
-        "The file system is mounted with user quotas enabled.\n" \
-        "Default is false.</p>\n")
+          "The file system is mounted with user quotas enabled.\n" \
+          "Default is false.</p>\n")
       end
 
       def init
@@ -506,23 +531,93 @@ module Y2Partitioner
       end
     end
 
-    # A input field that allows to set other options that are not handled by
-    # specific widgets
+    # An input field that allows to set other options that are not handled by
+    # specific widgets.
     #
-    # TODO: FIXME: Pending implementation, currently it is only drawing; all the options
-    # that it is responsible for should be defined, removing them if not set or
-    # supported by the current filesystem.
     class ArbitraryOptions < CWM::InputField
-      def initialize(controller)
+      include FstabCommon
+
+      def initialize(controller, parent_widget)
         @controller = controller
+        @parent_widget = parent_widget
+        @other_values = nil
+        @other_regexps = nil
       end
 
       def opt
-        %i(hstretch disabled)
+        %i(hstretch)
       end
 
       def label
         _("Arbitrary Option &Value")
+      end
+
+      def init
+        self.value = unhandled_options(filesystem.fstab_options).join(",")
+      end
+
+      def store
+        keep_only_options_handled_in_other_widgets
+        return unless value
+        options = clean_whitespace(value).split(",")
+        # Intentionally NOT filtering out only unhandled options: When the user
+        # adds anything here that also has a corresponding checkbox or combo
+        # box in this same dialog, the value here will win, and when entering
+        # this dialog again the dedicated widget will take the value from
+        # there, and it will be filtered out in this arbitrary options widget.
+        #
+        # So, when a user insists in adding "noauto,user" here, it is applied
+        # correctly, but when entering the dialog again, the checkboxes pick up
+        # those values and they won't show up in this field anymore.
+        add_fstab_options(*options)
+      end
+
+      def help
+        _("<p><b>Arbitrary Option Value:</b> " \
+          "Enter any other mount options here, separated with commas. " \
+          "Notice that this does not do any checking, so be careful " \
+          "what you enter here!</p>")
+      end
+
+    private
+
+      # Clean whitespace. We need to preserve whitespace that might possibly be
+      # intentional within a mount option, but we want graceful error handling
+      # when a user put additional blanks between them, e.g. "foo, bar" or
+      # "foo , bar".
+      def clean_whitespace(str)
+        str.gsub(/\s+,\s+/, ",")
+      end
+
+      def keep_only_options_handled_in_other_widgets
+        filesystem.fstab_options = filesystem.fstab_options.select do |opt|
+          handled_in_other_widget?(opt)
+        end
+      end
+
+      def unhandled_options(options)
+        options.reject do |opt|
+          handled_in_other_widget?(opt)
+        end
+      end
+
+      def handled_in_other_widget?(opt)
+        return true if other_values.include?(opt)
+        other_regexps.any? { |r| opt =~ r }
+      end
+
+      # Return all values that are handled by other widgets in this widget tree.
+      # @return [Array<String>]
+      def other_values
+        return [] unless @parent_widget && @parent_widget.respond_to?(:values)
+        @other_values ||= @parent_widget.values
+      end
+
+      # Return all regexps that are handled by other widgets in this widget tree.
+      # @return [Array<Regexp>]
+      def other_regexps
+        return [] unless @parent_widget && @parent_widget.respond_to?(:regexps)
+        @other_regexps ||= @parent_widget.regexps
       end
     end
 

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -384,7 +384,7 @@ module Y2Partitioner
       end
     end
 
-    # CheckBox to enable extended user attributes (xattr)
+    # CheckBox to enable extended user attributes (user_xattr)
     class UserXattr < FstabCheckBox
       include FstabCommon
 

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -586,7 +586,7 @@ module Y2Partitioner
       # when a user put additional blanks between them, e.g. "foo, bar" or
       # "foo , bar".
       def clean_whitespace(str)
-        str.gsub(/\s+,\s+/, ",")
+        str.gsub(/\s*,\s*/, ",")
       end
 
       def keep_only_options_handled_in_other_widgets

--- a/test/y2partitioner/widgets/fstab_options_test.rb
+++ b/test/y2partitioner/widgets/fstab_options_test.rb
@@ -99,8 +99,63 @@ describe Y2Partitioner::Widgets do
   end
 
   describe Y2Partitioner::Widgets::ArbitraryOptions do
-    subject { described_class.new(controller, nil) }
+    let(:handled_values)  { ["ro", "rw", "auto", "noauto", "user", "nouser"] }
+    let(:handled_regexps) { [/^iocharset=/, /^codepage=/] }
+    let(:options_widget)  { double("FstabOptions", values:  handled_values, regexps: handled_regexps) }
+
+    subject { described_class.new(controller, options_widget) }
     include_examples "CWM::InputField"
+
+    it "picks up values handled in other widgets" do
+      expect(subject.send(:other_values)).to eq handled_values
+    end
+
+    it "picks up regexps handled in other widgets" do
+      expect(subject.send(:other_regexps)).to eq handled_regexps
+    end
+
+    describe "#handled_in_other_widget?" do
+      it "detects simple values that are already handled in other widgets" do
+        expect(subject.send(:handled_in_other_widget?, "auto")).to be true
+        expect(subject.send(:handled_in_other_widget?, "ro")).to be true
+        expect(subject.send(:handled_in_other_widget?, "nouser")).to be true
+      end
+
+      it "detects regexps that are already handled in other widgets" do
+        expect(subject.send(:handled_in_other_widget?, "iocharset=none")).to be true
+        expect(subject.send(:handled_in_other_widget?, "codepage=42")).to be true
+      end
+
+      it "detects values that are not already handled in other widgets" do
+        expect(subject.send(:handled_in_other_widget?, "foo")).to be false
+        expect(subject.send(:handled_in_other_widget?, "bar")).to be false
+        expect(subject.send(:handled_in_other_widget?, "ook=yikes")).to be false
+        expect(subject.send(:handled_in_other_widget?, "somecodepage=42")).to be false
+      end
+    end
+
+    describe "#unhandled_options" do
+      it "filters out values that are handled in other widgets" do
+        expect(subject.send(:unhandled_options, [])).to eq []
+        expect(subject.send(:unhandled_options, handled_values)).to eq []
+        expect(subject.send(:unhandled_options, handled_values + ["foo", "bar"])).to eq ["foo", "bar"]
+        expect(subject.send(:unhandled_options, ["foo", "bar"])).to eq ["foo", "bar"]
+      end
+    end
+
+    describe "#clean_whitespace" do
+      it "does not modify strings without any whitespace" do
+        expect(subject.send(:clean_whitespace, "aaa,bbb,ccc")).to eq "aaa,bbb,ccc"
+      end
+
+      it "removes whitespace around commas" do
+        expect(subject.send(:clean_whitespace, "aaa, bbb , ccc")).to eq "aaa,bbb,ccc"
+      end
+
+      it "leaves internal whitespace alone" do
+        expect(subject.send(:clean_whitespace, "aa a, bb  b , ccc")).to eq "aa a,bb  b,ccc"
+      end
+    end
   end
 
   describe Y2Partitioner::Widgets::FilesystemsOptions do

--- a/test/y2partitioner/widgets/fstab_options_test.rb
+++ b/test/y2partitioner/widgets/fstab_options_test.rb
@@ -99,6 +99,7 @@ describe Y2Partitioner::Widgets do
   end
 
   describe Y2Partitioner::Widgets::ArbitraryOptions do
+    subject { described_class.new(controller, nil) }
     include_examples "CWM::InputField"
   end
 


### PR DESCRIPTION
This uses introspection to check the other widgets on that same dialog page which values are already handled there (both VALUES and REGEXP constants) and populates the input field only with those that are not.

Upon storing the value, it accepts all options from the user. If any of them is already handled by another widget, it will still be set, but when entering the dialog again, that widget will pick up the value and handle it.

There is no sanity checking which values are valid. The background is to avoid keeping track of every possible mount option for all types of filesystems; new ones might come without us taking notice, so we rather trust the user than our ability to keep any such tables up-to-date for all future releases.