### PR TITLE
ensure proper hierarchy when creating btrfs subvolumes (bsc#1078732)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,3 +1,10 @@
+-------------------------------------------------------------------
+Fri Mar  2 10:28:49 UTC 2018 - snwint@suse.com
+
+- ensure proper hierarchy when creating btrfs subvolumes (bsc#1078732)
+- 4.0.121
+
+-------------------------------------------------------------------
 Thu Mar  1 15:20:35 UTC 2018 - shundhammer@suse.com
 
 - Use default swap priority, not 42 (bsc#1066077)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.120
+Version:        4.0.121
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
+++ b/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
@@ -185,9 +185,8 @@ module Y2Partitioner
         #
         # @see Y2Storage::Filesystems::Btrfs#btrfs_subvolume_path
         def fix_path
+          self.value = filesystem.canonical_subvolume_name(value)
           return if value.empty?
-
-          self.value = value.sub(/^\/*/, "")
 
           default_subvolume_path = filesystem.default_btrfs_subvolume.path
           prefix = default_subvolume_path.empty? ? "" : default_subvolume_path + "/"

--- a/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
+++ b/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
@@ -125,7 +125,7 @@ module Y2Partitioner
         def validate
           fix_path
 
-          valid = content_validation && uniqueness_validation
+          valid = content_validation && uniqueness_validation && hierarchy_validation
           return true if valid
 
           focus
@@ -157,6 +157,24 @@ module Y2Partitioner
           return true unless exist_path?
 
           Yast::Popup.Error(format(_("Subvolume name %s already exists."), value))
+          false
+        end
+
+        # Validate proper hierarchy
+        # An error popup is shown when entered path is part of an already existing path.
+        #
+        # @return [Boolean] true if path is part of an already existing path
+        def hierarchy_validation
+          return true if filesystem.subvolume_can_be_created?(value)
+
+          msg = format(_("Cannot create subvolume %s."), value)
+
+          sv = filesystem.subvolume_descendants(value).first
+          if sv
+            msg << "\n" << format(_("Delete subvolume %s first."), sv.path)
+          end
+
+          Yast::Popup.Error(msg)
           false
         end
 

--- a/src/lib/y2storage/filesystems/btrfs.rb
+++ b/src/lib/y2storage/filesystems/btrfs.rb
@@ -82,16 +82,14 @@ module Y2Storage
 
       # Convert path to canonical form.
       #
-      # That is, a single slash between elements. No final slash except for "/".
+      # That is, a single slash between elements. No leading or final slashes.
       #
       # @param path [String] subvolume path
       #
       # @return [String] sanitized subvolume path
       #
       def canonical_subvolume_name(path)
-        path = path.squeeze("/")
-        path = path.chomp("/") if path != "/"
-        path
+        path.squeeze("/").chomp("/").sub(/^\//, "")
       end
 
       # Check if a subvolume can be created.
@@ -121,8 +119,8 @@ module Y2Storage
       #
       def subvolume_descendants(path)
         path = canonical_subvolume_name(path)
-        path += "/" unless path.end_with?("/")
-        btrfs_subvolumes.find_all { |sv| sv.path.start_with?(path) }
+        path += "/" unless path.empty?
+        btrfs_subvolumes.find_all { |sv| sv.path.start_with?(path) && sv.path != path }
       end
 
       # Returns the default subvolume, creating it when necessary

--- a/src/lib/y2storage/filesystems/btrfs.rb
+++ b/src/lib/y2storage/filesystems/btrfs.rb
@@ -80,6 +80,36 @@ module Y2Storage
         true
       end
 
+      # Check if a subvolume can be created.
+      #
+      # It can always be created if we're going to create the whole file
+      # system anyway.
+      #
+      # If the file system exists already there must at least be nothing
+      # else below path.
+      #
+      # @param path [String] subvolume path
+      #
+      # @return [Boolean]
+      #
+      def subvolume_can_be_created?(path)
+        return true unless exists_in_probed?
+        !subvolume_descendants_exist?(path)
+      end
+
+      # List of subvolumes hierarchically below path
+      #
+      # That is, subvolumes starting with path.
+      #
+      # @param path [String] subvolume path
+      #
+      # @return [Array<BtrfsSubvolume>]
+      #
+      def subvolume_descendants(path)
+        path += "/"
+        btrfs_subvolumes.find_all { |sv| sv.path.start_with?(path) }
+      end
+
       # Returns the default subvolume, creating it when necessary
       #
       # If a specific default subvolume path is requested, returns a subvolume with
@@ -119,7 +149,7 @@ module Y2Storage
         devicegraph.remove_btrfs_subvolume(subvolume)
       end
 
-      # Creates a new btrfs subvolume for the filesystem
+      # Create a new btrfs subvolume for the filesystem
       #
       # @note The subvolume mount point is generated from the filesystem mount point
       # and the subvolume path.
@@ -128,12 +158,23 @@ module Y2Storage
       #
       # @param path [string] absolute subvolume path
       # @param nocow [Boolean] no copy on write property
+      #
+      # @return [BtrfsSubvolume, nil] new subvolume
+      #
       def create_btrfs_subvolume(path, nocow)
-        subvolume = default_btrfs_subvolume.create_btrfs_subvolume(path)
-        subvolume.nocow = nocow
-        subvolume_mount_path = btrfs_subvolume_mount_point(path)
-        subvolume.create_mount_point(subvolume_mount_path) unless subvolume_mount_path.nil?
-        subvolume
+        subvolume = find_btrfs_subvolume_by_path(path)
+        return subvolume if subvolume
+
+        if !subvolume_can_be_created?(path)
+          log.error "cannot create subvolume #{path}"
+          return
+        end
+
+        if subvolume_descendants_exist?(path)
+          create_btrfs_subvolume_full_rebuild(path, nocow)
+        else
+          create_btrfs_subvolume_nochecks(path, nocow)
+        end
       end
 
       # Adds btrfs subvolumes defined from a list of specs
@@ -390,6 +431,98 @@ module Y2Storage
 
       def types_for_is
         super << :btrfs
+      end
+
+    private
+
+      # Check for existing descendants of a subvolume path.
+      #
+      # @param path [String] subvolume path
+      #
+      # @return [Boolean]
+      #
+      def subvolume_descendants_exist?(path)
+        !subvolume_descendants(path).empty?
+      end
+
+      # Find the most suitable parent for a new subvolume
+      #
+      # That is, the one with the longest path that is part of path.
+      #
+      # @param path [String] subvolume path
+      #
+      # @return [BtrfsSubvolume] parent subvolume
+      #
+      def best_match(path)
+        while path.include?("/")
+          path = path.gsub(/\/[^\/]*$/, "")
+          subvolume = find_btrfs_subvolume_by_path(path)
+          return subvolume if subvolume
+        end
+
+        top_level_btrfs_subvolume
+      end
+
+      # Create a new btrfs subvolume for the filesystem
+      #
+      # This method must be used if the new subvolume does not fit into the
+      # existing subvolume hierarchy.
+      #
+      # It will remove all subvolumes but the top level one and then rebuild
+      # them from scratch including the new subvolume.
+      #
+      # @see #create_btrfs_subvolume
+      #
+      # @param path [string] absolute subvolume path
+      # @param nocow [Boolean] no copy on write property
+      #
+      # @return [BtrfsSubvolume] new subvolume
+      #
+      def create_btrfs_subvolume_full_rebuild(path, nocow)
+        log.info "subvolume hierarchy mismatch - recreate all"
+
+        subvolumes = btrfs_subvolumes.map { |x| x.top_level? ? nil : [x.path, x.nocow?] }.compact
+        subvolumes.push([path, nocow])
+
+        default_subvolume = default_btrfs_subvolume.path
+        top_level_btrfs_subvolume.set_default_btrfs_subvolume
+
+        log.info "recreating subvolumes #{subvolumes}, default #{default_subvolume}"
+
+        top_level_btrfs_subvolume.remove_descendants
+
+        # sort: shortest path first
+        subvolumes.sort! { |x, y| x[0] <=> y[0] }
+        subvolumes.each { |x| create_btrfs_subvolume_nochecks(*x) }
+
+        subvolume = find_btrfs_subvolume_by_path(default_subvolume)
+        subvolume.set_default_btrfs_subvolume if subvolume
+
+        find_btrfs_subvolume_by_path(path)
+      end
+
+      # Create a new btrfs subvolume for the filesystem
+      #
+      # @see #create_btrfs_subvolume
+      #
+      # This method does not verify if the subvolume can be added to the
+      # existing subvolume hierarchy. Use {create_btrfs_subvolume} instead.
+      #
+      # @param path [string] absolute subvolume path
+      # @param nocow [Boolean] no copy on write property
+      #
+      # @return [BtrfsSubvolume] new subvolume
+      #
+      def create_btrfs_subvolume_nochecks(path, nocow)
+        parent_subvolume = best_match(path)
+
+        log.info "creating subvolume #{path} at #{parent_subvolume.path}"
+
+        subvolume = parent_subvolume.create_btrfs_subvolume(path)
+        subvolume.nocow = nocow
+        subvolume_mount_path = btrfs_subvolume_mount_point(path)
+        subvolume.create_mount_point(subvolume_mount_path) unless subvolume_mount_path.nil?
+        subvolume
       end
     end
   end

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -230,28 +230,28 @@ describe Y2Storage::Filesystems::Btrfs do
     end
 
     context "when the filesystem already exists" do
-      let(:result) {}
-
       before do
         allow(filesystem).to receive(:exists_in_probed?) .and_return(true)
       end
 
-      it "can not insert a subvolume into an existing hierarchy" do
-        filesystem.create_btrfs_subvolume(path2, nocow)
-        result = filesystem.create_btrfs_subvolume(path3, nocow)
-        expect(result).to be_nil
-        expect(filesystem.btrfs_subvolumes.map(&:path)).to_not include(path3)
-      end
+      context "and the subvolume does not fit in the existing hierarchy" do
+        before do
+          filesystem.create_btrfs_subvolume(path2, nocow)
+        end
 
-      it "and returns nil" do
-        expect(result).to be_nil
+        it "can not create a subvolume" do
+          filesystem.create_btrfs_subvolume(path3, nocow)
+          expect(filesystem.btrfs_subvolumes.map(&:path)).to_not include(path3)
+        end
+
+        it "and returns nil" do
+          expect(filesystem.create_btrfs_subvolume(path3, nocow)).to be_nil
+        end
       end
     end
   end
 
   describe "#canonical_subvolume_name" do
-    let(:devicegraph) { Y2Storage::StorageManager.instance.staging }
-
     it "converts subvolume name into the canonical form" do
       expect(filesystem.canonical_subvolume_name("@/foo")).to eq "@/foo"
       expect(filesystem.canonical_subvolume_name("@/foo/////bar//")).to eq "@/foo/bar"

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -230,15 +230,33 @@ describe Y2Storage::Filesystems::Btrfs do
     end
 
     context "when the filesystem already exists" do
+      let(:result) {}
+
       before do
         allow(filesystem).to receive(:exists_in_probed?) .and_return(true)
       end
 
       it "can not insert a subvolume into an existing hierarchy" do
         filesystem.create_btrfs_subvolume(path2, nocow)
-        filesystem.create_btrfs_subvolume(path3, nocow)
+        result = filesystem.create_btrfs_subvolume(path3, nocow)
+        expect(result).to be_nil
         expect(filesystem.btrfs_subvolumes.map(&:path)).to_not include(path3)
       end
+
+      it "and returns nil" do
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#canonical_subvolume_name" do
+    let(:devicegraph) { Y2Storage::StorageManager.instance.staging }
+
+    it "converts subvolume name into the canonical form" do
+      expect(filesystem.canonical_subvolume_name("@/foo")).to eq "@/foo"
+      expect(filesystem.canonical_subvolume_name("@/foo/////bar//")).to eq "@/foo/bar"
+      expect(filesystem.canonical_subvolume_name("/")).to eq "/"
+      expect(filesystem.canonical_subvolume_name("")).to eq ""
     end
   end
 

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -194,25 +194,114 @@ describe Y2Storage::Filesystems::Btrfs do
   describe "#create_btrfs_subvolume" do
     let(:devicegraph) { Y2Storage::StorageManager.instance.staging }
 
-    let(:path) { "@/foo" }
+    let(:path1) { "@/foo" }
+    let(:path2) { "@/foo/bar/baz" }
+    let(:path3) { "@/foo/bar" }
     let(:nocow) { true }
 
     it "creates a new subvolume" do
-      expect(filesystem.btrfs_subvolumes.map(&:path)).to_not include(path)
-      filesystem.create_btrfs_subvolume(path, nocow)
-      expect(filesystem.btrfs_subvolumes.map(&:path)).to include(path)
+      expect(filesystem.btrfs_subvolumes.map(&:path)).to_not include(path1)
+      filesystem.create_btrfs_subvolume(path1, nocow)
+      expect(filesystem.btrfs_subvolumes.map(&:path)).to include(path1)
     end
 
     it "returns the new created subvolume" do
-      subvolume = filesystem.create_btrfs_subvolume(path, nocow)
+      subvolume = filesystem.create_btrfs_subvolume(path1, nocow)
       expect(subvolume).to be_a(Y2Storage::BtrfsSubvolume)
-      expect(subvolume.path).to eq(path)
+      expect(subvolume.path).to eq(path1)
       expect(subvolume.nocow?).to eq(nocow)
     end
 
     it "creates the subvolume with the correct mount point" do
-      subvolume = filesystem.create_btrfs_subvolume(path, nocow)
-      expect(subvolume.mount_path).to eq("/foo")
+      subvolume = filesystem.create_btrfs_subvolume(path1, nocow)
+      expect(subvolume.mount_path).to eq(path1.delete("@"))
+    end
+
+    context "when the filesystem is going to be formatted" do
+      before do
+        allow(filesystem).to receive(:exists_in_probed?) .and_return(false)
+      end
+
+      it "can insert a subvolume into an existing hierarchy" do
+        filesystem.create_btrfs_subvolume(path2, nocow)
+        filesystem.create_btrfs_subvolume(path3, nocow)
+        expect(filesystem.btrfs_subvolumes.map(&:path)).to include(path3)
+      end
+    end
+
+    context "when the filesystem already exists" do
+      before do
+        allow(filesystem).to receive(:exists_in_probed?) .and_return(true)
+      end
+
+      it "can not insert a subvolume into an existing hierarchy" do
+        filesystem.create_btrfs_subvolume(path2, nocow)
+        filesystem.create_btrfs_subvolume(path3, nocow)
+        expect(filesystem.btrfs_subvolumes.map(&:path)).to_not include(path3)
+      end
+    end
+  end
+
+  describe "#subvolume_descendants" do
+    let(:devicegraph) { Y2Storage::StorageManager.instance.staging }
+
+    let(:path1) { "@/foo" }
+    let(:path2) { "@/foo/bar" }
+
+    it "returns a list of descendant subvolumes" do
+      filesystem.create_btrfs_subvolume(path1, false)
+      filesystem.create_btrfs_subvolume(path2, false)
+      subvolumes = filesystem.subvolume_descendants(path1)
+      expect(subvolumes).to be_a Array
+      expect(subvolumes).to all(be_a(Y2Storage::BtrfsSubvolume))
+      expect(subvolumes.first.path).to eq path2
+    end
+  end
+
+  describe "#subvolume_can_be_created?" do
+    let(:devicegraph) { Y2Storage::StorageManager.instance.staging }
+
+    let(:path1) { "@/foo" }
+    let(:path2) { "@/foo/bar" }
+
+    context "when the filesystem is going to be formatted" do
+      before do
+        allow(filesystem).to receive(:exists_in_probed?) .and_return(false)
+      end
+
+      context "and a subvolume must be inserted into an existing hierarchy" do
+        it "returns true" do
+          filesystem.create_btrfs_subvolume(path2, false)
+          expect(filesystem.subvolume_can_be_created?(path1)).to be(true)
+        end
+      end
+
+      context "and a subvolume must not be inserted into an existing hierarchy" do
+        it "returns true" do
+          filesystem.create_btrfs_subvolume(path1, false)
+          expect(filesystem.subvolume_can_be_created?(path2)).to be(true)
+        end
+      end
+    end
+
+    context "when the filesystem already exists" do
+      before do
+        allow(filesystem).to receive(:exists_in_probed?) .and_return(true)
+      end
+
+      context "and a subvolume must be inserted into an existing hierarchy" do
+        it "returns false" do
+          filesystem.create_btrfs_subvolume(path2, false)
+          expect(filesystem.subvolume_can_be_created?(path1)).to be(false)
+        end
+      end
+
+      context "and a subvolume must not be inserted into an existing hierarchy" do
+        it "returns true" do
+          filesystem.create_btrfs_subvolume(path1, false)
+          expect(filesystem.subvolume_can_be_created?(path2)).to be(true)
+        end
+      end
     end
   end
 

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -253,9 +253,12 @@ describe Y2Storage::Filesystems::Btrfs do
 
   describe "#canonical_subvolume_name" do
     it "converts subvolume name into the canonical form" do
-      expect(filesystem.canonical_subvolume_name("@/foo")).to eq "@/foo"
-      expect(filesystem.canonical_subvolume_name("@/foo/////bar//")).to eq "@/foo/bar"
-      expect(filesystem.canonical_subvolume_name("/")).to eq "/"
+      expect(filesystem.canonical_subvolume_name("foo")).to eq "foo"
+      expect(filesystem.canonical_subvolume_name("/foo")).to eq "foo"
+      expect(filesystem.canonical_subvolume_name("foo/bar")).to eq "foo/bar"
+      expect(filesystem.canonical_subvolume_name("foo//bar////xxx//")).to eq "foo/bar/xxx"
+      expect(filesystem.canonical_subvolume_name("///")).to eq ""
+      expect(filesystem.canonical_subvolume_name("/")).to eq ""
       expect(filesystem.canonical_subvolume_name("")).to eq ""
     end
   end

--- a/test/y2storage/subvol_specification_test.rb
+++ b/test/y2storage/subvol_specification_test.rb
@@ -50,7 +50,7 @@ describe Y2Storage::SubvolSpecification do
 
     it "returns a new SubvolSpecification with path and copy_on_write from real subvolume" do
       subvol_spec = Y2Storage::SubvolSpecification.create_from_btrfs_subvolume(subvolume)
-      expect(subvol_spec.path).to eq("/tmp")
+      expect(subvol_spec.path).to eq("tmp")
       expect(subvol_spec.copy_on_write).to eq(false)
     end
   end


### PR DESCRIPTION
When creating btrfs subvolumes the proper hierarchy must be preserved. It's not possible to create `/foo/bar` when a subvolume `/foo/bar/xxx` already exists.

If the filesystem hasn't been created yet we can just rearrange all subvolumes to fit the new one in. For an existing filesystem there's nothing we can do except notify the user.