### PR TITLE
Fix transaction issues

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb  9 19:05:17 UTC 2018 - jlopez@suse.com
+
+- Partitioner: fix issues using transactions (bsc#1079880 and
+  bsc#1079573).
+- 4.0.92
+
+-------------------------------------------------------------------
 Fri Feb  9 00:51:22 UTC 2018 - ancor@suse.com
 
 - Enable multipathd in the target system at the end of installation

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.91
+Version:        4.0.92
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/actions/add_lvm_lv.rb
+++ b/src/lib/y2partitioner/actions/add_lvm_lv.rb
@@ -34,7 +34,8 @@ module Y2Partitioner
       # @param vg [Y2Storage::LvmVg]
       def initialize(vg)
         super()
-        @controller = Controllers::LvmLv.new(vg)
+
+        @device_sid = vg.sid
       end
 
       # Wizard step to indicate properties for a new logical volume (i.e., the name and type)
@@ -78,6 +79,12 @@ module Y2Partitioner
 
       # @return [Controllers::LvmLv]
       attr_reader :controller
+
+      # @see TransactionWizard
+      def init_transaction
+        # The controller object must be created within the transaction
+        @controller = Controllers::LvmLv.new(device)
+      end
 
       # @see TransactionWizard
       def sequence_hash

--- a/src/lib/y2partitioner/actions/add_partition.rb
+++ b/src/lib/y2partitioner/actions/add_partition.rb
@@ -36,7 +36,7 @@ module Y2Partitioner
         textdomain "storage"
 
         super()
-        @part_controller = Controllers::Partition.new(disk.name)
+        @device_sid = disk.sid
       end
 
       # Removes the filesystem when the device is directly formatted
@@ -65,6 +65,12 @@ module Y2Partitioner
 
       # @return [Controllers::Partition]
       attr_reader :part_controller
+
+      # @see TransactionWizard
+      def init_transaction
+        # The controller object must be created within the transaction
+        @part_controller = Controllers::Partition.new(device.name)
+      end
 
       # @see TransactionWizard
       def sequence_hash

--- a/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
@@ -23,6 +23,7 @@ require "yast"
 require "y2storage"
 require "y2partitioner/device_graphs"
 require "y2partitioner/size_parser"
+require "y2partitioner/ui_state"
 
 module Y2Partitioner
   module Actions
@@ -213,16 +214,21 @@ module Y2Partitioner
         # @return [Symbol] :add, :resize
         attr_reader :action
 
-        # Set the action to perform and initialize necessary data
-        def initialize_action(vg)
-          detect_action(vg)
+        # Sets the action to perform and initializes necessary data
+        #
+        # @param current_vg [Y2Storage::LvmVg, nil] nil if the volume group is
+        #   going to be created.
+        def initialize_action(current_vg)
+          detect_action(current_vg)
 
           case action
           when :add
             initialize_for_add
           when :resize
-            initialize_for_resize(vg)
+            initialize_for_resize(current_vg)
           end
+
+          UIState.instance.select_row(vg) unless vg.nil?
         end
 
         # Detects current action

--- a/src/lib/y2partitioner/actions/controllers/md.rb
+++ b/src/lib/y2partitioner/actions/controllers/md.rb
@@ -243,13 +243,30 @@ module Y2Partitioner
           md
         end
 
+        # Whether the partition is available to be used in a MD RAID
+        #
+        # @note A partition is available if it is valid to be used in a MD RAID and
+        #   it is not formatted or not mounted.
+        #
+        # @return [Boolean] true if can be used for a MD RAID; false otherwise.
         def available?(partition)
-          return false unless partition.id.is?(:linux_system)
-          return false if partition.lvm_pv
-          return false if partition.md
-          return true if partition.filesystem.nil?
+          return false unless valid_for_md?(partition)
 
-          partition.filesystem.mount_point.nil?
+          partition.filesystem.nil? || partition.filesystem.mount_point.nil?
+        end
+
+        # Whether the partition is valid to be used in a MD RAID
+        #
+        # @note A partition is valid to be used in a MD RAID if it is not extended,
+        #   it is alinux system partition and it is not being used by LVM or other
+        #   MD RAID.
+        #
+        # @return [Boolean] true if it is valid; false otherwise.
+        def valid_for_md?(partition)
+          partition.id.is?(:linux_system) &&
+            !partition.type.is?(:extended) &&
+            partition.lvm_pv.nil? &&
+            partition.md.nil?
         end
 
         def min_chunk_size

--- a/src/lib/y2partitioner/actions/resize_lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/resize_lvm_vg.rb
@@ -34,7 +34,7 @@ module Y2Partitioner
       def initialize(lvm_vg)
         super()
 
-        @controller = Controllers::LvmVg.new(vg: lvm_vg)
+        @device_sid = lvm_vg.sid
       end
 
       # Runs the dialog for resizing the volume group
@@ -49,6 +49,12 @@ module Y2Partitioner
 
       # @return [Controllers::LvmVg]
       attr_reader :controller
+
+      # @see TransactionWizard
+      def init_transaction
+        # The controller object must be created within the transaction
+        @controller = Controllers::LvmVg.new(vg: device)
+      end
 
       # @see TransactionWizard
       def sequence_hash

--- a/src/lib/y2partitioner/actions/resize_md.rb
+++ b/src/lib/y2partitioner/actions/resize_md.rb
@@ -37,7 +37,7 @@ module Y2Partitioner
       def initialize(md)
         super()
 
-        @controller = Controllers::Md.new(md: md)
+        @device_sid = md.sid
       end
 
       # Calls the dialog for resizing the MD RAID
@@ -52,6 +52,12 @@ module Y2Partitioner
 
       # @return [Controllers::Md]
       attr_reader :controller
+
+      # @see TransactionWizard
+      def init_transaction
+        # The controller object must be created within the transaction
+        @controller = Controllers::Md.new(md: device)
+      end
 
       # @see TransactionWizard
       def sequence_hash

--- a/src/lib/y2partitioner/actions/transaction_wizard.rb
+++ b/src/lib/y2partitioner/actions/transaction_wizard.rb
@@ -60,6 +60,13 @@ module Y2Partitioner
 
     protected
 
+      # Sid of the current device
+      #
+      # To be set, if needed, by each subclass
+      #
+      # @return [Integer, nil]
+      attr_reader :device_sid
+
       # Specification of the steps of the sequence.
       #
       # To be defined by each subclass.
@@ -91,6 +98,15 @@ module Y2Partitioner
       # @return [Boolean]
       def run?
         true
+      end
+
+      # Current device
+      #
+      # @return [Y2Storage::Device, nil]
+      def device
+        return nil if device_sid.nil?
+
+        Y2Partitioner::DeviceGraphs.instance.current.find_device(device_sid)
       end
     end
   end

--- a/test/y2partitioner/actions/add_lvm_lv_test.rb
+++ b/test/y2partitioner/actions/add_lvm_lv_test.rb
@@ -60,6 +60,25 @@ describe Y2Partitioner::Actions::AddLvmLv do
 
     let(:controller) { Y2Partitioner::Actions::Controllers::LvmLv.new(vg) }
 
+    # Regression test
+    it "uses the device belonging to the current devicegraph" do
+      # Only to finish
+      allow(subject).to receive(:run?).and_return(false)
+
+      initial_graph = current_graph
+
+      expect(Y2Partitioner::Actions::Controllers::LvmLv).to receive(:new) do |vg|
+        # Modifies used device
+        vg.vg_name = "foo"
+
+        # Initial device is not modified
+        initial_vg = initial_graph.find_device(vg.sid)
+        expect(initial_vg.vg_name).to_not eq("foo")
+      end
+
+      subject.run
+    end
+
     context "if there is no free space in the vg" do
       before do
         allow(controller).to receive(:free_extents).and_return 0

--- a/test/y2partitioner/actions/add_partition_test.rb
+++ b/test/y2partitioner/actions/add_partition_test.rb
@@ -46,6 +46,30 @@ describe Y2Partitioner::Actions::AddPartition do
   let(:disk) { Y2Storage::Disk.find_by_name(current_graph, disk_name) }
 
   describe "#run" do
+    let(:scenario) { "lvm-two-vgs.yml" }
+
+    let(:disk_name) { "/dev/sda" }
+
+    # Regression test
+    it "uses the device belonging to the current devicegraph" do
+      # Only to finish
+      allow(subject).to receive(:run?).and_return(false)
+
+      initial_graph = current_graph
+
+      expect(Y2Partitioner::Actions::Controllers::Partition).to receive(:new) do |disk_name|
+        # Modifies used device
+        disk = Y2Storage::BlkDevice.find_by_name(current_graph, disk_name)
+        disk.remove_descendants
+
+        # Initial device is not modified
+        initial_disk = Y2Storage::BlkDevice.find_by_name(initial_graph, disk_name)
+        expect(initial_disk.descendants).to_not be_empty
+      end
+
+      subject.run
+    end
+
     context "if it is not possible to create a new partition on the disk" do
       let(:scenario) { "lvm-two-vgs.yml" }
 

--- a/test/y2partitioner/actions/controllers/md_test.rb
+++ b/test/y2partitioner/actions/controllers/md_test.rb
@@ -141,6 +141,14 @@ describe Y2Partitioner::Actions::Controllers::Md do
       new_md.add_device(sda3)
       expect(controller.available_devices).to_not include sda3
     end
+
+    context "when there are extended partitions" do
+      let(:scenario) { "lvm-two-vgs.yml" }
+
+      it "excludes extended partitions" do
+        expect(controller.available_devices.map(&:name)).to_not include("/dev/sda3")
+      end
+    end
   end
 
   describe "#devices_in_md" do

--- a/test/y2partitioner/actions/edit_blk_device_test.rb
+++ b/test/y2partitioner/actions/edit_blk_device_test.rb
@@ -32,49 +32,9 @@ describe Y2Partitioner::Actions::EditBlkDevice do
     devicegraph_stub(scenario)
   end
 
-  let(:scenario) { "complex-lvm-encrypt.yml" }
-
   let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
 
   let(:device) { Y2Storage::BlkDevice.find_by_name(current_graph, dev_name) }
-
-  describe "#initialize" do
-    let(:controller_class) { Y2Partitioner::Actions::Controllers::Filesystem }
-
-    context "if working on a partition" do
-      let(:dev_name) { "/dev/sda1" }
-
-      it "includes the partition device name in the title passed to the controller" do
-        expect(controller_class).to receive(:new).with(device, /dev\/sda1/)
-        described_class.new(device)
-      end
-    end
-
-    context "if working on a logical volume" do
-      let(:dev_name) { "/dev/vg0/lv1" }
-
-      it "includes the VG device name and the LV name in the title passed to the controller" do
-        expect(controller_class).to receive(:new) do |dev, title|
-          expect(dev).to eq device
-          expect(title).to include "/dev/vg0"
-          expect(title).to include "lv1"
-          expect(title).to_not include "/dev/vg0/lv1"
-        end
-        described_class.new(device)
-      end
-    end
-
-    context "if working on an MD array" do
-      before { Y2Storage::Md.create(current_graph, "/dev/md0") }
-
-      let(:dev_name) { "/dev/md0" }
-
-      it "includes the RAID device name in the title passed to the controller" do
-        expect(controller_class).to receive(:new).with(device, /dev\/md0/)
-        described_class.new(device)
-      end
-    end
-  end
 
   describe "#run" do
     subject(:sequence) { described_class.new(device) }
@@ -115,15 +75,55 @@ describe Y2Partitioner::Actions::EditBlkDevice do
     end
 
     context "if called on a device that can be edited" do
-      let(:scenario) { "lvm-two-vgs.yml" }
+      before do
+        # Only to finish
+        allow(Y2Partitioner::Dialogs::FormatAndMount).to receive(:run).and_return :abort
+      end
 
-      let(:dev_name) { "/dev/vg1/lv1" }
+      let(:scenario) { "complex-lvm-encrypt.yml" }
+
+      let(:controller_class) { Y2Partitioner::Actions::Controllers::Filesystem }
+
+      context "and the device is a partition" do
+        let(:dev_name) { "/dev/sda1" }
+
+        it "includes the partition device name in the title passed to the controller" do
+          expect(controller_class).to receive(:new).with(device, /dev\/sda1/)
+          sequence.run
+        end
+      end
+
+      context "and the device is a logical volume" do
+        let(:dev_name) { "/dev/vg0/lv1" }
+
+        it "includes the VG device name and the LV name in the title passed to the controller" do
+          expect(controller_class).to receive(:new) do |dev, title|
+            expect(dev).to eq device
+            expect(title).to include "/dev/vg0"
+            expect(title).to include "lv1"
+            expect(title).to_not include "/dev/vg0/lv1"
+          end
+          sequence.run
+        end
+      end
+
+      context "and the device is an MD array" do
+        before { Y2Storage::Md.create(current_graph, "/dev/md0") }
+
+        let(:dev_name) { "/dev/md0" }
+
+        it "includes the RAID device name in the title passed to the controller" do
+          expect(controller_class).to receive(:new).with(device, /dev\/md0/)
+          sequence.run
+        end
+      end
 
       context "if the user goes forward through all the dialogs" do
         before do
-          allow(Y2Partitioner::Dialogs::PartitionRole).to receive(:run).and_return :next
           allow(Y2Partitioner::Dialogs::FormatAndMount).to receive(:run).and_return :next
         end
+
+        let(:dev_name) { "/dev/vg0/lv1" }
 
         it "returns :finish" do
           expect(sequence.run).to eq(:finish)
@@ -132,9 +132,10 @@ describe Y2Partitioner::Actions::EditBlkDevice do
 
       context "if the user aborts the process at some point" do
         before do
-          allow(Y2Partitioner::Dialogs::PartitionRole).to receive(:run).and_return :next
           allow(Y2Partitioner::Dialogs::FormatAndMount).to receive(:run).and_return :abort
         end
+
+        let(:dev_name) { "/dev/vg0/lv1" }
 
         it "returns :abort" do
           expect(sequence.run).to eq(:abort)

--- a/test/y2partitioner/actions/edit_blk_device_test.rb
+++ b/test/y2partitioner/actions/edit_blk_device_test.rb
@@ -39,6 +39,29 @@ describe Y2Partitioner::Actions::EditBlkDevice do
   describe "#run" do
     subject(:sequence) { described_class.new(device) }
 
+    let(:scenario) { "complex-lvm-encrypt.yml" }
+
+    let(:dev_name) { "/dev/sda1" }
+
+    # Regression test
+    it "uses the device belonging to the current devicegraph" do
+      # Only to finish
+      allow(subject).to receive(:run?).and_return(false)
+
+      initial_graph = current_graph
+
+      expect(Y2Partitioner::Actions::Controllers::Filesystem).to receive(:new) do |device, _title|
+        # Modifies used device
+        device.remove_descendants
+
+        # Initial device is not modified
+        initial_device = initial_graph.find_device(device.sid)
+        expect(initial_device.descendants).to_not be_empty
+      end
+
+      subject.run
+    end
+
     context "if called on an extended partition" do
       let(:scenario) { "mixed_disks.yml" }
 

--- a/test/y2partitioner/actions/resize_lvm_vg_test.rb
+++ b/test/y2partitioner/actions/resize_lvm_vg_test.rb
@@ -40,6 +40,26 @@ describe Y2Partitioner::Actions::ResizeLvmVg do
   subject { described_class.new(vg) }
 
   describe "#run" do
+    # Regression test
+    it "uses the device belonging to the current devicegraph" do
+      # Only to finish
+      allow(subject).to receive(:run?).and_return(false)
+
+      initial_graph = current_graph
+
+      expect(Y2Partitioner::Actions::Controllers::LvmVg).to receive(:new) do |params|
+        # Modifies used device
+        vg = params[:vg]
+        vg.vg_name = "foo"
+
+        # Initial device is not modified
+        initial_vg = initial_graph.find_device(vg.sid)
+        expect(initial_vg.vg_name).to_not eq("foo")
+      end
+
+      subject.run
+    end
+
     context "if the user goes forward through the dialog" do
       before do
         allow(Y2Partitioner::Dialogs::LvmVgResize).to receive(:run).and_return :next

--- a/test/y2partitioner/actions/resize_lvm_vg_test.rb
+++ b/test/y2partitioner/actions/resize_lvm_vg_test.rb
@@ -37,7 +37,7 @@ describe Y2Partitioner::Actions::ResizeLvmVg do
 
   let(:vg) { Y2Storage::LvmVg.find_by_vg_name(current_graph, "vg0") }
 
-  subject { described_class.new(vg: vg) }
+  subject { described_class.new(vg) }
 
   describe "#run" do
     context "if the user goes forward through the dialog" do

--- a/test/y2partitioner/actions/resize_md_test.rb
+++ b/test/y2partitioner/actions/resize_md_test.rb
@@ -40,6 +40,30 @@ describe Y2Partitioner::Actions::ResizeMd do
 
     let(:devicegraph) { Y2Partitioner::DeviceGraphs.instance.current }
 
+    let(:scenario) { "md_raid.xml" }
+
+    let(:md) { devicegraph.md_raids.first }
+
+    # Regression test
+    it "uses the device belonging to the current devicegraph" do
+      # Only to finish
+      allow(subject).to receive(:run?).and_return(false)
+
+      initial_graph = devicegraph
+
+      expect(Y2Partitioner::Actions::Controllers::Md).to receive(:new) do |params|
+        # Modifies used device
+        md = params[:md]
+        md.remove_descendants
+
+        # Initial device is not modified
+        initial_md = initial_graph.find_device(md.sid)
+        expect(initial_md.descendants).to_not be_empty
+      end
+
+      subject.run
+    end
+
     context "if the MD RAID already exists on the disk" do
       let(:scenario) { "md_raid.xml" }
 


### PR DESCRIPTION
Bug reports:
* https://bugzilla.suse.com/show_bug.cgi?id=1079880
* https://bugzilla.suse.com/show_bug.cgi?id=1079573

The issue is caused because a wrong object is used inside a `DeviceGraphs#transaction`. Partitioner actions should ensure that controllers are always created with the correct device.

Note: Unit tests were not able to detect those issues. Regression tests are now added.