### PR TITLE
 Better handling of errors in the callbacks 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Feb 23 14:11:10 UTC 2018 - ancor@suse.com
+
+- Better handling of errors during hardware probing (bsc#1070459,
+  bsc#1079228, bsc#1079817, bsc#1063059, bsc#1080554, bsc#1076776,
+  bsc#1070459 and some others).
+- 4.0.109
+
+-------------------------------------------------------------------
 Fri Feb 23 13:42:46 UTC 2018 - jlopez@suse.com
 
 - Avoid to write files in tests (SCR.Write) (fate#323457).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.108
+Version:        4.0.109
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/callbacks/activate.rb
+++ b/src/lib/y2storage/callbacks/activate.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-#
 # encoding: utf-8
 
 # Copyright (c) [2017-2018] SUSE LLC
@@ -21,15 +19,17 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "storage"
+require "yast"
 require "y2storage/dialogs/callbacks/activate_luks"
+require "y2storage/callbacks/libstorage_callback"
 
 Yast.import "Popup"
 
 module Y2Storage
   module Callbacks
-    # class to implement callbacks used during activate
+    # Class to implement callbacks used during libstorage-ng activation
     class Activate < Storage::ActivateCallbacks
+      include LibstorageCallback
       include Yast::Logger
       include Yast::I18n
 
@@ -56,13 +56,6 @@ module Y2Storage
         password = activate ? dialog.encryption_password : ""
 
         Storage::PairBoolString.new(activate, password)
-      end
-
-      def message(_message)
-      end
-
-      def error(_message, _what)
-        false
       end
     end
   end

--- a/src/lib/y2storage/callbacks/commit.rb
+++ b/src/lib/y2storage/callbacks/commit.rb
@@ -21,7 +21,6 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "yast"
 require "y2storage/callbacks/libstorage_callback"
 
 module Y2Storage

--- a/src/lib/y2storage/callbacks/libstorage_callback.rb
+++ b/src/lib/y2storage/callbacks/libstorage_callback.rb
@@ -1,0 +1,76 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "storage"
+require "yast"
+
+Yast.import "Report"
+Yast.import "Popup"
+Yast.import "Label"
+
+module Y2Storage
+  module Callbacks
+    # Mixin with methods that are common to all kind of callbacks used for the
+    # interaction with libstorage-ng.
+    module LibstorageCallback
+      include Yast::Logger
+      include Yast::I18n
+
+      # Callback for libstorage-ng to show a message to the user.
+      #
+      # Currently it performs no action, we don't want to bother the regular
+      # user with information about every single step. Libstorage-ng is
+      # already writing that information to the YaST logs.
+      #
+      # See Storage::Callbacks#message in libstorage-ng
+      def message(message); end
+
+      # Callback for libstorage-ng to report an error to the user.
+      #
+      # In addition to displaying the error, it offers the user the possibility
+      # to ignore it and continue.
+      #
+      # @note If the user rejects to continue, the method will return false
+      # which implies libstorage-ng will raise the corresponding exception for
+      # the error.
+      #
+      # See Storage::Callbacks#error in libstorage-ng
+      #
+      # @param message [String] error title coming from libstorage-ng
+      # @param what [String] details coming from libstorage-ng
+      # @return [Boolean] true will make libstorage-ng ignore the error, false
+      #   will result in a libstorage-ng exception
+      def error(message, what)
+        textdomain "storage"
+        log.info "libstorage-ng reported an error, asking the user whether to continue"
+        log.info "Error details. Message: #{message}. What: #{what}."
+
+        question = _("Continue despite the error?")
+        result = Yast::Report.ErrorAnyQuestion(
+          Yast::Popup.NoHeadline, "#{message}\n\n#{what}\n\n#{question}",
+          Yast::Label.ContinueButton, Yast::Label.AbortButton, :focus_no
+        )
+        log.info "User answer: #{result}"
+        result
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/callbacks/probe.rb
+++ b/src/lib/y2storage/callbacks/probe.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-#
 # encoding: utf-8
 
 # Copyright (c) 2018 SUSE LLC
@@ -21,26 +19,14 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "storage"
+require "yast"
+require "y2storage/callbacks/libstorage_callback"
 
 module Y2Storage
   module Callbacks
-    # class to implement callbacks used during probe
+    # Class to implement callbacks used during libstorage-ng probe
     class Probe < Storage::ProbeCallbacks
-      include Yast::Logger
-      include Yast::I18n
-
-      def initialize
-        textdomain "storage"
-        super
-      end
-
-      def message(_message)
-      end
-
-      def error(_message, _what)
-        false
-      end
+      include LibstorageCallback
     end
   end
 end

--- a/src/lib/y2storage/callbacks/probe.rb
+++ b/src/lib/y2storage/callbacks/probe.rb
@@ -19,7 +19,6 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "yast"
 require "y2storage/callbacks/libstorage_callback"
 
 module Y2Storage

--- a/test/y2storage/callbacks/activate_test.rb
+++ b/test/y2storage/callbacks/activate_test.rb
@@ -21,10 +21,13 @@
 # find current contact information at www.suse.com.
 
 require_relative "../spec_helper"
+require_relative "callbacks_examples"
 require "y2storage/callbacks/activate"
 
 describe Y2Storage::Callbacks::Activate do
   subject { described_class.new }
+
+  include_examples "libstorage callbacks"
 
   describe "#luks" do
     let(:dialog) { instance_double(Y2Storage::Dialogs::Callbacks::ActivateLuks) }

--- a/test/y2storage/callbacks/callbacks_examples.rb
+++ b/test/y2storage/callbacks/callbacks_examples.rb
@@ -1,5 +1,4 @@
-#!/usr/bin/env ruby
-#
+#!/usr/bin/env rspec
 # encoding: utf-8
 
 # Copyright (c) [2017] SUSE LLC
@@ -21,14 +20,21 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "yast"
-require "y2storage/callbacks/libstorage_callback"
+RSpec.shared_examples "libstorage callbacks" do
+  describe "#error" do
+    it "displays the error to the user" do
+      expect(Yast::Report).to receive(:ErrorAnyQuestion) do |_headline, message|
+        expect(message).to include "the message"
+        expect(message).to include "the what"
+      end
+      subject.error("the message", "the what")
+    end
 
-module Y2Storage
-  module Callbacks
-    # Class to implement callbacks used during libstorage-ng commit
-    class Commit < Storage::CommitCallbacks
-      include LibstorageCallback
+    it "asks the user whether to continue and returns the answer" do
+      allow(Yast::Report).to receive(:ErrorAnyQuestion).and_return(false, false, true)
+      expect(subject.error("", "yes?")).to eq false
+      expect(subject.error("", "please")).to eq false
+      expect(subject.error("", "pretty please")).to eq true
     end
   end
 end

--- a/test/y2storage/callbacks/commit_test.rb
+++ b/test/y2storage/callbacks/commit_test.rb
@@ -21,25 +21,11 @@
 # find current contact information at www.suse.com.
 
 require_relative "../spec_helper"
+require_relative "callbacks_examples"
 require "y2storage/callbacks/commit"
 
 describe Y2Storage::Callbacks::Commit do
   subject(:callbacks) { described_class.new }
 
-  describe "#error" do
-    it "displays the error to the user" do
-      expect(Yast::Report).to receive(:ErrorAnyQuestion) do |_headline, message|
-        expect(message).to include "the message"
-        expect(message).to include "the what"
-      end
-      callbacks.error("the message", "the what")
-    end
-
-    it "asks the user whether to continue and returns the answer" do
-      allow(Yast::Report).to receive(:ErrorAnyQuestion).and_return(false, false, true)
-      expect(callbacks.error("", "yes?")).to eq false
-      expect(callbacks.error("", "please")).to eq false
-      expect(callbacks.error("", "pretty please")).to eq true
-    end
-  end
+  include_examples "libstorage callbacks"
 end

--- a/test/y2storage/callbacks/probe_test.rb
+++ b/test/y2storage/callbacks/probe_test.rb
@@ -1,5 +1,4 @@
-#!/usr/bin/env ruby
-#
+#!/usr/bin/env rspec
 # encoding: utf-8
 
 # Copyright (c) [2017] SUSE LLC
@@ -21,14 +20,12 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "yast"
-require "y2storage/callbacks/libstorage_callback"
+require_relative "../spec_helper"
+require_relative "callbacks_examples"
+require "y2storage/callbacks/probe"
 
-module Y2Storage
-  module Callbacks
-    # Class to implement callbacks used during libstorage-ng commit
-    class Commit < Storage::CommitCallbacks
-      include LibstorageCallback
-    end
-  end
+describe Y2Storage::Callbacks::Probe do
+  subject(:callbacks) { described_class.new }
+
+  include_examples "libstorage callbacks"
 end


### PR DESCRIPTION
This implements callbacks for https://trello.com/c/lo1jjvQDv/225-2-sles15-p1-1057869-build2011storage-ng-disk-will-be-encrypted-if-change-partition-settings-twice

![probing](https://user-images.githubusercontent.com/3638289/36598561-dbd78252-18ac-11e8-95a7-752359261f3d.png)

If the user clicks on abort the exception is still raised. That will be fixed in a separate pull request. But I wanted to ensure this to make it into RC1.