### PR TITLE
Partitioner: fix for bsc#1078721

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb  8 15:42:52 UTC 2018 - ancor@suse.com
+
+- Partitioner: fixed creation of partition tables (bsc#1078721).
+- 4.0.89
+
+-------------------------------------------------------------------
 Thu Feb  8 10:47:53 UTC 2018 - ancor@suse.com
 
 - Partitioner: fixed 'Installation Summary' section (part of

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.88
+Version:        4.0.89
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/actions/controllers/partition_table.rb
+++ b/src/lib/y2partitioner/actions/controllers/partition_table.rb
@@ -58,8 +58,8 @@ module Y2Partitioner
           @type = possible_partition_table_types.first
         end
 
-        # The disk we are working on
-        # @return [Y2Storage::Disk] or [Y2Storage::Dasd]
+        # The disk (or similar device) we are working on
+        # @return [Y2Storage::Partitionable]
         def disk
           DeviceGraphs.instance.current.find_by_name(disk_name)
         end

--- a/src/lib/y2partitioner/actions/create_partition_table.rb
+++ b/src/lib/y2partitioner/actions/create_partition_table.rb
@@ -27,6 +27,12 @@ require "y2partitioner/dialogs"
 module Y2Partitioner
   module Actions
     # Action for creating a new partition table
+    #
+    # TODO: simplify the code for this. Using transactions, several steps and a
+    # separate controller is clearly overkill for such an straighforward action.
+    #
+    # It's error prone (as proved by bug#1078721) and produces some surprising
+    # visual glitches, like a completely empty wizard step (in the DASD case).
     class CreatePartitionTable < TransactionWizard
       attr_reader :controller
 
@@ -50,6 +56,8 @@ module Y2Partitioner
         }
       end
 
+      skip_stack :select_type
+
       # Open a dialog to let the user select the partition table type
       # if there is more than one to select from.
       def select_type
@@ -66,7 +74,7 @@ module Y2Partitioner
         msg += _("This will delete all existing partitions on that device\n" \
                  "and all devices (LVM volume groups, RAIDs etc.)\n" \
                  "that use any of those partitions!")
-        Yast::Popup.YesNo(msg) ? :next : :abort
+        Yast::Popup.YesNo(msg) ? :next : :back
       end
 
       # Commit the action (creating a new partition table) to the staging


### PR DESCRIPTION
This fixes https://trello.com/c/ahhE9izy/260-3-bsc1078721-p1-openqa-test-fails-in-partitioningfulllvm-partitions-not-deleted-after-creating-partition-table

* Fixes the bug
* Modify unit tests to actually test something meaningful