### PR TITLE
Improvements when aborting on libstorage-ng errors

### DIFF
--- a/doc/installer-hacks.md
+++ b/doc/installer-hacks.md
@@ -65,19 +65,10 @@ equivalent, the old code is simply deleted, not commented.
 
 ## Changes in yast2-installation
 
-* Commented the code that searches for floppy drives during system analysis.
-
-* Commented the code that searches for autoinst.xml in a floppy disk.
-
 * Commented the check for destructive disk operations. As a result, when the
   users confirm they want the installation to actually start, the displayed
   popup will not contain the sentence explaining that some partitions will be
   deleted o formatted.
-
-* No more usage of StorageController, the module that loads additional drivers
-  for technologies like RAID or multipath. As soon as we introduce support for
-  such technologies we will need an object-oriented replacement. Or maybe it's
-  not needed anymore if udev does that job now.
 
 * Commented the code used to remember across executions (self-update) that the
   user canceled multipath activation.

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb 27 01:22:48 UTC 2018 - ancor@suse.com
+
+- Improved handling of libstorage-ng errors (bsc#1070459,
+  bsc#1079228, bsc#1079817, bsc#1063059, bsc#1080554, bsc#1076776,
+  bsc#1070459 and some others).
+- 4.0.114
+
+-------------------------------------------------------------------
 Mon Feb 26 16:11:12 UTC 2018 - shundhammer@suse.com
 
 - Use format(), not Ruby variable expansion for translated messages

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.113
+Version:        4.0.114
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/callbacks/commit.rb
+++ b/src/lib/y2storage/callbacks/commit.rb
@@ -28,6 +28,13 @@ module Y2Storage
     # Class to implement callbacks used during libstorage-ng commit
     class Commit < Storage::CommitCallbacks
       include LibstorageCallback
+
+      # @see LibstorageCallback#error
+      #
+      # @return [Boolean]
+      def default_answer_to_error
+        false
+      end
     end
   end
 end

--- a/src/lib/y2storage/callbacks/libstorage_callback.rb
+++ b/src/lib/y2storage/callbacks/libstorage_callback.rb
@@ -25,6 +25,7 @@ require "yast"
 Yast.import "Report"
 Yast.import "Popup"
 Yast.import "Label"
+Yast.import "Mode"
 
 module Y2Storage
   module Callbacks
@@ -64,12 +65,30 @@ module Y2Storage
         log.info "Error details. Message: #{message}. What: #{what}."
 
         question = _("Continue despite the error?")
+        focus = default_answer_to_error ? :focus_yes : :focus_no
         result = Yast::Report.ErrorAnyQuestion(
           Yast::Popup.NoHeadline, "#{message}\n\n#{what}\n\n#{question}",
-          Yast::Label.ContinueButton, Yast::Label.AbortButton, :focus_no
+          Yast::Label.ContinueButton, abort_button_label, focus
         )
         log.info "User answer: #{result}"
         result
+      end
+
+      # Label for the abort button displayed by {#error}
+      #
+      # @return [String]
+      def abort_button_label
+        Yast::Mode.installation ? Yast::Label.AbortInstallationButton : Yast::Label.AbortButton
+      end
+
+      # Default result for {#error}
+      #
+      # This is specially relevant in AutoYaST, since it will be the chosen
+      # answer if the timeout for the question is reached.
+      #
+      # @return [Boolean]
+      def default_answer_to_error
+        true
       end
     end
   end

--- a/test/y2storage/callbacks/activate_test.rb
+++ b/test/y2storage/callbacks/activate_test.rb
@@ -27,7 +27,10 @@ require "y2storage/callbacks/activate"
 describe Y2Storage::Callbacks::Activate do
   subject { described_class.new }
 
-  include_examples "libstorage callbacks"
+  describe "#error" do
+    include_examples "general #error examples"
+    include_examples "default #error true examples"
+  end
 
   describe "#luks" do
     let(:dialog) { instance_double(Y2Storage::Dialogs::Callbacks::ActivateLuks) }

--- a/test/y2storage/callbacks/callbacks_examples.rb
+++ b/test/y2storage/callbacks/callbacks_examples.rb
@@ -20,21 +20,37 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-RSpec.shared_examples "libstorage callbacks" do
-  describe "#error" do
-    it "displays the error to the user" do
-      expect(Yast::Report).to receive(:ErrorAnyQuestion) do |_headline, message|
-        expect(message).to include "the message"
-        expect(message).to include "the what"
-      end
-      subject.error("the message", "the what")
+RSpec.shared_examples "general #error examples" do
+  it "displays the error to the user" do
+    expect(Yast::Report).to receive(:ErrorAnyQuestion) do |_headline, message|
+      expect(message).to include "the message"
+      expect(message).to include "the what"
     end
+    subject.error("the message", "the what")
+  end
 
-    it "asks the user whether to continue and returns the answer" do
-      allow(Yast::Report).to receive(:ErrorAnyQuestion).and_return(false, false, true)
-      expect(subject.error("", "yes?")).to eq false
-      expect(subject.error("", "please")).to eq false
-      expect(subject.error("", "pretty please")).to eq true
+  it "asks the user whether to continue and returns the answer" do
+    allow(Yast::Report).to receive(:ErrorAnyQuestion).and_return(false, false, true)
+    expect(subject.error("", "yes?")).to eq false
+    expect(subject.error("", "please")).to eq false
+    expect(subject.error("", "pretty please")).to eq true
+  end
+end
+
+RSpec.shared_examples "default #error true examples" do
+  it "defaults to true" do
+    expect(Yast::Report).to receive(:ErrorAnyQuestion) do |*args|
+      expect(args[4]).to_not eq :focus_no
     end
+    subject.error("msg", "what")
+  end
+end
+
+RSpec.shared_examples "default #error false examples" do
+  it "defaults to false" do
+    expect(Yast::Report).to receive(:ErrorAnyQuestion) do |*args|
+      expect(args[4]).to eq :focus_no
+    end
+    subject.error("msg", "what")
   end
 end

--- a/test/y2storage/callbacks/commit_test.rb
+++ b/test/y2storage/callbacks/commit_test.rb
@@ -27,5 +27,9 @@ require "y2storage/callbacks/commit"
 describe Y2Storage::Callbacks::Commit do
   subject(:callbacks) { described_class.new }
 
-  include_examples "libstorage callbacks"
+  describe "#error" do
+    include_examples "general #error examples"
+    include_examples "default #error false examples"
+  end
+
 end

--- a/test/y2storage/callbacks/probe_test.rb
+++ b/test/y2storage/callbacks/probe_test.rb
@@ -27,5 +27,8 @@ require "y2storage/callbacks/probe"
 describe Y2Storage::Callbacks::Probe do
   subject(:callbacks) { described_class.new }
 
-  include_examples "libstorage callbacks"
+  describe "#error" do
+    include_examples "general #error examples"
+    include_examples "default #error true examples"
+  end
 end

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -301,6 +301,20 @@ describe Y2Storage::StorageManager do
       manager.commit(force_rw: true)
     end
 
+    it "returns true if everything goes fine" do
+      expect(manager.commit).to eq true
+    end
+
+    context "if libstorage-ng fails and the user decides to abort" do
+      before do
+        allow(manager.storage).to receive(:commit).and_raise Storage::Exception
+      end
+
+      it "returns false" do
+        expect(manager.commit).to eq false
+      end
+    end
+
     context "during installation" do
       let(:mode) { :installation }
       let(:staging) { double("Y2Storage::Devicegraph", filesystems: filesystems, to_xml: "xml") }
@@ -421,6 +435,20 @@ describe Y2Storage::StorageManager do
       manager.probe
       expect(manager.proposal).to be_nil
     end
+
+    it "returns true if everything goes fine" do
+      expect(manager.probe).to eq true
+    end
+
+    context "if libstorage-ng fails and the user decides to abort" do
+      before do
+        allow(manager.storage).to receive(:probe).and_raise Storage::Exception
+      end
+
+      it "returns false" do
+        expect(manager.probe).to eq false
+      end
+    end
   end
 
   describe "#probe_from_yaml" do
@@ -529,6 +557,20 @@ describe Y2Storage::StorageManager do
       it "starts libstorage-ng activation using given callbacks" do
         expect(manager.storage).to receive(:activate).with(custom_callbacks)
         manager.activate(custom_callbacks)
+      end
+    end
+
+    it "returns true if everything goes fine" do
+      expect(manager.activate).to eq true
+    end
+
+    context "if libstorage-ng fails and the user decides to abort" do
+      before do
+        allow(manager.storage).to receive(:activate).and_raise Storage::Exception
+      end
+
+      it "returns false" do
+        expect(manager.activate).to eq false
       end
     end
   end


### PR DESCRIPTION
Improvements for https://trello.com/c/ZFRZeyzr/240-3-ruby-code-handle-errors-during-probing

- Gentle handling of "abort" during commit (the exception is not longer visible)
- Infrastructure to do the same on activate+probe (used by https://github.com/yast/yast-installation/pull/663)
- Better Popup for libstorage-ng errors
  - Use "Abort Installation" button instead of simply "Abort"
  - Default to continue for activate and probe. Default to abort during commit.
- Updated the installer-hacks document (related to https://github.com/yast/yast-installation/pull/663, see https://trello.com/c/LiG0TAoK/213-finish-adaptation-of-instsystemanalysis)