### PR TITLE
Adjust sizes and weights in the boot-related partitions

### DIFF
--- a/doc/boot-partition.md
+++ b/doc/boot-partition.md
@@ -1,7 +1,7 @@
 Boot Partition Layout / Restrictions For Storage Proposal
 =========================================================
 
-[Revision 2018-02-12]
+[Revision 2018-02-15]
 
 #### Notes:
 
@@ -11,11 +11,10 @@ Boot Partition Layout / Restrictions For Storage Proposal
 ### Relevant bugs during SLE15 beta phase
 
 - In [bsc#1068772](https://bugzilla.suse.com/show_bug.cgi?id=1068772) and
-  [bsc#1076851](https://bugzilla.suse.com/show_bug.cgi?id=1076851) it has been
-  pointed that the PReP partition likely MUST be the first partition in the
-  disk.
+  [bsc#1076851](https://bugzilla.suse.com/show_bug.cgi?id=1076851) the
+  requirements for the PReP partition (position and size) have been discussed.
 - In [bsc#1073680](https://bugzilla.suse.com/show_bug.cgi?id=1073680) the
-  reporter points that `/boot/efi` should be also the first partition in the
+  reporter points that `/boot/efi` should be the first partition in the
   disk to please some buggy EFI implementations.
 - At the time of writing, there is nothing implemented in the proposal to ensure
   a given partition is located at the beginning of its disk.

--- a/doc/boot-requirements.md
+++ b/doc/boot-requirements.md
@@ -79,41 +79,49 @@
 		- **requires it to have the correct id**
 		- **requires it to be a non-encrypted partition**
 		- when aiming for the recommended size
-			- **requires it to be between 1 and 8MiB**
+			- **requires it to be at least 4 MiB (Grub2 stages 1+2, needed Grub modules and extra space)**
+			- **requires it to be at most 8 MiB (anything bigger would mean wasting space)**
 		- when aiming for the minimal size
-			- **requires it to be between 256KiB and 8MiB**
+			- **requires it to be at least 2 MiB (Grub2 stages 1+2 and needed Grub modules)**
+			- **requires it to be at most 8 MiB (anything bigger would mean wasting space)**
 	- when proposing an new EFI partition
 		- **requires /boot/efi to be a non-encrypted vfat partition**
 		- **requires /boot/efi to be close enough to the beginning of disk**
 		- when aiming for the recommended size
-			- **requires /boot/efi to be exactly 500 MiB large**
+			- **requires /boot/efi to be exactly 500 MiB large (enough for several operating systems)**
 		- when aiming for the minimal size
-			- **requires /boot/efi to be between 33 MiB and 500 MiB large**
+			- **requires it to be at least 256 MiB (min size for FAT32 in drives with 4-KiB-per-sector)**
+			- **requires it to be at most 500 MiB (enough space for several operating systems)**
 
 ## needed partitions in a PPC64 system
 - in a non-PowerNV system (KVM/LPAR)
 	- with a partitions-based proposal
 		- if there are no PReP partitions in the target disk
-			- **requires only a PReP partition**
+			- **requires only a PReP partition (to allocate Grub2)**
+			- **does not require a separate /boot partition (Grub2 can handle this setup)**
 		- if there is already a PReP partition in the disk
-			- **does not require any particular volume**
+			- **does not require any partition (PReP will be reused and Grub2 can handle this setup)**
 	- with a LVM-based proposal
 		- if there are no PReP partitions in the target disk
-			- **requires only a PReP partition**
+			- **requires only a PReP partition (to allocate Grub2)**
+			- **does not require a separate /boot partition (Grub2 can handle this setup)**
 		- if there is already a PReP partition in the disk
-			- **does not require any particular volume**
+			- **does not require any partition (PReP will be reused and Grub2 can handle this setup)**
 	- with an encrypted proposal
 		- if there are no PReP partitions in the target disk
-			- **requires only a PReP partition**
+			- **requires only a PReP partition (to allocate Grub2)**
+			- **does not require a separate /boot partition (Grub2 can handle this setup)**
 		- if there is already a PReP partition in the disk
-			- **does not require any particular volume**
+			- **does not require any partition (PReP will be reused and Grub2 can handle this setup)**
 - in bare metal (PowerNV)
 	- with a partitions-based proposal
-		- **does not require any particular volume**
+		- **does not require any booting partition (no Grub stage1, PPC firmware parses grub2.cfg)**
 	- with a LVM-based proposal
-		- **requires only a /boot partition**
+		- **does not require a PReP partition (no Grub stage1, PPC firmware parses grub2.cfg)**
+		- **requires only a /boot partition (for the PPC firmware to load the kernel)**
 	- with an encrypted proposal
-		- **requires only a /boot partition**
+		- **does not require a PReP partition (no Grub stage1, PPC firmware parses grub2.cfg)**
+		- **requires only a /boot partition (for the PPC firmware to load the kernel)**
 - when proposing a boot partition
 	- **requires /boot to be a non-encrypted ext4 partition in the booting disk**
 	- when aiming for the recommended size
@@ -123,10 +131,13 @@
 - when proposing a PReP partition
 	- **requires it to be a non-encrypted partition**
 	- **requires it to be bootable (ms-dos partition table)**
+	- **requires no particular position for it in the disk (since there is no evidence of such so far)**
 	- when aiming for the recommended size
-		- **requires it to be between 1MiB and 8MiB**
+		- **requires it to be at least 4 MiB (Grub2 stages 1+2, needed Grub modules and extra space)**
+		- **requires it to be at most 8 MiB (since it will be mapped to RAM)**
 	- when aiming for the minimal size
-		- **requires it to be between 256KiB and 8MiB**
+		- **requires it to be at least 2 MiB (Grub2 stages 1+2 and needed Grub modules)**
+		- **requires it to be at most 8 MiB (since it will be mapped to RAM)**
 
 ## needed partitions in a S/390 system
 - trying to install in a zfcp disk
@@ -152,9 +163,11 @@
 	- **requires /boot/zipl to be ext2 with at least 100 MiB**
 	- **requires /boot/zipl to be a non-encrypted partition in the boot disk**
 	- when aiming for the recommended size
-		- **requires /boot/zipl to be at least 200 MiB large**
+		- **requires /boot/zipl to be at least 200 MiB large (FIXME: why?)**
+		- **requires /boot/zipl to be at most 500 MiB large (FIXME: why?)**
 	- when aiming for the minimal size
-		- **requires /boot/zipl to be at least 100 MiB large**
+		- **requires /boot/zipl to be at least 100 MiB large (FIXME: why?)**
+		- **requires /boot/zipl to be at most 500 MiB large (FIXME: why?)**
 
 ## needed partitions in an aarch64 system
 - with a partitions-based proposal

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb 15 16:16:19 UTC 2018 - ancor@suse.com
+
+- Adjusted the suggested and minimum sizes of all the booting
+  partitions, both in the storage proposal and in the Partitioner
+  validations (bsc#1076851 and fate#318196).
+- 4.0.97
+
+-------------------------------------------------------------------
 Thu Feb 15 13:01:41 UTC 2018 - igonzalezsosa@suse.com
 
 - Fix hwinfo parsing to support more than one device_file property

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.96
+Version:        4.0.97
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
@@ -191,6 +191,15 @@ module Y2Storage
         planned_partitions_with_id(PartitionId::BIOS_BOOT)
       end
 
+      # Max weight from all the devices that were planned in advance
+      #
+      # @see #planned_devices
+      #
+      # @return [Float]
+      def max_planned_weight
+        @max_planned_weight ||= planned_devices.map { |dev| planned_weight(dev) }.compact.max
+      end
+
     protected
 
       attr_reader :devicegraph
@@ -228,6 +237,13 @@ module Y2Storage
         planned_devices.select do |dev|
           dev.is_a?(Planned::Partition) && dev.partition_id == id
         end
+      end
+
+      # Weight of a planned device, nil if none or not supported
+      #
+      # @return [Float, nil]
+      def planned_weight(device)
+        device.respond_to?(:weight) ? device.weight : nil
       end
     end
   end

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -152,6 +152,7 @@ module Y2Storage
         planned_partition.min_size = target == :min ? volume.min_size : volume.desired_size
         planned_partition.max_size = volume.max_size
         planned_partition.partition_id = volume.partition_id
+        planned_partition.weight = analyzer.max_planned_weight || 0.0
         planned_partition
       end
 

--- a/src/lib/y2storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/legacy.rb
@@ -139,8 +139,10 @@ module Y2Storage
         return @grub_volume unless @grub_volume.nil?
 
         @grub_volume = VolumeSpecification.new({})
-        @grub_volume.min_size = DiskSize.KiB(256)
-        @grub_volume.desired_size = DiskSize.MiB(1)
+        # Grub2 with all the modules we could possibly use (LVM, LUKS, etc.)
+        # is slightly bigger than 1MiB
+        @grub_volume.min_size = DiskSize.MiB(2)
+        @grub_volume.desired_size = DiskSize.MiB(4)
         @grub_volume.max_size = DiskSize.MiB(8)
         # Only required on GPT
         @grub_volume.partition_id = PartitionId::BIOS_BOOT

--- a/src/lib/y2storage/boot_requirements_strategies/prep.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/prep.rb
@@ -84,8 +84,10 @@ module Y2Storage
         @prep_volume = VolumeSpecification.new({})
         # So far we are always using msdos partition ids
         @prep_volume.partition_id = PartitionId::PREP
-        @prep_volume.min_size = DiskSize.KiB(256)
-        @prep_volume.desired_size = DiskSize.MiB(1)
+        # Grub2 with all the modules we could possibly use (LVM, LUKS, etc.)
+        # is slightly bigger than 1MiB
+        @prep_volume.min_size = DiskSize.MiB(2)
+        @prep_volume.desired_size = DiskSize.MiB(4)
         @prep_volume.max_size = DiskSize.MiB(8)
         # TODO: We have been told that PReP must be one of the first 4
         # partitions, ideally the first one. But we have not found any

--- a/src/lib/y2storage/boot_requirements_strategies/uefi.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/uefi.rb
@@ -51,7 +51,10 @@ module Y2Storage
 
     protected
 
-      MIN_SIZE = DiskSize.MiB(33).freeze
+      # Looks like 256MiB is the minimum size for FAT32 in 4K Native drives
+      # (4-KiB-per-sector), according to
+      # https://wiki.archlinux.org/index.php/EFI_System_Partition
+      MIN_SIZE = DiskSize.MiB(256).freeze
       DESIRED_SIZE = DiskSize.MiB(500).freeze
       MAX_SIZE = DiskSize.MiB(500).freeze
 

--- a/src/lib/y2storage/boot_requirements_strategies/zipl.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/zipl.rb
@@ -72,7 +72,7 @@ module Y2Storage
         @zipl_volume.fs_type = Filesystems::Type.zipl_filesystems.first
         @zipl_volume.min_size = DiskSize.MiB(100)
         @zipl_volume.desired_size = DiskSize.MiB(200)
-        @zipl_volume.max_size = DiskSize.GiB(1)
+        @zipl_volume.max_size = DiskSize.MiB(500)
         @zipl_volume
       end
 

--- a/test/data/devicegraphs/kvm_role_scenario.yml
+++ b/test/data/devicegraphs/kvm_role_scenario.yml
@@ -20,8 +20,6 @@
         id: swap
         file_system: swap
     - partition:
-        size: 1 MiB
+        size: 2 MiB
         name: "/dev/sda3"
         id: bios_boot
-    - free:
-        size: 8362 MiB (8.17 GiB)

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_15GiB_caasp.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_15GiB_caasp.yml
@@ -5,15 +5,18 @@
     partition_table: gpt
     partitions:
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda1"
         type: primary
         id: bios_boot
     - partition:
-        size: 15726575.5 KiB (15.00 GiB)
+        size: unlimited
         name: "/dev/sda2"
         id: linux
         file_system: btrfs
         mount_point: "/"
         btrfs:
           default_subvolume: "@"
+    # The final 16.5 KiB are reserved by GPT
+    - free:
+        size: 16.5 KiB

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-lvm-sep-home.yml
@@ -6,14 +6,17 @@
     partitions:
 
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: /dev/sda1
         id:   bios_boot
 
     - partition:
-        size: 26212335.5 KiB
+        size: unlimited
         name: /dev/sda2
         id:   lvm
+    # The final 16.5 KiB are reserved by GPT
+    - free:
+        size: 16.5 KiB
 
 - lvm_vg:
     vg_name: system
@@ -25,12 +28,12 @@
     lvm_lvs:
     - lvm_lv:
         lv_name:      home
-        size:         7984 MiB (7.80 GiB)
+        size:         7980 MiB
         file_system:  xfs
         mount_point:  "/home"
     - lvm_lv:
         lv_name:      root
-        size:         15565 MiB (15.20 GiB)
+        size:         15560 MiB
         file_system:  btrfs
         mount_point:  "/"
     - lvm_lv:

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-lvm.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-lvm.yml
@@ -6,14 +6,18 @@
     partitions:
 
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: /dev/sda1
         id:   bios_boot
 
     - partition:
-        size: 26212335.5 KiB
+        size: unlimited
         name: /dev/sda2
         id:   lvm
+
+    # The final 16.5 KiB are reserved by GPT
+    - free:
+        size: 16.5 KiB
 
 - lvm_vg:
     vg_name: system
@@ -25,7 +29,7 @@
     lvm_lvs:
     - lvm_lv:
         lv_name:      root
-        size:         23548 MiB
+        size:         23540 MiB
         file_system:  btrfs
         mount_point:  "/"
     - lvm_lv:

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB-sep-home.yml
@@ -6,11 +6,11 @@
     partitions:
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda1
         id:           bios_boot
     - partition:
-        size:         15565 MiB (15.20 GiB)
+        size:         15561 MiB (15.20 GiB)
         name:         /dev/sda2
         file_system:  btrfs
         mount_point:  "/"
@@ -21,7 +21,10 @@
         file_system:  swap
         mount_point:  swap
     - partition:
-        size:         8176623.5 KiB (7.80 GiB)
+        size:         unlimited
         name:         /dev/sda4
         file_system:  xfs
         mount_point:  "/home"
+    # The final 16.5 KiB are reserved by GPT
+    - free:
+        size: 16.5 KiB

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_25GiB.yml
@@ -6,17 +6,20 @@
     partitions:
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda1
         id:           bios_boot
     - partition:
-        size:         23549 MiB
+        size:         23542 MiB
         name:         /dev/sda2
         file_system:  btrfs
         mount_point:  "/"
     - partition:
-        size:         2098159.5 KiB
+        size:         unlimited
         name:         /dev/sda3
         id:           swap
         file_system:  swap
         mount_point:  swap
+    # The final 16.5 KiB are reserved by GPT
+    - free:
+        size: 16.5 KiB

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc-lvm-sep-home.yml
@@ -6,12 +6,12 @@
     partitions:
 
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: /dev/sda1
         id:   bios_boot
 
     - partition:
-        size: 52426735.5 KiB
+        size: unlimited
         name: /dev/sda2
         id:   lvm
         encryption:
@@ -33,12 +33,12 @@
     lvm_lvs:
     - lvm_lv:
         lv_name:      home
-        size:         23340 MiB (22.79 GiB)
+        size:         23336 MiB
         file_system:  xfs
         mount_point:  "/home"
     - lvm_lv:
         lv_name:      root
-        size:         25804 MiB
+        size:         25800 MiB
         file_system:  btrfs
         mount_point:  "/"
     - lvm_lv:

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc-lvm.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc-lvm.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: /dev/sda1
         id:   bios_boot
 

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc-sep-home.yml
@@ -6,11 +6,11 @@
     partitions:
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda1
         id:           bios_boot
     - partition:
-        size:         25805 MiB (25.20 GiB)
+        size:         25802 MiB (25.20 GiB)
         name:         /dev/sda2
         file_system:  btrfs
         mount_point:  "/"
@@ -29,7 +29,7 @@
           name: "/dev/mapper/cr_sda3"
           password: '12345678'
     - partition:
-        size:         23905263.5 KiB (22.80 GiB)
+        size:         unlimited
         name:         /dev/sda4
         file_system:  xfs
         mount_point:  "/home"
@@ -37,3 +37,5 @@
           type: luks
           name: "/dev/mapper/cr_sda4"
           password: '12345678'
+    - free:
+        size: 16.5 KiB

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda1
         id:           bios_boot
     - partition:

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-lvm-sep-home.yml
@@ -6,12 +6,12 @@
     partitions:
 
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: /dev/sda1
         id:   bios_boot
 
     - partition:
-        size: 52426735.5 KiB
+        size: unlimited
         name: /dev/sda2
         id:   lvm
 
@@ -29,12 +29,12 @@
     lvm_lvs:
     - lvm_lv:
         lv_name:      home
-        size:         23344 MiB
+        size:         23340 MiB
         file_system:  xfs
         mount_point:  "/home"
     - lvm_lv:
         lv_name:      root
-        size:         25804 MiB
+        size:         25800 MiB
         file_system:  btrfs
         mount_point:  "/"
     - lvm_lv:

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-lvm.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-lvm.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: /dev/sda1
         id:   bios_boot
 

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-docker-lvm.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-docker-lvm.yml
@@ -5,11 +5,11 @@
     partition_table: gpt
     partitions:
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda1"
         id: bios_boot
     - partition:
-        size: 52426735.5 KiB (50.00 GiB)
+        size: unlimited
         name: "/dev/sda2"
         id: lvm
     # Reserved by GPT
@@ -20,7 +20,7 @@
     lvm_lvs:
     - lvm_lv:
         lv_name: root
-        size: 30716 MiB (30.00 GiB)
+        size: 30708 MiB
         file_system: ext4
         mount_point: "/"
         fstab_options:

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-swap.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-swap.yml
@@ -5,11 +5,11 @@
     partition_table: gpt
     partitions:
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda1"
         id: bios_boot
     - partition:
-        size: 34813 MiB (34.00 GiB)
+        size: 34806 MiB (34.00 GiB)
         name: "/dev/sda2"
         id: linux
         file_system: ext4
@@ -19,7 +19,7 @@
           - acl
           - user_xattr
     - partition:
-        size: 16778223.5 KiB (16.00 GiB)
+        size: unlimited
         name: "/dev/sda3"
         id: swap
         file_system: swap

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-sep-home.yml
@@ -6,11 +6,11 @@
     partitions:
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda1
         id:           bios_boot
     - partition:
-        size:         25805 MiB (25.20 GiB)
+        size:         25802 MiB (25.20 GiB)
         name:         /dev/sda2
         file_system:  btrfs
         mount_point:  "/"
@@ -21,8 +21,10 @@
         file_system:  swap
         mount_point:  swap
     - partition:
-        # The final 16.5 KiB are reserved by GPT
-        size:         23905263.5 KiB (22.80 GiB)
+        size:         unlimited
         name:         /dev/sda4
         file_system:  xfs
         mount_point:  "/home"
+    # The final 16.5 KiB are reserved by GPT
+    - free:
+        size: 16.5 KiB

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda1
         id:           bios_boot
     - partition:

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB_caasp.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB_caasp.yml
@@ -5,7 +5,7 @@
     partition_table: gpt
     partitions:
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda1"
         id: bios_boot
     - partition:
@@ -17,8 +17,11 @@
         btrfs:
           default_subvolume: "@"
     - partition:
-        size: 20969455.5 KiB (20.00 GiB)
+        size: unlimited
         name: "/dev/sda3"
         id: linux
         file_system: btrfs
         mount_point: "/var/lib/docker"
+    # The final 16.5 KiB are reserved by GPT
+    - free:
+        size: 16.5 KiB

--- a/test/data/devicegraphs/output/gpt_and_msdos-sdb_root_device.yml
+++ b/test/data/devicegraphs/output/gpt_and_msdos-sdb_root_device.yml
@@ -25,7 +25,7 @@
         label:        data
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sdb2
         id:           bios_boot
 
@@ -43,7 +43,7 @@
         mount_point:  swap
 
     - partition:
-        size:         966785007.5 KiB
+        size:         unlimited
         name:         /dev/sdb5
         file_system:  xfs
         mount_point:  "/home"

--- a/test/data/devicegraphs/output/kvm_role_scenario.yml
+++ b/test/data/devicegraphs/output/kvm_role_scenario.yml
@@ -17,11 +17,11 @@
         file_system: swap
         mount_point: swap
     - partition:
-        size: 1 MiB
+        size: 2 MiB
         name: "/dev/sda3"
         id: bios_boot
     - partition:
-        size: 8562671.5 KiB (8.17 GiB)
+        size: unlimited
         name: "/dev/sda4"
         id: linux
         file_system: xfs

--- a/test/data/devicegraphs/output/multi-linux-pc-gpt-enc-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-gpt-enc-lvm-sep-home.yml
@@ -32,12 +32,12 @@
         label:        shared_home
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda5
         id:           bios_boot
 
     - partition:
-        size:         629143535.5 KiB
+        size:         unlimited
         name:         /dev/sda6
         id: lvm
         encryption:
@@ -67,7 +67,7 @@
 
     - lvm_lv:
         lv_name: home
-        size: 571384 MiB
+        size: 571376 MiB
         file_system: xfs
         mount_point: "/home"
 

--- a/test/data/devicegraphs/output/multi-linux-pc-gpt-enc-lvm.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-gpt-enc-lvm.yml
@@ -32,7 +32,7 @@
         label:        shared_home
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda5
         id:           bios_boot
 

--- a/test/data/devicegraphs/output/multi-linux-pc-gpt-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-gpt-enc-sep-home.yml
@@ -32,7 +32,7 @@
         label:        shared_home
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda5
         id:           bios_boot
 
@@ -59,7 +59,7 @@
           password: '12345678'
 
     - partition:
-        size:         585103343.5 KiB (0.54 TiB)
+        size:         unlimited
         name:         "/dev/sda8"
         id:           linux
         file_system:  xfs

--- a/test/data/devicegraphs/output/multi-linux-pc-gpt-enc.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-gpt-enc.yml
@@ -32,7 +32,7 @@
         label:        shared_home
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda5
         id:           bios_boot
 

--- a/test/data/devicegraphs/output/multi-linux-pc-gpt-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-gpt-lvm-sep-home.yml
@@ -32,12 +32,12 @@
         label:        shared_home
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda5
         id:           bios_boot
 
     - partition:
-        size:         629143535.5 KiB
+        size:         unlimited
         name:         /dev/sda6
         id: lvm
 
@@ -63,7 +63,7 @@
 
     - lvm_lv:
         lv_name: home
-        size: 571388 MiB
+        size: 571380 MiB
         file_system: xfs
         mount_point: "/home"
 

--- a/test/data/devicegraphs/output/multi-linux-pc-gpt-lvm.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-gpt-lvm.yml
@@ -32,7 +32,7 @@
         label:        shared_home
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda5
         id:           bios_boot
 

--- a/test/data/devicegraphs/output/multi-linux-pc-gpt-sep-home.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-gpt-sep-home.yml
@@ -32,7 +32,7 @@
         label:        shared_home
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda5
         id:           bios_boot
 
@@ -44,7 +44,7 @@
         mount_point:  "/"
 
     - partition:
-        size:         587200495.5 KiB
+        size:         unlimited
         name:         /dev/sda7
         id:           linux
         file_system:  xfs

--- a/test/data/devicegraphs/output/multi-linux-pc-gpt.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-gpt.yml
@@ -32,7 +32,7 @@
         label:        shared_home
 
     - partition:
-        size:         1 MiB
+        size:         8 MiB
         name:         /dev/sda5
         id:           bios_boot
 

--- a/test/data/devicegraphs/output/ppc_non_power_nv-lvm.yml
+++ b/test/data/devicegraphs/output/ppc_non_power_nv-lvm.yml
@@ -5,7 +5,7 @@
     partition_table: gpt
     partitions:
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda1"
         type: primary
         id: prep

--- a/test/data/devicegraphs/output/ppc_non_power_nv.yml
+++ b/test/data/devicegraphs/output/ppc_non_power_nv.yml
@@ -5,7 +5,7 @@
     partition_table: gpt
     partitions:
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda1"
         type: primary
         id: prep

--- a/test/data/devicegraphs/output/ppc_power_nv-lvm.yml
+++ b/test/data/devicegraphs/output/ppc_power_nv-lvm.yml
@@ -5,7 +5,7 @@
     partition_table: gpt
     partitions:
     - partition:
-        size: 200 MiB
+        size: 500 MiB
         name: "/dev/sda1"
         type: primary
         id: linux

--- a/test/data/devicegraphs/output/s390_dasd_zipl-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl-lvm-sep-home.yml
@@ -6,7 +6,7 @@
     partition_table: dasd
     partitions:
     - partition:
-        size: 102432 KiB (100.03 MiB)
+        size: 511968 KiB (499.97 MiB)
         name: "/dev/sda1"
         id: linux
         file_system: ext2
@@ -15,7 +15,7 @@
           - acl
           - user_xattr
     - partition:
-        size: 24014688 KiB (22.90 GiB)
+        size: 23605152 KiB (22.51 GiB)
         name: "/dev/sda2"
         id: lvm
 - lvm_vg:
@@ -23,12 +23,12 @@
     lvm_lvs:
     - lvm_lv:
         lv_name: home
-        size: 6696 MiB (6.54 GiB)
+        size: 6456 MiB
         file_system: xfs
         mount_point: "/home"
     - lvm_lv:
         lv_name: root
-        size: 14704 MiB (14.36 GiB)
+        size: 14544 MiB (14.20 GiB)
         file_system: btrfs
         mount_point: "/"
     - lvm_lv:

--- a/test/data/devicegraphs/output/s390_dasd_zipl-lvm.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl-lvm.yml
@@ -6,7 +6,7 @@
     partition_table: dasd
     partitions:
     - partition:
-        size: 102432 KiB (100.03 MiB)
+        size: 511968 KiB (499.97 MiB)
         name: "/dev/sda1"
         id: linux
         file_system: ext2
@@ -15,7 +15,7 @@
           - acl
           - user_xattr
     - partition:
-        size: 24014688 KiB (22.90 GiB)
+        size: 23605152 KiB (22.51 GiB)
         name: "/dev/sda2"
         id: lvm
 - lvm_vg:
@@ -23,7 +23,7 @@
     lvm_lvs:
     - lvm_lv:
         lv_name: root
-        size: 21400 MiB (20.90 GiB)
+        size: 21000 MiB
         file_system: btrfs
         mount_point: "/"
         btrfs:

--- a/test/data/devicegraphs/output/s390_dasd_zipl.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl.yml
@@ -6,7 +6,7 @@
     partition_table: dasd
     partitions:
     - partition:
-        size: 102432 KiB (100.03 MiB)
+        size: 511968 KiB (499.97 MiB)
         name: "/dev/sda1"
         id: linux
         file_system: ext2
@@ -15,7 +15,7 @@
           - acl
           - user_xattr
     - partition:
-        size: 21917568 KiB (20.90 GiB)
+        size: 21508032 KiB (20.51 GiB)
         name: "/dev/sda2"
         id: linux
         file_system: btrfs

--- a/test/data/devicegraphs/output/s390_zfcp_zipl.yml
+++ b/test/data/devicegraphs/output/s390_zfcp_zipl.yml
@@ -5,7 +5,7 @@
     partition_table: gpt
     partitions:
     - partition:
-        size: 200 MiB
+        size: 500 MiB
         name: "/dev/sda1"
         id: linux
         file_system: ext2

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-enc-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-enc-lvm-sep-home.yml
@@ -18,11 +18,11 @@
         mount_point: swap
         label: swap
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda3"
         id: bios_boot
     - partition:
-        size: 260044783.5 KiB
+        size: unlimited
         name: "/dev/sda4"
         id: lvm
         encryption:
@@ -52,7 +52,7 @@
 
     - lvm_lv:
         lv_name: home
-        size: 210936 MiB
+        size: 210928 MiB
         file_system: xfs
         mount_point: "/home"
 

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-enc-lvm.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-enc-lvm.yml
@@ -18,7 +18,7 @@
         mount_point: swap
         label: swap
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda3"
         id: bios_boot
     - partition:

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-enc-sep-home.yml
@@ -19,7 +19,7 @@
         mount_point: swap
         label: swap
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda3"
         id: bios_boot
     - partition:
@@ -45,7 +45,7 @@
           name: "/dev/mapper/cr_sda5"
           password: '12345678'
     - partition:
-        size: 216004591.5 KiB (206.00 GiB)
+        size: unlimited
         name: "/dev/sda6"
         id: linux
         file_system: xfs

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-enc.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-enc.yml
@@ -18,7 +18,7 @@
         mount_point: swap
         label: swap
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda3"
         type: primary
         id: bios_boot

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-lvm-sep-home.yml
@@ -18,11 +18,11 @@
         mount_point: swap
         label: swap
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda3"
         id: bios_boot
     - partition:
-        size: 260044783.5 KiB
+        size: unlimited
         name: "/dev/sda4"
         id: lvm
 
@@ -48,7 +48,7 @@
 
     - lvm_lv:
         lv_name: home
-        size: 210940 MiB
+        size: 210932 MiB
         file_system: xfs
         mount_point: "/home"
 

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-lvm.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-lvm.yml
@@ -18,7 +18,7 @@
         mount_point: swap
         label: swap
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda3"
         id: bios_boot
     - partition:

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-sep-home.yml
@@ -19,7 +19,7 @@
         mount_point: swap
         label: swap
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda3"
         id: bios_boot
     - partition:
@@ -30,7 +30,7 @@
         file_system: btrfs
         mount_point: "/"
     - partition:
-        size: 218101743.5 KiB
+        size: unlimited
         name: "/dev/sda5"
         id: linux
         file_system: xfs

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt.yml
@@ -18,7 +18,7 @@
         mount_point: swap
         label: swap
     - partition:
-        size: 1 MiB
+        size: 8 MiB
         name: "/dev/sda3"
         id: bios_boot
     - partition:

--- a/test/data/devicegraphs/output/windows-pc-50GiB-gpt-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-50GiB-gpt-sep-home.yml
@@ -9,14 +9,14 @@
     partition_table: gpt
     partitions:
     - partition:
-        size: 36172783.5 KiB (34.50 GiB)
+        size: 36171759.5 KiB (34.50 GiB)
         name: "/dev/sda1"
         type: primary
         id: windows_basic_data
         file_system: ntfs
         label: windows
     - partition:
-        size: 1 MiB
+        size: 2 MiB
         name: "/dev/sda2"
         type: primary
         id: bios_boot

--- a/test/data/devicegraphs/output/windows-pc-50GiB-gpt.yml
+++ b/test/data/devicegraphs/output/windows-pc-50GiB-gpt.yml
@@ -9,14 +9,14 @@
     partition_table: gpt
     partitions:
     - partition:
-        size: 8385519.5 KiB (8.00 GiB)
+        size: 8382447.5 KiB (7.99 GiB)
         name: "/dev/sda1"
         type: primary
         id: windows_basic_data
         file_system: ntfs
         label: windows
     - partition:
-        size: 1 MiB
+        size: 4 MiB
         name: "/dev/sda2"
         type: primary
         id: bios_boot

--- a/test/data/devicegraphs/output/windows-pc-gpt-enc-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-enc-lvm-sep-home.yml
@@ -6,14 +6,14 @@
     partitions:
 
     - partition:
-        size: 745468 MiB
+        size: 745465 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 1 MiB
+        size: 4 MiB
         name: /dev/sda3
         id: bios_boot
 

--- a/test/data/devicegraphs/output/windows-pc-gpt-enc-lvm.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-enc-lvm.yml
@@ -6,14 +6,14 @@
     partitions:
 
     - partition:
-        size: 755708 MiB
+        size: 755705 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 1 MiB
+        size: 4 MiB
         name: /dev/sda3
         id: bios_boot
 

--- a/test/data/devicegraphs/output/windows-pc-gpt-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-enc-sep-home.yml
@@ -6,19 +6,19 @@
     partitions:
 
     - partition:
-        size: 745470 MiB
+        size: 745467 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 1.00 MiB
+        size: 5 MiB
         name: "/dev/sda3"
         id: bios_boot
 
     - partition:
-        size: 40.00 GiB
+        size: 40 GiB
         name: "/dev/sda4"
         id: linux
         file_system: btrfs
@@ -29,7 +29,7 @@
           password: '12345678'
 
     - partition:
-        size: 2.00 GiB
+        size: 2 GiB
         name: "/dev/sda5"
         id: swap
         file_system: swap
@@ -40,7 +40,7 @@
           password: '12345678'
 
     - partition:
-        size: 10241 MiB
+        size: 10 GiB
         name: "/dev/sda6"
         id: linux
         file_system: xfs

--- a/test/data/devicegraphs/output/windows-pc-gpt-enc.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-enc.yml
@@ -6,19 +6,19 @@
     partitions:
 
     - partition:
-        size: 755710 MiB
+        size: 755707 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 1.00 MiB
+        size: 5 MiB
         name: "/dev/sda3"
         id: bios_boot
 
     - partition:
-        size: 40.00 GiB
+        size: 40 GiB
         name: "/dev/sda4"
         id: linux
         file_system: btrfs
@@ -29,7 +29,7 @@
           password: '12345678'
 
     - partition:
-        size: 2.00 GiB
+        size: 2 GiB
         name: "/dev/sda5"
         id: swap
         file_system: swap
@@ -38,9 +38,6 @@
           type: luks
           name: "/dev/mapper/cr_sda5"
           password: '12345678'
-
-    - free:
-        size: 1 MiB
 
     - partition:
         size: unlimited

--- a/test/data/devicegraphs/output/windows-pc-gpt-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-lvm-sep-home.yml
@@ -6,14 +6,14 @@
     partitions:
 
     - partition:
-        size: 745470 MiB
+        size: 745467 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 1 MiB
+        size: 4 MiB
         name: /dev/sda3
         id: bios_boot
 

--- a/test/data/devicegraphs/output/windows-pc-gpt-lvm.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-lvm.yml
@@ -6,14 +6,14 @@
     partitions:
 
     - partition:
-        size: 755710 MiB
+        size: 755707 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 1 MiB
+        size: 4 MiB
         name: /dev/sda3
         id: bios_boot
 

--- a/test/data/devicegraphs/output/windows-pc-gpt-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-sep-home.yml
@@ -1,38 +1,38 @@
 ---
 - disk:
-    size: 800.00 GiB
+    size: 800 GiB
     name: "/dev/sda"
     partition_table: gpt
     partitions:
 
     - partition:
-        size: 745470 MiB
+        size: 745467 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 1.00 MiB
+        size: 5 MiB
         name: "/dev/sda3"
         id: bios_boot
 
     - partition:
-        size: 40.00 GiB
+        size: 40 GiB
         name: "/dev/sda4"
         id: linux
         file_system: btrfs
         mount_point: "/"
 
     - partition:
-        size: 2.00 GiB
+        size: 2 GiB
         name: "/dev/sda5"
         id: swap
         file_system: swap
         mount_point: swap
 
     - partition:
-        size: 10241 MiB
+        size: 10 GiB
         name: "/dev/sda6"
         id: linux
         file_system: xfs

--- a/test/data/devicegraphs/output/windows-pc-gpt.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt.yml
@@ -1,38 +1,35 @@
 ---
 - disk:
-    size: 800.00 GiB
+    size: 800 GiB
     name: "/dev/sda"
     partition_table: gpt
     partitions:
 
     - partition:
-        size: 755710 MiB
+        size: 755707 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 1.00 MiB
+        size: 5 MiB
         name: "/dev/sda3"
         id: bios_boot
 
     - partition:
-        size: 40.00 GiB
+        size: 40 GiB
         name: "/dev/sda4"
         id: linux
         file_system: btrfs
         mount_point: "/"
 
     - partition:
-        size: 2.00 GiB
+        size: 2 GiB
         name: "/dev/sda5"
         id: swap
         file_system: swap
         mount_point: swap
-
-    - free:
-        size: 1 MiB
 
     - partition:
         size: unlimited

--- a/test/support/boot_requirements_context.rb
+++ b/test/support/boot_requirements_context.rb
@@ -51,7 +51,8 @@ RSpec.shared_context "boot requirements" do
       btrfs_root?:             use_btrfs,
       planned_prep_partitions: planned_prep_partitions,
       planned_grub_partitions: planned_grub_partitions,
-      planned_devices:         planned_grub_partitions + planned_prep_partitions
+      planned_devices:         planned_grub_partitions + planned_prep_partitions,
+      max_planned_weight:      0.0
     )
   end
 

--- a/test/support/proposed_partitions_examples.rb
+++ b/test/support/proposed_partitions_examples.rb
@@ -66,8 +66,11 @@ RSpec.shared_examples "proposed GRUB partition" do
   context "when aiming for the recommended size" do
     let(:target) { :desired }
 
-    it "requires it to be between 1 and 8MiB" do
-      expect(grub_part.min).to eq 1.MiB
+    it "requires it to be at least 4 MiB (Grub2 stages 1+2, needed Grub modules and extra space)" do
+      expect(grub_part.min).to eq 4.MiB
+    end
+
+    it "requires it to be at most 8 MiB (anything bigger would mean wasting space)" do
       expect(grub_part.max).to eq 8.MiB
     end
   end
@@ -75,8 +78,11 @@ RSpec.shared_examples "proposed GRUB partition" do
   context "when aiming for the minimal size" do
     let(:target) { :min }
 
-    it "requires it to be between 256KiB and 8MiB" do
-      expect(grub_part.min).to eq 256.KiB
+    it "requires it to be at least 2 MiB (Grub2 stages 1+2 and needed Grub modules)" do
+      expect(grub_part.min).to eq 2.MiB
+    end
+
+    it "requires it to be at most 8 MiB (anything bigger would mean wasting space)" do
       expect(grub_part.max).to eq 8.MiB
     end
   end
@@ -100,7 +106,7 @@ RSpec.shared_examples "proposed EFI partition" do
   context "when aiming for the recommended size" do
     let(:target) { :desired }
 
-    it "requires /boot/efi to be exactly 500 MiB large" do
+    it "requires /boot/efi to be exactly 500 MiB large (enough for several operating systems)" do
       expect(efi_part.min_size).to eq 500.MiB
       expect(efi_part.max_size).to eq 500.MiB
     end
@@ -109,9 +115,12 @@ RSpec.shared_examples "proposed EFI partition" do
   context "when aiming for the minimal size" do
     let(:target) { :min }
 
-    it "requires /boot/efi to be between 33 MiB and 500 MiB large" do
-      expect(efi_part.min_size).to eq 33.MiB
-      expect(efi_part.max_size).to eq 500.MiB
+    it "requires it to be at least 256 MiB (min size for FAT32 in drives with 4-KiB-per-sector)" do
+      expect(efi_part.min).to eq 256.MiB
+    end
+
+    it "requires it to be at most 500 MiB (enough space for several operating systems)" do
+      expect(efi_part.max).to eq 500.MiB
     end
   end
 end
@@ -130,11 +139,18 @@ RSpec.shared_examples "proposed PReP partition" do
     expect(prep_part.bootable).to eq true
   end
 
+  it "requires no particular position for it in the disk (since there is no evidence of such so far)" do
+    expect(prep_part.max_start_offset).to be_nil
+  end
+
   context "when aiming for the recommended size" do
     let(:target) { :desired }
 
-    it "requires it to be between 1MiB and 8MiB" do
-      expect(prep_part.min).to eq 1.MiB
+    it "requires it to be at least 4 MiB (Grub2 stages 1+2, needed Grub modules and extra space)" do
+      expect(prep_part.min).to eq 4.MiB
+    end
+
+    it "requires it to be at most 8 MiB (since it will be mapped to RAM)" do
       expect(prep_part.max).to eq 8.MiB
     end
   end
@@ -142,8 +158,11 @@ RSpec.shared_examples "proposed PReP partition" do
   context "when aiming for the minimal size" do
     let(:target) { :min }
 
-    it "requires it to be between 256KiB and 8MiB" do
-      expect(prep_part.min).to eq 256.KiB
+    it "requires it to be at least 2 MiB (Grub2 stages 1+2 and needed Grub modules)" do
+      expect(prep_part.min).to eq 2.MiB
+    end
+
+    it "requires it to be at most 8 MiB (since it will be mapped to RAM)" do
       expect(prep_part.max).to eq 8.MiB
     end
   end
@@ -167,16 +186,24 @@ RSpec.shared_examples "proposed /boot/zipl partition" do
   context "when aiming for the recommended size" do
     let(:target) { :desired }
 
-    it "requires /boot/zipl to be at least 200 MiB large" do
+    it "requires /boot/zipl to be at least 200 MiB large (FIXME: why?)" do
       expect(zipl_part.min_size).to eq 200.MiB
+    end
+
+    it "requires /boot/zipl to be at most 500 MiB large (FIXME: why?)" do
+      expect(zipl_part.max_size).to eq 500.MiB
     end
   end
 
   context "when aiming for the minimal size" do
     let(:target) { :min }
 
-    it "requires /boot/zipl to be at least 100 MiB large" do
+    it "requires /boot/zipl to be at least 100 MiB large (FIXME: why?)" do
       expect(zipl_part.min_size).to eq 100.MiB
+    end
+
+    it "requires /boot/zipl to be at most 500 MiB large (FIXME: why?)" do
+      expect(zipl_part.max_size).to eq 500.MiB
     end
   end
 end

--- a/test/y2storage/guided_proposal_test.rb
+++ b/test/y2storage/guided_proposal_test.rb
@@ -126,6 +126,11 @@ describe Y2Storage::GuidedProposal do
       let(:separate_home) { true }
       let(:lvm) { false }
 
+      before do
+        # Focus on multipath devices
+        settings.candidate_devices = fake_devicegraph.multipaths.map(&:name)
+      end
+
       it "does not fail to make a proposal" do
         expect { proposal.propose }.to_not raise_error
       end


### PR DESCRIPTION
Main PR for https://trello.com/c/7NcmMuGq/264-sles15-p1-shipstopper-1076851-build-4201-and-4211-ppc64le-unable-to-boot-after-installation

- Ensures the boot-related partitions get a sensible weight, so they don't stick always to its initial (minimum) size.
- Updates min/desired/max for all the partition types, after several conversations.
- Adds rationale to the RSpec tests and `doc/boot-requirements.md` for future discussions