### PR TITLE
Special path handling for mount options in partitioner

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 20 16:43:31 UTC 2018 - shundhammer@suse.com
+
+- Special handling for mount options for / and /boot/*
+  in the partitioner (bsc#1080731)
+- 4.0.101
+
+-------------------------------------------------------------------
 Tue Feb 20 09:43:12 UTC 2018 - ancor@suse.com
 
 - Partitioner: bring back traditional list of mount points for both

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.100
+Version:        4.0.101
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -459,9 +459,23 @@ module Y2Partitioner
         def apply_mount_point_options(options)
           return if mount_point.nil?
 
+          # FIXME: Simplify this. This generic anonymous hash might contain
+          # anything; it's very similar to the old target map that left
+          # everybody guessing what it contained.  If we need a helper class to
+          # store some old values for the mount point object, let's create
+          # one. But probably it's just those two fields mentioned above that
+          # need to be taken into account, and for this that "options" hash is
+          # not only complete overkill, it also wraps the wrapper class into
+          # another layer of indirection.
+          # See RFC 1925 section 6a (and section 3).
           options.each_pair do |attr, value|
             mount_point.send(:"#{attr}=", value) unless value.nil?
           end
+
+          # Special handling for some mount paths ("/", "/boot/*")
+          opt = options[:mount_options] || []
+          opt = filesystem.type.special_path_fstab_options(opt, mount_point.path)
+          mount_point.mount_options = opt
         end
 
         def current_value_for(attribute)

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -240,7 +240,7 @@ module Y2Partitioner
       include FstabCommon
 
       def label
-        _("Mount in /etc/fstab by")
+        _("Mount in /etc/fstab By")
       end
 
       def store
@@ -739,7 +739,7 @@ module Y2Partitioner
       end
 
       def label
-        _("Char&set for file names")
+        _("Char&set for File Names")
       end
 
       def help
@@ -759,7 +759,7 @@ module Y2Partitioner
       end
 
       def label
-        _("Code&page for short FAT names")
+        _("Code&page for Short FAT Names")
       end
 
       def help

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -490,6 +490,8 @@ module Y2Partitioner
 
       # Overriding FstabCommon::supported_by_filesystem? to make use of the
       # REGEXP and to avoid having to duplicate it in VALUES
+      #
+      # @return [Boolean]
       def supported_by_filesystem?
         return false if filesystem.nil?
         return false unless supported_by_mount_path?
@@ -498,6 +500,7 @@ module Y2Partitioner
 
       # Check if this mount option is supported by the current mount path.
       # For /boot/* or the root filesystem some options might not be supported.
+      #
       # @return [Boolean]
       def supported_by_mount_path?
         true


### PR DESCRIPTION
Second part of  https://trello.com/c/9c9qZoIn/269-special-mount-options-for-boot-efi-bsc1080731

## Partitioner Part

This makes sure to not force mount options that should not be used for some special paths ("/", "/boot/*") back into the mount options when the user enters the "mount options" dialog in the partitioner.

For ext3/ext4, this removes the "journal" combo box, for vfat, it removes the "iocharset" combo box.

First I tried to just disable them, but this looks so unnatural and awkward that it raises a lot of questions: At least in my Qt widget style, only the combo box label is greyed out, the combo box itself is not; yet, you cannot click it, and it displays a value that is no longer applicable.

So, removing those combo boxes in just that scenario worked a lot better (and it is consistent with what we do otherwise: Simply not offer options that are not applicable in the current scenario).

If the user insists, he can still enter that option manually in the "arbitrary mount options" field.

I also changed the controller to make sure it always performs the special path handling whenever the mount path or the filesystem type changes; before, it would sometimes keep mount options which may or may not be desirable anymore.

## Special Handling for VFAT /boot/EFI

![mount-opt-boot-efi](https://user-images.githubusercontent.com/11538225/36435425-f46816f8-1661-11e8-9ffe-e431dfddefcd.png)

_Notice no "Charset for file names" ("iocharset=...") combo box_

## Normal Handling for VFAT

![mount-opt-vfat](https://user-images.githubusercontent.com/11538225/36435441-fd45abb4-1661-11e8-880b-8aad9bd45f0a.png)

## Special Handling for Ext4 Root Filesystem

![mount-opt-root-ext4](https://user-images.githubusercontent.com/11538225/36435478-0dd73f38-1662-11e8-83fb-c126b6bb7b12.png)

_Notice no "Data Journaling Mode" ("data=...") combo box_

## Normal Handling for Ext4

![mount-opt-ext4](https://user-images.githubusercontent.com/11538225/36435486-16293092-1662-11e8-9fd6-20bbfed6886d.png)
