### PR TITLE
Partitioner: bringing back old partitioner logic about mount points

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue Feb 20 09:43:12 UTC 2018 - ancor@suse.com
+
+- Partitioner: bring back traditional list of mount points for both
+  installation and installed system (bsc#1076167 and bsc#1081200).
+- Partitioner: bring back traditional behavior of the "Operating
+  System" and "Data" roles during installation (bsc#1078975 and
+  bsc#1073854).
+- 4.0.100
+
+-------------------------------------------------------------------
 Mon Feb 19 18:08:01 UTC 2018 - shundhammer@suse.com
 
 - Special handling for mount options for / and /boot/*

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.99
+Version:        4.0.100
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -387,7 +387,9 @@ module Y2Partitioner
         #
         # @return [Array<String>]
         def mount_paths
-          all_mount_paths - mounted_paths
+          mount_paths = all_mount_paths - mounted_paths
+          mount_paths.unshift("swap") if filesystem && filesystem.type.is?(:swap)
+          mount_paths
         end
 
         # All paths used by the preexisting subvolumes (those that will not be

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -497,6 +497,9 @@ module Y2Partitioner
           else
             part_id = DEFAULT_PARTITION_ID
             fs_type = (role == :system) ? DEFAULT_FS : DEFAULT_HOME_FS
+            # Behavior of the old SingleMountPointProposal (behavior introduced
+            # back in 2005 with unknown rationale)
+            mount_path = mount_paths.first unless Yast::Mode.normal
           end
 
           {

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -27,6 +27,7 @@ require "y2storage/filesystems/btrfs"
 require "y2storage/subvol_specification"
 
 Yast.import "Mode"
+Yast.import "Stage"
 
 # TODO: This class is too long. Please, consider refactoring.
 # The code could be splitted in two kind of groups: one for actions
@@ -373,6 +374,33 @@ module Y2Partitioner
           filesystem.configure_snapper
         end
 
+        # Paths that are mounted in the current device graph, excluding
+        # subvolumes
+        #
+        # @return [Array<String>]
+        def mounted_paths
+          devices = mounted_devices.reject { |d| d.is?(:btrfs_subvolume) }
+          devices.map(&:mount_path)
+        end
+
+        # Sorted list of the default mount paths to offer to the user
+        #
+        # @return [Array<String>]
+        def mount_paths
+          all_mount_paths - mounted_paths
+        end
+
+        # All paths used by the preexisting subvolumes (those that will not be
+        # automatically deleted if they are shadowed)
+        #
+        # @return [Array<String>]
+        def subvolumes_mount_paths
+          subvolumes = mounted_devices.select do |dev|
+            dev.is?(:btrfs_subvolume) && !dev.can_be_auto_deleted?
+          end
+          subvolumes.map(&:mount_path).compact.select { |m| !m.empty? }
+        end
+
       private
 
         def working_graph
@@ -509,8 +537,7 @@ module Y2Partitioner
         #
         # @return [Y2Storage::BtrfsSubvolume, nil]
         def find_not_probed_subvolume
-          device_graph = DeviceGraphs.instance.system
-          subvolumes.detect { |s| !s.exists_in_devicegraph?(device_graph) }
+          subvolumes.detect { |s| !s.exists_in_devicegraph?(system_graph) }
         end
 
         # A proposed subvolume is added only when it does not exist in the filesystem and it
@@ -551,6 +578,85 @@ module Y2Partitioner
 
         def root?
           filesystem.root?
+        end
+
+        # This implements the code that used to live in
+        # Yast::Filesystems::SuggestMPoints (whatever the rationle behind those
+        # mount paths was back then) with the only exception mentioned in
+        # {#booting_paths}
+        #
+        # @return [Array<String>]
+        def all_mount_paths
+          @all_mount_paths ||=
+            if Yast::Stage.initial
+              %w(/ /home /var /opt) + booting_paths + non_system_paths
+            else
+              ["/home"] + non_system_paths
+            end
+        end
+
+        # Mount paths suggested for the boot-related partitions.
+        #
+        # This is somehow similar to the old Yast::Partitions::BootMount but
+        # with an important difference - it returns a list instead of a single
+        # path. yast-storage used to consider there was only a single "boot"
+        # partition, with /boot/efi and /boot/zipl being considered some kind
+        # of alternative to /boot.
+        #
+        # @see #mount_paths
+        #
+        # @return [Array<String>]
+        def booting_paths
+          paths = ["/boot"]
+          paths << "/boot/efi" if arch.efiboot?
+          paths << "/boot/zipl" if arch.s390?
+          paths
+        end
+
+        # @see #mount_paths
+        #
+        # @return [Array<String>]
+        def non_system_paths
+          ["/srv", "/tmp", "/usr/local"]
+        end
+
+        # Devices that are currently mounted in the system, except those
+        # associated to the current filesystem.
+        #
+        # @see #filesystem_devices
+        #
+        # @return [Array<Y2Storage::Mountable>]
+        def mounted_devices
+          fs_sids = filesystem_devices.map(&:sid)
+          devices = Y2Storage::Mountable.all(working_graph)
+          devices = devices.select { |d| !d.mount_point.nil? }
+          devices.reject { |d| fs_sids.include?(d.sid) }
+        end
+
+        # Returns the devices associated to the current filesystem.
+        #
+        # @note The devices associated to the filesystem are the filesystem itself and its
+        #   subvolumes in case of a btrfs filesystem.
+        #
+        # @return [Array<Y2Storage::Mountable>]
+        def filesystem_devices
+          fs = filesystem
+          return [] if fs.nil?
+
+          devices = [fs]
+          devices += filesystem_subvolumes if fs.is?(:btrfs)
+          devices
+        end
+
+        # Subvolumes to take into account
+        # @return [Array[Y2Storage::BtrfsSubvolume]]
+        def filesystem_subvolumes
+          filesystem.btrfs_subvolumes.select { |s| !s.top_level? && !s.default_btrfs_subvolume? }
+        end
+
+        # @return [Storage::Arch]
+        def arch
+          Y2Storage::StorageManager.instance.arch
         end
       end
     end


### PR DESCRIPTION
Main PR for two cards: https://trello.com/c/FBPlQOBf/262-1-partitioner-apply-role-correctly and https://trello.com/c/EzGZXxXN/274-sles15-several-reports-irritating-mount-point-suggestions-for-existing-swap-efi-zipl

This adds three commits fixing a total of 4 bugs.

- First commit: bring back the original list of mount points instead of a fixed list
  - Fixes half of [bsc#1076167](https://bugzilla.suse.com/show_bug.cgi?id=1076167) by bringing `/boot/efi' back
  - Fixes [bsc#1081200](https://bugzilla.suse.com/show_bug.cgi?id=1081200) by bringing `/boot/zipl' back
- Second commit: bring back original logic for the "Mount Device" option in the roles "Operating System" and "Data".
  - Fixes [bsc#1078975](https://bugzilla.suse.com/show_bug.cgi?id=1078975) and [bsc#1073854](https://bugzilla.suse.com/show_bug.cgi?id=1073854)
- Third commit: offer "swap" as mount point for preexisting swap partitions
  - Fixes second half of [bsc#1076167](https://bugzilla.suse.com/show_bug.cgi?id=1076167) (and several duplicates about swap reusing).

Everything manually tested.

The code climate issues are not really new. The `Actions::Controllers::Filesystem` class had already some disabled cops. We need to break it into pieces... but not now.