### PR TITLE
New finish client to enable multipathd

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb  9 00:51:22 UTC 2018 - ancor@suse.com
+
+- Enable multipathd in the target system at the end of installation
+  if there are multipath devices (bsc#1076183).
+- 4.0.91
+
+-------------------------------------------------------------------
 Thu Feb  8 16:48:20 UTC 2018 - jlopez@suse.com
 
 - Add class MountPoint (needed for bsc#1076305 and bsc#1066763).

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -3,6 +3,7 @@ Fri Feb  9 00:51:22 UTC 2018 - ancor@suse.com
 
 - Enable multipathd in the target system at the end of installation
   if there are multipath devices (bsc#1076183).
+- Updated required version of libstorage-ng-ruby (bsc#1079541).
 - 4.0.91
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -26,12 +26,12 @@ Source:		%{name}-%{version}.tar.bz2
 # Yast2::FsSnapshots.configure_on_install=
 Requires:	yast2 >= 4.0.24
 Requires:	yast2-ruby-bindings
-# Storage::CommitOptions
-Requires:	libstorage-ng-ruby >= 3.3.45
+# Storage::GraphvizFlags_DISPLAYNAME
+Requires:	libstorage-ng-ruby >= 3.3.148
 
 BuildRequires:	update-desktop-files
-# BlkDevice#remove_encryption
-BuildRequires:	libstorage-ng-ruby >= 3.3.22
+# Storage::GraphvizFlags_DISPLAYNAME
+BuildRequires:	libstorage-ng-ruby >= 3.3.148
 BuildRequires:	yast2-ruby-bindings
 BuildRequires:	yast2-devtools
 # yast2-xml dependency is added by yast2 but ignored in the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.90
+Version:        4.0.91
 Release:	0
 BuildArch:	noarch
 

--- a/src/clients/storage_finish.rb
+++ b/src/clients/storage_finish.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may
+# find current contact information at www.novell.com.
+
+require "yast"
+require "y2storage/clients/finish"
+
+Y2Storage::Clients::Finish.run

--- a/src/lib/y2storage/clients/finish.rb
+++ b/src/lib/y2storage/clients/finish.rb
@@ -41,12 +41,6 @@ module Y2Storage
         _("Saving file system configuration...")
       end
 
-      # Modes in which the client should run
-      # @return [Array<Symbol>]
-      def modes
-        [:installation, :update, :autoinst, :autoupg, :live_installation]
-      end
-
       # Performs the final actions in the target system
       def write
         return unless multipath?

--- a/src/lib/y2storage/clients/finish.rb
+++ b/src/lib/y2storage/clients/finish.rb
@@ -1,0 +1,67 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "installation/finish_client"
+
+module Y2Storage
+  module Clients
+    # Finish client for storage-related tasks
+    class Finish < ::Installation::FinishClient
+      # Constructor
+      def initialize
+        textdomain "storage"
+        Yast.import "Service"
+      end
+
+    protected
+
+      # Title to tell the user what is happening
+      # @return [String]
+      def title
+        # progress step title
+        _("Saving file system configuration...")
+      end
+
+      # Modes in which the client should run
+      # @return [Array<Symbol>]
+      def modes
+        [:installation, :update, :autoinst, :autoupg, :live_installation]
+      end
+
+      # Performs the final actions in the target system
+      def write
+        return unless multipath?
+
+        log.info "Enabling multipathd in the target system"
+        Yast::Service.Enable("multipathd")
+      end
+
+      # Checks whether multipath will be used in the target system
+      # @return [Boolean]
+      def multipath?
+        staging = StorageManager.instance.staging
+        features = UsedStorageFeatures.new(staging).collect_features
+        features.include?(:UF_MULTIPATH)
+      end
+    end
+  end
+end

--- a/test/y2storage/clients/finish_test.rb
+++ b/test/y2storage/clients/finish_test.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage/clients/finish"
+
+describe Y2Storage::Clients::Finish do
+  subject(:client) { described_class.new }
+
+  describe "#run" do
+    before do
+      allow(Yast::WFM).to receive(:Args).with(no_args).and_return(args)
+      allow(Yast::WFM).to receive(:Args) { |n| n.nil? ? args : args[n] }
+    end
+
+    context "Info" do
+      let(:args) { ["Info"] }
+
+      it "returns a hash describing the client" do
+        expect(client.run).to be_kind_of(Hash)
+      end
+    end
+
+    context "Write" do
+      let(:args) { ["Write"] }
+      before { fake_scenario(scenario) }
+
+      context "if Multipath is used in the target system" do
+        let(:scenario) { "multipath-formatted.xml" }
+
+        it "enables multipathd" do
+          expect(Yast::Service).to receive(:Enable).with("multipathd")
+          client.run
+        end
+      end
+
+      context "if Multipath is not used in the target system" do
+        let(:scenario) { "output/windows-pc" }
+
+        it "does not enable any service" do
+          expect(Yast::Service).to_not receive(:Enable)
+          client.run
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements https://trello.com/c/dXnAZX6L/261-sles15-p1-1076183-multipathdservice-isnt-enabled-after-installation-on-multipath

Already tested manually

Bonus: update dependency on libstorage-ng to fix another reported bug