### PR TITLE
Special mount option handling for certain mount paths

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 19 18:08:01 UTC 2018 - shundhammer@suse.com
+
+- Special handling for mount options for / and /boot/*
+  (bsc#1080731, bsc#1061867, bsc#1077859)
+- 4.0.99
+
+-------------------------------------------------------------------
 Mon Feb 19 14:19:30 UTC 2018 - jreidinger@suse.com
 
 - Ensure that there is always selected item in table, if it is not

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.98
+Version:        4.0.99
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -245,7 +245,7 @@ module Y2Partitioner
           # A mount is not created if there is already a mount point
           return unless mount_point.nil?
 
-          options[:mount_options] ||= filesystem.type.default_mount_options
+          options[:mount_options] ||= filesystem.type.default_mount_options(path)
 
           before_change_mount_point
           filesystem.create_mount_point(path)

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -298,7 +298,7 @@ module Y2Storage
       # @param mount_path [String] (optional) path where this filesystem will be mounted
       #
       # @return [Array<String>]
-      def default_fstab_options(mount_path = "")
+      def default_fstab_options(mount_path = nil)
         properties = PROPERTIES[to_sym]
         fallback = []
         return fallback unless properties
@@ -318,7 +318,7 @@ module Y2Storage
       #
       # @return [Array<String>] changed fstab options
       #
-      def special_path_fstab_options(opt, mount_path = "")
+      def special_path_fstab_options(opt, mount_path = nil)
         if mount_path.nil?
           opt
         elsif mount_path == "/"

--- a/src/lib/y2storage/planned/can_be_formatted.rb
+++ b/src/lib/y2storage/planned/can_be_formatted.rb
@@ -161,7 +161,7 @@ module Y2Storage
         if fstab_options
           mount_point.mount_options = fstab_options
         elsif filesystem_type
-          mount_point.mount_options = filesystem_type.default_fstab_options
+          mount_point.mount_options = filesystem_type.default_fstab_options(mount_point.path)
         end
       end
 

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-docker-lvm.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-docker-lvm.yml
@@ -24,7 +24,6 @@
         file_system: ext4
         mount_point: "/"
         fstab_options:
-          - data=ordered
           - acl
           - user_xattr
     - lvm_lv:

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-swap.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-swap.yml
@@ -15,7 +15,6 @@
         file_system: ext4
         mount_point: "/"
         fstab_options:
-          - data=ordered
           - acl
           - user_xattr
     - partition:

--- a/test/y2storage/filesystems/type_test.rb
+++ b/test/y2storage/filesystems/type_test.rb
@@ -182,5 +182,53 @@ describe Y2Storage::Filesystems::Type do
         expect(described_class::VFAT.default_fstab_options).to eq ["iocharset=iso8859-15"]
       end
     end
+
+    context "for special paths" do
+      context "for root filesystems" do
+        it "ext2 has the correct fstab options" do
+          expect(described_class::EXT2.default_fstab_options("/")).to eq ["acl", "user_xattr"]
+        end
+
+        it "ext3 has the correct fstab options" do
+          expect(described_class::EXT3.default_fstab_options("/")).to eq ["acl", "user_xattr"]
+        end
+
+        it "ext4 has the correct fstab options" do
+          expect(described_class::EXT4.default_fstab_options("/")).to eq ["acl", "user_xattr"]
+        end
+      end
+
+      context "for /boot or /boot/**" do
+        it "vfat has the correct fstab options for a utf8 locale" do
+          Yast::Encoding.SetUtf8Lang(true)
+          Yast::Encoding.SetEncLang("de_DE")
+          expect(described_class::VFAT.default_fstab_options("/boot")).to eq []
+          expect(described_class::VFAT.default_fstab_options("/boot/efi")).to eq []
+          expect(described_class::VFAT.default_fstab_options("/boot/whatever")).to eq []
+        end
+
+        it "vfat has the correct fstab options for a non-utf8 de_DE locale" do
+          Yast::Encoding.SetUtf8Lang(false)
+          Yast::Encoding.SetEncLang("de_DE")
+          # "codepage=437" is default and thus omitted
+          expect(described_class::VFAT.default_fstab_options("/boot/efi")).to eq ["iocharset=iso8859-15"]
+        end
+      end
+
+      context "for /bootme" do
+        it "vfat has the correct fstab options for a utf8 locale" do
+          Yast::Encoding.SetUtf8Lang(true)
+          Yast::Encoding.SetEncLang("de_DE")
+          expect(described_class::VFAT.default_fstab_options("/bootme")).to eq ["iocharset=utf8"]
+        end
+
+        it "vfat has the correct fstab options for a non-utf8 de_DE locale" do
+          Yast::Encoding.SetUtf8Lang(false)
+          Yast::Encoding.SetEncLang("de_DE")
+          # "codepage=437" is default and thus omitted
+          expect(described_class::VFAT.default_fstab_options("/bootme")).to eq ["iocharset=iso8859-15"]
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/9c9qZoIn/269-special-mount-options-for-boot-efi-bsc1080731

This is a bit of a mess; it reintroduces special handling we had in yast-storage-old for mount options for certain mount points. We had meant to leave this kind of thing behind, but it turns out we still need some of the old workarounds for some quirks or limitations of some kernel filesystem modules or low-level tools.

I tried to keep this localized in one file so anybody needing to change yet another one of those special cases doesn't need to hunt a half dozen files and a half dozen classes for all the places where this needs to be adapted.

At some points, the code may seem a little overkill, but this is meant to be extensible and, equally important, easy to understand.

The downside is that this is all in the base class where some of it could be moved to derived classes (ext3, ext4, vfat), and that the caller now needs to pass an additional `mount_path` parameter to the `default_fstab_options` method (but this parameter is optional).

So now we have some of the messy part of the old code back, but that's life; at least the mess should now be clear to read, understand and modify.