### PR TITLE
AutoYaST default filesystem

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 21 08:46:02 UTC 2018 - igonzalezsosa@suse.com
+
+- AutoYaST: guess which filesystem type should be used for a given
+  partition/logical volume when it is not specified in the profile
+  (bsc#1075203).
+
+-------------------------------------------------------------------
 Tue Feb 20 16:43:31 UTC 2018 - shundhammer@suse.com
 
 - Special handling for mount options for / and /boot/*

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -28,6 +28,7 @@ require "y2storage/boot_requirements_strategies/analyzer"
 require "y2storage/exceptions"
 require "y2storage/volume_specification"
 require "y2storage/setup_error"
+require "y2storage/volume_specification_builder"
 
 module Y2Storage
   module BootRequirementsStrategies
@@ -122,16 +123,12 @@ module Y2Storage
 
       # @return [VolumeSpecification]
       def boot_volume
-        return @boot_volume unless @boot_volume.nil?
+        @boot_volume ||= volume_specification_for("/boot")
+      end
 
-        @boot_volume = VolumeSpecification.new({})
-        @boot_volume.mount_point = "/boot"
-        @boot_volume.fs_types = Filesystems::Type.root_filesystems
-        @boot_volume.fs_type = Filesystems::Type::EXT4
-        @boot_volume.min_size = DiskSize.MiB(100)
-        @boot_volume.desired_size = DiskSize.MiB(200)
-        @boot_volume.max_size = DiskSize.MiB(500)
-        @boot_volume
+      # @return [VolumeSpecification,nil]
+      def volume_specification_for(mount_point)
+        VolumeSpecificationBuilder.new.for(mount_point)
       end
 
       # @return [Planned::Partition]

--- a/src/lib/y2storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/legacy.rb
@@ -136,17 +136,7 @@ module Y2Storage
 
       # @return [VolumeSpecification]
       def grub_volume
-        return @grub_volume unless @grub_volume.nil?
-
-        @grub_volume = VolumeSpecification.new({})
-        # Grub2 with all the modules we could possibly use (LVM, LUKS, etc.)
-        # is slightly bigger than 1MiB
-        @grub_volume.min_size = DiskSize.MiB(2)
-        @grub_volume.desired_size = DiskSize.MiB(4)
-        @grub_volume.max_size = DiskSize.MiB(8)
-        # Only required on GPT
-        @grub_volume.partition_id = PartitionId::BIOS_BOOT
-        @grub_volume
+        @grub_volume ||= volume_specification_for("grub")
       end
 
       # @return [Planned::Partition]

--- a/src/lib/y2storage/boot_requirements_strategies/prep.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/prep.rb
@@ -79,20 +79,7 @@ module Y2Storage
 
       # @return [VolumeSpecification]
       def prep_volume
-        return @prep_volume unless @prep_volume.nil?
-
-        @prep_volume = VolumeSpecification.new({})
-        # So far we are always using msdos partition ids
-        @prep_volume.partition_id = PartitionId::PREP
-        # Grub2 with all the modules we could possibly use (LVM, LUKS, etc.)
-        # is slightly bigger than 1MiB
-        @prep_volume.min_size = DiskSize.MiB(2)
-        @prep_volume.desired_size = DiskSize.MiB(4)
-        @prep_volume.max_size = DiskSize.MiB(8)
-        # TODO: We have been told that PReP must be one of the first 4
-        # partitions, ideally the first one. But we have not found any
-        # rationale/evidence. Not implementing that for the time being
-        @prep_volume
+        @prep_volume ||= volume_specification_for("prep")
       end
 
       # @return [Planned::Partition]

--- a/src/lib/y2storage/boot_requirements_strategies/uefi.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/uefi.rb
@@ -51,29 +51,13 @@ module Y2Storage
 
     protected
 
-      # Looks like 256MiB is the minimum size for FAT32 in 4K Native drives
-      # (4-KiB-per-sector), according to
-      # https://wiki.archlinux.org/index.php/EFI_System_Partition
-      MIN_SIZE = DiskSize.MiB(256).freeze
-      DESIRED_SIZE = DiskSize.MiB(500).freeze
-      MAX_SIZE = DiskSize.MiB(500).freeze
-
       def efi_missing?
         free_mountpoint?("/boot/efi")
       end
 
       # @return [VolumeSpecification]
       def efi_volume
-        return @efi_volume unless @efi_volume.nil?
-
-        @efi_volume = VolumeSpecification.new({})
-        @efi_volume.mount_point = "/boot/efi"
-        @efi_volume.fs_types = [Filesystems::Type::VFAT]
-        @efi_volume.fs_type = Filesystems::Type::VFAT
-        @efi_volume.min_size = MIN_SIZE
-        @efi_volume.desired_size = DESIRED_SIZE
-        @efi_volume.max_size = MAX_SIZE
-        @efi_volume
+        @efi_volume ||= volume_specification_for("/boot/efi")
       end
 
       # @return [Planned::Partition]

--- a/src/lib/y2storage/boot_requirements_strategies/zipl.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/zipl.rb
@@ -64,16 +64,7 @@ module Y2Storage
 
       # @return [VolumeSpecification]
       def zipl_volume
-        return @zipl_volume unless @zipl_volume.nil?
-
-        @zipl_volume = VolumeSpecification.new({})
-        @zipl_volume.mount_point = "/boot/zipl"
-        @zipl_volume.fs_types = Filesystems::Type.zipl_filesystems
-        @zipl_volume.fs_type = Filesystems::Type.zipl_filesystems.first
-        @zipl_volume.min_size = DiskSize.MiB(100)
-        @zipl_volume.desired_size = DiskSize.MiB(200)
-        @zipl_volume.max_size = DiskSize.MiB(500)
-        @zipl_volume
+        @zipl_volume ||= volume_specification_for("/boot/zipl")
       end
 
       # @return [Planned::Partition]

--- a/src/lib/y2storage/proposal/autoinst_devices_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_planner.rb
@@ -188,7 +188,7 @@ module Y2Storage
         device.mount_point = section.mount
         device.label = section.label
         device.uuid = section.uuid
-        device.filesystem_type = section.type_for_filesystem
+        device.filesystem_type = filesystem_for(section)
         device.mount_by = section.type_for_mountby
         device.mkfs_options = section.mkfs_options
         device.fstab_options = section.fstab_options
@@ -439,6 +439,26 @@ module Y2Storage
       # @see AutoinstSizeParser
       def parse_size(section, min, max)
         AutoinstSizeParser.new(proposal_settings).parse(section.size, section.mount, min, max)
+      end
+
+      # Return the filesystem type for a given section
+      #
+      # @param section [AutoinstProfile::PartitionSection]
+      # @return [Filesystems::Type] Filesystem type
+      def filesystem_for(section)
+        return section.type_for_filesystem if section.type_for_filesystem
+        return nil unless section.mount
+        default_filesystem_for(section)
+      end
+
+      # Return the default filesystem type for a given section
+      #
+      # @param section [AutoinstProfile::PartitionSection]
+      # @return [Filesystems::Type] Filesystem type
+      def default_filesystem_for(section)
+        spec = VolumeSpecificationBuilder.new(proposal_settings).for(section.mount)
+        return spec.fs_type if spec && spec.fs_type
+        section.mount == "swap" ? Filesystems::Type::SWAP : Filesystems::Type::BTRFS
       end
     end
   end

--- a/src/lib/y2storage/proposal/autoinst_size_parser.rb
+++ b/src/lib/y2storage/proposal/autoinst_size_parser.rb
@@ -20,7 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "y2storage/proposal/autoinst_size"
-require "y2storage/volume_specification"
+require "y2storage/volume_specification_builder"
 
 module Y2Storage
   module Proposal
@@ -111,8 +111,7 @@ module Y2Storage
 
       # @return [nil,Array<DiskSize>]
       def auto_sizes_for(mount_point)
-        spec = volume_spec_for(mount_point)
-
+        spec = VolumeSpecificationBuilder.new(proposal_settings).for(mount_point)
         return nil if spec.nil?
 
         AutoinstSize.new(
@@ -121,32 +120,6 @@ module Y2Storage
           max:    spec.max_size,
           weight: spec.weight
         )
-      end
-
-      # @return [VolumeSpecification,nil]
-      def volume_spec_for(mount_point)
-        volume_spec =
-          if proposal_settings.volumes.nil? || proposal_settings.volumes.empty?
-            nil
-          else
-            proposal_settings.volumes.find { |v| v.mount_point == mount_point }
-          end
-
-        volume_spec || fallback_volume_spec(mount_point)
-      end
-
-      DEFAULT_SIZES = {
-        "swap" => {
-          "min_size" => "512MB",
-          "max_size" => "2GB"
-        }
-      }.freeze
-
-      # @return [VolumeSpecification,nil]
-      def fallback_volume_spec(mount_point)
-        features = DEFAULT_SIZES.fetch(mount_point, {})
-        return nil if features.empty?
-        Y2Storage::VolumeSpecification.new(features)
       end
     end
   end

--- a/src/lib/y2storage/volume_specification_builder.rb
+++ b/src/lib/y2storage/volume_specification_builder.rb
@@ -1,0 +1,227 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may
+# find current contact information at www.novell.com.
+
+require "y2storage/filesystems/type"
+require "y2storage/partition_id"
+require "y2storage/proposal_settings"
+
+module Y2Storage
+  # This class is able to provide a volume specification for a given mount point.
+  #
+  # If no specification exists for a given mount point, it will try to offer
+  # a fallback.
+  #
+  # @example Volume specification for /boot
+  #   builder = VolumeSpecificationBuilder.new
+  #   builder.for("/boot")
+  #
+  # @example Non-existent volume specification
+  #   builder = VolumeSpecificationBuilder.new
+  #   builder.for("/some/mount/point") #=> nil
+  class VolumeSpecificationBuilder
+    attr_reader :proposal_settings
+
+    # Constructor
+    #
+    # @param proposal_settings [ProposalSettings] Proposal settings
+    def initialize(proposal_settings = nil)
+      @proposal_settings = proposal_settings || Y2Storage::ProposalSettings.new_for_current_product
+    end
+
+    # Return a volume specification for a given mount point
+    #
+    # It will use the volume specification found within the list of volumes
+    # in the proposal settings. If it is not found, it will try to propose
+    # a fallback.
+    #
+    # @param mount_point [String] Volume mount point
+    # @return [VolumeSpecification] Volume specification;, nil if the
+    #   specification was not found and no fallback could be proposed.
+    def for(mount_point)
+      proposal_spec(mount_point) || fallback_spec(mount_point)
+    end
+
+  private
+
+    # Return a volume spec from proposal settings for the given mount point
+    #
+    # @param mount_point [String] Volume mount point
+    # @return [VolumeSpecification,nil] Volume specification if found; otherwise,
+    #   it returns nil.
+    def proposal_spec(mount_point)
+      case proposal_settings.format
+      when :ng
+        ng_proposal_spec(mount_point)
+      when :legacy
+        legacy_proposal_spec(mount_point)
+      end
+    end
+
+    # Return a volume spec from proposal settings for the given mount point when using ng settings
+    #
+    # @param mount_point [String] Volume mount point
+    # @return [VolumeSpecification,nil] Volume specification if found; otherwise,
+    #   it returns nil.
+    def ng_proposal_spec(mount_point)
+      return nil if proposal_settings.volumes.nil?
+      proposal_settings.volumes.find { |v| v.mount_point == mount_point }
+    end
+
+    # Return a volume spec from proposal settings for the given mount point when using legacy
+    # settings
+    #
+    # @param mount_point [String] Volume mount point
+    # @return [VolumeSpecification,nil] Volume specification if found; otherwise,
+    #   it returns nil.
+    def legacy_proposal_spec(mount_point)
+      case mount_point
+      when "/"
+        legacy_for_root
+      when "/home"
+        legacy_for_home
+      end
+    end
+
+    # Return a volume spec fallback
+    #
+    # @param mount_point [String] Volume mount point
+    # @return [VolumeSpecification,nil] Volume specification if a suitable fallback
+    #   is defined; nil otherwise.
+    def fallback_spec(mount_point)
+      name = mount_point.delete_prefix("/").tr("/", "_")
+      meth = "fallback_for_#{name}"
+      return send(meth) if respond_to?(meth, true)
+    end
+
+    # Volume specification fallback for /boot
+    #
+    # @return [VolumeSpecification]
+    def fallback_for_boot
+      VolumeSpecification.new({}).tap do |v|
+        v.mount_point = "/boot"
+        v.fs_types = Filesystems::Type.root_filesystems
+        v.fs_type = Filesystems::Type::EXT4
+        v.min_size = DiskSize.MiB(100)
+        v.desired_size = DiskSize.MiB(200)
+        v.max_size = DiskSize.MiB(500)
+      end
+    end
+
+    # Volume specification fallback for /boot/efi
+    #
+    # Regarding sizes, it looks like 256MiB is the minimum size for FAT32 in 4K
+    # Native drives (4-KiB-per-sector), according to
+    # https://wiki.archlinux.org/index.php/EFI_System_Partition
+    #
+    # @return [VolumeSpecification]
+    def fallback_for_boot_efi
+      VolumeSpecification.new({}).tap do |v|
+        v.mount_point = "/boot/efi"
+        v.fs_types = [Filesystems::Type::VFAT]
+        v.fs_type = Filesystems::Type::VFAT
+        v.min_size = DiskSize.MiB(256)
+        v.desired_size = DiskSize.MiB(500)
+        v.max_size = DiskSize.MiB(500)
+      end
+    end
+
+    # Volume specification fallback for /boot/zipl
+    #
+    # @return [VolumeSpecification]
+    def fallback_for_boot_zipl
+      VolumeSpecification.new({}).tap do |v|
+        v.mount_point = "/boot/zipl"
+        v.fs_types = Filesystems::Type.zipl_filesystems
+        v.fs_type = Filesystems::Type.zipl_filesystems.first
+        v.min_size = DiskSize.MiB(100)
+        v.desired_size = DiskSize.MiB(200)
+        v.max_size = DiskSize.MiB(500)
+      end
+    end
+
+    # Volume specification fallback for grub partition
+    #
+    # @return [VolumeSpecification]
+    def fallback_for_grub
+      VolumeSpecification.new({}).tap do |v|
+        # Grub2 with all the modules we could possibly use (LVM, LUKS, etc.)
+        # is slightly bigger than 1MiB
+        v.min_size = DiskSize.MiB(2)
+        v.desired_size = DiskSize.MiB(4)
+        v.max_size = DiskSize.MiB(8)
+        # Only required on GPT
+        v.partition_id = PartitionId::BIOS_BOOT
+      end
+    end
+
+    # Volume specification fallback for prep partition
+    #
+    # @return [VolumeSpecification]
+    def fallback_for_prep
+      # TODO: We have been told that PReP must be one of the first 4
+      # partitions, ideally the first one. But we have not found any
+      # rationale/evidence. Not implementing that for the time being
+      VolumeSpecification.new({}).tap do |v|
+        # Grub2 with all the modules we could possibly use (LVM, LUKS, etc.)
+        # is slightly bigger than 1MiB
+        v.min_size = DiskSize.MiB(2)
+        v.desired_size = DiskSize.MiB(4)
+        v.max_size = DiskSize.MiB(8)
+        # So far we are always using msdos partition ids
+        v.partition_id = PartitionId::PREP
+      end
+    end
+
+    # Volume specification fallback for swap
+    #
+    # @return [VolumeSpecification]
+    def fallback_for_swap
+      VolumeSpecification.new({}).tap do |v|
+        v.mount_point = "swap"
+        v.fs_type = Filesystems::Type::SWAP
+        v.min_size = DiskSize.MiB(512)
+        v.max_size = DiskSize.GiB(2)
+      end
+    end
+
+    # Volume specification for root when using legacy settings
+    #
+    # @return [VolumeSpecification]
+    def legacy_for_root
+      VolumeSpecification.new({}).tap do |v|
+        v.mount_point = "/"
+        v.fs_types = Filesystems::Type.root_filesystems
+        v.fs_type = proposal_settings.root_filesystem_type
+      end
+    end
+
+    # Volume specification for /home when using legacy settings
+    #
+    # @return [VolumeSpecification]
+    def legacy_for_home
+      VolumeSpecification.new({}).tap do |v|
+        v.mount_point = "/home"
+        v.fs_types = Filesystems::Type.home_filesystems
+        v.fs_type = proposal_settings.home_filesystem_type
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/volume_specification_builder.rb
+++ b/src/lib/y2storage/volume_specification_builder.rb
@@ -67,37 +67,8 @@ module Y2Storage
     # @return [VolumeSpecification,nil] Volume specification if found; otherwise,
     #   it returns nil.
     def proposal_spec(mount_point)
-      case proposal_settings.format
-      when :ng
-        ng_proposal_spec(mount_point)
-      when :legacy
-        legacy_proposal_spec(mount_point)
-      end
-    end
-
-    # Return a volume spec from proposal settings for the given mount point when using ng settings
-    #
-    # @param mount_point [String] Volume mount point
-    # @return [VolumeSpecification,nil] Volume specification if found; otherwise,
-    #   it returns nil.
-    def ng_proposal_spec(mount_point)
       return nil if proposal_settings.volumes.nil?
       proposal_settings.volumes.find { |v| v.mount_point == mount_point }
-    end
-
-    # Return a volume spec from proposal settings for the given mount point when using legacy
-    # settings
-    #
-    # @param mount_point [String] Volume mount point
-    # @return [VolumeSpecification,nil] Volume specification if found; otherwise,
-    #   it returns nil.
-    def legacy_proposal_spec(mount_point)
-      case mount_point
-      when "/"
-        legacy_for_root
-      when "/home"
-        legacy_for_home
-      end
     end
 
     # Return a volume spec fallback
@@ -199,28 +170,6 @@ module Y2Storage
         v.fs_type = Filesystems::Type::SWAP
         v.min_size = DiskSize.MiB(512)
         v.max_size = DiskSize.GiB(2)
-      end
-    end
-
-    # Volume specification for root when using legacy settings
-    #
-    # @return [VolumeSpecification]
-    def legacy_for_root
-      VolumeSpecification.new({}).tap do |v|
-        v.mount_point = "/"
-        v.fs_types = Filesystems::Type.root_filesystems
-        v.fs_type = proposal_settings.root_filesystem_type
-      end
-    end
-
-    # Volume specification for /home when using legacy settings
-    #
-    # @return [VolumeSpecification]
-    def legacy_for_home
-      VolumeSpecification.new({}).tap do |v|
-        v.mount_point = "/home"
-        v.fs_types = Filesystems::Type.home_filesystems
-        v.fs_type = proposal_settings.home_filesystem_type
       end
     end
   end

--- a/src/lib/y2storage/volume_specification_builder.rb
+++ b/src/lib/y2storage/volume_specification_builder.rb
@@ -53,7 +53,7 @@ module Y2Storage
     # a fallback.
     #
     # @param mount_point [String] Volume mount point
-    # @return [VolumeSpecification] Volume specification;, nil if the
+    # @return [VolumeSpecification] Volume specification; nil if the
     #   specification was not found and no fallback could be proposed.
     def for(mount_point)
       proposal_spec(mount_point) || fallback_spec(mount_point)

--- a/test/y2storage/guided_proposal_test.rb
+++ b/test/y2storage/guided_proposal_test.rb
@@ -44,6 +44,11 @@ describe Y2Storage::GuidedProposal do
     context "when settings are not passed" do
       let(:current_settings) { nil }
 
+      before do
+        allow(Y2Storage::ProposalSettings).to receive(:new_for_current_product)
+          .and_call_original
+      end
+
       it "creates initial proposal settings based on the product (control.xml)" do
         expect(Y2Storage::ProposalSettings).to receive(:new_for_current_product)
           .and_call_original

--- a/test/y2storage/proposal/autoinst_size_parser_test.rb
+++ b/test/y2storage/proposal/autoinst_size_parser_test.rb
@@ -29,7 +29,7 @@ describe Y2Storage::Proposal::AutoinstSizeParser do
   subject(:parser) { described_class.new(settings) }
 
   let(:settings) do
-    instance_double(Y2Storage::ProposalSettings, volumes: volumes)
+    instance_double(Y2Storage::ProposalSettings, volumes: volumes, format: :ng)
   end
 
   let(:volumes) do

--- a/test/y2storage/proposal/initial_strategies/legacy_test.rb
+++ b/test/y2storage/proposal/initial_strategies/legacy_test.rb
@@ -38,6 +38,8 @@ describe Y2Storage::Proposal::InitialStrategies::Legacy do
     subject(:proposal) { described_class.new.initial_proposal(settings: current_settings) }
 
     before do
+      allow(Y2Storage::ProposalSettings).to receive(:new_for_current_product)
+        .and_call_original
       settings.root_filesystem_type = root_filesystem
       settings.use_snapshots = snapshots
       settings.root_base_size = root_base_size

--- a/test/y2storage/proposal/initial_strategies/ng_test.rb
+++ b/test/y2storage/proposal/initial_strategies/ng_test.rb
@@ -123,6 +123,11 @@ describe Y2Storage::Proposal::InitialStrategies::Ng do
     context "when settings are not passed" do
       let(:settings) { nil }
 
+      before do
+        allow(Y2Storage::ProposalSettings).to receive(:new_for_current_product)
+          .and_call_original
+      end
+
       it "creates initial proposal settings based on the product (control.xml)" do
         expect(Y2Storage::ProposalSettings).to receive(:new_for_current_product)
           .and_call_original

--- a/test/y2storage/volume_specification_builder_test.rb
+++ b/test/y2storage/volume_specification_builder_test.rb
@@ -30,55 +30,16 @@ describe Y2Storage::VolumeSpecificationBuilder do
   subject(:builder) { described_class.new(settings) }
 
   let(:settings) do
-    instance_double(Y2Storage::ProposalSettings, volumes: volumes, format: format)
+    instance_double(Y2Storage::ProposalSettings, volumes: volumes)
   end
 
   let(:volumes) { [home_spec] }
   let(:home_spec) { Y2Storage::VolumeSpecification.new("mount_point" => "/home") }
-  let(:format) { :ng }
 
   describe "#for" do
     context "when a volume specification for the given mount point exist" do
       it "returns the existing specification" do
         expect(builder.for("/home")).to eq(home_spec)
-      end
-    end
-
-    context "legacy mode" do
-      let(:format) { :legacy }
-      let(:volumes) { nil }
-
-      let(:settings) do
-        instance_double(
-          Y2Storage::ProposalSettings,
-          format:               :legacy,
-          root_filesystem_type: Y2Storage::Filesystems::Type::BTRFS,
-          home_filesystem_type: Y2Storage::Filesystems::Type::XFS
-        )
-      end
-
-      context "when mount point is /" do
-        it "returns a / volume specification" do
-          expect(builder.for("/")).to have_attributes(
-            fs_types: Y2Storage::Filesystems::Type.home_filesystems,
-            fs_type:  Y2Storage::Filesystems::Type::BTRFS
-          )
-        end
-      end
-
-      context "when mount point is /home" do
-        it "returns a /home volume specification" do
-          expect(builder.for("/home")).to have_attributes(
-            fs_types: Y2Storage::Filesystems::Type.home_filesystems,
-            fs_type:  Y2Storage::Filesystems::Type::XFS
-          )
-        end
-      end
-
-      context "when mount point is not / nor /home" do
-        it "returns nil" do
-          expect(builder.for("/other")).to be_nil
-        end
       end
     end
 

--- a/test/y2storage/volume_specification_builder_test.rb
+++ b/test/y2storage/volume_specification_builder_test.rb
@@ -1,0 +1,163 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+require "y2storage/volume_specification_builder"
+
+describe Y2Storage::VolumeSpecificationBuilder do
+  using Y2Storage::Refinements::SizeCasts
+  subject(:builder) { described_class.new(settings) }
+
+  let(:settings) do
+    instance_double(Y2Storage::ProposalSettings, volumes: volumes, format: format)
+  end
+
+  let(:volumes) { [home_spec] }
+  let(:home_spec) { Y2Storage::VolumeSpecification.new("mount_point" => "/home") }
+  let(:format) { :ng }
+
+  describe "#for" do
+    context "when a volume specification for the given mount point exist" do
+      it "returns the existing specification" do
+        expect(builder.for("/home")).to eq(home_spec)
+      end
+    end
+
+    context "legacy mode" do
+      let(:format) { :legacy }
+      let(:volumes) { nil }
+
+      let(:settings) do
+        instance_double(
+          Y2Storage::ProposalSettings,
+          format:               :legacy,
+          root_filesystem_type: Y2Storage::Filesystems::Type::BTRFS,
+          home_filesystem_type: Y2Storage::Filesystems::Type::XFS
+        )
+      end
+
+      context "when mount point is /" do
+        it "returns a / volume specification" do
+          expect(builder.for("/")).to have_attributes(
+            fs_types: Y2Storage::Filesystems::Type.home_filesystems,
+            fs_type:  Y2Storage::Filesystems::Type::BTRFS
+          )
+        end
+      end
+
+      context "when mount point is /home" do
+        it "returns a /home volume specification" do
+          expect(builder.for("/home")).to have_attributes(
+            fs_types: Y2Storage::Filesystems::Type.home_filesystems,
+            fs_type:  Y2Storage::Filesystems::Type::XFS
+          )
+        end
+      end
+
+      context "when mount point is not / nor /home" do
+        it "returns nil" do
+          expect(builder.for("/other")).to be_nil
+        end
+      end
+    end
+
+    context "when a volume specification nor a fallback for the given mount point does not exist" do
+      it "returns nil" do
+        expect(builder.for("home")).to be_nil
+      end
+
+      context "and mount point is /boot" do
+        it "returns a /boot volume specification" do
+          expect(builder.for("/boot")).to have_attributes(
+            mount_point:  "/boot",
+            fs_types:     Y2Storage::Filesystems::Type.root_filesystems,
+            fs_type:      Y2Storage::Filesystems::Type::EXT4,
+            min_size:     100.MiB,
+            desired_size: 200.MiB,
+            max_size:     500.MiB
+          )
+        end
+      end
+
+      context "when mount point is /boot/efi" do
+        it "returns a /boot/efi volume specification" do
+          expect(builder.for("/boot/efi")).to have_attributes(
+            mount_point:  "/boot/efi",
+            fs_types:     [Y2Storage::Filesystems::Type::VFAT],
+            fs_type:      Y2Storage::Filesystems::Type::VFAT,
+            min_size:     256.MiB,
+            desired_size: 500.MiB,
+            max_size:     500.MiB
+          )
+        end
+      end
+
+      context "when mount point is /boot/zipl" do
+        it "returns a /boot/zipl volume specification" do
+          expect(builder.for("/boot/zipl")).to have_attributes(
+            mount_point:  "/boot/zipl",
+            fs_types:     Y2Storage::Filesystems::Type.zipl_filesystems,
+            fs_type:      Y2Storage::Filesystems::Type.zipl_filesystems.first,
+            min_size:     100.MiB,
+            desired_size: 200.MiB,
+            max_size:     500.MiB
+          )
+        end
+      end
+
+      context "when is a grub2 partition" do
+        it "returns a grub2 partition volume specification" do
+          expect(builder.for("grub")).to have_attributes(
+            min_size:     2.MiB,
+            desired_size: 4.MiB,
+            max_size:     8.MiB,
+            partition_id: Y2Storage::PartitionId::BIOS_BOOT
+          )
+        end
+      end
+
+      context "when is a prep partition" do
+        it "returns a prep partition volume specification" do
+          expect(builder.for("prep")).to have_attributes(
+            min_size:     2.MiB,
+            desired_size: 4.MiB,
+            max_size:     8.MiB,
+            partition_id: Y2Storage::PartitionId::PREP
+          )
+        end
+      end
+
+      context "when is a swap partition" do
+        it "returns a swap volume specification" do
+          expect(builder.for("swap")).to have_attributes(
+            mount_point: "swap",
+            fs_type:     Y2Storage::Filesystems::Type::SWAP,
+            min_size:    512.MiB,
+            max_size:    2.GiB
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support to AutoYaST to select a filesystem when it is not specified in the profile. It's still a WIP as, for instance, we should handle the "legacy" configuration.