### PR TITLE
Disabled (commented out) empty partitioner pages

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -3,13 +3,14 @@ Wed Feb  7 16:47:58 UTC 2018 - shundhammer@suse.com
 
 - Disabled empty pages in partitioner for the time being
   (bsc#1078849) 
-- 4.0.85
+- 4.0.86
 
 -------------------------------------------------------------------
 Wed Feb  7 10:57:26 UTC 2018 - igonzalezsosa@suse.com
 
 - AutoYaST: support reuse of already existing partitions as LVM
   physical volumes or MD RAIDs (bsc#1077277).
+- 4.0.85
   
 -------------------------------------------------------------------
 Wed Feb  7 00:18:34 UTC 2018 - ancor@suse.com

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,10 +1,16 @@
 -------------------------------------------------------------------
+Wed Feb  7 16:47:58 UTC 2018 - shundhammer@suse.com
+
+- Disabled empty pages in partitioner for the time being
+  (bsc#1078849) 
+- 4.0.85
+
+-------------------------------------------------------------------
 Wed Feb  7 10:57:26 UTC 2018 - igonzalezsosa@suse.com
 
 - AutoYaST: support reuse of already existing partitions as LVM
   physical volumes or MD RAIDs (bsc#1077277).
-- 4.0.85
-
+  
 -------------------------------------------------------------------
 Wed Feb  7 00:18:34 UTC 2018 - ancor@suse.com
 

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.85
+Version:        4.0.86
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -93,6 +93,7 @@ module Y2Partitioner
           system_items,
           *graph_items,
           item_for("summary", _("Installation Summary"), icon: Icons::SUMMARY)
+          # TODO: Bring this back to life - disabled for now (bsc#1078849)
           # item_for("settings", _("Settings"), icon: Icons::SETTINGS)
         ]
       end
@@ -159,10 +160,12 @@ module Y2Partitioner
           disks_items,
           raids_items,
           lvm_items,
+          # TODO: Bring this back to life - disabled for now (bsc#1078849)
           # crypt_files_items,
           # device_mapper_items,
           nfs_items,
           btrfs_items
+          # TODO: Bring this back to life - disabled for now (bsc#1078849)
           # unused_items
         ]
         CWM::PagerTreeItem.new(page, children: children, icon: Icons::ALL)
@@ -259,6 +262,7 @@ module Y2Partitioner
 
         page = Pages::DeviceGraph.new(self)
         dev_item = CWM::PagerTreeItem.new(page, icon: Icons::GRAPH)
+        # TODO: Bring this back to life - disabled for now (bsc#1078849)
         # mount_item = item_for("mountgraph", _("Mount Graph"), icon: Icons::GRAPH)
         # [dev_item, mount_item]
         [dev_item]

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -92,8 +92,8 @@ module Y2Partitioner
         [
           system_items,
           *graph_items,
-          item_for("summary", _("Installation Summary"), icon: Icons::SUMMARY),
-          item_for("settings", _("Settings"), icon: Icons::SETTINGS)
+          item_for("summary", _("Installation Summary"), icon: Icons::SUMMARY)
+          # item_for("settings", _("Settings"), icon: Icons::SETTINGS)
         ]
       end
 
@@ -159,11 +159,11 @@ module Y2Partitioner
           disks_items,
           raids_items,
           lvm_items,
-          crypt_files_items,
-          device_mapper_items,
+          # crypt_files_items,
+          # device_mapper_items,
           nfs_items,
-          btrfs_items,
-          unused_items
+          btrfs_items
+          # unused_items
         ]
         CWM::PagerTreeItem.new(page, children: children, icon: Icons::ALL)
       end
@@ -259,9 +259,9 @@ module Y2Partitioner
 
         page = Pages::DeviceGraph.new(self)
         dev_item = CWM::PagerTreeItem.new(page, icon: Icons::GRAPH)
-        mount_item = item_for("mountgraph", _("Mount Graph"), icon: Icons::GRAPH)
-
-        [dev_item, mount_item]
+        # mount_item = item_for("mountgraph", _("Mount Graph"), icon: Icons::GRAPH)
+        # [dev_item, mount_item]
+        [dev_item]
       end
 
       # @return [CWM::PagerTreeItem]


### PR DESCRIPTION
https://trello.com/c/dtrBS2Fq/229-1-beta7-expert-partitioner-remove-empty-screens
https://bugzilla.suse.com/show_bug.cgi?id=1078849

Disabled (commented out in the code) the empty pages for the time being:

- Crypt Files
- Device Mapper
- Unused Devices
- Mount Graph
- Settings (this one will be back soon with content)

Now it looks like this:

![partitioner-02-no-unused-pages](https://user-images.githubusercontent.com/11538225/35929414-be3af3ac-0c2f-11e8-8928-d3876b611945.png)

---------------------------------

For comparison: Before:

![partitioner-01-with-unused-pages](https://user-images.githubusercontent.com/11538225/35929430-c67cb64a-0c2f-11e8-9a2b-c18dc5d75d81.png)
