### PR TITLE
Check if partition resize is possible based on filesystem type

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 15 15:37:51 UTC 2018 - shundhammer@suse.com
+
+- Partitioner: Check if resize is possible based on filesystem type
+  (fate#318196)
+- 4.0.134
+
+-------------------------------------------------------------------
 Thu Mar 15 09:57:41 UTC 2018 - jlopez@suse.com
 
 - Partitioner: do not allow to remove implicit partitions.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.133
+Version:        4.0.134
 Release:	0
 BuildArch:	noarch
 
@@ -26,12 +26,12 @@ Source:		%{name}-%{version}.tar.bz2
 # Yast2::FsSnapshots.configure_on_install=
 Requires:	yast2 >= 4.0.24
 Requires:	yast2-ruby-bindings
-# ActivateCallbacks::multipath signature
-Requires:	libstorage-ng-ruby >= 3.3.181
+# BlkFilesystem::supports_shrink() / _grow()
+Requires:	libstorage-ng-ruby >= 3.3.191
 
 BuildRequires:	update-desktop-files
-# ActivateCallbacks::multipath signature
-BuildRequires:	libstorage-ng-ruby >= 3.3.181
+# BlkFilesystem::supports_shrink() / _grow()
+BuildRequires:	libstorage-ng-ruby >= 3.3.191
 BuildRequires:	yast2-ruby-bindings
 BuildRequires:	yast2-devtools
 # yast2-xml dependency is added by yast2 but ignored in the

--- a/src/lib/y2partitioner/actions/resize_blk_device.rb
+++ b/src/lib/y2partitioner/actions/resize_blk_device.rb
@@ -85,7 +85,9 @@ module Y2Partitioner
       #
       # @return [Array<Strings>]
       def errors
-        [used_device_error, cannot_be_resized_error].compact
+        [used_device_error,
+         fstype_resize_support_error,
+         cannot_be_resized_error].compact
       end
 
       # Error when trying to resize an used device
@@ -102,6 +104,17 @@ module Y2Partitioner
             "resized. To resize %{name}, make sure it is not used."),
           name: device.name
         )
+      end
+
+      # Error when the filesystem type cannot be resized
+      #
+      # @return [String, nil] nil if the filesystem can be resized.
+      def fstype_resize_support_error
+        return nil unless device.formatted?
+        fs = device.blk_filesystem
+        return nil if fs.supports_grow? || fs.supports_shrink?
+
+        _("This filesystem type cannot be resized.")
       end
 
       # Error when the device cannot be resized

--- a/src/lib/y2partitioner/actions/resize_blk_device.rb
+++ b/src/lib/y2partitioner/actions/resize_blk_device.rb
@@ -111,8 +111,7 @@ module Y2Partitioner
       # @return [String, nil] nil if the filesystem can be resized.
       def fstype_resize_support_error
         return nil unless device.formatted?
-        fs = device.blk_filesystem
-        return nil if fs.supports_grow? || fs.supports_shrink?
+        return nil if device.blk_filesystem.supports_resize?
 
         _("This filesystem type cannot be resized.")
       end

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -63,7 +63,7 @@ module Y2Storage
       storage_forward :supports_shrink?, to: :supports_shrink
 
       # @!method supports_grow?
-      #   @return [Boolean] whether the filesystem supports shrinking
+      #   @return [Boolean] whether the filesystem supports growing
       storage_forward :supports_grow?, to: :supports_grow
 
       # @!attribute mkfs_options
@@ -117,6 +117,14 @@ module Y2Storage
       def in_network?
         disks = ancestors.find_all { |d| d.is?(:disk) }
         disks.any?(&:in_network?)
+      end
+
+      # Check if this filesystem type supports any kind of resize at all,
+      # either shrinking or growing.
+      #
+      # @return [Boolean]
+      def supports_resize?
+        supports_shrink? || supports_grow?
       end
 
     protected

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -58,6 +58,14 @@ module Y2Storage
       storage_forward :uuid
       storage_forward :uuid=
 
+      # @!method supports_shrink?
+      #   @return [Boolean] whether the filesystem supports shrinking
+      storage_forward :supports_shrink?, to: :supports_shrink
+
+      # @!method supports_grow?
+      #   @return [Boolean] whether the filesystem supports shrinking
+      storage_forward :supports_grow?, to: :supports_grow
+
       # @!attribute mkfs_options
       #   Options to use when calling mkfs during devicegraph commit (if the
       #   filesystem needs to be created in the system).

--- a/test/y2storage/filesystems/blk_filesystem_test.rb
+++ b/test/y2storage/filesystems/blk_filesystem_test.rb
@@ -30,22 +30,77 @@ describe Y2Storage::Filesystems::BlkFilesystem do
   end
   let(:scenario) { "mixed_disks_btrfs" }
   let(:blk_device) { Y2Storage::BlkDevice.find_by_name(fake_devicegraph, dev_name) }
+  let(:btrfs_part) { "/dev/sdb2" }
+  let(:xfs_part)   { "/dev/sdb5" }
+  let(:ntfs_part)  { "/dev/sda1" }
   subject(:filesystem) { blk_device.blk_filesystem }
 
   describe "#supports_btrfs_subvolumes?" do
     context "for a Btrfs filesystem" do
-      let(:dev_name) { "/dev/sdb2" }
+      let(:dev_name) { btrfs_part }
 
       it "returns true" do
         expect(filesystem.supports_btrfs_subvolumes?).to eq true
       end
     end
 
-    context "for a no-Btrfs filesystem" do
-      let(:dev_name) { "/dev/sdb5" }
+    context "for a non-Btrfs filesystem" do
+      let(:dev_name) { xfs_part }
 
       it "returns false" do
         expect(filesystem.supports_btrfs_subvolumes?).to eq false
+      end
+    end
+  end
+
+  describe "#supports_grow?" do
+    context "for a Btrfs filesystem" do
+      let(:dev_name) { btrfs_part }
+
+      it "returns true" do
+        expect(filesystem.supports_grow?).to eq true
+      end
+    end
+
+    context "for an XFS filesystem" do
+      let(:dev_name) { xfs_part }
+
+      it "returns false" do
+        expect(filesystem.supports_grow?).to eq true
+      end
+    end
+
+    context "for an NTFS filesystem" do
+      let(:dev_name) { ntfs_part }
+
+      it "returns true" do
+        expect(filesystem.supports_grow?).to eq true
+      end
+    end
+  end
+
+  describe "#supports_shrink?" do
+    context "for a Btrfs filesystem" do
+      let(:dev_name) { btrfs_part }
+
+      it "returns true" do
+        expect(filesystem.supports_shrink?).to eq true
+      end
+    end
+
+    context "for an XFS filesystem" do
+      let(:dev_name) { xfs_part }
+
+      it "returns true" do
+        expect(filesystem.supports_shrink?).to eq false
+      end
+    end
+
+    context "for an NTFS filesystem" do
+      let(:dev_name) { ntfs_part }
+
+      it "returns true" do
+        expect(filesystem.supports_shrink?).to eq true
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/lD8N7IET/200-5-partitioner-show-specific-error-messages-when-resizing-partitions

This is the first line of defence: If the filesystem type doesn't support resizing at all, this is the most obvious reason; we don't need to check if other, more complex conditions are met that the user might try to fix first. 

Since a filesystem is the innermost thing that is affected by a resize, otherwise the user might get errors about
- the partition that cannot be resized for any other reason
- an encryption layer that cannot be resized

There might still be more reasons, also on the filesystem level, why resizing is currently (!) not possible. But if it can't be done for a specific filesystem type at all, we don't need to bother with anything else; this is checked here, and it is checked first before going into any more details. We don't even need any more details if it doesn't work in principle.