### PR TITLE
Default for partition table type is now GPT, no longer MSDOS

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 22 12:02:57 UTC 2018 - shundhammer@suse.com
+
+- Changed default partition table from MSDOS to GPT (fate#323457)
+- 4.0.104
+
+-------------------------------------------------------------------
 Thu Feb 22 11:41:45 UTC 2018 - snwint@suse.com
 
 - ensure partition name changes during the proposal process are taken

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.103
+Version:        4.0.104
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/actions/controllers/partition_table.rb
+++ b/src/lib/y2partitioner/actions/controllers/partition_table.rb
@@ -79,6 +79,12 @@ module Y2Partitioner
           disk.possible_partition_table_types
         end
 
+        # Return the default partition table types for this disk.
+        def default_partition_table_type
+          return nil if disk.nil?
+          disk.preferred_ptable_type || possible_partition_table_types.first
+        end
+
         # Check if a partition table can be created on this disk.
         def can_create_partition_table?
           possible_partition_table_types.size > 0

--- a/src/lib/y2partitioner/dialogs/partition_table_type.rb
+++ b/src/lib/y2partitioner/dialogs/partition_table_type.rb
@@ -50,16 +50,12 @@ module Y2Partitioner
 
         # @macro seeAbstractWidget
         def init
-          set_default
+          self.value = @controller.default_partition_table_type
         end
 
         # @macro seeAbstractWidget
         def store
           @controller.type = Y2Storage::PartitionTables::Type.new(value)
-        end
-
-        def set_default
-          self.value = @supported_types.first
         end
       end
 

--- a/src/lib/y2storage/partitionable.rb
+++ b/src/lib/y2storage/partitionable.rb
@@ -210,7 +210,7 @@ module Y2Storage
       end
     end
 
-    # Executes the given block in a context in which the device always have a
+    # Executes the given block in a context in which the device always has a
     # partition table if possible, creating a temporary frozen one if needed.
     #
     # This allows any code to work under the assumption that a given device
@@ -252,7 +252,7 @@ module Y2Storage
     #
     # This method is needed because YaST criteria does not necessarily match
     # the one followed by Storage::Disk#default_partition_table_type (which
-    # defaults to MBR partition tables in many cases)
+    # defaults to GPT partition tables in many cases)
     #
     # @return [PartitionTables::Type]
     def preferred_ptable_type

--- a/test/y2partitioner/actions/controllers/partition_table_test.rb
+++ b/test/y2partitioner/actions/controllers/partition_table_test.rb
@@ -63,6 +63,12 @@ describe Y2Partitioner::Actions::Controllers::PartitionTable do
       end
     end
 
+    describe "#default_partition_table_type" do
+      it "returns type GPT" do
+        expect(subject.default_partition_table_type).to eq Y2Storage::PartitionTables::Type::GPT
+      end
+    end
+
     describe "#can_create_partition_table?" do
       it "detects that it can create a partition table" do
         expect(subject.can_create_partition_table?).to eq true
@@ -117,6 +123,12 @@ describe Y2Partitioner::Actions::Controllers::PartitionTable do
     describe "#possible_partition_table_types" do
       it "returns only type DASD" do
         expect(subject.possible_partition_table_types).to eq [Y2Storage::PartitionTables::Type::DASD]
+      end
+    end
+
+    describe "#default_partition_table_type" do
+      it "returns type DASD" do
+        expect(subject.default_partition_table_type).to eq Y2Storage::PartitionTables::Type::DASD
       end
     end
 

--- a/test/y2partitioner/actions/controllers/partition_table_test.rb
+++ b/test/y2partitioner/actions/controllers/partition_table_test.rb
@@ -34,7 +34,7 @@ describe Y2Partitioner::Actions::Controllers::PartitionTable do
 
     describe "#new" do
       it "has an initial type" do
-        expect(subject.type).to be_a(Y2Storage::PartitionTables::Type)
+        expect(subject.type).to eq Y2Storage::PartitionTables::Type::GPT
       end
     end
 

--- a/test/y2partitioner/actions/controllers/partition_table_test.rb
+++ b/test/y2partitioner/actions/controllers/partition_table_test.rb
@@ -34,7 +34,7 @@ describe Y2Partitioner::Actions::Controllers::PartitionTable do
 
     describe "#new" do
       it "has an initial type" do
-        expect(subject.type).to eq Y2Storage::PartitionTables::Type::GPT
+        expect(subject.type).to be_a Y2Storage::PartitionTables::Type
       end
     end
 


### PR DESCRIPTION
https://trello.com/c/3LaKjLaH/248-1-sles15-p2-1078709-build-4321storage-ng-ms-dos-is-pre-selected-when-creating-new-partition-table

https://fate.suse.com/323457

See also the discussion in the PBI:

The old default coming from libstorage-ng was MSDOS unless it wouldn't work (because it's size limited to MaxUInt32 sectors or something like that). That default is overridden for certain classes in our Ruby part which preferred GPT everywhere.

The partitioner was the only part of the code simply using the default type coming from libstorage-ng; now this changed to GPT as well.

My changes in this PR reflect that changed default (in the unit tests), and it now build-requires the latest libstorage-ng that introduced that change to make sure the unit tests don't fail.