### PR TITLE
Fix for bsc#1084213 and bsc#1084261

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Mar  9 09:36:27 UTC 2018 - ancor@suse.com
+
+- Shadowed subvolumes that are ignored in the first proposal
+  attempt are not longer omitted in subsequent ones (#bsc#1084213
+  and bsc#1084261).
+- 4.0.129
+
+-------------------------------------------------------------------
 Thu Mar  8 14:35:20 UTC 2018 - jlopez@suse.com
 
 - Make proposal to work with implicit partition tables (s390).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.128
+Version:        4.0.129
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/planned/can_be_formatted.rb
+++ b/src/lib/y2storage/planned/can_be_formatted.rb
@@ -39,8 +39,12 @@ module Y2Storage
       # @return [String] UUID to enforce in the filesystem
       attr_accessor :uuid
 
-      # @return [Array<SubvolSpecification>] Btrfs subvolume specifications
-      attr_accessor :subvolumes
+      # Btrfs subvolume specifications.
+      #
+      # @see #subvolumes= which doesn't work exactly as the standard Ruby setter
+      #
+      # @return [Array<SubvolSpecification>]
+      attr_reader :subvolumes
 
       # @return [String] Parent for all Btrfs subvolumes (typically "@")
       attr_accessor :default_subvolume
@@ -58,6 +62,29 @@ module Y2Storage
         @subvolumes = []
         @reformat = false
         @snapshots = false
+      end
+
+      # Setter for #subvolumes which always create a local copy of the passed array
+      #
+      # When assigning the list of subvolumes, this method automatically creates
+      # a copy of the original list to avoid the situation in which modifying
+      # the subvolumes of a planned device ends up modifying the original source
+      # of such list (bsc#1084213 and bsc#1084261).
+      #
+      # Take into account this is not a deep copy. Only the collection is
+      # duplicated, the contained objects are still shared.
+      #
+      # @example
+      #   planned.subvolumes = my_list
+      #   my_list << a_new_one
+      #   # planned.subvolumes doesn't contain a_new_one now. This is not the
+      #   # most common ruby behavior.
+      #   my_list.first.path = "changed" # This change affects planned.subvolumes
+      #   # because the object is also in that collection (not a deep copy).
+      #
+      # @param list [Array<SubvolSpecification>]
+      def subvolumes=(list)
+        @subvolumes = list.dup
       end
 
       # Creates a filesystem for the planned device on the specified real

--- a/src/lib/y2storage/planned/can_be_formatted.rb
+++ b/src/lib/y2storage/planned/can_be_formatted.rb
@@ -39,11 +39,30 @@ module Y2Storage
       # @return [String] UUID to enforce in the filesystem
       attr_accessor :uuid
 
-      # Btrfs subvolume specifications.
+      # @overload subvolumes
+      #   Btrfs subvolume specifications.
       #
-      # @see #subvolumes= which doesn't work exactly as the standard Ruby setter
+      #   @return [Array<SubvolSpecification>]
+      # @overload subvolumes=(list)
+      #   Setter for #subvolumes which always create a local copy of the passed array
       #
-      # @return [Array<SubvolSpecification>]
+      #   When assigning the list of subvolumes, this method automatically creates
+      #   a copy of the original list to avoid the situation in which modifying
+      #   the subvolumes of a planned device ends up modifying the original source
+      #   of such list (bsc#1084213 and bsc#1084261).
+      #
+      #   Take into account this is not a deep copy. Only the collection is
+      #   duplicated, the contained objects are still shared.
+      #
+      #   @example
+      #     planned.subvolumes = my_list
+      #     my_list << a_new_one
+      #     # planned.subvolumes doesn't contain a_new_one now. This is not the
+      #     # most common ruby behavior.
+      #     my_list.first.path = "changed" # This change affects planned.subvolumes
+      #     # because the object is also in that collection (not a deep copy).
+      #
+      #   @param list [Array<SubvolSpecification>]
       attr_reader :subvolumes
 
       # @return [String] Parent for all Btrfs subvolumes (typically "@")
@@ -64,25 +83,7 @@ module Y2Storage
         @snapshots = false
       end
 
-      # Setter for #subvolumes which always create a local copy of the passed array
-      #
-      # When assigning the list of subvolumes, this method automatically creates
-      # a copy of the original list to avoid the situation in which modifying
-      # the subvolumes of a planned device ends up modifying the original source
-      # of such list (bsc#1084213 and bsc#1084261).
-      #
-      # Take into account this is not a deep copy. Only the collection is
-      # duplicated, the contained objects are still shared.
-      #
-      # @example
-      #   planned.subvolumes = my_list
-      #   my_list << a_new_one
-      #   # planned.subvolumes doesn't contain a_new_one now. This is not the
-      #   # most common ruby behavior.
-      #   my_list.first.path = "changed" # This change affects planned.subvolumes
-      #   # because the object is also in that collection (not a deep copy).
-      #
-      # @param list [Array<SubvolSpecification>]
+      # See #subvolumes
       def subvolumes=(list)
         @subvolumes = list.dup
       end

--- a/test/support/proposal_context.rb
+++ b/test/support/proposal_context.rb
@@ -82,7 +82,14 @@ RSpec.shared_context "proposal" do
     settings
   end
 
-  let(:ng_settings) { Y2Storage::ProposalSettings.new_for_current_product }
+  let(:ng_settings) do
+    settings = Y2Storage::ProposalSettings.new_for_current_product
+    home = settings.volumes.find { |v| v.mount_point == "/home" }
+    home.proposed = separate_home if home
+    settings.lvm = lvm
+    settings.encryption_password = encrypt ? "12345678" : nil
+    settings
+  end
 
   let(:control_file) { nil }
 

--- a/test/y2storage/proposal/initial_strategies/ng_test.rb
+++ b/test/y2storage/proposal/initial_strategies/ng_test.rb
@@ -117,6 +117,7 @@ describe Y2Storage::Proposal::InitialStrategies::Ng do
     let(:swap_settings) { volume_settings(proposal.settings, "swap") }
 
     let(:lvm) { false }
+    let(:separate_home) { true }
 
     let(:root_proposed_configurable) { false }
 


### PR DESCRIPTION
First step to fix https://trello.com/c/MSBg5L2S/304-sles15-p1-1084213-storage-ng-home-subvolume-not-created-if-user-opts-to-not-have-a-home-partition