### PR TITLE
Added missing textdomain

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 22 17:12:46 UTC 2018 - shundhammer@suse.com
+
+- Added missing textdomain calls (bsc#1081454)
+- 4.0.107
+
+-------------------------------------------------------------------
 Thu Feb 22 16:59:52 UTC 2018 - igonzalezsosa@suse.com
 
 - AutoYaST: fix support to create multiple volume groups
@@ -167,7 +173,7 @@ Thu Feb  8 10:15:18 UTC 2018 - igonzalezsosa@suse.com
 Wed Feb  7 16:47:58 UTC 2018 - shundhammer@suse.com
 
 - Disabled empty pages in partitioner for the time being
-  (bsc#1078849) 
+  (bsc#1078849)
 - 4.0.86
 
 -------------------------------------------------------------------
@@ -176,7 +182,7 @@ Wed Feb  7 10:57:26 UTC 2018 - igonzalezsosa@suse.com
 - AutoYaST: support reuse of already existing partitions as LVM
   physical volumes or MD RAIDs (bsc#1077277).
 - 4.0.85
-  
+
 -------------------------------------------------------------------
 Wed Feb  7 00:18:34 UTC 2018 - ancor@suse.com
 

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.106
+Version:        4.0.107
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/actions/add_lvm_lv.rb
+++ b/src/lib/y2partitioner/actions/add_lvm_lv.rb
@@ -34,6 +34,7 @@ module Y2Partitioner
       # @param vg [Y2Storage::LvmVg]
       def initialize(vg)
         super()
+        textdomain "storage"
 
         @device_sid = vg.sid
       end

--- a/src/lib/y2partitioner/actions/add_lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/add_lvm_vg.rb
@@ -28,6 +28,11 @@ module Y2Partitioner
   module Actions
     # Action for creating a new LVM volume group
     class AddLvmVg < TransactionWizard
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # Runs the dialog for creating the volume group and applies
       # the given values to new created volume group.
       #
@@ -69,7 +74,6 @@ module Y2Partitioner
       # @return [Boolean] true whether there are available devices; false otherwise.
       def run?
         return true if controller.available_devices.size > 0
-        textdomain "storage"
 
         Yast::Popup.Error(
           _("There are not enough suitable unused devices to create a volume group.\n") + "\n" +

--- a/src/lib/y2partitioner/actions/add_lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/add_lvm_vg.rb
@@ -69,6 +69,7 @@ module Y2Partitioner
       # @return [Boolean] true whether there are available devices; false otherwise.
       def run?
         return true if controller.available_devices.size > 0
+        textdomain "storage"
 
         Yast::Popup.Error(
           _("There are not enough suitable unused devices to create a volume group.\n") + "\n" +

--- a/src/lib/y2partitioner/actions/add_md.rb
+++ b/src/lib/y2partitioner/actions/add_md.rb
@@ -70,6 +70,7 @@ module Y2Partitioner
       # @see TransactionWizard
       def run?
         return true unless md_controller.available_devices.size < 2
+        textdomain "storage"
 
         Yast::Popup.Error(
           _("There are not enough suitable unused devices to create a RAID.")

--- a/src/lib/y2partitioner/actions/add_md.rb
+++ b/src/lib/y2partitioner/actions/add_md.rb
@@ -34,6 +34,11 @@ module Y2Partitioner
     class AddMd < TransactionWizard
       include NewBlkDevice
 
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       def devices
         result = Dialogs::Md.run(md_controller)
         md_controller.apply_default_options if result == :next
@@ -70,7 +75,6 @@ module Y2Partitioner
       # @see TransactionWizard
       def run?
         return true unless md_controller.available_devices.size < 2
-        textdomain "storage"
 
         Yast::Popup.Error(
           _("There are not enough suitable unused devices to create a RAID.")

--- a/src/lib/y2partitioner/actions/delete_disk.rb
+++ b/src/lib/y2partitioner/actions/delete_disk.rb
@@ -29,14 +29,17 @@ module Y2Partitioner
     #
     # @see DeleteDevice
     class DeleteDisk < DeleteDevice
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # Checks whether there is any partition for deleting
       #
       # @note An error popup is shown when there is no partition.
       #
       # @return [Boolean]
       def validate
-        textdomain "storage"
-
         partition_table = device.partition_table
         if partition_table.nil? || partition_table.partitions.empty?
           Yast::Popup.Error(_("There are no partitions to delete on this disk"))

--- a/src/lib/y2partitioner/actions/delete_disk.rb
+++ b/src/lib/y2partitioner/actions/delete_disk.rb
@@ -35,6 +35,8 @@ module Y2Partitioner
       #
       # @return [Boolean]
       def validate
+        textdomain "storage"
+
         partition_table = device.partition_table
         if partition_table.nil? || partition_table.partitions.empty?
           Yast::Popup.Error(_("There are no partitions to delete on this disk"))

--- a/src/lib/y2partitioner/actions/delete_lvm_lv.rb
+++ b/src/lib/y2partitioner/actions/delete_lvm_lv.rb
@@ -28,6 +28,11 @@ module Y2Partitioner
     #
     # @see DeleteDevice
     class DeleteLvmLv < DeleteDevice
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # Confirmation message before performing the delete action
       def confirm
         used_pool? ? confirm_for_used_pool : confirm_for_lv
@@ -54,8 +59,6 @@ module Y2Partitioner
 
       # Confirmation when the device is not a LVM thin pool, or the pool is not used yet
       def confirm_for_lv
-        textdomain "storage"
-
         Yast::Popup.YesNo(
           # TRANSLATORS: Confirmation message when a LVM logical volume is going to be deleted,
           # where %{name} is replaced by the name of the logical volume (e.g., /dev/system/lv1)

--- a/src/lib/y2partitioner/actions/delete_lvm_lv.rb
+++ b/src/lib/y2partitioner/actions/delete_lvm_lv.rb
@@ -54,6 +54,8 @@ module Y2Partitioner
 
       # Confirmation when the device is not a LVM thin pool, or the pool is not used yet
       def confirm_for_lv
+        textdomain "storage"
+
         Yast::Popup.YesNo(
           # TRANSLATORS: Confirmation message when a LVM logical volume is going to be deleted,
           # where %{name} is replaced by the name of the logical volume (e.g., /dev/system/lv1)

--- a/src/lib/y2partitioner/actions/delete_lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/delete_lvm_vg.rb
@@ -28,6 +28,11 @@ module Y2Partitioner
     #
     # @see DeleteDevice
     class DeleteLvmVg < DeleteDevice
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # Confirmation message before performing the delete action
       def confirm
         if device.lvm_lvs.empty?
@@ -50,8 +55,6 @@ module Y2Partitioner
       # @see DeleteDevice#dependent_devices
       # @see DeleteDevice#confirm_recursive_delete
       def confirm_for_used
-        textdomain "storage"
-
         confirm_recursive_delete(
           dependent_devices,
           _("Confirm Deleting of Volume Group"),

--- a/src/lib/y2partitioner/actions/delete_lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/delete_lvm_vg.rb
@@ -50,6 +50,8 @@ module Y2Partitioner
       # @see DeleteDevice#dependent_devices
       # @see DeleteDevice#confirm_recursive_delete
       def confirm_for_used
+        textdomain "storage"
+
         confirm_recursive_delete(
           dependent_devices,
           _("Confirm Deleting of Volume Group"),

--- a/src/lib/y2partitioner/actions/delete_md.rb
+++ b/src/lib/y2partitioner/actions/delete_md.rb
@@ -28,10 +28,13 @@ module Y2Partitioner
     #
     # @see DeleteDevice
     class DeleteMd < DeleteDevice
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # Confirmation message before performing the delete action
       def confirm
-        textdomain "storage"
-
         if used_by_lvm?
           confirm_for_used_by_lvm
         else

--- a/src/lib/y2partitioner/actions/delete_md.rb
+++ b/src/lib/y2partitioner/actions/delete_md.rb
@@ -30,6 +30,8 @@ module Y2Partitioner
     class DeleteMd < DeleteDevice
       # Confirmation message before performing the delete action
       def confirm
+        textdomain "storage"
+
         if used_by_lvm?
           confirm_for_used_by_lvm
         else
@@ -51,8 +53,6 @@ module Y2Partitioner
       # @see DeleteDevice#confirm_recursive_delete
       # @see DeleteDevice#lvm_vg
       def confirm_for_used_by_lvm
-        textdomain "storage"
-
         confirm_recursive_delete(
           dependent_devices,
           _("Confirm Deleting RAID Used by LVM"),

--- a/src/lib/y2partitioner/actions/delete_md.rb
+++ b/src/lib/y2partitioner/actions/delete_md.rb
@@ -51,6 +51,8 @@ module Y2Partitioner
       # @see DeleteDevice#confirm_recursive_delete
       # @see DeleteDevice#lvm_vg
       def confirm_for_used_by_lvm
+        textdomain "storage"
+
         confirm_recursive_delete(
           dependent_devices,
           _("Confirm Deleting RAID Used by LVM"),

--- a/src/lib/y2partitioner/actions/delete_partition.rb
+++ b/src/lib/y2partitioner/actions/delete_partition.rb
@@ -29,6 +29,11 @@ module Y2Partitioner
     #
     # @see DeleteDevice
     class DeletePartition < DeleteDevice
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # Confirmation message before performing the delete action
       def confirm
         if used_by_lvm?
@@ -56,8 +61,6 @@ module Y2Partitioner
       # @see DeleteDevice#confirm_recursive_delete
       # @see DeleteDevice#lvm_vg
       def confirm_for_used_by_lvm
-        textdomain "storage"
-
         confirm_recursive_delete(
           dependent_devices,
           _("Confirm Deleting Partition Used by LVM"),

--- a/src/lib/y2partitioner/actions/delete_partition.rb
+++ b/src/lib/y2partitioner/actions/delete_partition.rb
@@ -56,6 +56,8 @@ module Y2Partitioner
       # @see DeleteDevice#confirm_recursive_delete
       # @see DeleteDevice#lvm_vg
       def confirm_for_used_by_lvm
+        textdomain "storage"
+
         confirm_recursive_delete(
           dependent_devices,
           _("Confirm Deleting Partition Used by LVM"),

--- a/src/lib/y2partitioner/actions/resize_md.rb
+++ b/src/lib/y2partitioner/actions/resize_md.rb
@@ -36,6 +36,7 @@ module Y2Partitioner
       # @param md [Y2Storage::Md]
       def initialize(md)
         super()
+        textdomain "storage"
 
         @device_sid = md.sid
       end

--- a/src/lib/y2partitioner/widgets/blk_device_description.rb
+++ b/src/lib/y2partitioner/widgets/blk_device_description.rb
@@ -47,6 +47,8 @@ module Y2Partitioner
       #
       # @return [String]
       def blk_device_description
+        textdomain "storage"
+
         # TRANSLATORS: heading for the section about a block device
         output = Yast::HTML.Heading(_("Device:"))
         output << Yast::HTML.List(blk_device_attributes)

--- a/src/lib/y2partitioner/widgets/blk_device_description.rb
+++ b/src/lib/y2partitioner/widgets/blk_device_description.rb
@@ -32,6 +32,11 @@ module Y2Partitioner
 
       include BlkDeviceAttributes
 
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # @see #blk_device_description
       # @see #filesystem_description
       #
@@ -47,8 +52,6 @@ module Y2Partitioner
       #
       # @return [String]
       def blk_device_description
-        textdomain "storage"
-
         # TRANSLATORS: heading for the section about a block device
         output = Yast::HTML.Heading(_("Device:"))
         output << Yast::HTML.List(blk_device_attributes)

--- a/src/lib/y2partitioner/widgets/blk_device_edit_button.rb
+++ b/src/lib/y2partitioner/widgets/blk_device_edit_button.rb
@@ -31,9 +31,12 @@ module Y2Partitioner
   module Widgets
     # Button for editing a block device
     class BlkDeviceEditButton < DeviceButton
-      def label
+      def initialize(*args)
+        super
         textdomain "storage"
+      end
 
+      def label
         # TRANSLATORS: button label for editing a block device
         _("Edit...")
       end

--- a/src/lib/y2partitioner/widgets/blk_device_edit_button.rb
+++ b/src/lib/y2partitioner/widgets/blk_device_edit_button.rb
@@ -32,6 +32,8 @@ module Y2Partitioner
     # Button for editing a block device
     class BlkDeviceEditButton < DeviceButton
       def label
+        textdomain "storage"
+
         # TRANSLATORS: button label for editing a block device
         _("Edit...")
       end

--- a/src/lib/y2partitioner/widgets/device_delete_button.rb
+++ b/src/lib/y2partitioner/widgets/device_delete_button.rb
@@ -31,10 +31,13 @@ module Y2Partitioner
   module Widgets
     # Button for deleting a device
     class DeviceDeleteButton < DeviceButton
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # @macro seeAbstractWidget
       def label
-        textdomain "storage"
-
         # TRANSLATORS: label for button to delete a device
         _("Delete...")
       end

--- a/src/lib/y2partitioner/widgets/device_delete_button.rb
+++ b/src/lib/y2partitioner/widgets/device_delete_button.rb
@@ -33,6 +33,8 @@ module Y2Partitioner
     class DeviceDeleteButton < DeviceButton
       # @macro seeAbstractWidget
       def label
+        textdomain "storage"
+
         # TRANSLATORS: label for button to delete a device
         _("Delete...")
       end

--- a/src/lib/y2partitioner/widgets/device_resize_button.rb
+++ b/src/lib/y2partitioner/widgets/device_resize_button.rb
@@ -31,10 +31,13 @@ module Y2Partitioner
   module Widgets
     # Button for resizing a device
     class DeviceResizeButton < DeviceButton
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # @macro seeAbstractWidget
       def label
-        textdomain "storage"
-
         # TRANSLATORS: label for button for resizing a device
         _("Resize...")
       end

--- a/src/lib/y2partitioner/widgets/device_resize_button.rb
+++ b/src/lib/y2partitioner/widgets/device_resize_button.rb
@@ -33,6 +33,8 @@ module Y2Partitioner
     class DeviceResizeButton < DeviceButton
       # @macro seeAbstractWidget
       def label
+        textdomain "storage"
+
         # TRANSLATORS: label for button for resizing a device
         _("Resize...")
       end

--- a/src/lib/y2partitioner/widgets/disk_device_description.rb
+++ b/src/lib/y2partitioner/widgets/disk_device_description.rb
@@ -27,6 +27,11 @@ module Y2Partitioner
     #
     # The disk device is given during initialization (see {BlkDeviceDescription}).
     class DiskDeviceDescription < BlkDeviceDescription
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # @see #blk_device_description
       # @see #disk_description
       #
@@ -42,8 +47,6 @@ module Y2Partitioner
       #
       # @return [String]
       def disk_description
-        textdomain "storage"
-
         # TRANSLATORS: heading for section about a disk device
         output = Yast::HTML.Heading(_("Hard Disk:"))
         output << Yast::HTML.List(disk_attributes)

--- a/src/lib/y2partitioner/widgets/disk_device_description.rb
+++ b/src/lib/y2partitioner/widgets/disk_device_description.rb
@@ -42,6 +42,8 @@ module Y2Partitioner
       #
       # @return [String]
       def disk_description
+        textdomain "storage"
+
         # TRANSLATORS: heading for section about a disk device
         output = Yast::HTML.Heading(_("Hard Disk:"))
         output << Yast::HTML.List(disk_attributes)

--- a/src/lib/y2partitioner/widgets/disk_expert_menu_button.rb
+++ b/src/lib/y2partitioner/widgets/disk_expert_menu_button.rb
@@ -29,13 +29,12 @@ module Y2Partitioner
       include Yast::Logger
 
       def initialize(disk: nil)
+        textdomain "storage"
         @disk = disk
         self.handle_all_events = true
       end
 
       def label
-        textdomain "storage"
-
         # Translators: Expert menu for disks in the partitioner.
         _("&Expert...")
       end

--- a/src/lib/y2partitioner/widgets/disk_expert_menu_button.rb
+++ b/src/lib/y2partitioner/widgets/disk_expert_menu_button.rb
@@ -34,6 +34,8 @@ module Y2Partitioner
       end
 
       def label
+        textdomain "storage"
+
         # Translators: Expert menu for disks in the partitioner.
         _("&Expert...")
       end

--- a/src/lib/y2partitioner/widgets/lvm_edit_button.rb
+++ b/src/lib/y2partitioner/widgets/lvm_edit_button.rb
@@ -36,8 +36,6 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def label
-        textdomain "storage"
-
         _("Edit...")
       end
 

--- a/src/lib/y2partitioner/widgets/lvm_edit_button.rb
+++ b/src/lib/y2partitioner/widgets/lvm_edit_button.rb
@@ -29,6 +29,11 @@ module Y2Partitioner
   module Widgets
     # Button for editing a volume group or logical volume
     class LvmEditButton < DeviceButton
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # @macro seeAbstractWidget
       def label
         textdomain "storage"

--- a/src/lib/y2partitioner/widgets/lvm_edit_button.rb
+++ b/src/lib/y2partitioner/widgets/lvm_edit_button.rb
@@ -31,6 +31,8 @@ module Y2Partitioner
     class LvmEditButton < DeviceButton
       # @macro seeAbstractWidget
       def label
+        textdomain "storage"
+
         _("Edit...")
       end
 

--- a/src/lib/y2partitioner/widgets/lvm_lv_add_button.rb
+++ b/src/lib/y2partitioner/widgets/lvm_lv_add_button.rb
@@ -27,10 +27,13 @@ module Y2Partitioner
   module Widgets
     # Button for opening the workflow to add a logical volume to a volume group
     class LvmLvAddButton < DeviceButton
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # @macro seeAbstractWidget
       def label
-        textdomain "storage"
-
         # TRANSLATORS: button label to add a logical volume
         _("Add...")
       end

--- a/src/lib/y2partitioner/widgets/lvm_lv_add_button.rb
+++ b/src/lib/y2partitioner/widgets/lvm_lv_add_button.rb
@@ -29,6 +29,8 @@ module Y2Partitioner
     class LvmLvAddButton < DeviceButton
       # @macro seeAbstractWidget
       def label
+        textdomain "storage"
+
         # TRANSLATORS: button label to add a logical volume
         _("Add...")
       end

--- a/src/lib/y2partitioner/widgets/lvm_lv_description.rb
+++ b/src/lib/y2partitioner/widgets/lvm_lv_description.rb
@@ -32,6 +32,11 @@ module Y2Partitioner
 
       include LvmLvAttributes
 
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # @see #blk_device_description
       # @see #lvm_lv_description
       # @see #filesystem_description
@@ -58,8 +63,6 @@ module Y2Partitioner
       #
       # @return [String]
       def lvm_lv_description
-        textdomain "storage"
-
         output = Yast::HTML.Heading(_("LVM:"))
         output << Yast::HTML.List(lvm_lv_attributes)
       end

--- a/src/lib/y2partitioner/widgets/lvm_lv_description.rb
+++ b/src/lib/y2partitioner/widgets/lvm_lv_description.rb
@@ -58,6 +58,8 @@ module Y2Partitioner
       #
       # @return [String]
       def lvm_lv_description
+        textdomain "storage"
+
         output = Yast::HTML.Heading(_("LVM:"))
         output << Yast::HTML.List(lvm_lv_attributes)
       end

--- a/src/lib/y2partitioner/widgets/lvm_vg_description.rb
+++ b/src/lib/y2partitioner/widgets/lvm_vg_description.rb
@@ -34,6 +34,8 @@ module Y2Partitioner
       #
       # @return [String]
       def device_description
+        textdomain "storage"
+
         output = Yast::HTML.Heading(_("Device:"))
         output << Yast::HTML.List(device_attributes)
         output << lvm_vg_description

--- a/src/lib/y2partitioner/widgets/lvm_vg_description.rb
+++ b/src/lib/y2partitioner/widgets/lvm_vg_description.rb
@@ -27,6 +27,11 @@ module Y2Partitioner
     #
     # The volume group is given during initialization (see {DeviceDescription}).
     class LvmVgDescription < DeviceDescription
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # A volume group description is composed by the header "Device" and a list
       # of attributes
       #
@@ -34,8 +39,6 @@ module Y2Partitioner
       #
       # @return [String]
       def device_description
-        textdomain "storage"
-
         output = Yast::HTML.Heading(_("Device:"))
         output << Yast::HTML.List(device_attributes)
         output << lvm_vg_description

--- a/src/lib/y2partitioner/widgets/lvm_vg_devices_selector.rb
+++ b/src/lib/y2partitioner/widgets/lvm_vg_devices_selector.rb
@@ -32,6 +32,8 @@ module Y2Partitioner
       #
       # @param controller [Actions::Controllers::LvmVg]
       def initialize(controller)
+        textdomain "storage"
+
         @controller = controller
         super()
       end

--- a/src/lib/y2partitioner/widgets/md_description.rb
+++ b/src/lib/y2partitioner/widgets/md_description.rb
@@ -42,6 +42,8 @@ module Y2Partitioner
       #
       # @return [String]
       def raid_description
+        textdomain "storage"
+
         # TRANSLATORS: heading for section about RAID details
         output = Yast::HTML.Heading(_("RAID:"))
         output << Yast::HTML.List(raid_attributes)

--- a/src/lib/y2partitioner/widgets/md_description.rb
+++ b/src/lib/y2partitioner/widgets/md_description.rb
@@ -27,6 +27,11 @@ module Y2Partitioner
     #
     # The MD RAID is given during initialization (see {BlkDeviceDescription}).
     class MdDescription < BlkDeviceDescription
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # @see #blk_device_description
       # @see #raid_description
       # @see #filesystem_description
@@ -42,8 +47,6 @@ module Y2Partitioner
       #
       # @return [String]
       def raid_description
-        textdomain "storage"
-
         # TRANSLATORS: heading for section about RAID details
         output = Yast::HTML.Heading(_("RAID:"))
         output << Yast::HTML.List(raid_attributes)

--- a/src/lib/y2partitioner/widgets/md_devices_selector.rb
+++ b/src/lib/y2partitioner/widgets/md_devices_selector.rb
@@ -29,6 +29,8 @@ module Y2Partitioner
     # Widget making possible to add and remove partitions to a MD RAID
     class MdDevicesSelector < DevicesSelection
       def initialize(controller)
+        textdomain "storage"
+
         @controller = controller
         super()
       end
@@ -73,7 +75,6 @@ module Y2Partitioner
       # @macro seeAbstractWidget
       def validate
         return true if controller.devices_in_md.size >= controller.min_devices
-
         error_args = { raid_level: controller.md_level.to_human_string, min: controller.min_devices }
         Yast::Popup.Error(
           # TRANSLATORS: raid_level is a RAID level (e.g. RAID10); min is a number

--- a/src/lib/y2partitioner/widgets/partition_add_button.rb
+++ b/src/lib/y2partitioner/widgets/partition_add_button.rb
@@ -27,11 +27,14 @@ module Y2Partitioner
   module Widgets
     # Button for adding a partition
     class PartitionAddButton < DeviceButton
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # @macro seeAbstractWidget
       # The label depends on the page where the button is used
       def label
-        textdomain "storage"
-
         # TRANSLATORS: label for button to add a partition
         disks_page? ? _("Add Partition...") : _("Add...")
       end

--- a/src/lib/y2partitioner/widgets/partition_add_button.rb
+++ b/src/lib/y2partitioner/widgets/partition_add_button.rb
@@ -30,6 +30,8 @@ module Y2Partitioner
       # @macro seeAbstractWidget
       # The label depends on the page where the button is used
       def label
+        textdomain "storage"
+
         # TRANSLATORS: label for button to add a partition
         disks_page? ? _("Add Partition...") : _("Add...")
       end

--- a/src/lib/y2partitioner/widgets/partition_description.rb
+++ b/src/lib/y2partitioner/widgets/partition_description.rb
@@ -41,6 +41,8 @@ module Y2Partitioner
       #
       # @return [String]
       def partition_id
+        textdomain "storage"
+
         # TRANSLATORS: Partition Identifier, where %s is replaced by the partition id (e.g., SWAP)
         format(_("Partition ID: %s"), device.id.to_human_string)
       end

--- a/src/lib/y2partitioner/widgets/partition_description.rb
+++ b/src/lib/y2partitioner/widgets/partition_description.rb
@@ -27,6 +27,11 @@ module Y2Partitioner
     #
     # The partition is given during initialization (see {BlkDeviceDescription}).
     class PartitionDescription < BlkDeviceDescription
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # Attributes for describing a partition
       #
       # @note Same description than a general block device, but including information
@@ -41,8 +46,6 @@ module Y2Partitioner
       #
       # @return [String]
       def partition_id
-        textdomain "storage"
-
         # TRANSLATORS: Partition Identifier, where %s is replaced by the partition id (e.g., SWAP)
         format(_("Partition ID: %s"), device.id.to_human_string)
       end

--- a/src/lib/y2partitioner/yast_nfs_client.rb
+++ b/src/lib/y2partitioner/yast_nfs_client.rb
@@ -82,6 +82,7 @@ module Y2Partitioner
     # @return [Yast::Term, nil] a term defining the UI, nil if the client is
     #   not available and was not installed
     def init_ui
+      textdomain "storage"
       return nil unless try_to_ensure_client
 
       configure_client

--- a/src/lib/y2partitioner/yast_nfs_client.rb
+++ b/src/lib/y2partitioner/yast_nfs_client.rb
@@ -45,6 +45,10 @@ module Y2Partitioner
     PACKAGE = "yast2-nfs-client".freeze
     private_constant :PACKAGE
 
+    def initialize
+      textdomain "storage"
+    end
+
     # Whether the client at yast2-nfs-client has read the related system
     # configuration.
     #
@@ -82,7 +86,6 @@ module Y2Partitioner
     # @return [Yast::Term, nil] a term defining the UI, nil if the client is
     #   not available and was not installed
     def init_ui
-      textdomain "storage"
       return nil unless try_to_ensure_client
 
       configure_client

--- a/src/lib/y2storage/actions_presenter.rb
+++ b/src/lib/y2storage/actions_presenter.rb
@@ -30,6 +30,8 @@ module Y2Storage
     include Yast::I18n
 
     def initialize(actiongraph)
+      textdomain "storage"
+
       @actiongraph = actiongraph
       @collapsed_subvolumes = true
     end

--- a/src/lib/y2storage/autoinst_issues/exception.rb
+++ b/src/lib/y2storage/autoinst_issues/exception.rb
@@ -41,6 +41,8 @@ module Y2Storage
 
       # @param error [StandardError]
       def initialize(error)
+        textdomain "storage"
+
         @error = error
       end
 

--- a/src/lib/y2storage/autoinst_issues/invalid_value.rb
+++ b/src/lib/y2storage/autoinst_issues/invalid_value.rb
@@ -40,6 +40,8 @@ module Y2Storage
       # @param attr      [Symbol] Name of the invalid attribute
       # @param new_value [Integer,String,Symbol] New value or :skip to skip the section
       def initialize(section, attr, new_value = :skip)
+        textdomain "storage"
+
         @section = section
         @attr = attr
         @new_value = new_value

--- a/src/lib/y2storage/autoinst_issues/missing_reusable_device.rb
+++ b/src/lib/y2storage/autoinst_issues/missing_reusable_device.rb
@@ -31,6 +31,8 @@ module Y2Storage
     class MissingReusableDevice < Issue
       # @param section [#parent,#section_name] Section where it was detected (see {AutoinstProfile})
       def initialize(section)
+        textdomain "storage"
+
         @section = section
       end
 

--- a/src/lib/y2storage/autoinst_issues/missing_reuse_info.rb
+++ b/src/lib/y2storage/autoinst_issues/missing_reuse_info.rb
@@ -32,6 +32,8 @@ module Y2Storage
     class MissingReuseInfo < Issue
       # @param section [#parent,#section_name] Section where it was detected (see {AutoinstProfile})
       def initialize(section)
+        textdomain "storage"
+
         @section = section
       end
 

--- a/src/lib/y2storage/autoinst_issues/missing_root.rb
+++ b/src/lib/y2storage/autoinst_issues/missing_root.rb
@@ -27,6 +27,11 @@ module Y2Storage
     #
     # This is a fatal error because the installation is not possible.
     class MissingRoot < Issue
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # Return problem severity
       #
       # @return [Symbol] :fatal
@@ -40,8 +45,6 @@ module Y2Storage
       # @return [String] Error message
       # @see Issue#message
       def message
-        textdomain "storage"
-
         _("No root partition (/) was found.")
       end
     end

--- a/src/lib/y2storage/autoinst_issues/missing_root.rb
+++ b/src/lib/y2storage/autoinst_issues/missing_root.rb
@@ -40,6 +40,8 @@ module Y2Storage
       # @return [String] Error message
       # @see Issue#message
       def message
+        textdomain "storage"
+
         _("No root partition (/) was found.")
       end
     end

--- a/src/lib/y2storage/autoinst_issues/missing_value.rb
+++ b/src/lib/y2storage/autoinst_issues/missing_value.rb
@@ -36,6 +36,8 @@ module Y2Storage
       # @param section [#parent,#section_name] Section where it was detected (see {AutoinstProfile})
       # @param attr    [Symbol] Name of the missing attribute
       def initialize(section, attr)
+        textdomain "storage"
+
         @section = section
         @attr = attr
       end

--- a/src/lib/y2storage/autoinst_issues/no_disk.rb
+++ b/src/lib/y2storage/autoinst_issues/no_disk.rb
@@ -30,6 +30,8 @@ module Y2Storage
     class NoDisk < Issue
       # @param section [#parent,#section_name] Section where it was detected (see {AutoinstProfile})
       def initialize(section)
+        textdomain "storage"
+
         @section = section
       end
 

--- a/src/lib/y2storage/autoinst_issues/no_disk_space.rb
+++ b/src/lib/y2storage/autoinst_issues/no_disk_space.rb
@@ -25,6 +25,11 @@ module Y2Storage
   module AutoinstIssues
     # There is no enough disk space to build the storage proposal
     class NoDiskSpace < Issue
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # Fatal problem
       #
       # @return [Symbol] :fatal
@@ -38,8 +43,6 @@ module Y2Storage
       # @return [String] Error message
       # @see Issue#message
       def message
-        textdomain "storage"
-
         _("Not enough disk space")
       end
     end

--- a/src/lib/y2storage/autoinst_issues/no_disk_space.rb
+++ b/src/lib/y2storage/autoinst_issues/no_disk_space.rb
@@ -38,6 +38,8 @@ module Y2Storage
       # @return [String] Error message
       # @see Issue#message
       def message
+        textdomain "storage"
+
         _("Not enough disk space")
       end
     end

--- a/src/lib/y2storage/autoinst_issues/shrinked_planned_devices.rb
+++ b/src/lib/y2storage/autoinst_issues/shrinked_planned_devices.rb
@@ -37,6 +37,8 @@ module Y2Storage
       # @param device_shrinkages [Array<device_shrinkages_info>] List of objects containing
       #   information about shrinking devices.
       def initialize(device_shrinkages)
+        textdomain "storage"
+
         @device_shrinkages = device_shrinkages
       end
 

--- a/src/lib/y2storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/legacy.rb
@@ -178,6 +178,8 @@ module Y2Storage
       #
       # @return [SetupError]
       def unknown_boot_partition_table_error
+        textdomain "storage"
+
         # TRANSLATORS: error message
         error_message = _(
           "Boot disk has no partition table and it is not possible to boot from it." \

--- a/src/lib/y2storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/legacy.rb
@@ -29,6 +29,11 @@ module Y2Storage
       GRUB_SIZE = DiskSize.KiB(256)
       GRUBENV_SIZE = DiskSize.KiB(1)
 
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # @see Base#needed_partitions
       def needed_partitions(target)
         raise Error if grub_in_mbr? && mbr_gap && !valid_mbr_gap?
@@ -178,8 +183,6 @@ module Y2Storage
       #
       # @return [SetupError]
       def unknown_boot_partition_table_error
-        textdomain "storage"
-
         # TRANSLATORS: error message
         error_message = _(
           "Boot disk has no partition table and it is not possible to boot from it." \

--- a/src/lib/y2storage/boot_requirements_strategies/zipl.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/zipl.rb
@@ -25,6 +25,11 @@ module Y2Storage
   module BootRequirementsStrategies
     # Strategy to calculate boot requirements in systems using ZIPL
     class ZIPL < Base
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
       # @see Base#needed_partitions
       def needed_partitions(target)
         raise Error, "Impossible to boot system from the chosen disk" unless supported_boot_disk?
@@ -78,8 +83,6 @@ module Y2Storage
       #
       # @return [SetupError]
       def unsupported_boot_disk_error
-        textdomain "storage"
-
         # TRANSLATORS: error message
         error_message = _(
           "Looks like the system is going to be installed on a FBA " \

--- a/src/lib/y2storage/boot_requirements_strategies/zipl.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/zipl.rb
@@ -78,6 +78,8 @@ module Y2Storage
       #
       # @return [SetupError]
       def unsupported_boot_disk_error
+        textdomain "storage"
+
         # TRANSLATORS: error message
         error_message = _(
           "Looks like the system is going to be installed on a FBA " \

--- a/src/lib/y2storage/dialogs/guided_setup/select_filesystem/legacy.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_filesystem/legacy.rb
@@ -33,6 +33,11 @@ module Y2Storage
         # support only a separate home volume.
         # See also SelectFilesystem::Ng.
         class Legacy < Base
+          def initialize(*args)
+            super
+            textdomain "storage"
+          end
+
           def root_filesystem_handler
             filesystem = Filesystems::Type.find(widget_value(:root_filesystem))
             widget_update(:snapshots, filesystem.is?(:btrfs), attr: :Enabled)
@@ -91,8 +96,6 @@ module Y2Storage
           end
 
           def initialize_widgets
-            textdomain "storage"
-
             widget_update(:root_filesystem, settings.root_filesystem_type.to_sym)
             widget_update(:snapshots, settings.use_snapshots)
             widget_update(:home_filesystem, settings.home_filesystem_type.to_sym)

--- a/src/lib/y2storage/dialogs/guided_setup/select_filesystem/legacy.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_filesystem/legacy.rb
@@ -91,6 +91,8 @@ module Y2Storage
           end
 
           def initialize_widgets
+            textdomain "storage"
+
             widget_update(:root_filesystem, settings.root_filesystem_type.to_sym)
             widget_update(:snapshots, settings.use_snapshots)
             widget_update(:home_filesystem, settings.home_filesystem_type.to_sym)

--- a/src/lib/y2storage/dialogs/guided_setup/select_filesystem/volume_widget.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_filesystem/volume_widget.rb
@@ -38,6 +38,8 @@ module Y2Storage
           # @param settings [ProposalSettings] see {#settings}
           # @param index [Integer] see {#index}
           def initialize(settings, index)
+            textdomain "storage"
+
             @settings = settings
             @index = index
             @volume = settings.volumes[index]


### PR DESCRIPTION
https://trello.com/c/B6Cx73jd/285-multiple-p1s-add-missing-textdomain-in-y-storage-ng
https://bugzilla.suse.com/show_bug.cgi?id=1081454 and more

## Strategy

We need one `textdomain` per file that uses translations so the _gettext_ tools can pick up the translations and put them into the correct .pot file.

We also need one `textdomain` in the execution path that uses the translations so the corresponding .po file is loaded. For that, one `textdomain` in some constructor in the inheritance hierarchy is sufficient.

What I did here was to add one `textdomain` in each file where they were missing at the most convenient place: Either in `def initialize` if there is one, or in a similar init-like method, or, if there is none, in the first method that has `_(...)` translation markers.

I tried to check as good as possible that in the latter case some parent class has a `textdomain` in its constructor. One is enough in this case, since it is always the same `textdomain "storage"`.

It might still be not 100% correct, though, but probably a lot better than having 39 files where it's completely missing.