### PR TITLE
Fixed remaining translation

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 26 16:11:12 UTC 2018 - shundhammer@suse.com
+
+- Use format(), not Ruby variable expansion for translated messages
+  (bsc#1081454)
+- 4.0.112
+
+-------------------------------------------------------------------
 Mon Feb 26 14:54:59 UTC 2018 - ancor@suse.com
 
 - Partitioner: ensure a valid password is provided when encrypting

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -3,7 +3,7 @@ Mon Feb 26 16:11:12 UTC 2018 - shundhammer@suse.com
 
 - Use format(), not Ruby variable expansion for translated messages
   (bsc#1081454)
-- 4.0.112
+- 4.0.113
 
 -------------------------------------------------------------------
 Mon Feb 26 14:54:59 UTC 2018 - ancor@suse.com

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.112
+Version:        4.0.113
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/actions_presenter.rb
+++ b/src/lib/y2storage/actions_presenter.rb
@@ -103,11 +103,11 @@ module Y2Storage
 
       event = toggle_subvolumes_event
       if collapsed_subvolumes?
-        # TRANSLATORS: %d is the amount of actions. Do not change href
-        [_("%d subvolume actions (<a href=\"#{event}\">see details</a>)") % actions.size]
+        # TRANSLATORS: %d is the amount of actions, %s an URL
+        [format(_("%d subvolume actions (<a href=\"%s\">see details</a>)"), actions.size, event)]
       else
-        # TRANSLATORS: %d is the amount of actions. Do not change href
-        header = _("%d subvolume actions (<a href=\"#{event}\">hide details</a>)") % actions.size
+        # TRANSLATORS: %d is the amount of actions, %s an URL
+        header = format(_("%d subvolume actions (<a href=\"%s\">hide details</a>)"), actions.size, event)
         list = html_list(actions_to_items(actions))
         [header, list]
       end


### PR DESCRIPTION
https://trello.com/c/B6Cx73jd/285-multiple-p1s-add-missing-textdomain-in-y-storage-ng

https://bugzilla.suse.com/show_bug.cgi?id=1081454

The reason why this file was not picked up by y2makepot was that all translatable messages contain `#`. But that doesn't work for `_(...)` anyway since Ruby will expand the string inside the message before the message gets to `_(...)`, so the string is not constant, so it cannot be looked up as a `msgid` in the `.po` file.