### PR TITLE
[WIP] first version of fatal errors

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb 15 12:33:23 UTC 2018 - jreidinger@suse.com
+
+- Split detection of problematic boot scenarios into erros and
+  warnings. With warnings user can continue, but not with errors.
+  (bsc#1074475)
+- 4.0.95
+
+-------------------------------------------------------------------
 Wed Feb 14 09:39:42 UTC 2018 - jlopez@suse.com
 
 - PowerPC: do not require /boot partition for non-PowerNV

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Feb 15 12:33:23 UTC 2018 - jreidinger@suse.com
 
-- Split detection of problematic boot scenarios into erros and
+- Split detection of problematic boot scenarios into errors and
   warnings. With warnings user can continue, but not with errors.
   (bsc#1074475)
 - 4.0.95

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.94
+Version:        4.0.95
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/setup_errors_presenter.rb
+++ b/src/lib/y2partitioner/setup_errors_presenter.rb
@@ -44,13 +44,13 @@ module Y2Partitioner
     #
     # @return [String]
     def to_html
-      fatal_errors = fatal_errors_html
-      return fatal_errors if fatal_errors
+      errors = errors_html
+      return errors if errors
 
-      errors = [boot_errors_html, product_errors_html].compact
-      return "" if errors.empty?
+      warnings = [boot_warnings_html, product_warnings_html].compact
+      return "" if warnings.empty?
 
-      errors.join(Yast::HTML.Newline)
+      warnings.join(Yast::HTML.Newline)
     end
 
   private
@@ -58,37 +58,37 @@ module Y2Partitioner
     # @return [SetupChecker] checker for the current setup
     attr_reader :setup_checker
 
-    # HTML representation for boot errors
+    # HTML representation for boot warnings
     #
-    # @return [String, nil] nil if there is no boot error
-    def boot_errors_html
-      errors = setup_checker.boot_errors
+    # @return [String, nil] nil if there is no boot warning
+    def boot_warnings_html
+      warnings = setup_checker.boot_warnings
       # TRANSLATORS
       header = _("The system might not be able to boot:\n")
 
-      errors_html(header, errors)
+      create_html(header, warnings)
     end
 
-    # HTML representation for mandatory product errors
+    # HTML representation for mandatory product warnings
     #
-    # @return [String, nil] nil if there is no product error
-    def product_errors_html
-      errors = setup_checker.product_errors
+    # @return [String, nil] nil if there is no product warning
+    def product_warnings_html
+      warnings = setup_checker.product_warnings
       # TRANSLATORS
-      header = _("The system could not work properly because the following errors were found:\n")
+      header = _("The system could not work properly because the following warnings were found:\n")
 
-      errors_html(header, errors)
+      create_html(header, warnings)
     end
 
     # HTML representation for fatal booting errors
     #
-    # @return [String, nil] nil if there is no product error
-    def fatal_errors_html
-      errors = setup_checker.fatal_errors
+    # @return [String, nil] nil if there is no error
+    def errors_html
+      errors = setup_checker.errors
       # TRANSLATORS
       header = _("The system cannot be installed because the following errors were found:\n")
 
-      errors_html(header, errors)
+      create_html(header, errors)
     end
 
     # HTML representation for a set of errors
@@ -99,7 +99,7 @@ module Y2Partitioner
     # @param errors [Array<SetupError>] list of errors
     #
     # @return [String, nil] nil if there is no error
-    def errors_html(header, errors)
+    def create_html(header, errors)
       return nil if errors.empty?
 
       error_messages = errors.map(&:message)

--- a/src/lib/y2partitioner/setup_errors_presenter.rb
+++ b/src/lib/y2partitioner/setup_errors_presenter.rb
@@ -44,7 +44,7 @@ module Y2Partitioner
     #
     # @return [String]
     def to_html
-      errors_html || warnings_html || nil
+      errors_html || warnings_html || ""
     end
 
   private

--- a/src/lib/y2partitioner/setup_errors_presenter.rb
+++ b/src/lib/y2partitioner/setup_errors_presenter.rb
@@ -44,19 +44,23 @@ module Y2Partitioner
     #
     # @return [String]
     def to_html
-      errors = errors_html
-      return errors if errors
-
-      warnings = [boot_warnings_html, product_warnings_html].compact
-      return "" if warnings.empty?
-
-      warnings.join(Yast::HTML.Newline)
+      errors_html || warnings_html || nil
     end
 
   private
 
     # @return [SetupChecker] checker for the current setup
     attr_reader :setup_checker
+
+    # HTML representation for boot warnings
+    #
+    # @return [String, nil] nil if there is no boot warning
+    def warnings_html
+      warnings = [boot_warnings_html, product_warnings_html].compact
+      return nil if warnings.empty?
+
+      warnings.join(Yast::HTML.Newline)
+    end
 
     # HTML representation for boot warnings
     #
@@ -75,7 +79,7 @@ module Y2Partitioner
     def product_warnings_html
       warnings = setup_checker.product_warnings
       # TRANSLATORS
-      header = _("The system could not work properly because the following warnings were found:\n")
+      header = _("The system could not work properly because the following product requirements were not fulfilled:\n")
 
       create_html(header, warnings)
     end

--- a/src/lib/y2partitioner/setup_errors_presenter.rb
+++ b/src/lib/y2partitioner/setup_errors_presenter.rb
@@ -79,7 +79,10 @@ module Y2Partitioner
     def product_warnings_html
       warnings = setup_checker.product_warnings
       # TRANSLATORS
-      header = _("The system could not work properly because the following product requirements were not fulfilled:\n")
+      header = _(
+        "The system could not work properly because the following product " \
+          "requirements were not fulfilled:\n"
+      )
 
       create_html(header, warnings)
     end

--- a/src/lib/y2partitioner/setup_errors_presenter.rb
+++ b/src/lib/y2partitioner/setup_errors_presenter.rb
@@ -44,6 +44,9 @@ module Y2Partitioner
     #
     # @return [String]
     def to_html
+      fatal_errors = fatal_errors_html
+      return fatal_errors if fatal_errors
+
       errors = [boot_errors_html, product_errors_html].compact
       return "" if errors.empty?
 
@@ -73,6 +76,17 @@ module Y2Partitioner
       errors = setup_checker.product_errors
       # TRANSLATORS
       header = _("The system could not work properly because the following errors were found:\n")
+
+      errors_html(header, errors)
+    end
+
+    # HTML representation for fatal booting errors
+    #
+    # @return [String, nil] nil if there is no product error
+    def fatal_errors_html
+      errors = setup_checker.fatal_errors
+      # TRANSLATORS
+      header = _("The system cannot be installed because the following errors were found:\n")
 
       errors_html(header, errors)
     end

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -123,13 +123,20 @@ module Y2Partitioner
         return true if setup_checker.valid?
 
         errors = SetupErrorsPresenter.new(setup_checker).to_html
-        # FIXME: improve Yast2::Popup to allow some text before the buttons
-        errors += _("Do you want to continue?")
 
-        result = Yast2::Popup.show(errors,
-          headline: :error, richtext: true, buttons: :yes_no, focus: :no)
+        if setup_checker.fatal_errors.empty?
+          # FIXME: improve Yast2::Popup to allow some text before the buttons
+          errors += _("Do you want to continue?")
 
-        result == :yes
+          result = Yast2::Popup.show(errors,
+            headline: :error, richtext: true, buttons: :yes_no, focus: :no)
+
+          result == :yes
+        else
+          result = Yast2::Popup.show(errors,
+            headline: :error, richtext: true, buttons: :ok)
+          false
+        end
       end
 
     private

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -133,7 +133,7 @@ module Y2Partitioner
 
           result == :yes
         else
-          result = Yast2::Popup.show(errors,
+          Yast2::Popup.show(errors,
             headline: :error, richtext: true, buttons: :ok)
           false
         end

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -124,7 +124,7 @@ module Y2Partitioner
 
         errors = SetupErrorsPresenter.new(setup_checker).to_html
 
-        if setup_checker.fatal_errors.empty?
+        if setup_checker.errors.empty? # so only warnings there
           # FIXME: improve Yast2::Popup to allow some text before the buttons
           errors += _("Do you want to continue?")
 

--- a/src/lib/y2storage/boot_requirements_checker.rb
+++ b/src/lib/y2storage/boot_requirements_checker.rb
@@ -73,7 +73,6 @@ module Y2Storage
     # All boot warnings detected in the setup, for example, when size of a /boot/efi partition
     # is out of borders.
     #
-    # @raise Error if {fatal_errors} is not empty
     # @see SetupError
     #
     # @return [Array<SetupError>]

--- a/src/lib/y2storage/boot_requirements_checker.rb
+++ b/src/lib/y2storage/boot_requirements_checker.rb
@@ -67,18 +67,18 @@ module Y2Storage
     #
     # @return [Boolean]
     def valid?
-      errors.empty?
+      errors.empty? && warnings.empty?
     end
 
-    # All boot errors detected in the setup, for example, when size of a /boot/efi partition
+    # All boot warnings detected in the setup, for example, when size of a /boot/efi partition
     # is out of borders.
     #
     # @raise Error if {fatal_errors} is not empty
     # @see SetupError
     #
     # @return [Array<SetupError>]
-    def errors
-      strategy.errors
+    def warnings
+      strategy.warnings
     end
 
     # All fatal boot errors detected in the setup, for example, when a /boot/efi partition
@@ -87,8 +87,8 @@ module Y2Storage
     # @see SetupError
     #
     # @return [Array<SetupError>]
-    def fatal_errors
-      strategy.fatal_errors
+    def errors
+      strategy.errors
     end
 
   protected

--- a/src/lib/y2storage/boot_requirements_checker.rb
+++ b/src/lib/y2storage/boot_requirements_checker.rb
@@ -70,14 +70,25 @@ module Y2Storage
       errors.empty?
     end
 
-    # All boot errors detected in the setup, for example, when a /boot/efi partition
-    # is missing in a UEFI system
+    # All boot errors detected in the setup, for example, when size of a /boot/efi partition
+    # is out of borders.
     #
+    # @raise Error if {fatal_errors} is not empty
     # @see SetupError
     #
     # @return [Array<SetupError>]
     def errors
       strategy.errors
+    end
+
+    # All fatal boot errors detected in the setup, for example, when a /boot/efi partition
+    # is missing in a UEFI system
+    #
+    # @see SetupError
+    #
+    # @return [Array<SetupError>]
+    def fatal_errors
+      strategy.fatal_errors
     end
 
   protected

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -68,17 +68,14 @@ module Y2Storage
         planned_partitions
       end
 
-      # All boot errors detected in the setup, for example, when a /boot/efi partition
-      # is missing in a UEFI system
+      # All boot warnings detected in the setup, for example, when required partition is too small
       #
       # @note This method should be overloaded for derived classes.
       #
       # @see SetupError
       #
       # @return [Array<SetupError>]
-      def errors
-        raise Error, "There are fatal errors, so cannot detect soft errors." unless fatal_errors.empty?
-
+      def warnings
         []
       end
 
@@ -90,7 +87,7 @@ module Y2Storage
       # @see SetupError
       #
       # @return [Array<SetupError>]
-      def fatal_errors
+      def errors
         res = []
         if root_filesystem_missing?
           error_message = _("There is no device mounted to '/'")

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -90,7 +90,7 @@ module Y2Storage
       def errors
         res = []
         if root_filesystem_missing?
-          error_message = _("There is no device mounted to '/'")
+          error_message = _("There is no device mounted at '/'")
           res << SetupError.new(message: error_message)
         end
 

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -77,7 +77,27 @@ module Y2Storage
       #
       # @return [Array<SetupError>]
       def errors
+        raise Error, "There are fatal errors, so cannot detect soft errors." unless fatal_errors.empty?
+
         []
+      end
+
+      # All fatal boot errors detected in the setup, for example, when a / partition
+      # is missing
+      #
+      # @note This method can be overloaded for derived classes.
+      #
+      # @see SetupError
+      #
+      # @return [Array<SetupError>]
+      def fatal_errors
+        res = []
+        if root_filesystem_missing?
+          error_message = _("There is no device mounted to '/'")
+          res << SetupError.new(message: error_message)
+        end
+
+        res
       end
 
     protected

--- a/src/lib/y2storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/legacy.rb
@@ -43,17 +43,23 @@ module Y2Storage
       def errors
         errors = super
 
-        if root_filesystem_missing?
-          errors << unknown_boot_disk_error
-        elsif boot_partition_table_missing?
-          errors << unknown_boot_partition_table_error
-        elsif boot_ptable_type?(:gpt)
+        if boot_ptable_type?(:gpt)
           errors += errors_on_gpt
         else
           errors += errors_on_msdos
         end
 
         errors
+      end
+
+      def fatal_errors
+        res = super
+
+        if boot_partition_table_missing?
+          res << unknown_boot_partition_table_error
+        end
+
+        res
       end
 
     protected
@@ -177,8 +183,7 @@ module Y2Storage
       def unknown_boot_partition_table_error
         # TRANSLATORS: error message
         error_message = _(
-          "Boot requirements cannot be determined because " \
-          "boot disk has not partition table"
+          "Boot disk is without partition table"
         )
         SetupError.new(message: error_message)
       end

--- a/src/lib/y2storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/legacy.rb
@@ -37,22 +37,22 @@ module Y2Storage
         planned_partitions
       end
 
-      # Boot errors in the current setup
+      # Boot warnings in the current setup
       #
       # @return [Array<SetupError>]
-      def errors
-        errors = super
+      def warnings
+        res = super
 
         if boot_ptable_type?(:gpt)
-          errors += errors_on_gpt
+          res.concat(errors_on_gpt)
         else
-          errors += errors_on_msdos
+          res.concat(errors_on_msdos)
         end
 
-        errors
+        res
       end
 
-      def fatal_errors
+      def errors
         res = super
 
         if boot_partition_table_missing?

--- a/src/lib/y2storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/legacy.rb
@@ -52,8 +52,13 @@ module Y2Storage
         res
       end
 
+      # Boot errors in the current setup
+      #
+      # @return [Array<SetupError>]
       def errors
         res = super
+        # other checks is useless if we have base fatal error
+        return res unless res.empty?
 
         if boot_partition_table_missing?
           res << unknown_boot_partition_table_error
@@ -183,7 +188,8 @@ module Y2Storage
       def unknown_boot_partition_table_error
         # TRANSLATORS: error message
         error_message = _(
-          "Boot disk is without partition table"
+          "Boot disk is without partition table and we does not support " \
+            "booting from it. You can fix it by creating partition table on disk."
         )
         SetupError.new(message: error_message)
       end

--- a/src/lib/y2storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/legacy.rb
@@ -188,8 +188,8 @@ module Y2Storage
       def unknown_boot_partition_table_error
         # TRANSLATORS: error message
         error_message = _(
-          "Boot disk is without partition table and we does not support " \
-            "booting from it. You can fix it by creating partition table on disk."
+          "Boot disk has no partition table and it is not possible to boot from it." \
+          "You can fix it by creating a partition table on the boot disk."
         )
         SetupError.new(message: error_message)
       end

--- a/src/lib/y2storage/boot_requirements_strategies/prep.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/prep.rb
@@ -42,16 +42,12 @@ module Y2Storage
       def errors
         errors = super
 
-        if root_filesystem_missing?
-          errors << unknown_boot_disk_error
-        else
-          if prep_partition_needed? && missing_partition_for?(prep_volume)
-            errors << SetupError.new(missing_volume: prep_volume)
-          end
+        if prep_partition_needed? && missing_partition_for?(prep_volume)
+          errors << SetupError.new(missing_volume: prep_volume)
+        end
 
-          if boot_partition_needed? && missing_partition_for?(boot_volume)
-            errors << SetupError.new(missing_volume: boot_volume)
-          end
+        if boot_partition_needed? && missing_partition_for?(boot_volume)
+          errors << SetupError.new(missing_volume: boot_volume)
         end
 
         errors
@@ -60,6 +56,9 @@ module Y2Storage
     protected
 
       def boot_partition_needed?
+        # FIXME: I (JR) think this is needed only for powernv where firmware have
+        #        to load grub2 configuration and kernel itself. For prep case
+        #        grub2 loads it itself.
         root_in_lvm? || root_in_software_raid? || encrypted_root?
       end
 

--- a/src/lib/y2storage/boot_requirements_strategies/prep.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/prep.rb
@@ -56,6 +56,12 @@ module Y2Storage
     protected
 
       def boot_partition_needed?
+        # PowerNV uses it's own firmware instead of Grub stage 1, but other
+        # PPC systems use regular Grub. Just use the default logic for those.
+        return super unless arch.ppc_power_nv?
+
+        # We cannot ensure the mentioned firmware can handle technologies like
+        # LVM, MD or LUKS, so propose a separate /boot partition for those cases
         root_in_lvm? || root_in_software_raid? || encrypted_root?
       end
 

--- a/src/lib/y2storage/boot_requirements_strategies/prep.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/prep.rb
@@ -36,21 +36,21 @@ module Y2Storage
         planned_partitions
       end
 
-      # Boot errors in the current setup
+      # Boot warnings in the current setup
       #
       # @return [Array<SetupError>]
-      def errors
-        errors = super
+      def warnings
+        res = super
 
         if prep_partition_needed? && missing_partition_for?(prep_volume)
-          errors << SetupError.new(missing_volume: prep_volume)
+          res << SetupError.new(missing_volume: prep_volume)
         end
 
         if boot_partition_needed? && missing_partition_for?(boot_volume)
-          errors << SetupError.new(missing_volume: boot_volume)
+          res << SetupError.new(missing_volume: boot_volume)
         end
 
-        errors
+        res
       end
 
     protected

--- a/src/lib/y2storage/boot_requirements_strategies/uefi.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/uefi.rb
@@ -37,16 +37,16 @@ module Y2Storage
       # Boot errors in the current setup
       #
       # @return [Array<SetupError>]
-      def errors
-        errors = super
+      def warnings
+        res = super
 
         # missing EFI does not need to be fatal e.g. when boot from network.
         # User just have to not select grub2-efi bootloader.
         if missing_partition_for?(efi_volume)
-          errors << SetupError.new(missing_volume: efi_volume)
+          res << SetupError.new(missing_volume: efi_volume)
         end
 
-        errors
+        res
       end
 
     protected

--- a/src/lib/y2storage/boot_requirements_strategies/uefi.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/uefi.rb
@@ -40,8 +40,8 @@ module Y2Storage
       def warnings
         res = super
 
-        # missing EFI does not need to be fatal e.g. when boot from network.
-        # User just have to not select grub2-efi bootloader.
+        # Missing EFI does not need to be a fatal (e.g. when boot from network).
+        # User just has to not select grub2-efi bootloader.
         if missing_partition_for?(efi_volume)
           res << SetupError.new(missing_volume: efi_volume)
         end

--- a/src/lib/y2storage/boot_requirements_strategies/uefi.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/uefi.rb
@@ -40,6 +40,8 @@ module Y2Storage
       def errors
         errors = super
 
+        # missing EFI does not need to be fatal e.g. when boot from network.
+        # User just have to not select grub2-efi bootloader.
         if missing_partition_for?(efi_volume)
           errors << SetupError.new(missing_volume: efi_volume)
         end

--- a/src/lib/y2storage/boot_requirements_strategies/zipl.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/zipl.rb
@@ -50,7 +50,7 @@ module Y2Storage
         res = super
         return res unless res.empty?
 
-        if missing_partition_for?(zipl_volume)
+        if missing_partition_for?(minimal_zipl_volume)
           res << SetupError.new(missing_volume: minimal_zipl_volume)
         end
 

--- a/src/lib/y2storage/boot_requirements_strategies/zipl.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/zipl.rb
@@ -31,27 +31,16 @@ module Y2Storage
         zipl_partition_missing? ? [zipl_partition(target)] : []
       end
 
-      # Boot errors in the current setup
+      # Boot warnings in the current setup
       #
       # @return [Array<SetupError>]
-      def errors
-        errors = super
+      def warnings
+        res = super
 
         if !supported_boot_disk?
-          errors << unsupported_boot_disk_error
+          res << unsupported_boot_disk_error
         elsif missing_partition_for?(zipl_volume)
-          errors << SetupError.new(missing_volume: zipl_volume)
-        end
-
-        errors
-      end
-
-      def fatal_errors
-        res = super
-        return res unless res.empty?
-
-        if missing_partition_for?(minimal_zipl_volume)
-          res << SetupError.new(missing_volume: minimal_zipl_volume)
+          res << SetupError.new(missing_volume: zipl_volume)
         end
 
         res
@@ -85,16 +74,6 @@ module Y2Storage
         @zipl_volume.desired_size = DiskSize.MiB(200)
         @zipl_volume.max_size = DiskSize.GiB(1)
         @zipl_volume
-      end
-
-      # Minimal zipl requirement for which we are sure we cannot boot
-      # @return [VolumeSpecification]
-      def minimal_zipl_volume
-        res = VolumeSpecification.new({})
-        res.mount_point = "/boot/zipl"
-        res.fs_types = Filesystems::Type.zipl_filesystems
-
-        res
       end
 
       # @return [Planned::Partition]

--- a/src/lib/y2storage/boot_requirements_strategies/zipl.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/zipl.rb
@@ -37,15 +37,24 @@ module Y2Storage
       def errors
         errors = super
 
-        if root_filesystem_missing?
-          errors << unknown_boot_disk_error
-        elsif !supported_boot_disk?
+        if !supported_boot_disk?
           errors << unsupported_boot_disk_error
         elsif missing_partition_for?(zipl_volume)
           errors << SetupError.new(missing_volume: zipl_volume)
         end
 
         errors
+      end
+
+      def fatal_errors
+        res = super
+        return res unless res.empty?
+
+        if missing_partition_for?(zipl_volume)
+          res << SetupError.new(missing_volume: minimal_zipl_volume)
+        end
+
+        res
       end
 
     protected
@@ -76,6 +85,16 @@ module Y2Storage
         @zipl_volume.desired_size = DiskSize.MiB(200)
         @zipl_volume.max_size = DiskSize.GiB(1)
         @zipl_volume
+      end
+
+      # Minimal zipl requirement for which we are sure we cannot boot
+      # @return [VolumeSpecification]
+      def minimal_zipl_volume
+        res = VolumeSpecification.new({})
+        res.mount_point = "/boot/zipl"
+        res.fs_types = Filesystems::Type.zipl_filesystems
+
+        res
       end
 
       # @return [Planned::Partition]

--- a/src/lib/y2storage/setup_checker.rb
+++ b/src/lib/y2storage/setup_checker.rb
@@ -55,24 +55,24 @@ module Y2Storage
     #
     # @return [Boolean]
     def valid?
-      fatal_errors.empty? && errors.empty?
+      errors.empty? && warnings.empty?
     end
 
     # Whether the system contain fatal errors preventing to continue
     #
     # @return [Array<SetupError>]
-    def fatal_errors
-      boot_requirements_checker.fatal_errors
+    def errors
+      boot_requirements_checker.errors
     end
 
-    # All storage errors detected in the setup, for example, when a /boot/efi partition
-    # is missing in a UEFI system, or a valid partition for root is missing.
+    # All storage warnings detected in the setup, for example, when a /boot/efi partition
+    # is missing in a UEFI system, or missing separate /boot.
     #
     # @see SetupError
     #
     # @return [Array<SetupError>]
-    def errors
-      boot_errors + product_errors
+    def warnings
+      boot_warnings + product_warnings
     end
 
     # All boot errors detected in the setup
@@ -80,18 +80,18 @@ module Y2Storage
     # @return [Array<SetupError>]
     #
     # @see BootRequirementsChecker#errors
-    def boot_errors
-      @boot_errors ||= boot_requirements_checker.errors
+    def boot_warnings
+      @boot_warnings ||= boot_requirements_checker.warnings
     end
 
-    # All product errors detected in the setup
+    # All product warnings detected in the setup
     #
     # This checks that all mandatory volumes specified in control file are present
     # in the system.
     #
     # @return [Array<SetupError>]
-    def product_errors
-      @product_errors ||= missing_product_volumes.map { |v| SetupError.new(missing_volume: v) }
+    def product_warnings
+      @product_warnings ||= missing_product_volumes.map { |v| SetupError.new(missing_volume: v) }
     end
 
   private

--- a/src/lib/y2storage/setup_checker.rb
+++ b/src/lib/y2storage/setup_checker.rb
@@ -66,7 +66,7 @@ module Y2Storage
     end
 
     # All storage warnings detected in the setup, for example, when a /boot/efi partition
-    # is missing in a UEFI system, or missing separate /boot.
+    # is missing in a UEFI system, or a required product volume (e.g., swap) is missing.
     #
     # @see SetupError
     #
@@ -139,6 +139,8 @@ module Y2Storage
       BlkDevice.all(devicegraph).none? { |d| d.match_volume?(volume) }
     end
 
+    # @return [BootRequirementsChecker] shortcut for boot requirements checker
+    # with given device graph
     def boot_requirements_checker
       @boot_requirements_checker ||= BootRequirementsChecker.new(devicegraph)
     end

--- a/src/lib/y2storage/setup_checker.rb
+++ b/src/lib/y2storage/setup_checker.rb
@@ -55,14 +55,14 @@ module Y2Storage
     #
     # @return [Boolean]
     def valid?
-      errors.empty?
+      fatal_errors.empty? && errors.empty?
     end
 
-    # Whether the system would be bootable using current setup
+    # Whether the system contain fatal errors preventing to continue
     #
-    # @return[Boolean] true if the system is bootable; false otherwise.
-    def bootable?
-      boot_errors.empty?
+    # @return [Array<SetupError>]
+    def fatal_errors
+      boot_requirements_checker.fatal_errors
     end
 
     # All storage errors detected in the setup, for example, when a /boot/efi partition
@@ -81,7 +81,7 @@ module Y2Storage
     #
     # @see BootRequirementsChecker#errors
     def boot_errors
-      @boot_errors ||= BootRequirementsChecker.new(devicegraph).errors
+      @boot_errors ||= boot_requirements_checker.errors
     end
 
     # All product errors detected in the setup
@@ -137,6 +137,10 @@ module Y2Storage
     # @return [Boolean] true if the volume is missing; false otherwise.
     def missing?(volume)
       BlkDevice.all(devicegraph).none? { |d| d.match_volume?(volume) }
+    end
+
+    def boot_requirements_checker
+      @boot_requirements_checker ||= BootRequirementsChecker.new(devicegraph)
     end
   end
 end

--- a/test/y2partitioner/setup_errors_presenter_test.rb
+++ b/test/y2partitioner/setup_errors_presenter_test.rb
@@ -31,9 +31,9 @@ describe Y2Partitioner::SetupErrorsPresenter do
 
   before do
     Y2Storage::StorageManager.create_test_instance
-    allow(setup_checker).to receive(:boot_errors).and_return(boot_errors)
-    allow(setup_checker).to receive(:product_errors).and_return(product_errors)
-    allow(setup_checker).to receive(:fatal_errors).and_return(fatal_errors)
+    allow(setup_checker).to receive(:boot_warnings).and_return(boot_errors)
+    allow(setup_checker).to receive(:product_warnings).and_return(product_errors)
+    allow(setup_checker).to receive(:errors).and_return(fatal_errors)
   end
 
   subject { described_class.new(setup_checker) }

--- a/test/y2partitioner/setup_errors_presenter_test.rb
+++ b/test/y2partitioner/setup_errors_presenter_test.rb
@@ -33,11 +33,14 @@ describe Y2Partitioner::SetupErrorsPresenter do
     Y2Storage::StorageManager.create_test_instance
     allow(setup_checker).to receive(:boot_errors).and_return(boot_errors)
     allow(setup_checker).to receive(:product_errors).and_return(product_errors)
+    allow(setup_checker).to receive(:fatal_errors).and_return(fatal_errors)
   end
 
   subject { described_class.new(setup_checker) }
 
   let(:boot_errors) { [] }
+
+  let(:fatal_errors) { [] }
 
   let(:product_errors) { [] }
 
@@ -48,6 +51,14 @@ describe Y2Partitioner::SetupErrorsPresenter do
 
       it "returns an empty string" do
         expect(subject.to_html).to be_empty
+      end
+    end
+
+    context "when there are fatal errors" do
+      let(:fatal_errors) { [instance_double(Y2Storage::SetupError, message: "fatal error 1")] }
+
+      it "contains messages only for fatal errors" do
+        expect(subject.to_html).to match(/fatal error 1/)
       end
     end
 

--- a/test/y2partitioner/widgets/overview_test.rb
+++ b/test/y2partitioner/widgets/overview_test.rb
@@ -222,7 +222,7 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
     before do
       allow(Y2Storage::SetupChecker).to receive(:new).and_return(checker)
       allow(checker).to receive(:valid?).and_return(valid_setup)
-      allow(checker).to receive(:fatal_errors).and_return(fatal_errors)
+      allow(checker).to receive(:errors).and_return(fatal_errors)
 
       allow(Y2Partitioner::SetupErrorsPresenter).to receive(:new).and_return(presenter)
       allow(presenter).to receive(:to_html).and_return("html representation")

--- a/test/y2partitioner/widgets/overview_test.rb
+++ b/test/y2partitioner/widgets/overview_test.rb
@@ -222,6 +222,7 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
     before do
       allow(Y2Storage::SetupChecker).to receive(:new).and_return(checker)
       allow(checker).to receive(:valid?).and_return(valid_setup)
+      allow(checker).to receive(:fatal_errors).and_return(fatal_errors)
 
       allow(Y2Partitioner::SetupErrorsPresenter).to receive(:new).and_return(presenter)
       allow(presenter).to receive(:to_html).and_return("html representation")
@@ -237,27 +238,46 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
 
     let(:user_input) { nil }
 
+    let(:fatal_errors) { [] }
+
     context "when the current setup is not valid" do
-      let(:valid_setup) { false }
+      context "and when errors are fatal" do
+        let(:valid_setup) { false }
+        let(:fatal_errors) { [double] }
 
-      it "shows an error popup" do
-        expect(Yast2::Popup).to receive(:show)
-        subject.validate
-      end
+        it "shows an error popup" do
+          expect(Yast2::Popup).to receive(:show)
+          subject.validate
+        end
 
-      context "and the user accepts to continue" do
-        let(:user_input) { :yes }
-
-        it "returns true" do
-          expect(subject.validate).to eq(true)
+        it "prevents continuing" do
+          expect(Yast2::Popup).to receive(:show)
+          expect(subject.validate).to eq(false)
         end
       end
 
-      context "and the user declines to continue" do
-        let(:user_input) { :no }
+      context "and errors are no fatal" do
+        let(:valid_setup) { false }
 
-        it "returns false" do
-          expect(subject.validate).to eq(false)
+        it "shows an error popup" do
+          expect(Yast2::Popup).to receive(:show)
+          subject.validate
+        end
+
+        context "and the user accepts to continue" do
+          let(:user_input) { :yes }
+
+          it "returns true" do
+            expect(subject.validate).to eq(true)
+          end
+        end
+
+        context "and the user declines to continue" do
+          let(:user_input) { :no }
+
+          it "returns false" do
+            expect(subject.validate).to eq(false)
+          end
         end
       end
     end

--- a/test/y2storage/boot_requirements_errors_test.rb
+++ b/test/y2storage/boot_requirements_errors_test.rb
@@ -222,9 +222,6 @@ describe Y2Storage::BootRequirementsChecker do
       allow_any_instance_of(Y2Storage::BootRequirementsStrategies::ZIPL)
         .to receive(:zipl_volume).and_return(zipl_volume)
 
-      allow_any_instance_of(Y2Storage::BootRequirementsStrategies::ZIPL)
-        .to receive(:minimal_zipl_volume).and_return(zipl_volume)
-
       allow(Y2Storage::Partition).to receive(:all).and_return partitions
 
       allow(boot_partition).to receive(:match_volume?).with(anything).and_return(false)
@@ -284,7 +281,7 @@ describe Y2Storage::BootRequirementsChecker do
         context "when boot device has no partition table" do
           let(:boot_partition_table) { nil }
 
-          it "contains an fatal error for unknown partition table" do
+          it "contains a fatal error for unknown partition table" do
             expect(checker.errors.size).to eq(1)
             expect(checker.errors).to all(be_a(Y2Storage::SetupError))
 

--- a/test/y2storage/boot_requirements_errors_test.rb
+++ b/test/y2storage/boot_requirements_errors_test.rb
@@ -405,19 +405,7 @@ describe Y2Storage::BootRequirementsChecker do
 
         context "with a partitions-based proposal" do
           let(:use_lvm) { false }
-
-          context "and there is no a PReP partition in the system" do
-            let(:partitions) { [boot_partition] }
-            include_examples "missing prep partition"
-          end
-
-          context "and there is a PReP partition in the system" do
-            let(:partitions) { [boot_partition, prep_partition] }
-
-            it "does not contain errors" do
-              expect(checker.warnings).to be_empty
-            end
-          end
+          include_examples "PReP partition"
         end
 
         context "with a LVM-based proposal" do

--- a/test/y2storage/boot_requirements_errors_test.rb
+++ b/test/y2storage/boot_requirements_errors_test.rb
@@ -103,7 +103,7 @@ describe Y2Storage::BootRequirementsChecker do
         expect(checker.errors).to all(be_a(Y2Storage::SetupError))
 
         message = checker.errors.first.message
-        expect(message).to match(/no device mounted to '\/'/)
+        expect(message).to match(/no device mounted at '\/'/)
       end
     end
 
@@ -406,7 +406,18 @@ describe Y2Storage::BootRequirementsChecker do
         context "with a partitions-based proposal" do
           let(:use_lvm) { false }
 
-          include_examples "PReP partition"
+          context "and there is no a PReP partition in the system" do
+            let(:partitions) { [boot_partition] }
+            include_examples "missing prep partition"
+          end
+
+          context "and there is a PReP partition in the system" do
+            let(:partitions) { [boot_partition, prep_partition] }
+
+            it "does not contain errors" do
+              expect(checker.warnings).to be_empty
+            end
+          end
         end
 
         context "with a LVM-based proposal" do

--- a/test/y2storage/setup_checker_test.rb
+++ b/test/y2storage/setup_checker_test.rb
@@ -48,6 +48,7 @@ describe Y2Storage::SetupChecker do
   before do
     allow(Y2Storage::BootRequirementsChecker).to receive(:new).and_return(boot_checker)
     allow(boot_checker).to receive(:errors).and_return(boot_errors)
+    allow(boot_checker).to receive(:fatal_errors).and_return(fatal_errors)
 
     allow(Y2Storage::ProposalSettings).to receive(:new_for_current_product).and_return(settings)
     allow(settings).to receive(:volumes).and_return(product_volumes)
@@ -58,6 +59,8 @@ describe Y2Storage::SetupChecker do
   let(:settings) { instance_double(Y2Storage::ProposalSettings) }
 
   let(:boot_errors) { [] }
+
+  let(:fatal_errors) { [] }
 
   let(:product_volumes) { [] }
 
@@ -114,6 +117,14 @@ describe Y2Storage::SetupChecker do
       end
     end
 
+    context "when there is a fatal error" do
+      let(:fatal_errors) { [boot_error] }
+
+      it "returns false" do
+        expect(subject.valid?).to eq(false)
+      end
+    end
+
     context "when all mandatory product volumes are present in the system and there is no boot error" do
       let(:product_volumes) { [root_volume, home_volume] }
       let(:boot_errors) { [] }
@@ -124,24 +135,6 @@ describe Y2Storage::SetupChecker do
 
       it "returns true" do
         expect(subject.valid?).to eq(true)
-      end
-    end
-  end
-
-  describe "#bootable?" do
-    context "when there is some boot error" do
-      let(:boot_errors) { [boot_error] }
-
-      it "returns false" do
-        expect(subject.bootable?).to eq(false)
-      end
-    end
-
-    context "when there is no boot error" do
-      let(:boot_errors) { [] }
-
-      it "returns true" do
-        expect(subject.bootable?).to eq(true)
       end
     end
   end

--- a/test/y2storage/setup_checker_test.rb
+++ b/test/y2storage/setup_checker_test.rb
@@ -224,8 +224,12 @@ describe Y2Storage::SetupChecker do
     end
 
     it "includes an error for each mandatory product volume not present in the system" do
-      expect(subject.product_warnings).to include(an_object_having_attributes(missing_volume: root_volume))
-      expect(subject.product_warnings).to include(an_object_having_attributes(missing_volume: swap_volume))
+      expect(subject.product_warnings).to include(
+        an_object_having_attributes(missing_volume: root_volume)
+      )
+      expect(subject.product_warnings).to include(
+        an_object_having_attributes(missing_volume: swap_volume)
+      )
     end
 
     context "when a mandatory product volume is present in the system" do

--- a/test/y2storage/setup_checker_test.rb
+++ b/test/y2storage/setup_checker_test.rb
@@ -47,8 +47,8 @@ describe Y2Storage::SetupChecker do
 
   before do
     allow(Y2Storage::BootRequirementsChecker).to receive(:new).and_return(boot_checker)
-    allow(boot_checker).to receive(:errors).and_return(boot_errors)
-    allow(boot_checker).to receive(:fatal_errors).and_return(fatal_errors)
+    allow(boot_checker).to receive(:warnings).and_return(boot_warnings)
+    allow(boot_checker).to receive(:errors).and_return(fatal_errors)
 
     allow(Y2Storage::ProposalSettings).to receive(:new_for_current_product).and_return(settings)
     allow(settings).to receive(:volumes).and_return(product_volumes)
@@ -58,7 +58,7 @@ describe Y2Storage::SetupChecker do
 
   let(:settings) { instance_double(Y2Storage::ProposalSettings) }
 
-  let(:boot_errors) { [] }
+  let(:boot_warnings) { [] }
 
   let(:fatal_errors) { [] }
 
@@ -101,7 +101,7 @@ describe Y2Storage::SetupChecker do
   describe "#valid?" do
     context "when some mandatory product volume is not present in the system" do
       let(:product_volumes) { [root_volume, home_volume] }
-      let(:boot_errors) { [] }
+      let(:boot_warnings) { [] }
 
       it "returns false" do
         expect(subject.valid?).to eq(false)
@@ -110,7 +110,7 @@ describe Y2Storage::SetupChecker do
 
     context "when there is some boot error" do
       let(:product_volumes) { [] }
-      let(:boot_errors) { [boot_error] }
+      let(:boot_warnings) { [boot_error] }
 
       it "returns false" do
         expect(subject.valid?).to eq(false)
@@ -127,7 +127,7 @@ describe Y2Storage::SetupChecker do
 
     context "when all mandatory product volumes are present in the system and there is no boot error" do
       let(:product_volumes) { [root_volume, home_volume] }
-      let(:boot_errors) { [] }
+      let(:boot_warnings) { [] }
 
       before do
         create_root
@@ -139,24 +139,24 @@ describe Y2Storage::SetupChecker do
     end
   end
 
-  describe "#errors" do
+  describe "#warnings" do
     let(:boot_error1) { instance_double(Y2Storage::SetupError) }
     let(:boot_error2) { instance_double(Y2Storage::SetupError) }
-    let(:boot_errors) { [boot_error1, boot_error2] }
+    let(:boot_warnings) { [boot_error1, boot_error2] }
 
     let(:product_volumes) { [root_volume, swap_volume, home_volume] }
 
-    it "includes all boot errors" do
-      expect(subject.errors).to include(boot_error1, boot_error2)
+    it "includes all boot warnings" do
+      expect(subject.warnings).to include(boot_error1, boot_error2)
     end
 
     it "does not include an error for optional product volumes" do
-      expect(subject.errors).to_not include(an_object_having_attributes(missing_volume: home_volume))
+      expect(subject.warnings).to_not include(an_object_having_attributes(missing_volume: home_volume))
     end
 
     it "includes an error for each mandatory product volume not present in the system" do
-      expect(subject.errors).to include(an_object_having_attributes(missing_volume: root_volume))
-      expect(subject.errors).to include(an_object_having_attributes(missing_volume: swap_volume))
+      expect(subject.warnings).to include(an_object_having_attributes(missing_volume: root_volume))
+      expect(subject.warnings).to include(an_object_having_attributes(missing_volume: swap_volume))
     end
 
     context "when a mandatory product volume is present in the system" do
@@ -165,12 +165,12 @@ describe Y2Storage::SetupChecker do
       end
 
       it "does not include an error for that volume" do
-        expect(subject.errors).to_not include(an_object_having_attributes(missing_volume: root_volume))
+        expect(subject.warnings).to_not include(an_object_having_attributes(missing_volume: root_volume))
       end
     end
 
     context "when there is no boot error and all mandatory product volumes are present in the system" do
-      let(:boot_errors) { [] }
+      let(:boot_warnings) { [] }
       let(:product_volumes) { [root_volume, home_volume] }
 
       before do
@@ -178,54 +178,54 @@ describe Y2Storage::SetupChecker do
       end
 
       it "returns an empty list" do
-        expect(subject.errors).to be_empty
+        expect(subject.warnings).to be_empty
       end
     end
   end
 
-  describe "#boot_errors" do
+  describe "#boot_warnings" do
     let(:boot_error1) { instance_double(Y2Storage::SetupError) }
     let(:boot_error2) { instance_double(Y2Storage::SetupError) }
-    let(:boot_errors) { [boot_error1, boot_error2] }
+    let(:boot_warnings) { [boot_error1, boot_error2] }
 
     let(:product_volumes) { [root_volume, swap_volume, home_volume] }
 
     it "includes all boot errors" do
-      expect(subject.boot_errors).to contain_exactly(boot_error1, boot_error2)
+      expect(subject.boot_warnings).to contain_exactly(boot_error1, boot_error2)
     end
 
     context "when there is no boot error" do
-      let(:boot_errors) { [] }
+      let(:boot_warnings) { [] }
 
       it "returns an empty list" do
-        expect(subject.boot_errors).to be_empty
+        expect(subject.boot_warnings).to be_empty
       end
     end
   end
 
-  describe "#product_errors" do
+  describe "#product_warnings" do
     let(:boot_error1) { instance_double(Y2Storage::SetupError) }
     let(:boot_error2) { instance_double(Y2Storage::SetupError) }
-    let(:boot_errors) { [boot_error1, boot_error2] }
+    let(:boot_warnings) { [boot_error1, boot_error2] }
 
     let(:product_volumes) { [root_volume, swap_volume, home_volume] }
 
     it "returns a list of setup errors" do
-      expect(subject.product_errors).to all(be_a(Y2Storage::SetupError))
+      expect(subject.product_warnings).to all(be_a(Y2Storage::SetupError))
     end
 
     it "does not include boot errors" do
-      expect(subject.product_errors).to_not include(boot_error1, boot_error2)
+      expect(subject.product_warnings).to_not include(boot_error1, boot_error2)
     end
 
     it "does not include an error for optional product volumes" do
-      expect(subject.product_errors)
+      expect(subject.product_warnings)
         .to_not include(an_object_having_attributes(missing_volume: home_volume))
     end
 
     it "includes an error for each mandatory product volume not present in the system" do
-      expect(subject.product_errors).to include(an_object_having_attributes(missing_volume: root_volume))
-      expect(subject.product_errors).to include(an_object_having_attributes(missing_volume: swap_volume))
+      expect(subject.product_warnings).to include(an_object_having_attributes(missing_volume: root_volume))
+      expect(subject.product_warnings).to include(an_object_having_attributes(missing_volume: swap_volume))
     end
 
     context "when a mandatory product volume is present in the system" do
@@ -234,7 +234,7 @@ describe Y2Storage::SetupChecker do
       end
 
       it "does not include an error for that volume" do
-        expect(subject.product_errors)
+        expect(subject.product_warnings)
           .to_not include(an_object_having_attributes(missing_volume: root_volume))
       end
     end
@@ -247,7 +247,7 @@ describe Y2Storage::SetupChecker do
       end
 
       it "returns an empty list" do
-        expect(subject.product_errors).to be_empty
+        expect(subject.product_warnings).to be_empty
       end
     end
 
@@ -256,7 +256,7 @@ describe Y2Storage::SetupChecker do
       let(:product_volumes) { nil }
 
       it "returns an empty list" do
-        expect(subject.product_errors).to be_empty
+        expect(subject.product_warnings).to be_empty
       end
     end
   end


### PR DESCRIPTION
plan is to also add all current checks in bootloader itself.
screenshot from manual testing:

![snimek obrazovky_2018-02-15_09-44-19](https://user-images.githubusercontent.com/478871/36247610-ef31d25e-1234-11e8-9f4d-e44002466a43.png)

and warnings still works:

![snimek obrazovky_2018-02-15_09-48-26](https://user-images.githubusercontent.com/478871/36247716-59c34602-1235-11e8-8def-aa2c05e71122.png)
