### PR TITLE
AutoYaST: use find_by_any_name

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  8 10:15:18 UTC 2018 - igonzalezsosa@suse.com
+
+- AutoYaST: support additional names in the drive/device element
+  (bsc#1077277).
+- 4.0.87
+
+-------------------------------------------------------------------
 Wed Feb  7 16:47:58 UTC 2018 - shundhammer@suse.com
 
 - Disabled empty pages in partitioner for the time being

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.86
+Version:        4.0.87
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/proposal/autoinst_drives_map.rb
+++ b/src/lib/y2storage/proposal/autoinst_drives_map.rb
@@ -178,16 +178,14 @@ module Y2Storage
         end
       end
 
-      # Find a disk using its name or a udev link
-      #
-      # First it tries using the kernel name (eg. /dev/sda1) and, if it fails,
-      # it tries again using udev links.
+      # Find a disk using any possible name
       #
       # @return [Disk,nil] Usable disk or nil if none is found
+      # @see [Y2Storage::Devicegraph#find_by_any_name]
       def find_disk(devicegraph, device_name)
-        devicegraph.disk_devices.find do |device|
-          device.name == device_name || device.udev_full_all.include?(device_name)
-        end
+        device = devicegraph.find_by_any_name(device_name)
+        return nil unless device
+        device.ancestors.last || device
       end
     end
   end

--- a/src/lib/y2storage/proposal/autoinst_drives_map.rb
+++ b/src/lib/y2storage/proposal/autoinst_drives_map.rb
@@ -185,7 +185,7 @@ module Y2Storage
       def find_disk(devicegraph, device_name)
         device = devicegraph.find_by_any_name(device_name)
         return nil unless device
-        device.ancestors.last || device
+        ([device] + device.ancestors).find { |d| d.is?(:disk_device) }
       end
     end
   end

--- a/test/y2storage/proposal/autoinst_drives_map_test.rb
+++ b/test/y2storage/proposal/autoinst_drives_map_test.rb
@@ -45,6 +45,10 @@ describe Y2Storage::Proposal::AutoinstDrivesMap do
 
   describe ".new" do
     context "when a device does not exist" do
+      before do
+        allow(fake_devicegraph).to receive(:find_by_any_name).and_return(nil)
+      end
+
       let(:partitioning_array) do
         [{ "device" => "/dev/sdx", "use" => "all" }]
       end
@@ -80,18 +84,8 @@ describe Y2Storage::Proposal::AutoinstDrivesMap do
     context "when a disk udev link is used" do
       let(:udev_link) { "/dev/disk/by-label/root" }
 
-      let(:disk) do
-        instance_double(Y2Storage::Disk, name: "/dev/sda", udev_full_all: [udev_link])
-      end
-
       let(:partitioning_array) do
         [{ "device" => udev_link }]
-      end
-
-      before do
-        allow(fake_devicegraph).to receive(:disk_devices)
-          .and_return([disk])
-        allow(disk).to receive(:udev_full_all).and_return([udev_link])
       end
 
       it "uses its kernel name" do


### PR DESCRIPTION
This change adds support to use devices names like `/dev/disk/by-label/some-label` in `drive/device` element.