### PR TITLE
Consistent mount_by for subvolumes

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar  7 16:41:08 UTC 2018 - shundhammer@suse.com
+
+- Make sure subvolumes use the same mount_by as their parent btrfs
+  (bsc#1080408)
+- 4.0.127
+
+-------------------------------------------------------------------
 Wed Mar  7 15:01:47 UTC 2018 - ancor@suse.com
 
 - Better control on whether a separate /boot/zipl is needed in

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Wed Mar  7 16:41:08 UTC 2018 - shundhammer@suse.com
+Wed Mar  7 16:41:09 UTC 2018 - shundhammer@suse.com
 
 - Make sure subvolumes use the same mount_by as their parent btrfs
   (bsc#1080408)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.126
+Version:        4.0.127
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -403,6 +403,13 @@ module Y2Partitioner
           subvolumes.map(&:mount_path).compact.select { |m| !m.empty? }
         end
 
+        # Check if the filesystem is a btrfs.
+        #
+        # @return [Boolean]
+        def btrfs?
+          filesystem.supports_btrfs_subvolumes?
+        end
+
       private
 
         def working_graph
@@ -588,10 +595,6 @@ module Y2Partitioner
           filesystem.btrfs_subvolumes.select do |subvolume|
             !subvolume.top_level? && !subvolume.default_btrfs_subvolume?
           end
-        end
-
-        def btrfs?
-          filesystem.supports_btrfs_subvolumes?
         end
 
         def root?

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -107,6 +107,13 @@ module Y2Partitioner
         @controller.filesystem
       end
 
+      # Check if the underlying filesystem is a btrfs.
+      #
+      # @return [Boolean]
+      def btrfs?
+        @controller.btrfs?
+      end
+
       # Mount point of the current filesystem
       #
       # @return [Y2Storage::MountPoint]
@@ -337,6 +344,10 @@ module Y2Partitioner
 
       def store
         mount_point.mount_by = selected_mount_by
+        filesystem.copy_mount_by_to_subvolumes if btrfs?
+        # TODO: If some day we get more a more sophisticated UI for editing
+        # subvolumes, don't always simply overwrite the subvolumes' mount_by
+        # with whatever is set here - ask the user if this is desired.
       end
 
       def init

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -317,7 +317,11 @@ module Y2Partitioner
       # @return [Boolean] true if the label is duplicated; false otherwise.
       def duplicated_label?
         return false if value.empty?
-        working_graph.filesystems.any? { |f| f.sid != filesystem.sid && f.label == value }
+        working_graph.filesystems.any? do |fs|
+          next false if fs.sid == filesystem.sid
+          next false unless fs.respond_to?(:label) # NFS doesn't support labels
+          fs.label == value
+        end
       end
 
       # Widget to select the mount by option

--- a/src/lib/y2storage/btrfs_subvolume.rb
+++ b/src/lib/y2storage/btrfs_subvolume.rb
@@ -77,6 +77,24 @@ module Y2Storage
       to_storage_value.public_send(:default_btrfs_subvolume=)
     end
 
+    # Create a mount point with the same mount_by as the parent Btrfs.
+    #
+    # @param path [String]
+    # @return [MountPoint]
+    def create_mount_point(path)
+      super
+      copy_mount_by_from_filesystem
+      mount_point
+    end
+
+    # Copy the parent filesystem's mount_by from the parent filesystem.
+    #
+    # @return [Filesystems::MountByType, nil]
+    def copy_mount_by_from_filesystem
+      return nil if mount_point.nil? || filesystem.mount_point.nil?
+      mount_point.mount_by = filesystem.mount_point.mount_by
+    end
+
     # Whether the subvolume can be auto deleted, for example when a proposed
     # subvolume is shadowed
     #

--- a/src/lib/y2storage/filesystems/btrfs.rb
+++ b/src/lib/y2storage/filesystems/btrfs.rb
@@ -393,6 +393,23 @@ module Y2Storage
         @snapshots_root ||= Pathname.new(subvolumes_prefix).join(SNAPSHOTS_ROOT_SUBVOL_NAME).to_s
       end
 
+      # Copy the mount_by mode from this btrfs to all subvolumes (that have a
+      # mount point).
+      #
+      # @return [Filesystems::MountByType, nil]
+      #
+      def copy_mount_by_to_subvolumes
+        return nil if mount_point.nil?
+
+        mount_by = mount_point.mount_by
+        log.info "copying mount_by #{mount_by} to all subvolumes"
+        btrfs_subvolumes.each do |subvol|
+          next if subvol.mount_point.nil?
+          subvol.mount_point.mount_by = mount_by
+        end
+        mount_by
+      end
+
     protected
 
       # Removes a subvolume

--- a/test/data/devicegraphs/mixed_disks_btrfs.yml
+++ b/test/data/devicegraphs/mixed_disks_btrfs.yml
@@ -20,6 +20,7 @@
         name:         /dev/sda2
         mount_point:  /
         label:        root
+        mount_by:     label
         file_system:  btrfs
         btrfs:
             default_subvolume: "@"

--- a/test/y2storage/btrfs_subvolume_test.rb
+++ b/test/y2storage/btrfs_subvolume_test.rb
@@ -40,7 +40,7 @@ describe Y2Storage::BtrfsSubvolume do
 
   describe ".shadowing?" do
 
-    context "when a mount point is shadowing to other mount point" do
+    context "when a mount point is shadowing another mount point" do
       let(:mount_point) { "/foo" }
       let(:other_mount_point) { "/foo/bar" }
 
@@ -49,7 +49,7 @@ describe Y2Storage::BtrfsSubvolume do
       end
     end
 
-    context "when a mount point is not shadowing to other mount point" do
+    context "when a mount point is not shadowing another mount point" do
       let(:mount_point) { "/foo" }
       let(:other_mount_point) { "/foobar" }
 

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -867,25 +867,37 @@ describe Y2Storage::Filesystems::Btrfs do
 
   describe "#copy_mount_by_to_subvolumes" do
     let(:subvol_mount_points) { filesystem.btrfs_subvolumes.reject { |s| s.mount_point.nil? } }
-    let(:subvol_mount_bys) { subvol_mount_points.map { |m| m.mount_by.to_sym } }
-    let(:btrfs_mount_by) { filesystem.mount_by.to_sym }
 
-    it "starts with both the btrfs and all subvolumes mounted by label" do
+    # Need some real methods here to avoid 'let' blocks being cached between
+    # the 'before' block and the 'it' block. Notice that 'let!' does NOT
+    # prevent that in this case: It would only reevaluate the block between
+    # different examples, not between the 'before' block and the 'it' block
+    # within the same example.
+    def subvol_mount_bys
+      subvol_mount_points.map { |m| m.mount_by.to_sym }
+    end
+
+    def btrfs_mount_by
+      filesystem.mount_by.to_sym
+    end
+
+    before do
+      # Assert the correct starting conditions
       expect(btrfs_mount_by).to eq :label
       expect(subvol_mount_bys).to all(eq :label)
     end
 
-    it "changing only the btrfs mount_by does not affect the subvolumes" do
-      filesystem.mount_point.mount_by = Y2Storage::Filesystems::MountByType::UUID
-      expect(btrfs_mount_by).to eq :uuid
-      expect(subvol_mount_bys).to all(eq :label)
-    end
-
-    it "copy_mount_by_to_subvolumes copies the modified btrfs mount_by to all subvolumes" do
+    it "copies the btrfs mount_by value to all subvolumes" do
       filesystem.mount_point.mount_by = Y2Storage::Filesystems::MountByType::UUID
       filesystem.copy_mount_by_to_subvolumes
       expect(btrfs_mount_by).to eq :uuid
       expect(subvol_mount_bys).to all(eq :uuid)
+    end
+
+    it "not using it keeps the previous mount_by value for all subvolumes" do
+      filesystem.mount_point.mount_by = Y2Storage::Filesystems::MountByType::UUID
+      expect(btrfs_mount_by).to eq :uuid
+      expect(subvol_mount_bys).to all(eq :label)
     end
   end
 end

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -864,4 +864,28 @@ describe Y2Storage::Filesystems::Btrfs do
       end
     end
   end
+
+  describe "#copy_mount_by_to_subvolumes" do
+    let(:subvol_mount_points) { filesystem.btrfs_subvolumes.reject { |s| s.mount_point.nil? } }
+    let(:subvol_mount_bys) { subvol_mount_points.map { |m| m.mount_by.to_sym } }
+    let(:btrfs_mount_by) { filesystem.mount_by.to_sym }
+
+    it "starts with both the btrfs and all subvolumes mounted by label" do
+      expect(btrfs_mount_by).to eq :label
+      expect(subvol_mount_bys).to all(eq :label)
+    end
+
+    it "changing only the btrfs mount_by does not affect the subvolumes" do
+      filesystem.mount_point.mount_by = Y2Storage::Filesystems::MountByType::UUID
+      expect(btrfs_mount_by).to eq :uuid
+      expect(subvol_mount_bys).to all(eq :label)
+    end
+
+    it "copy_mount_by_to_subvolumes copies the modified btrfs mount_by to all subvolumes" do
+      filesystem.mount_point.mount_by = Y2Storage::Filesystems::MountByType::UUID
+      filesystem.copy_mount_by_to_subvolumes
+      expect(btrfs_mount_by).to eq :uuid
+      expect(subvol_mount_bys).to all(eq :uuid)
+    end
+  end
 end

--- a/test/y2storage/mount_point_test.rb
+++ b/test/y2storage/mount_point_test.rb
@@ -52,4 +52,34 @@ describe Y2Storage::MountPoint do
       expect(mount_point.mount_options).to_not include("ro")
     end
   end
+
+  describe "#mount_by" do
+    context "for non-btrfs" do
+      let(:dev_name) { "/dev/sdb5" } # XFS /home
+      subject { blk_device.blk_filesystem.mount_point }
+
+      before do
+        subject.mount_by = Y2Storage::Filesystems::MountByType::ID
+      end
+
+      it "returns the correct mount_by" do
+        expect(subject.mount_by.to_sym).to eq :id
+      end
+    end
+
+    context "for btrfs" do
+      let(:dev_name) { "/dev/sda2" } # Btrfs /, mount_by: label
+      let(:btrfs) { blk_device.blk_filesystem }
+
+      it "returns the correct mount_by mode" do
+        expect(btrfs.mount_point.mount_by.to_sym).to eq :label
+      end
+
+      it "subvolumes inherit the mount_by mode from the parent btrfs" do
+        # Don't use the first two subvolumes: They don't have a mount point.
+        # One is the toplevel subvolume, one is the default subvolume.
+        expect(btrfs.btrfs_subvolumes.last.mount_point.mount_by.to_sym).to eq :label
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/c4V8FLoO/276-1-sles15-p1-1080408-hps-bug-sles15-beta6-installer-writes-inconsistent-fstab-entries-for-btrfs-subvolumes

https://bugzilla.suse.com/show_bug.cgi?id=1080408

When creating subvolumes or their mount points, copy _mount_by_ from the parent Btrfs.

Also, when changing _mount_by_ for a Btrfs in the expert partitioner, apply that change to all subvolumes (all that have a mount point) as well; this is the best we can do right now because we don't have much of a user interface for any more detailed settings for subvolumes.