### PR TITLE
Warn if reusing an existing system mount point in the partitioner during installation

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 13 15:04:59 UTC 2018 - shundhammer@suse.com
+
+- Post a warning if reusing an existing system mount point without
+  formatting during installation in the partitioner (bsc#1080073)
+- 4.0.132
+
+-------------------------------------------------------------------
 Mon Mar 12 11:35:55 UTC 2018 - igonzalezsosa@suse.com
 
 - Add a new btrfs_read_only property to force the root filesystem

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.131
+Version:        4.0.132
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -300,7 +300,7 @@ module Y2Partitioner
       def validate_system_mount_points
         return true unless Yast::Mode.installation
         return true if to_be_formatted?
-        return true if !mounted?
+        return true unless mounted?
         return true unless ["/", "/usr", "/boot"].include?(mount_path)
         warn_unformatted_system_mount_points
       end
@@ -319,7 +319,7 @@ module Y2Partitioner
         ) +
           # continued popup text
           _(
-            "- if this is an existing ReiserFS partition\n" \
+            "- if this is an existing Btrfs partition\n" \
             "- if this partition already contains a Linux distribution that will be\n" \
             "overwritten\n" \
             "- if this partition does not yet contain a file system\n"
@@ -334,14 +334,8 @@ module Y2Partitioner
           _(
             "If you decide to format the partition, all data on it will be lost.\n" \
             "\n" \
-            "Really keep the partition unformatted?\n"
+            "Really skip formatting the partition?\n"
           )
-        # FIXME: Keeping the message from old yast-storage and just replacing
-        # ReiserFS with Btrfs after the translation because of the late release
-        # state to avoid breaking existing translations. After the SLE-15
-        # release, replace it in the text to avoid possible problems with the
-        # translations.
-        message.gsub!("ReiserFS", "Btrfs")
         Yast::Popup.YesNo(message)
       end
 


### PR DESCRIPTION
https://trello.com/c/BgAmje4M/

- Only during installation (not in the installed system, not during upgrade)
- Only if creating or editing a mount point that is not to be formatted
- Only for a small number of well-known system mount points:
  - /
  - /usr
  - /boot

...post a warning:

![warn-reuse-part](https://user-images.githubusercontent.com/11538225/37350267-abee2052-26d8-11e8-8d6f-9799c0693d12.png)

Upon "Yes" (keep unformatted), apply the changes and close this dialog.
Upon "No", go back and let the user choose something else (format or change mount point).