### PR TITLE
 Ensure PReP as primary (bsc#1082468) 

### DIFF
--- a/doc/boot-partition.md
+++ b/doc/boot-partition.md
@@ -1,7 +1,7 @@
 Boot Partition Layout / Restrictions For Storage Proposal
 =========================================================
 
-[Revision 2018-02-15]
+[Revision 2018-03-02]
 
 #### Notes:
 
@@ -10,8 +10,12 @@ Boot Partition Layout / Restrictions For Storage Proposal
 
 ### Relevant bugs during SLE15 beta phase
 
+- [bsc#1082468](https://bugzilla.suse.com/show_bug.cgi?id=1082468) is an example
+  of yast2-bootloader failing to configure a logical PReP. PReP must be primary
+  so it can have the 'boot' flag and can be found by firmwares not understanding
+  the structure of extended partitions.
 - In [bsc#1068772](https://bugzilla.suse.com/show_bug.cgi?id=1068772) and
-  [bsc#1076851](https://bugzilla.suse.com/show_bug.cgi?id=1076851) the
+  [bsc#1076851](https://bugzilla.suse.com/show_bug.cgi?id=1076851) other
   requirements for the PReP partition (position and size) have been discussed.
 - In [bsc#1073680](https://bugzilla.suse.com/show_bug.cgi?id=1073680) the
   reporter points that `/boot/efi` should be the first partition in the

--- a/doc/boot-requirements.md
+++ b/doc/boot-requirements.md
@@ -97,19 +97,19 @@
 - in a non-PowerNV system (KVM/LPAR)
 	- with a partitions-based proposal
 		- if there are no PReP partitions in the target disk
-			- **requires only a PReP partition (to allocate Grub2)**
+			- **requires only a new PReP partition (to allocate Grub2)**
 			- **does not require a separate /boot partition (Grub2 can handle this setup)**
 		- if there is already a PReP partition in the disk
 			- **does not require any partition (PReP will be reused and Grub2 can handle this setup)**
 	- with a LVM-based proposal
 		- if there are no PReP partitions in the target disk
-			- **requires only a PReP partition (to allocate Grub2)**
+			- **requires only a new PReP partition (to allocate Grub2)**
 			- **does not require a separate /boot partition (Grub2 can handle this setup)**
 		- if there is already a PReP partition in the disk
 			- **does not require any partition (PReP will be reused and Grub2 can handle this setup)**
 	- with an encrypted proposal
 		- if there are no PReP partitions in the target disk
-			- **requires only a PReP partition (to allocate Grub2)**
+			- **requires only a new PReP partition (to allocate Grub2)**
 			- **does not require a separate /boot partition (Grub2 can handle this setup)**
 		- if there is already a PReP partition in the disk
 			- **does not require any partition (PReP will be reused and Grub2 can handle this setup)**
@@ -130,7 +130,8 @@
 		- **requires /boot to be at least 100 MiB large**
 - when proposing a PReP partition
 	- **requires it to be a non-encrypted partition**
-	- **requires it to be bootable (ms-dos partition table)**
+	- **requires it to be bootable (ms-dos partition table) for some firmwares to find it**
+	- **requires it to be primary since some firmwares cannot find logical partitions**
 	- **requires no particular position for it in the disk (since there is no evidence of such so far)**
 	- when aiming for the recommended size
 		- **requires it to be at least 4 MiB (Grub2 stages 1+2, needed Grub modules and extra space)**

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar  2 11:59:29 UTC 2018 - ancor@suse.com
+
+- New PReP partitions proposed by the Guided Setup are now always
+  primary (bsc#1082468).
+- 4.0.122
+
+-------------------------------------------------------------------
 Fri Mar  2 10:28:49 UTC 2018 - snwint@suse.com
 
 - ensure proper hierarchy when creating btrfs subvolumes (bsc#1078732)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.121
+Version:        4.0.122
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/boot_requirements_strategies/prep.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/prep.rb
@@ -86,6 +86,9 @@ module Y2Storage
       def prep_partition(target)
         planned_partition = create_planned_partition(prep_volume, target)
         planned_partition.bootable = true
+        # The PReP partition cannot be logical (see bsc#1082468 and
+        # information in /doc and the RSpec tests)
+        planned_partition.primary = true
         planned_partition
       end
 

--- a/src/lib/y2storage/planned/assigned_space.rb
+++ b/src/lib/y2storage/planned/assigned_space.rb
@@ -81,6 +81,7 @@ module Y2Storage
       #  - the chances of having 2 volumes with max_start_offset in the same
       #    free space are very low
       def valid?
+        return false unless primary_partitions_fit?
         return true if usable_size >= DiskSize.sum(partitions.map(&:min), rounding: align_grain)
         # At first sight, there is no enough space, but maybe enforcing some
         # order...
@@ -185,6 +186,18 @@ module Y2Storage
       # @return [Boolean]
       def require_end_alignment?
         disk_space.require_end_alignment?
+      end
+
+      # Whether the planned partitions that must be primary are indeed being to
+      # be created as primary partitions.
+      #
+      # @see Planned::Partition#primary
+      #
+      # @return [Boolean]
+      def primary_partitions_fit?
+        # We always create the logical partitions at the end of the space
+        logical_parts = partitions.last(num_logical)
+        logical_parts.none?(&:primary)
       end
 
       # Sorts the planned partitions in the most convenient way in order to

--- a/src/lib/y2storage/planned/partition.rb
+++ b/src/lib/y2storage/planned/partition.rb
@@ -56,6 +56,9 @@ module Y2Storage
       #   flag but is not needed in our grub2 setup.
       attr_accessor :bootable
 
+      # @return [Boolean] whether the partition must be primary
+      attr_accessor :primary
+
       # @return [String] name of the MD array to which this partition should
       #   be added
       attr_accessor :raid_name
@@ -74,6 +77,7 @@ module Y2Storage
 
         @mount_point = mount_point
         @filesystem_type = filesystem_type
+        @primary = false
       end
 
       def self.to_string_attrs

--- a/src/lib/y2storage/volume_specification_builder.rb
+++ b/src/lib/y2storage/volume_specification_builder.rb
@@ -156,7 +156,6 @@ module Y2Storage
         v.min_size = DiskSize.MiB(2)
         v.desired_size = DiskSize.MiB(4)
         v.max_size = DiskSize.MiB(8)
-        # So far we are always using msdos partition ids
         v.partition_id = PartitionId::PREP
       end
     end

--- a/test/support/proposed_partitions_examples.rb
+++ b/test/support/proposed_partitions_examples.rb
@@ -135,8 +135,14 @@ RSpec.shared_examples "proposed PReP partition" do
     expect(prep_part.encrypt?).to eq false
   end
 
-  it "requires it to be bootable (ms-dos partition table)" do
+  it "requires it to be bootable (ms-dos partition table) for some firmwares to find it" do
     expect(prep_part.bootable).to eq true
+  end
+
+  # For more information, see the "Relevant Bugs during SLE15 beta phase"
+  # in doc/boot-partition.md
+  it "requires it to be primary since some firmwares cannot find logical partitions" do
+    expect(prep_part.primary).to eq true
   end
 
   it "requires no particular position for it in the disk (since there is no evidence of such so far)" do

--- a/test/y2storage/boot_requirements_checker_ppc_test.rb
+++ b/test/y2storage/boot_requirements_checker_ppc_test.rb
@@ -50,7 +50,7 @@ describe Y2Storage::BootRequirementsChecker do
       context "if there are no PReP partitions in the target disk" do
         let(:prep_partitions) { [] }
 
-        it "requires only a PReP partition (to allocate Grub2)" do
+        it "requires only a new PReP partition (to allocate Grub2)" do
           expect(checker.needed_partitions).to contain_exactly(
             an_object_having_attributes(mount_point: nil, partition_id: prep_id)
           )

--- a/test/y2storage/proposal_scenarios_ppc_test.rb
+++ b/test/y2storage/proposal_scenarios_ppc_test.rb
@@ -107,5 +107,17 @@ describe Y2Storage::GuidedProposal do
         expect(sda1.filesystem).to be_nil
       end
     end
+
+    # Regression test for bug#1082468 which proposed PReP as a logical partition
+    context "with plenty of space in the extended partition" do
+      let(:scenario) { "multi-linux-pc" }
+      let(:ppc_power_nv) { false }
+
+      it "ensures the new PReP is a primary partition" do
+        proposal.propose
+        prep = proposal.devices.disks.first.prep_partitions.first
+        expect(prep.type).to eq Y2Storage::PartitionType::PRIMARY
+      end
+    end
   end
 end


### PR DESCRIPTION
Implements https://trello.com/c/LKmwH0cb/286-3-sles15-p1-1082468-sles15-beta7-error-during-yast-installation-bootloader-prep

- General support to enforce primary planned partitions.
- Ensures the new PReP partition suggested by BootRequirementsChecker to be primary.
- Updated documentation.