### PR TITLE
Fix errors with zero-size devices 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Mar 19 07:47:13 UTC 2018 - jlopez@suse.com
+
+- Fix issues with zero-size devices (bsc#1083887).
+- Proposal: do not use zero-size devices.
+- Partitioner: completely hide zero-size devices.
+- 4.0.138
+
+-------------------------------------------------------------------
 Fri Mar 16 16:44:51 UTC 2018 - ancor@suse.com
 
 - Added methods to deal with /etc/fstab specs (part of bsc#1071454)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.137
+Version:        4.0.138
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
@@ -145,13 +145,13 @@ module Y2Partitioner
         # @return [Array<Y2Storage::BlkDevice>]
         def available_devices
           devices =
-            working_graph.disks +
-            working_graph.multipaths +
-            working_graph.dm_raids +
+            working_graph.disk_devices +
             working_graph.md_raids +
             working_graph.partitions
 
-          devices.flatten.compact.select { |d| available?(d) }
+          devices.reject! { |d| d.is?(:dasd) }
+
+          devices.select { |d| available?(d) }
         end
 
         # Devices that are already used as physical volume by the volume group

--- a/src/lib/y2partitioner/actions/controllers/md.rb
+++ b/src/lib/y2partitioner/actions/controllers/md.rb
@@ -248,6 +248,7 @@ module Y2Partitioner
         # @note A partition is available if it is valid to be used in a MD RAID and
         #   it is not formatted or not mounted.
         #
+        # @param partition [Y2Storage::Partition]
         # @return [Boolean] true if can be used for a MD RAID; false otherwise.
         def available?(partition)
           return false unless valid_for_md?(partition)
@@ -261,6 +262,7 @@ module Y2Partitioner
         #   it is alinux system partition and it is not being used by LVM or other
         #   MD RAID.
         #
+        # @param partition [Y2Storage::Partition]
         # @return [Boolean] true if it is valid; false otherwise.
         def valid_for_md?(partition)
           partition.id.is?(:linux_system) &&

--- a/src/lib/y2storage/autoinst_proposal.rb
+++ b/src/lib/y2storage/autoinst_proposal.rb
@@ -193,7 +193,7 @@ module Y2Storage
     #
     # @param devicegraph [Devicegraph]       Starting point
     # @param drives      [AutoinstDrivesMap] Devices map from an AutoYaST profile
-    # @return [Devicegraph] Proposed devicegraph using the guidede proposal approach
+    # @return [Devicegraph] Proposed devicegraph using the guided proposal approach
     #
     # @raise [Error] No suitable devicegraph was found
     # @see proposed_guided_devicegraph

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -109,6 +109,8 @@ module Y2Storage
 
     # Position of the last block of the region
     #
+    # @raise [Storage::Exception] if the region is empty
+    #
     # @return [Integer]
     def end
       region.end

--- a/src/lib/y2storage/disk_device.rb
+++ b/src/lib/y2storage/disk_device.rb
@@ -73,6 +73,8 @@ module Y2Storage
     def disk_device?
       # If we cannot create partitions on it, this doesn't look like a disk
       return false if respond_to?(:usable_as_partitionable?) && !usable_as_partitionable?
+      # If this is a zero-size device, we cannot use it
+      return false if size.zero?
       # If this is the wire of a multipath, we better don't fiddle with it
       return false if multipath_wire?
       # Same applies if this is part of a BIOS RAID

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -270,8 +270,8 @@ module Y2Storage
 
       log.info("#{__method__}( #{args} )")
       name = args["name"] || "/dev/sda"
-      size = args["size"] || DiskSize.zero
-      raise ArgumentError, "\"size\" missing for disk #{name}" if size.zero?
+      size = args["size"]
+      raise ArgumentError, "\"size\" missing for disk #{name}" if size.nil?
       raise ArgumentError, "Duplicate disk name #{name}" if @disks.include?(name)
       @disks << name
       block_size = args["block_size"] if args["block_size"]
@@ -432,6 +432,8 @@ module Y2Storage
 
       # align partition if specified
       region = disk.topology.align(region, align) if align
+
+      raise Error, "Trying to create a zero-size partition" if region.empty?
 
       partition = ptable.create_partition(part_name, region, type)
       partition.id = id

--- a/src/lib/y2storage/region.rb
+++ b/src/lib/y2storage/region.rb
@@ -57,6 +57,7 @@ module Y2Storage
     storage_forward :block_size=
 
     # @!method end
+    #   @raise [Storage::Exception] if the region is empty
     #   @return [Integer] position of the last sector of the region
     storage_forward :end
 
@@ -141,7 +142,11 @@ module Y2Storage
     end
 
     def show_range
-      "#{start} - #{self.end}"
+      if empty?
+        "#{start} - unknown"
+      else
+        "#{start} - #{self.end}"
+      end
     end
 
     alias_method :to_s, :inspect

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -72,12 +72,19 @@ module Y2Storage
     # @return [Array<Hash>]
     def yaml_device_tree(devicegraph)
       yaml = []
-      devicegraph.disk_devices.each { |device| yaml << yaml_disk_device(device) }
+      devices(devicegraph).each { |device| yaml << yaml_disk_device(device) }
       devicegraph.lvm_vgs.each { |lvm_vg| yaml << yaml_lvm_vg(lvm_vg) }
       yaml
     end
 
   private
+
+    # Devices that will be converted to yaml format
+    #
+    # @return [Array<Y2Storage::Device>]
+    def devices(devicegraph)
+      devicegraph.disks + devicegraph.dasds
+    end
 
     # Return the YAML counterpart of a disk device
     #

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -72,17 +72,17 @@ module Y2Storage
     # @return [Array<Hash>]
     def yaml_device_tree(devicegraph)
       yaml = []
-      devices(devicegraph).each { |device| yaml << yaml_disk_device(device) }
+      top_level_devices(devicegraph).each { |device| yaml << yaml_disk_device(device) }
       devicegraph.lvm_vgs.each { |lvm_vg| yaml << yaml_lvm_vg(lvm_vg) }
       yaml
     end
 
   private
 
-    # Devices that will be converted to yaml format
+    # Top level devices that will be converted to yaml format
     #
     # @return [Array<Y2Storage::Device>]
-    def devices(devicegraph)
+    def top_level_devices(devicegraph)
       devicegraph.disks + devicegraph.dasds
     end
 

--- a/test/data/devicegraphs/complex-lvm-encrypt.yml
+++ b/test/data/devicegraphs/complex-lvm-encrypt.yml
@@ -23,7 +23,7 @@
         label:        root
 
     - partition:
-        size:         10
+        size:         10 KiB
         name:         /dev/sda3
         id:           lvm
 

--- a/test/data/devicegraphs/false-swaps.yml
+++ b/test/data/devicegraphs/false-swaps.yml
@@ -19,7 +19,7 @@
 
     # Wrong id
     - partition:
-        size:         3
+        size:         3 KiB
         name:         /dev/sda3
         id:           swap
         file_system:  ext4

--- a/test/data/devicegraphs/zero-size_disk.yml
+++ b/test/data/devicegraphs/zero-size_disk.yml
@@ -1,0 +1,4 @@
+---
+- disk:
+    name: /dev/sda
+    size: 0

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -25,6 +25,8 @@ require "storage"
 require "y2storage"
 
 describe Y2Storage::AutoinstProposal do
+  using Y2Storage::Refinements::SizeCasts
+
   subject(:proposal) do
     described_class.new(
       partitioning: partitioning, devicegraph: fake_devicegraph, issues_list: issues_list
@@ -524,7 +526,14 @@ describe Y2Storage::AutoinstProposal do
         end
       end
 
-      let(:planned_root) { planned_partition(mount_point: "/", type: :ext4) }
+      let(:planned_root) do
+        planned_partition(
+          mount_point: "/",
+          type:        :ext4,
+          size:        5.GiB,
+          min_size:    5.GiB
+        )
+      end
 
       let(:planner) do
         instance_double(Y2Storage::Proposal::DevicesPlanner, planned_devices: [planned_root])

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -509,7 +509,7 @@ describe Y2Storage::Devicegraph do
       end
     end
 
-    context "if there are BIOS RAIDs" do
+    context "if there are DM RAIDs" do
       let(:scenario) { "empty-dm_raids.xml" }
 
       it "returns a sorted array of devices" do
@@ -519,18 +519,44 @@ describe Y2Storage::Devicegraph do
         expect(devices).to all(satisfy { |dev| less_than_next?(dev, devices) })
       end
 
-      it "includes all BIOS RAIDs" do
+      it "includes all DM RAIDs" do
         expect(graph.disk_devices.map(&:name)).to include(
           "/dev/mapper/isw_ddgdcbibhd_test1", "/dev/mapper/isw_ddgdcbibhd_test2"
         )
       end
 
-      it "includes all disks and DASDs that are not part of an MD RAID" do
+      it "includes all disks and DASDs that are not part of a DM RAID" do
         expect(graph.disk_devices.map(&:name)).to include("/dev/sda")
       end
 
-      it "does not include individual disks and DASDs from the MD RAID" do
+      it "does not include individual disks or DASDs from the DM RAID" do
         expect(graph.disk_devices.map(&:name)).to_not include("/dev/sdb", "/dev/sdc")
+      end
+    end
+
+    context "if there are MD Member RAIDs" do
+      let(:scenario) { "md-imsm1-devicegraph.xml" }
+
+      it "returns a sorted array of devices" do
+        devices = graph.disk_devices
+        expect(devices).to be_an Array
+        expect(devices).to all(be_a(Y2Storage::Device))
+        expect(devices).to all(satisfy { |dev| less_than_next?(dev, devices) })
+      end
+
+      it "includes all MD Member RAIDs" do
+        expect(graph.disk_devices.map(&:name)).to include(
+          "/dev/md/a", "/dev/md/b"
+        )
+      end
+
+      it "includes all disks and DASDs that are not part of a MD Member RAID" do
+        expect(graph.disk_devices.map(&:name)).to include("/dev/sda")
+      end
+
+      it "does not include individual disks or DASDs from the MD Member RAID" do
+        expect(graph.disk_devices.map(&:name))
+          .to_not include("/dev/sdb", "/dev/sdc", "/dev/sdd")
       end
     end
 

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -512,10 +512,6 @@ describe Y2Storage::Devicegraph do
     context "if there are BIOS RAIDs" do
       let(:scenario) { "empty-dm_raids.xml" }
 
-      before do
-        Y2Storage::MdMember.create(graph, "/dev/md0")
-      end
-
       it "returns a sorted array of devices" do
         devices = graph.disk_devices
         expect(devices).to be_an Array
@@ -525,7 +521,7 @@ describe Y2Storage::Devicegraph do
 
       it "includes all BIOS RAIDs" do
         expect(graph.disk_devices.map(&:name)).to include(
-          "/dev/mapper/isw_ddgdcbibhd_test1", "/dev/mapper/isw_ddgdcbibhd_test2", "/dev/md0"
+          "/dev/mapper/isw_ddgdcbibhd_test1", "/dev/mapper/isw_ddgdcbibhd_test2"
         )
       end
 
@@ -556,6 +552,15 @@ describe Y2Storage::Devicegraph do
 
       it "does not include unformatted DASDs" do
         expect(graph.disk_devices.map(&:name)).to_not include("/dev/dasdb")
+      end
+    end
+
+    context "if there are zero-size devices" do
+      let(:scenario) { "zero-size_disk" }
+
+      it "does not include zero-size devices" do
+        expect(graph.disks).to include(an_object_having_attributes(name: "/dev/sda"))
+        expect(graph.disk_devices).to_not include(an_object_having_attributes(name: "/dev/sda"))
       end
     end
   end

--- a/test/y2storage/fake_device_factory_test.rb
+++ b/test/y2storage/fake_device_factory_test.rb
@@ -23,445 +23,433 @@
 require_relative "spec_helper"
 
 describe Y2Storage::FakeDeviceFactory do
+  describe ".load_yaml_file" do
+    let(:staging) do
+      environment = Storage::Environment.new(true, Storage::ProbeMode_NONE, Storage::TargetMode_DIRECT)
+      storage = Storage::Storage.new(environment)
+      storage.staging
+    end
 
-  it "reads yaml of simple dasd and partition setup" do
+    let(:io) { StringIO.new(input) }
 
-    environment = Storage::Environment.new(true, Storage::ProbeMode_NONE, Storage::TargetMode_DIRECT)
-    storage = Storage::Storage.new(environment)
-    staging = storage.staging
+    context "when yaml contains a simple dasd and partition setup" do
+      let(:input) do
+        %(---
+          - dasd:
+              name: "/dev/sda"
+              type: eckd
+              size: 256 GiB
+              block_size: 4 KiB
+              partition_table: dasd
+              partitions:
+              - free:
+                  size: 1 MiB
+                  start: 0 B
+              - partition:
+                  size: 0.5 GiB
+                  start: 1 MiB
+                  name: "/dev/sda1"
+                  type: primary
+                  file_system: swap
+                  mount_point: swap
+              - partition:
+                  size: 16 GiB
+                  start: 513 MiB (0.50 GiB)
+                  name: "/dev/sda2"
+                  type: primary
+                  id: linux
+                  file_system: ext4
+                  mount_point: "/"
+        )
+      end
 
-    # rubocop:disable Style/StringLiterals
+      it "creates the expected devicegraph" do
+        described_class.load_yaml_file(staging, io)
 
-    input = ['---',
-             '- dasd:',
-             '    name: "/dev/sda"',
-             '    type: eckd',
-             '    size: 256 GiB',
-             '    block_size: 4 KiB',
-             '    partition_table: dasd',
-             '    partitions:',
-             '    - free:',
-             '        size: 1 MiB',
-             '        start: 0 B',
-             '    - partition:',
-             '        size: 0.5 GiB',
-             '        start: 1 MiB',
-             '        name: "/dev/sda1"',
-             '        type: primary',
-             '        file_system: swap',
-             '        mount_point: swap',
-             '    - partition:',
-             '        size: 16 GiB',
-             '        start: 513 MiB (0.50 GiB)',
-             '        name: "/dev/sda2"',
-             '        type: primary',
-             '        id: linux',
-             '        file_system: ext4',
-             '        mount_point: "/"']
+        expect(staging.num_devices).to eq 8
+        expect(staging.num_holders).to eq 7
 
-    # rubocop:enable all
+        sda = Storage::Dasd.find_by_name(staging, "/dev/sda")
+        expect(sda.type).to eq Y2Storage::DasdType::ECKD.to_i
+        expect(sda.size).to eq 256 * Storage.GiB
+        expect(sda.region.block_size).to eq 4 * Storage.KiB
+        expect(sda.topology.minimal_grain).to eq 4 * Storage.KiB
 
-    io = StringIO.new(input.join("\n"))
-    Y2Storage::FakeDeviceFactory.load_yaml_file(staging, io)
+        sda1 = Storage::Partition.find_by_name(staging, "/dev/sda1")
+        expect(sda1.size).to eq 512 * Storage.MiB
 
-    expect(staging.num_devices).to eq 8
-    expect(staging.num_holders).to eq 7
+        sda2 = Storage::Partition.find_by_name(staging, "/dev/sda2")
+        expect(sda2.size).to eq 16 * Storage.GiB
+      end
+    end
 
-    sda = Storage::Dasd.find_by_name(staging, "/dev/sda")
-    expect(sda.type).to eq Y2Storage::DasdType::ECKD.to_i
-    expect(sda.size).to eq 256 * Storage.GiB
-    expect(sda.region.block_size).to eq 4 * Storage.KiB
-    expect(sda.topology.minimal_grain).to eq 4 * Storage.KiB
+    context "when yaml contains a simple disk and partition setup" do
+      let(:input) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 256 GiB
+              block_size: 4 KiB
+              partition_table: gpt
+              partitions:
+              - free:
+                  size: 1 MiB
+                  start: 0 B
+              - partition:
+                  size: 0.5 GiB
+                  start: 1 MiB
+                  name: "/dev/sda1"
+                  type: primary
+                  id: swap
+                  file_system: swap
+                  mount_point: swap
+              - partition:
+                  size: 16 GiB
+                  start: 513 MiB (0.50 GiB)
+                  name: "/dev/sda2"
+                  type: primary
+                  id: linux
+                  file_system: ext4
+                  mount_point: "/"
+                  mount_by: path
+                  fstab_options:
+                  - acl
+                  - user_xattr
+                  mkfs_options: -b 2048
+              - free:
+                  size: 245247 MiB (239.50 GiB)
+                  start: 16897 MiB (16.50 GiB)
+        )
+      end
 
-    sda1 = Storage::Partition.find_by_name(staging, "/dev/sda1")
-    expect(sda1.size).to eq 512 * Storage.MiB
+      it "creates the expected devicegraph" do
+        described_class.load_yaml_file(staging, io)
 
-    sda2 = Storage::Partition.find_by_name(staging, "/dev/sda2")
-    expect(sda2.size).to eq 16 * Storage.GiB
+        expect(staging.num_devices).to eq 8
+        expect(staging.num_holders).to eq 7
+
+        sda = Storage.to_disk(Storage::BlkDevice.find_by_name(staging, "/dev/sda"))
+        expect(sda.size).to eq 256 * Storage.GiB
+        expect(sda.region.block_size).to eq 4 * Storage.KiB
+
+        sda1 = Storage.to_partition(Storage::BlkDevice.find_by_name(staging, "/dev/sda1"))
+        expect(sda1.size).to eq 512 * Storage.MiB
+
+        sda2 = Storage.to_partition(Storage::BlkDevice.find_by_name(staging, "/dev/sda2"))
+        expect(sda2.size).to eq 16 * Storage.GiB
+        expect(sda2.filesystem.fstab_options.to_a).to contain_exactly("acl", "user_xattr")
+        expect(sda2.filesystem.mkfs_options).to eq("-b 2048")
+        expect(sda2.filesystem.mount_by).to eql(Y2Storage::Filesystems::MountByType::PATH.to_i)
+      end
+    end
+
+    context "when yaml contains a simple lvm setup" do
+      let(:input) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 1 TiB
+              block_size: 0.5 KiB
+              io_size: 0 B
+              min_grain: 1 MiB
+              align_ofs: 0 B
+          - lvm_vg:
+              vg_name: system
+              extent_size: 8 MiB
+              lvm_lvs:
+              - lvm_lv:
+                  lv_name: root
+                  size: 16 GiB
+                  file_system: ext4
+                  stripes: 2
+                  stripe_size: 8 GiB
+                  mount_point: "/"
+              lvm_pvs:
+              - lvm_pv:
+                  blk_device: "/dev/sda"
+        )
+      end
+
+      it "creates the expected devicegraph" do
+        described_class.load_yaml_file(staging, io)
+
+        expect(staging.num_devices).to eq 6
+        expect(staging.num_holders).to eq 5
+
+        root = Storage.to_lvm_lv(Storage::BlkDevice.find_by_name(staging, "/dev/system/root"))
+        expect(root.lv_name).to eq "root"
+        expect(root.size).to eq 16 * Storage.GiB
+
+        system = root.lvm_vg
+        expect(system.vg_name).to eq "system"
+        expect(system.extent_size).to eq 8 * Storage.MiB
+        expect(system.lvm_lvs.size).to eq 1
+        expect(system.lvm_pvs.size).to eq 1
+      end
+    end
+
+    context "when yaml contains a simple encryption setup" do
+      let(:input) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 256 GiB
+              block_size: 4 KiB
+              partition_table: gpt
+              partitions:
+              - partition:
+                  size: 0.5 GiB
+                  start: 1 MiB
+                  name: "/dev/sda1"
+                  type: primary
+                  id: swap
+                  file_system: swap
+                  mount_point: swap
+              - partition:
+                  size: 16 GiB
+                  start: 513 MiB (0.50 GiB)
+                  name: "/dev/sda2"
+                  type: primary
+                  id: linux
+                  file_system: ext4
+                  mount_point: "/"
+                  fstab_options:
+                  - acl
+                  - user_xattr
+                  encryption:
+                      type: "luks"
+                      name: "/dev/mapper/cr_root"
+                      password: "s3cr3t"
+        )
+      end
+
+      it "creates the expected devicegraph" do
+        described_class.load_yaml_file(staging, io)
+
+        sda2 = Storage.to_partition(Storage::BlkDevice.find_by_name(staging, "/dev/sda2"))
+        encryption = sda2.encryption
+
+        expect(sda2.has_encryption).to be true
+        expect(encryption.has_filesystem).to be true
+
+        expect(encryption.password).to eq "s3cr3t"
+        expect(encryption.name).to eq "/dev/mapper/cr_root"
+        expect(encryption.filesystem.mount_point.path).to eq "/"
+      end
+    end
+
+    context "when yaml contains an LVM encrypted on the PV level" do
+      let(:input) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 512 GiB
+              block_size: 0.5 KiB
+              io_size: 0 B
+              min_grain: 1 MiB
+              align_ofs: 0 B
+              partition_table: msdos
+              partitions:
+              - partition:
+                  size: 511 GiB
+                  start: 2 MiB
+                  name: "/dev/sda1"
+                  type: primary
+                  id: lvm
+                  encryption:
+                      type: "luks"
+                      name: "/dev/mapper/cr_sda1"
+                      password: "s3cr3t"
+          - lvm_vg:
+              vg_name: system
+              lvm_lvs:
+              - lvm_lv:
+                  lv_name: root
+                  size: 100 GiB
+                  file_system: xfs
+                  mount_point: "/"
+              lvm_pvs:
+              - lvm_pv:
+                  blk_device: "/dev/mapper/cr_sda1"
+        )
+      end
+
+      it "creates the expected devicegraph" do
+        described_class.load_yaml_file(staging, io)
+
+        root_lv = Storage.to_lvm_lv(Storage::BlkDevice.find_by_name(staging, "/dev/system/root"))
+        sda1 = Storage.to_partition(Storage::BlkDevice.find_by_name(staging, "/dev/sda1"))
+        root_fs = root_lv.filesystem
+        encryption = sda1.encryption
+
+        expect(sda1.has_encryption).to be true
+        expect(root_lv.has_encryption).to be false
+        expect(root_lv.has_filesystem).to be true
+        expect(encryption.has_filesystem).to be false
+
+        expect(root_fs.mount_point.path).to eq "/"
+        expect(encryption.password).to eq "s3cr3t"
+        expect(encryption.name).to eq "/dev/mapper/cr_sda1"
+      end
+    end
+
+    context "when yaml contains an LVM encrypted on the LV level" do
+      let(:input) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 512 GiB
+              block_size: 0.5 KiB
+              io_size: 0 B
+              min_grain: 1 MiB
+              align_ofs: 0 B
+              partition_table: msdos
+              partitions:
+              - partition:
+                  size: 511 GiB
+                  start: 2 MiB
+                  name: "/dev/sda1"
+                  type: primary
+                  id: lvm
+          - lvm_vg:
+              vg_name: system
+              lvm_lvs:
+              - lvm_lv:
+                  lv_name: root
+                  size: 100 GiB
+                  file_system: xfs
+                  mount_point: "/"
+                  encryption:
+                      type: "luks"
+                      name: "/dev/mapper/cr_root"
+                      password: "s3cr3t"
+              lvm_pvs:
+              - lvm_pv:
+                  blk_device: "/dev/sda1"
+        )
+      end
+
+      it "creates the expected devicegraph" do
+        described_class.load_yaml_file(staging, io)
+
+        root_lv = Storage.to_lvm_lv(Storage::BlkDevice.find_by_name(staging, "/dev/system/root"))
+        sda1 = Storage.to_partition(Storage::BlkDevice.find_by_name(staging, "/dev/sda1"))
+        encryption = root_lv.encryption
+        root_fs = encryption.filesystem
+
+        expect(sda1.has_encryption).to be false
+        expect(root_lv.has_encryption).to be true
+        expect(root_lv.has_filesystem).to be false
+        expect(encryption.has_filesystem).to be true
+
+        expect(root_fs.mount_point.path).to eq "/"
+        expect(encryption.password).to eq "s3cr3t"
+        expect(encryption.name).to eq "/dev/mapper/cr_root"
+      end
+    end
+
+    context "when yaml contains a filesystem directly on the disk without a partition table" do
+      let(:input) do
+        %(---
+          - disk:
+              name: "/dev/sdb"
+              size: 512 GiB
+              file_system: ext4
+              mount_point: "/data"
+              label: "backup"
+              uuid: 4711-abcd-0815
+        )
+      end
+
+      it "creates the expected devicegraph" do
+        described_class.load_yaml_file(staging, io)
+
+        disk = Storage.to_disk(Storage::BlkDevice.find_by_name(staging, "/dev/sdb"))
+
+        expect(disk.has_filesystem).to be true
+        expect(disk.has_partition_table).to be false
+
+        fs = disk.filesystem
+        expect(fs.mount_point.path).to eq "/data"
+        expect(fs.label).to eq "backup"
+        expect(fs.uuid).to eq "4711-abcd-0815"
+      end
+    end
+
+    context "when yaml contains an encrypted filesystem directly on the disk" do
+      let(:input) do
+        %(---
+          - disk:
+              name: "/dev/sdb"
+              size: 512 GiB
+              file_system: ext4
+              mount_point: "/data"
+              label: "backup"
+              encryption:
+                  type: "luks"
+                  name: "/dev/mapper/cr_data"
+                  password: "s3cr3t"
+        )
+      end
+
+      it "creates the expected devicegraph" do
+        described_class.load_yaml_file(staging, io)
+
+        disk = Storage.to_disk(Storage::BlkDevice.find_by_name(staging, "/dev/sdb"))
+
+        expect(disk.has_encryption).to be true
+        expect(disk.has_filesystem).to be false
+        expect(disk.has_partition_table).to be false
+        encryption = disk.encryption
+        fs = encryption.filesystem
+
+        expect(fs.mount_point.path).to eq "/data"
+        expect(fs.label).to eq "backup"
+      end
+    end
+
+    context "when yaml contains a zero-size disk" do
+      before do
+        Y2Storage::StorageManager.create_test_instance
+      end
+
+      let(:input) do
+        %(---
+          - disk:
+              name: /dev/sda
+              size: 0
+        )
+      end
+
+      it "creates the expected devicegraph" do
+        described_class.load_yaml_file(fake_devicegraph, io)
+
+        sda = fake_devicegraph.find_by_name("/dev/sda")
+
+        expect(sda).to_not be_nil
+        expect(sda.size).to be_zero
+        expect(sda.has_children?).to eq(false)
+      end
+    end
+
+    context "when yaml contains both, a filesystem and a partition table directly on the disk" do
+      let(:input) do
+        %(---
+          - disk:
+              name: "/dev/sdb"
+              size: 512 GiB
+              partition_table: gpt
+              file_system: ext4
+              mount_point: "/data"
+              label: "backup"
+              uuid: 4711-abcd-0815
+        )
+      end
+
+      it "cannot create a devicegraph" do
+        err = Y2Storage::AbstractDeviceFactory::HierarchyError
+        expect { described_class.load_yaml_file(staging, io) }.to raise_error(err)
+      end
+    end
   end
-
-  it "reads yaml of simple disk and partition setup" do
-
-    environment = Storage::Environment.new(true, Storage::ProbeMode_NONE, Storage::TargetMode_DIRECT)
-    storage = Storage::Storage.new(environment)
-    staging = storage.staging
-
-    # rubocop:disable Style/StringLiterals
-
-    input = ['---',
-             '- disk:',
-             '    name: "/dev/sda"',
-             '    size: 256 GiB',
-             '    block_size: 4 KiB',
-             '    partition_table: gpt',
-             '    partitions:',
-             '    - free:',
-             '        size: 1 MiB',
-             '        start: 0 B',
-             '    - partition:',
-             '        size: 0.5 GiB',
-             '        start: 1 MiB',
-             '        name: "/dev/sda1"',
-             '        type: primary',
-             '        id: swap',
-             '        file_system: swap',
-             '        mount_point: swap',
-             '    - partition:',
-             '        size: 16 GiB',
-             '        start: 513 MiB (0.50 GiB)',
-             '        name: "/dev/sda2"',
-             '        type: primary',
-             '        id: linux',
-             '        file_system: ext4',
-             '        mount_point: "/"',
-             '        mount_by: path',
-             '        fstab_options:',
-             '        - acl',
-             '        - user_xattr',
-             '        mkfs_options: -b 2048',
-             '    - free:',
-             '        size: 245247 MiB (239.50 GiB)',
-             '        start: 16897 MiB (16.50 GiB)']
-
-    # rubocop:enable all
-
-    io = StringIO.new(input.join("\n"))
-    Y2Storage::FakeDeviceFactory.load_yaml_file(staging, io)
-
-    expect(staging.num_devices).to eq 8
-    expect(staging.num_holders).to eq 7
-
-    sda = Storage.to_disk(Storage::BlkDevice.find_by_name(staging, "/dev/sda"))
-    expect(sda.size).to eq 256 * Storage.GiB
-    expect(sda.region.block_size).to eq 4 * Storage.KiB
-
-    sda1 = Storage.to_partition(Storage::BlkDevice.find_by_name(staging, "/dev/sda1"))
-    expect(sda1.size).to eq 512 * Storage.MiB
-
-    sda2 = Storage.to_partition(Storage::BlkDevice.find_by_name(staging, "/dev/sda2"))
-    expect(sda2.size).to eq 16 * Storage.GiB
-    expect(sda2.filesystem.fstab_options.to_a).to contain_exactly("acl", "user_xattr")
-    expect(sda2.filesystem.mkfs_options).to eq("-b 2048")
-    expect(sda2.filesystem.mount_by).to eql(Y2Storage::Filesystems::MountByType::PATH.to_i)
-  end
-
-  it "reads yaml of simple lvm setup" do
-
-    environment = Storage::Environment.new(true, Storage::ProbeMode_NONE, Storage::TargetMode_DIRECT)
-    storage = Storage::Storage.new(environment)
-    staging = storage.staging
-
-    # rubocop:disable Style/StringLiterals
-
-    input = ['---',
-             '- disk:',
-             '    name: "/dev/sda"',
-             '    size: 1 TiB',
-             '    block_size: 0.5 KiB',
-             '    io_size: 0 B',
-             '    min_grain: 1 MiB',
-             '    align_ofs: 0 B',
-             '- lvm_vg:',
-             '    vg_name: system',
-             '    extent_size: 8 MiB',
-             '    lvm_lvs:',
-             '    - lvm_lv:',
-             '        lv_name: root',
-             '        size: 16 GiB',
-             '        file_system: ext4',
-             '        stripes: 2',
-             '        stripe_size: 8 GiB',
-             '        mount_point: "/"',
-             '    lvm_pvs:',
-             '    - lvm_pv:',
-             '        blk_device: "/dev/sda"']
-
-    # rubocop:enable all
-
-    io = StringIO.new(input.join("\n"))
-    Y2Storage::FakeDeviceFactory.load_yaml_file(staging, io)
-
-    expect(staging.num_devices).to eq 6
-    expect(staging.num_holders).to eq 5
-
-    root = Storage.to_lvm_lv(Storage::BlkDevice.find_by_name(staging, "/dev/system/root"))
-    expect(root.lv_name).to eq "root"
-    expect(root.size).to eq 16 * Storage.GiB
-
-    system = root.lvm_vg
-    expect(system.vg_name).to eq "system"
-    expect(system.extent_size).to eq 8 * Storage.MiB
-    expect(system.lvm_lvs.size).to eq 1
-    expect(system.lvm_pvs.size).to eq 1
-
-  end
-
-  it "reads yaml for a simple encryption setup" do
-    environment = Storage::Environment.new(true, Storage::ProbeMode_NONE, Storage::TargetMode_DIRECT)
-    storage = Storage::Storage.new(environment)
-    staging = storage.staging
-
-    # rubocop:disable Style/StringLiterals
-
-    input = ['---',
-             '- disk:',
-             '    name: "/dev/sda"',
-             '    size: 256 GiB',
-             '    block_size: 4 KiB',
-             '    partition_table: gpt',
-             '    partitions:',
-             '    - partition:',
-             '        size: 0.5 GiB',
-             '        start: 1 MiB',
-             '        name: "/dev/sda1"',
-             '        type: primary',
-             '        id: swap',
-             '        file_system: swap',
-             '        mount_point: swap',
-             '    - partition:',
-             '        size: 16 GiB',
-             '        start: 513 MiB (0.50 GiB)',
-             '        name: "/dev/sda2"',
-             '        type: primary',
-             '        id: linux',
-             '        file_system: ext4',
-             '        mount_point: "/"',
-             '        fstab_options:',
-             '        - acl',
-             '        - user_xattr',
-             '        encryption:',
-             '            type: "luks"',
-             '            name: "/dev/mapper/cr_root"',
-             '            password: "s3cr3t"',
-             '']
-
-    # rubocop:enable all
-
-    io = StringIO.new(input.join("\n"))
-    Y2Storage::FakeDeviceFactory.load_yaml_file(staging, io)
-
-    sda2 = Storage.to_partition(Storage::BlkDevice.find_by_name(staging, "/dev/sda2"))
-    encryption = sda2.encryption
-
-    expect(sda2.has_encryption).to be true
-    expect(encryption.has_filesystem).to be true
-
-    expect(encryption.password).to eq "s3cr3t"
-    expect(encryption.name).to eq "/dev/mapper/cr_root"
-    expect(encryption.filesystem.mount_point.path).to eq "/"
-
-  end
-
-  it "reads yaml for LVM encrypted on the PV level" do
-    environment = Storage::Environment.new(true, Storage::ProbeMode_NONE, Storage::TargetMode_DIRECT)
-    storage = Storage::Storage.new(environment)
-    staging = storage.staging
-
-    # rubocop:disable Style/StringLiterals
-
-    input = ['---',
-             '- disk:',
-             '    name: "/dev/sda"',
-             '    size: 512 GiB',
-             '    block_size: 0.5 KiB',
-             '    io_size: 0 B',
-             '    min_grain: 1 MiB',
-             '    align_ofs: 0 B',
-             '    partition_table: msdos',
-             '    partitions:',
-             '    - partition:',
-             '        size: 511 GiB',
-             '        start: 2 MiB',
-             '        name: "/dev/sda1"',
-             '        type: primary',
-             '        id: lvm',
-             '        encryption:',
-             '            type: "luks"',
-             '            name: "/dev/mapper/cr_sda1"',
-             '            password: "s3cr3t"',
-             '- lvm_vg:',
-             '    vg_name: system',
-             '    lvm_lvs:',
-             '    - lvm_lv:',
-             '        lv_name: root',
-             '        size: 100 GiB',
-             '        file_system: xfs',
-             '        mount_point: "/"',
-             '    lvm_pvs:',
-             '    - lvm_pv:',
-             '        blk_device: "/dev/mapper/cr_sda1"']
-
-    # rubocop:enable all
-
-    io = StringIO.new(input.join("\n"))
-    Y2Storage::FakeDeviceFactory.load_yaml_file(staging, io)
-
-    root_lv = Storage.to_lvm_lv(Storage::BlkDevice.find_by_name(staging, "/dev/system/root"))
-    sda1 = Storage.to_partition(Storage::BlkDevice.find_by_name(staging, "/dev/sda1"))
-    root_fs = root_lv.filesystem
-    encryption = sda1.encryption
-
-    expect(sda1.has_encryption).to be true
-    expect(root_lv.has_encryption).to be false
-    expect(root_lv.has_filesystem).to be true
-    expect(encryption.has_filesystem).to be false
-
-    expect(root_fs.mount_point.path).to eq "/"
-    expect(encryption.password).to eq "s3cr3t"
-    expect(encryption.name).to eq "/dev/mapper/cr_sda1"
-
-  end
-
-  it "reads yaml for LVM encrypted on the LV level" do
-    environment = Storage::Environment.new(true, Storage::ProbeMode_NONE, Storage::TargetMode_DIRECT)
-    storage = Storage::Storage.new(environment)
-    staging = storage.staging
-
-    # rubocop:disable Style/StringLiterals
-
-    input = ['---',
-             '- disk:',
-             '    name: "/dev/sda"',
-             '    size: 512 GiB',
-             '    block_size: 0.5 KiB',
-             '    io_size: 0 B',
-             '    min_grain: 1 MiB',
-             '    align_ofs: 0 B',
-             '    partition_table: msdos',
-             '    partitions:',
-             '    - partition:',
-             '        size: 511 GiB',
-             '        start: 2 MiB',
-             '        name: "/dev/sda1"',
-             '        type: primary',
-             '        id: lvm',
-             '- lvm_vg:',
-             '    vg_name: system',
-             '    lvm_lvs:',
-             '    - lvm_lv:',
-             '        lv_name: root',
-             '        size: 100 GiB',
-             '        file_system: xfs',
-             '        mount_point: "/"',
-             '        encryption:',
-             '            type: "luks"',
-             '            name: "/dev/mapper/cr_root"',
-             '            password: "s3cr3t"',
-             '    lvm_pvs:',
-             '    - lvm_pv:',
-             '        blk_device: "/dev/sda1"']
-
-    # rubocop:enable all
-
-    io = StringIO.new(input.join("\n"))
-    Y2Storage::FakeDeviceFactory.load_yaml_file(staging, io)
-
-    root_lv = Storage.to_lvm_lv(Storage::BlkDevice.find_by_name(staging, "/dev/system/root"))
-    sda1 = Storage.to_partition(Storage::BlkDevice.find_by_name(staging, "/dev/sda1"))
-    encryption = root_lv.encryption
-    root_fs = encryption.filesystem
-
-    expect(sda1.has_encryption).to be false
-    expect(root_lv.has_encryption).to be true
-    expect(root_lv.has_filesystem).to be false
-    expect(encryption.has_filesystem).to be true
-
-    expect(root_fs.mount_point.path).to eq "/"
-    expect(encryption.password).to eq "s3cr3t"
-    expect(encryption.name).to eq "/dev/mapper/cr_root"
-
-  end
-
-  it "reads yaml for a filesystem directly on the disk without a partition table" do
-    environment = Storage::Environment.new(true, Storage::ProbeMode_NONE, Storage::TargetMode_DIRECT)
-    storage = Storage::Storage.new(environment)
-    staging = storage.staging
-
-    # rubocop:disable Style/StringLiterals
-
-    input = ['---',
-             '- disk:',
-             '    name: "/dev/sdb"',
-             '    size: 512 GiB',
-             '    file_system: ext4',
-             '    mount_point: "/data"',
-             '    label: "backup"',
-             '    uuid: 4711-abcd-0815']
-
-    # rubocop:enable all
-
-    io = StringIO.new(input.join("\n"))
-    Y2Storage::FakeDeviceFactory.load_yaml_file(staging, io)
-
-    disk = Storage.to_disk(Storage::BlkDevice.find_by_name(staging, "/dev/sdb"))
-
-    expect(disk.has_filesystem).to be true
-    expect(disk.has_partition_table).to be false
-
-    fs = disk.filesystem
-    expect(fs.mount_point.path).to eq "/data"
-    expect(fs.label).to eq "backup"
-    expect(fs.uuid).to eq "4711-abcd-0815"
-  end
-
-  it "reads yaml for an encrypted filesystem directly on the disk" do
-    environment = Storage::Environment.new(true, Storage::ProbeMode_NONE, Storage::TargetMode_DIRECT)
-    storage = Storage::Storage.new(environment)
-    staging = storage.staging
-
-    # rubocop:disable Style/StringLiterals
-
-    input = ['---',
-             '- disk:',
-             '    name: "/dev/sdb"',
-             '    size: 512 GiB',
-             '    file_system: ext4',
-             '    mount_point: "/data"',
-             '    label: "backup"',
-             '    encryption:',
-             '        type: "luks"',
-             '        name: "/dev/mapper/cr_data"',
-             '        password: "s3cr3t"']
-
-    # rubocop:enable all
-
-    io = StringIO.new(input.join("\n"))
-    Y2Storage::FakeDeviceFactory.load_yaml_file(staging, io)
-
-    disk = Storage.to_disk(Storage::BlkDevice.find_by_name(staging, "/dev/sdb"))
-
-    expect(disk.has_encryption).to be true
-    expect(disk.has_filesystem).to be false
-    expect(disk.has_partition_table).to be false
-    encryption = disk.encryption
-    fs = encryption.filesystem
-
-    expect(fs.mount_point.path).to eq "/data"
-    expect(fs.label).to eq "backup"
-  end
-
-  it "complains when both a filesystem and a partition table are directly on the disk" do
-    environment = Storage::Environment.new(true, Storage::ProbeMode_NONE, Storage::TargetMode_DIRECT)
-    storage = Storage::Storage.new(environment)
-    staging = storage.staging
-
-    # rubocop:disable Style/StringLiterals
-
-    input = ['---',
-             '- disk:',
-             '    name: "/dev/sdb"',
-             '    size: 512 GiB',
-             '    partition_table: gpt',
-             '    file_system: ext4',
-             '    mount_point: "/data"',
-             '    label: "backup"',
-             '    uuid: 4711-abcd-0815']
-
-    # rubocop:enable all
-
-    io = StringIO.new(input.join("\n"))
-    err = Y2Storage::AbstractDeviceFactory::HierarchyError
-    expect { Y2Storage::FakeDeviceFactory.load_yaml_file(staging, io) }.to raise_error(err)
-  end
-
 end

--- a/test/y2storage/guided_proposal_test.rb
+++ b/test/y2storage/guided_proposal_test.rb
@@ -484,6 +484,15 @@ describe Y2Storage::GuidedProposal do
         end
       end
     end
+
+    # Regression test for bsc#1083887
+    context "when installing on a zero-size device" do
+      let(:scenario) { "zero-size_disk" }
+
+      it "cannot create a valid proposal" do
+        expect { proposal.propose }.to raise_error(Y2Storage::Error)
+      end
+    end
   end
 
   describe "#failed?" do

--- a/test/y2storage/region_test.rb
+++ b/test/y2storage/region_test.rb
@@ -26,7 +26,9 @@ require "y2storage"
 describe Y2Storage::Region do
   using Y2Storage::Refinements::SizeCasts
 
-  subject(:region) { Y2Storage::Region.create(100, 1000, 1.KiB) }
+  subject(:region) { Y2Storage::Region.create(100, length, 1.KiB) }
+
+  let(:length) { 1000 }
 
   describe "#==" do
     context "if both regions has a different block size" do
@@ -102,6 +104,19 @@ describe Y2Storage::Region do
     it "produces an informative String" do
       expect(subject.inspect)
         .to eq "<Region range: 100 - 1099, block_size: 1 KiB>"
+    end
+
+    context "when the region is empty" do
+      let(:length) { 0 }
+
+      it "does not fail" do
+        expect { subject.inspect }.to_not raise_error
+      end
+
+      it "produces an informative String with unknown end" do
+        expect(subject.inspect)
+          .to eq("<Region range: 100 - unknown, block_size: 1 KiB>")
+      end
     end
   end
 

--- a/test/y2storage/yaml_writer_test.rb
+++ b/test/y2storage/yaml_writer_test.rb
@@ -23,435 +23,455 @@
 require_relative "spec_helper"
 
 describe Y2Storage::YamlWriter do
-
   before do
     Y2Storage::StorageManager.create_test_instance
   end
+
   let(:staging) { Y2Storage::StorageManager.instance.staging }
 
-  it "produces yaml of a simple DASD disk setup" do
-
-    sda = Y2Storage::Dasd.create(staging, "/dev/sda")
-    sda.size = 256 * Storage.GiB
-    sda.type = Y2Storage::DasdType::ECKD
-    sda.format = Y2Storage::DasdFormat::LDL
-
-    sda.create_partition_table(Y2Storage::PartitionTables::Type::DASD)
-
-    # rubocop:disable Style/StringLiterals
-
-    result = ['---',
-              '- dasd:',
-              '    name: "/dev/sda"',
-              '    size: 256 GiB',
-              '    block_size: 0.5 KiB',
-              '    io_size: 0 B',
-              '    min_grain: 1 MiB',
-              '    align_ofs: 0 B',
-              '    type: eckd',
-              '    format: ldl',
-              '    partition_table: dasd',
-              '    partitions:',
-              '    - free:',
-              '        size: 256 GiB',
-              '        start: 0 B']
-
-    # rubocop:enable all
-
-    io = StringIO.new
-    Y2Storage::YamlWriter.write(staging, io)
-    expect(io.string).to eq result.join("\n") + "\n"
+  def plain_content(content)
+    content.split("\n").map(&:lstrip).join("\n")
   end
 
-  it "produces yaml of a simple disk and partition setup" do
+  describe ".write" do
+    let(:io) { StringIO.new }
 
-    sda = Y2Storage::Disk.create(staging, "/dev/sda")
-    sda.size = 256 * Storage.GiB
+    context "when the devicegraph contains a simple DASD disk setup" do
+      before do
+        sda = Y2Storage::Dasd.create(staging, "/dev/sda")
+        sda.size = 256 * Storage.GiB
+        sda.type = Y2Storage::DasdType::ECKD
+        sda.format = Y2Storage::DasdFormat::LDL
 
-    gpt = sda.create_partition_table(Y2Storage::PartitionTables::Type::GPT)
+        sda.create_partition_table(Y2Storage::PartitionTables::Type::DASD)
+      end
 
-    sda1 = gpt.create_partition("/dev/sda1", Y2Storage::Region.create(2048, 1048576, 512),
-      Y2Storage::PartitionType::PRIMARY)
-    sda1.id = Y2Storage::PartitionId::SWAP
+      let(:expected_result) do
+        %(---
+          - dasd:
+              name: "/dev/sda"
+              size: 256 GiB
+              block_size: 0.5 KiB
+              io_size: 0 B
+              min_grain: 1 MiB
+              align_ofs: 0 B
+              type: eckd
+              format: ldl
+              partition_table: dasd
+              partitions:
+              - free:
+                  size: 256 GiB
+                  start: 0 B)
+      end
 
-    swap = sda1.create_filesystem(Y2Storage::Filesystems::Type::SWAP)
-    swap.create_mount_point("swap")
+      it "generates the expected yaml content" do
+        described_class.write(staging, io)
+        expect(plain_content(io.string)).to eq(plain_content(expected_result))
+      end
+    end
 
-    sda2 = gpt.create_partition("/dev/sda2", Y2Storage::Region.create(1050624, 33554432, 512),
-      Y2Storage::PartitionType::PRIMARY)
+    context "when the devicegraph contains a simple disk and partition setup" do
+      before do
+        sda = Y2Storage::Disk.create(staging, "/dev/sda")
+        sda.size = 256 * Storage.GiB
 
-    ext4 = sda2.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
-    ext4.create_mount_point("/")
-    ext4.mount_point.mount_options = ["acl", "user_xattr"]
+        gpt = sda.create_partition_table(Y2Storage::PartitionTables::Type::GPT)
 
-    # rubocop:disable Style/StringLiterals
+        sda1 = gpt.create_partition("/dev/sda1", Y2Storage::Region.create(2048, 1048576, 512),
+          Y2Storage::PartitionType::PRIMARY)
+        sda1.id = Y2Storage::PartitionId::SWAP
 
-    result = ['---',
-              '- disk:',
-              '    name: "/dev/sda"',
-              '    size: 256 GiB',
-              '    block_size: 0.5 KiB',
-              '    io_size: 0 B',
-              '    min_grain: 1 MiB',
-              '    align_ofs: 0 B',
-              '    partition_table: gpt',
-              '    partitions:',
-              '    - free:',
-              '        size: 1 MiB',
-              '        start: 0 B',
-              '    - partition:',
-              '        size: 0.5 GiB',
-              '        start: 1 MiB',
-              '        name: "/dev/sda1"',
-              '        type: primary',
-              '        id: swap',
-              '        file_system: swap',
-              '        mount_point: swap',
-              '    - partition:',
-              '        size: 16 GiB',
-              '        start: 513 MiB (0.50 GiB)',
-              '        name: "/dev/sda2"',
-              '        type: primary',
-              '        id: linux',
-              '        file_system: ext4',
-              '        mount_point: "/"',
-              '        fstab_options:',
-              '        - acl',
-              '        - user_xattr',
-              '    - free:',
-              '        size: 245247 MiB (239.50 GiB)',
-              '        start: 16897 MiB (16.50 GiB)']
+        swap = sda1.create_filesystem(Y2Storage::Filesystems::Type::SWAP)
+        swap.create_mount_point("swap")
 
-    # rubocop:enable all
+        sda2 = gpt.create_partition("/dev/sda2", Y2Storage::Region.create(1050624, 33554432, 512),
+          Y2Storage::PartitionType::PRIMARY)
 
-    io = StringIO.new
-    Y2Storage::YamlWriter.write(staging, io)
-    expect(io.string).to eq result.join("\n") + "\n"
+        ext4 = sda2.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
+        ext4.create_mount_point("/")
+        ext4.mount_point.mount_options = ["acl", "user_xattr"]
+      end
 
+      let(:expected_result) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 256 GiB
+              block_size: 0.5 KiB
+              io_size: 0 B
+              min_grain: 1 MiB
+              align_ofs: 0 B
+              partition_table: gpt
+              partitions:
+              - free:
+                  size: 1 MiB
+                  start: 0 B
+              - partition:
+                  size: 0.5 GiB
+                  start: 1 MiB
+                  name: "/dev/sda1"
+                  type: primary
+                  id: swap
+                  file_system: swap
+                  mount_point: swap
+              - partition:
+                  size: 16 GiB
+                  start: 513 MiB (0.50 GiB)
+                  name: "/dev/sda2"
+                  type: primary
+                  id: linux
+                  file_system: ext4
+                  mount_point: "/"
+                  fstab_options:
+                  - acl
+                  - user_xattr
+              - free:
+                  size: 245247 MiB (239.50 GiB)
+                  start: 16897 MiB (16.50 GiB))
+      end
+
+      it "generates the expected yaml content" do
+        described_class.write(staging, io)
+        expect(plain_content(io.string)).to eq(plain_content(expected_result))
+      end
+    end
+
+    context "when the devicegraph contains a simple lvm setup" do
+      before do
+        sda = Y2Storage::Disk.create(staging, "/dev/sda")
+        sda.size = 1 * Storage.TiB
+
+        lvm_vg = Y2Storage::LvmVg.create(staging, "system")
+        lvm_vg.add_lvm_pv(sda)
+
+        lvm_lv = lvm_vg.create_lvm_lv("root", 16 * Storage.GiB)
+        lvm_lv.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
+      end
+
+      let(:expected_result) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 1 TiB
+              block_size: 0.5 KiB
+              io_size: 0 B
+              min_grain: 1 MiB
+              align_ofs: 0 B
+          - lvm_vg:
+              vg_name: system
+              extent_size: 4 MiB
+              lvm_lvs:
+              - lvm_lv:
+                  lv_name: root
+                  size: 16 GiB
+                  stripes: 1
+                  file_system: ext4
+              lvm_pvs:
+              - lvm_pv:
+                  blk_device: "/dev/sda")
+      end
+
+      it "generates the expected yaml content" do
+        described_class.write(staging, io)
+        expect(plain_content(io.string)).to eq(plain_content(expected_result))
+      end
+    end
+
+    context "when the devicegraph contains a simple DASD disk setup" do
+      before do
+        sda = Y2Storage::Disk.create(staging, "/dev/sda")
+        sda.size = 256 * Storage.GiB
+
+        gpt = sda.create_partition_table(Y2Storage::PartitionTables::Type::GPT)
+
+        sda1 = gpt.create_partition("/dev/sda1", Y2Storage::Region.create(2048, 1048576, 512),
+          Y2Storage::PartitionType::PRIMARY)
+        sda1.id = Y2Storage::PartitionId::SWAP
+
+        swap = sda1.create_filesystem(Y2Storage::Filesystems::Type::SWAP)
+        swap.create_mount_point("swap")
+
+        sda2 = gpt.create_partition("/dev/sda2", Y2Storage::Region.create(1050624, 33554432, 512),
+          Y2Storage::PartitionType::PRIMARY)
+
+        encryption = sda2.create_encryption("cr_system")
+        encryption.password = "vry!s3cret"
+
+        ext4 = encryption.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
+        ext4.create_mount_point("/")
+        ext4.mount_point.mount_options = ["acl", "user_xattr"]
+      end
+
+      let(:expected_result) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 256 GiB
+              block_size: 0.5 KiB
+              io_size: 0 B
+              min_grain: 1 MiB
+              align_ofs: 0 B
+              partition_table: gpt
+              partitions:
+              - free:
+                  size: 1 MiB
+                  start: 0 B
+              - partition:
+                  size: 0.5 GiB
+                  start: 1 MiB
+                  name: "/dev/sda1"
+                  type: primary
+                  id: swap
+                  file_system: swap
+                  mount_point: swap
+              - partition:
+                  size: 16 GiB
+                  start: 513 MiB (0.50 GiB)
+                  name: "/dev/sda2"
+                  type: primary
+                  id: linux
+                  file_system: ext4
+                  mount_point: "/"
+                  fstab_options:
+                  - acl
+                  - user_xattr
+                  encryption:
+                    type: luks
+                    name: "/dev/mapper/cr_system"
+                    password: vry!s3cret
+              - free:
+                  size: 245247 MiB (239.50 GiB)
+                  start: 16897 MiB (16.50 GiB))
+      end
+
+      it "generates the expected yaml content" do
+        described_class.write(staging, io)
+        expect(plain_content(io.string)).to eq(plain_content(expected_result))
+      end
+    end
+
+    context "when the devicegraph contains an lvm setup with encryption on the PV level" do
+      before do
+        sda = Y2Storage::Disk.create(staging, "/dev/sda")
+        sda.size = 256 * Storage.GiB
+
+        ptable = sda.create_partition_table(Y2Storage::PartitionTables::Type::MSDOS)
+        blocks = sda.size.to_i / 512 - 2048
+
+        sda1 = ptable.create_partition("/dev/sda1", Y2Storage::Region.create(2048, blocks, 512),
+          Y2Storage::PartitionType::PRIMARY)
+        sda1.id = Y2Storage::PartitionId::LVM
+
+        encryption = sda1.create_encryption("cr_sda1")
+        encryption.password = "s3cr3t"
+
+        lvm_vg = Y2Storage::LvmVg.create(staging, "system")
+        lvm_vg.add_lvm_pv(encryption)
+
+        lvm_lv = lvm_vg.create_lvm_lv("root", 16 * Storage.GiB)
+        fs = lvm_lv.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
+        fs.create_mount_point("/")
+      end
+
+      let(:expected_result) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 256 GiB
+              block_size: 0.5 KiB
+              io_size: 0 B
+              min_grain: 1 MiB
+              align_ofs: 0 B
+              partition_table: msdos
+              mbr_gap: 1 MiB
+              partitions:
+              - free:
+                  size: 1 MiB
+                  start: 0 B
+              - partition:
+                  size: 262143 MiB (256.00 GiB)
+                  start: 1 MiB
+                  name: "/dev/sda1"
+                  type: primary
+                  id: lvm
+                  encryption:
+                    type: luks
+                    name: "/dev/mapper/cr_sda1"
+                    password: s3cr3t
+          - lvm_vg:
+              vg_name: system
+              extent_size: 4 MiB
+              lvm_lvs:
+              - lvm_lv:
+                  lv_name: root
+                  size: 16 GiB
+                  stripes: 1
+                  file_system: ext4
+                  mount_point: "/"
+              lvm_pvs:
+              - lvm_pv:
+                  blk_device: "/dev/mapper/cr_sda1")
+      end
+
+      it "generates the expected yaml content" do
+        described_class.write(staging, io)
+        expect(plain_content(io.string)).to eq(plain_content(expected_result))
+      end
+    end
+
+    context "when the devicegraph contains an lvm setup with encryption on the LV level" do
+      before do
+        sda = Y2Storage::Disk.create(staging, "/dev/sda")
+        sda.size = 256 * Storage.GiB
+
+        ptable = sda.create_partition_table(Y2Storage::PartitionTables::Type::MSDOS)
+        blocks = sda.size.to_i / 512 - 2048
+
+        sda1 = ptable.create_partition("/dev/sda1", Y2Storage::Region.create(2048, blocks, 512),
+          Y2Storage::PartitionType::PRIMARY)
+        sda1.id = Y2Storage::PartitionId::LVM
+
+        lvm_vg = Y2Storage::LvmVg.create(staging, "system")
+        lvm_vg.add_lvm_pv(sda1)
+
+        lvm_lv = lvm_vg.create_lvm_lv("root", 16 * Storage.GiB)
+
+        encryption = lvm_lv.create_encryption("cr_sda1")
+        encryption.password = "s3cr3t"
+
+        fs = encryption.create_filesystem(Y2Storage::Filesystems::Type::XFS)
+        fs.create_mount_point("/")
+      end
+
+      let(:expected_result) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 256 GiB
+              block_size: 0.5 KiB
+              io_size: 0 B
+              min_grain: 1 MiB
+              align_ofs: 0 B
+              partition_table: msdos
+              mbr_gap: 1 MiB
+              partitions:
+              - free:
+                  size: 1 MiB
+                  start: 0 B
+              - partition:
+                  size: 262143 MiB (256.00 GiB)
+                  start: 1 MiB
+                  name: "/dev/sda1"
+                  type: primary
+                  id: lvm
+          - lvm_vg:
+              vg_name: system
+              extent_size: 4 MiB
+              lvm_lvs:
+              - lvm_lv:
+                  lv_name: root
+                  size: 16 GiB
+                  stripes: 1
+                  file_system: xfs
+                  mount_point: "/"
+                  encryption:
+                    type: luks
+                    name: "/dev/mapper/cr_sda1"
+                    password: s3cr3t
+              lvm_pvs:
+              - lvm_pv:
+                  blk_device: "/dev/sda1")
+      end
+
+      it "generates the expected yaml content" do
+        described_class.write(staging, io)
+        expect(plain_content(io.string)).to eq(plain_content(expected_result))
+      end
+    end
+
+    context "when the devicegraph contains an encrypted partition setup" do
+      before do
+        disk = Y2Storage::Disk.create(staging, "/dev/sda")
+        disk.size = 256 * Storage.GiB
+
+        fs = disk.create_filesystem(Y2Storage::Filesystems::Type::XFS)
+        fs.create_mount_point("/data")
+      end
+
+      let(:expected_result) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 256 GiB
+              block_size: 0.5 KiB
+              io_size: 0 B
+              min_grain: 1 MiB
+              align_ofs: 0 B
+              file_system: xfs
+              mount_point: "/data")
+      end
+
+      it "generates the expected yaml content" do
+        described_class.write(staging, io)
+        expect(plain_content(io.string)).to eq(plain_content(expected_result))
+      end
+    end
+
+    context "when the devicegraph contains a filesystem directly on a disk without a partition table" do
+      before do
+        disk = Y2Storage::Disk.create(staging, "/dev/sda")
+        disk.size = 256 * Storage.GiB
+
+        encryption = disk.create_encryption("cr_data")
+        encryption.password = "s3cr3t"
+
+        fs = encryption.create_filesystem(Y2Storage::Filesystems::Type::XFS)
+        fs.create_mount_point("/data")
+      end
+
+      let(:expected_result) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 256 GiB
+              block_size: 0.5 KiB
+              io_size: 0 B
+              min_grain: 1 MiB
+              align_ofs: 0 B
+              file_system: xfs
+              mount_point: "/data"
+              encryption:
+                type: luks
+                name: "/dev/mapper/cr_data"
+                password: s3cr3t)
+      end
+
+      it "generates the expected yaml content" do
+        described_class.write(staging, io)
+        expect(plain_content(io.string)).to eq(plain_content(expected_result))
+      end
+    end
+
+    context "when the devicegraph contains a zero-size disk" do
+      before do
+        Y2Storage::Disk.create(staging, "/dev/sda", 0)
+      end
+
+      let(:expected_result) do
+        %(---
+          - disk:
+              name: "/dev/sda"
+              size: 0 B
+              block_size: 0.5 KiB
+              io_size: 0 B
+              min_grain: 1 MiB
+              align_ofs: 0 B)
+      end
+
+      it "generates the expected yaml content" do
+        described_class.write(staging, io)
+        expect(plain_content(io.string)).to eq(plain_content(expected_result))
+      end
+    end
   end
-
-  xit "produces yaml of a simple lvm setup" do
-
-    sda = Y2Storage::Disk.create(staging, "/dev/sda")
-    sda.size = 1 * Storage.TiB
-
-    lvm_vg = Y2Storage::LvmVg.create(staging, "system")
-    lvm_vg.add_lvm_pv(sda)
-
-    lvm_lv = lvm_vg.create_lvm_lv("root", 16 * Storage.GiB)
-    lvm_lv.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
-
-    # rubocop:disable Style/StringLiterals
-
-    result = ['---',
-              '- disk:',
-              '    name: "/dev/sda"',
-              '    size: 1 TiB',
-              '    block_size: 0.5 KiB',
-              '    io_size: 0 B',
-              '    min_grain: 1 MiB',
-              '    align_ofs: 0 B',
-              '- lvm_vg:',
-              '    vg_name: system',
-              '    extent_size: 4 MiB',
-              '    lvm_lvs:',
-              '    - lvm_lv:',
-              '        lv_name: root',
-              '        size: 16 GiB',
-              '        stripes: 1',
-              '        file_system: ext4',
-              '    lvm_pvs:',
-              '    - lvm_pv:',
-              '        blk_device: "/dev/sda"']
-
-    # rubocop:enable all
-
-    io = StringIO.new
-    Y2Storage::YamlWriter.write(staging, io)
-    expect(io.string).to eq result.join("\n") + "\n"
-
-  end
-
-  it "produces yaml of an encrypted partition setup" do
-
-    sda = Y2Storage::Disk.create(staging, "/dev/sda")
-    sda.size = 256 * Storage.GiB
-
-    gpt = sda.create_partition_table(Y2Storage::PartitionTables::Type::GPT)
-
-    sda1 = gpt.create_partition("/dev/sda1", Y2Storage::Region.create(2048, 1048576, 512),
-      Y2Storage::PartitionType::PRIMARY)
-    sda1.id = Y2Storage::PartitionId::SWAP
-
-    swap = sda1.create_filesystem(Y2Storage::Filesystems::Type::SWAP)
-    swap.create_mount_point("swap")
-
-    sda2 = gpt.create_partition("/dev/sda2", Y2Storage::Region.create(1050624, 33554432, 512),
-      Y2Storage::PartitionType::PRIMARY)
-
-    encryption = sda2.create_encryption("cr_system")
-    encryption.password = "vry!s3cret"
-
-    ext4 = encryption.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
-    ext4.create_mount_point("/")
-    ext4.mount_point.mount_options = ["acl", "user_xattr"]
-
-    # rubocop:disable Style/StringLiterals
-
-    result = ['---',
-              '- disk:',
-              '    name: "/dev/sda"',
-              '    size: 256 GiB',
-              '    block_size: 0.5 KiB',
-              '    io_size: 0 B',
-              '    min_grain: 1 MiB',
-              '    align_ofs: 0 B',
-              '    partition_table: gpt',
-              '    partitions:',
-              '    - free:',
-              '        size: 1 MiB',
-              '        start: 0 B',
-              '    - partition:',
-              '        size: 0.5 GiB',
-              '        start: 1 MiB',
-              '        name: "/dev/sda1"',
-              '        type: primary',
-              '        id: swap',
-              '        file_system: swap',
-              '        mount_point: swap',
-              '    - partition:',
-              '        size: 16 GiB',
-              '        start: 513 MiB (0.50 GiB)',
-              '        name: "/dev/sda2"',
-              '        type: primary',
-              '        id: linux',
-              '        file_system: ext4',
-              '        mount_point: "/"',
-              '        fstab_options:',
-              '        - acl',
-              '        - user_xattr',
-              '        encryption:',
-              '          type: luks',
-              '          name: "/dev/mapper/cr_system"',
-              '          password: vry!s3cret',
-              '    - free:',
-              '        size: 245247 MiB (239.50 GiB)',
-              '        start: 16897 MiB (16.50 GiB)']
-
-    # rubocop:enable all
-
-    io = StringIO.new
-    Y2Storage::YamlWriter.write(staging, io)
-    expect(io.string).to eq result.join("\n") + "\n"
-
-  end
-
-  it "produces yaml of an lvm setup with encryption on the PV level" do
-
-    sda = Y2Storage::Disk.create(staging, "/dev/sda")
-    sda.size = 256 * Storage.GiB
-
-    ptable = sda.create_partition_table(Y2Storage::PartitionTables::Type::MSDOS)
-    blocks = sda.size.to_i / 512 - 2048
-
-    sda1 = ptable.create_partition("/dev/sda1", Y2Storage::Region.create(2048, blocks, 512),
-      Y2Storage::PartitionType::PRIMARY)
-    sda1.id = Y2Storage::PartitionId::LVM
-
-    encryption = sda1.create_encryption("cr_sda1")
-    encryption.password = "s3cr3t"
-
-    lvm_vg = Y2Storage::LvmVg.create(staging, "system")
-    lvm_vg.add_lvm_pv(encryption)
-
-    lvm_lv = lvm_vg.create_lvm_lv("root", 16 * Storage.GiB)
-    fs = lvm_lv.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
-    fs.create_mount_point("/")
-
-    # rubocop:disable Style/StringLiterals
-
-    result = ['---',
-              '- disk:',
-              '    name: "/dev/sda"',
-              '    size: 256 GiB',
-              '    block_size: 0.5 KiB',
-              '    io_size: 0 B',
-              '    min_grain: 1 MiB',
-              '    align_ofs: 0 B',
-              '    partition_table: msdos',
-              '    mbr_gap: 1 MiB',
-              '    partitions:',
-              '    - free:',
-              '        size: 1 MiB',
-              '        start: 0 B',
-              '    - partition:',
-              '        size: 262143 MiB (256.00 GiB)',
-              '        start: 1 MiB',
-              '        name: "/dev/sda1"',
-              '        type: primary',
-              '        id: lvm',
-              '        encryption:',
-              '          type: luks',
-              '          name: "/dev/mapper/cr_sda1"',
-              '          password: s3cr3t',
-              '- lvm_vg:',
-              '    vg_name: system',
-              '    extent_size: 4 MiB',
-              '    lvm_lvs:',
-              '    - lvm_lv:',
-              '        lv_name: root',
-              '        size: 16 GiB',
-              '        stripes: 1',
-              '        file_system: ext4',
-              '        mount_point: "/"',
-              '    lvm_pvs:',
-              '    - lvm_pv:',
-              '        blk_device: "/dev/mapper/cr_sda1"']
-
-    # rubocop:enable all
-
-    io = StringIO.new
-    Y2Storage::YamlWriter.write(staging, io)
-    expect(io.string).to eq result.join("\n") + "\n"
-
-  end
-
-  it "produces yaml of an lvm setup with encryption on the LV level" do
-
-    sda = Y2Storage::Disk.create(staging, "/dev/sda")
-    sda.size = 256 * Storage.GiB
-
-    ptable = sda.create_partition_table(Y2Storage::PartitionTables::Type::MSDOS)
-    blocks = sda.size.to_i / 512 - 2048
-
-    sda1 = ptable.create_partition("/dev/sda1", Y2Storage::Region.create(2048, blocks, 512),
-      Y2Storage::PartitionType::PRIMARY)
-    sda1.id = Y2Storage::PartitionId::LVM
-
-    lvm_vg = Y2Storage::LvmVg.create(staging, "system")
-    lvm_vg.add_lvm_pv(sda1)
-
-    lvm_lv = lvm_vg.create_lvm_lv("root", 16 * Storage.GiB)
-
-    encryption = lvm_lv.create_encryption("cr_sda1")
-    encryption.password = "s3cr3t"
-
-    fs = encryption.create_filesystem(Y2Storage::Filesystems::Type::XFS)
-    fs.create_mount_point("/")
-
-    # rubocop:disable Style/StringLiterals
-
-    result = ['---',
-              '- disk:',
-              '    name: "/dev/sda"',
-              '    size: 256 GiB',
-              '    block_size: 0.5 KiB',
-              '    io_size: 0 B',
-              '    min_grain: 1 MiB',
-              '    align_ofs: 0 B',
-              '    partition_table: msdos',
-              '    mbr_gap: 1 MiB',
-              '    partitions:',
-              '    - free:',
-              '        size: 1 MiB',
-              '        start: 0 B',
-              '    - partition:',
-              '        size: 262143 MiB (256.00 GiB)',
-              '        start: 1 MiB',
-              '        name: "/dev/sda1"',
-              '        type: primary',
-              '        id: lvm',
-              '- lvm_vg:',
-              '    vg_name: system',
-              '    extent_size: 4 MiB',
-              '    lvm_lvs:',
-              '    - lvm_lv:',
-              '        lv_name: root',
-              '        size: 16 GiB',
-              '        stripes: 1',
-              '        file_system: xfs',
-              '        mount_point: "/"',
-              '        encryption:',
-              '          type: luks',
-              '          name: "/dev/mapper/cr_sda1"',
-              '          password: s3cr3t',
-              '    lvm_pvs:',
-              '    - lvm_pv:',
-              '        blk_device: "/dev/sda1"']
-
-    # rubocop:enable all
-
-    io = StringIO.new
-    Y2Storage::YamlWriter.write(staging, io)
-    expect(io.string).to eq result.join("\n") + "\n"
-
-  end
-
-  it "produces yaml of a filesystem directly on a disk without a partition table" do
-
-    disk = Y2Storage::Disk.create(staging, "/dev/sda")
-    disk.size = 256 * Storage.GiB
-
-    fs = disk.create_filesystem(Y2Storage::Filesystems::Type::XFS)
-    fs.create_mount_point("/data")
-
-    # rubocop:disable Style/StringLiterals
-
-    result = ['---',
-              '- disk:',
-              '    name: "/dev/sda"',
-              '    size: 256 GiB',
-              '    block_size: 0.5 KiB',
-              '    io_size: 0 B',
-              '    min_grain: 1 MiB',
-              '    align_ofs: 0 B',
-              '    file_system: xfs',
-              '    mount_point: "/data"']
-
-    # rubocop:enable all
-
-    io = StringIO.new
-    Y2Storage::YamlWriter.write(staging, io)
-    # print io.string
-    expect(io.string).to eq result.join("\n") + "\n"
-
-  end
-
-  it "produces yaml of an encrypted filesystem directly on a disk" do
-
-    disk = Y2Storage::Disk.create(staging, "/dev/sda")
-    disk.size = 256 * Storage.GiB
-
-    encryption = disk.create_encryption("cr_data")
-    encryption.password = "s3cr3t"
-
-    fs = encryption.create_filesystem(Y2Storage::Filesystems::Type::XFS)
-    fs.create_mount_point("/data")
-
-    # rubocop:disable Style/StringLiterals
-
-    result = ['---',
-              '- disk:',
-              '    name: "/dev/sda"',
-              '    size: 256 GiB',
-              '    block_size: 0.5 KiB',
-              '    io_size: 0 B',
-              '    min_grain: 1 MiB',
-              '    align_ofs: 0 B',
-              '    file_system: xfs',
-              '    mount_point: "/data"',
-              '    encryption:',
-              '      type: luks',
-              '      name: "/dev/mapper/cr_data"',
-              '      password: s3cr3t']
-
-    # rubocop:enable all
-
-    io = StringIO.new
-    Y2Storage::YamlWriter.write(staging, io)
-    # print io.string
-    expect(io.string).to eq result.join("\n") + "\n"
-
-  end
-
 end


### PR DESCRIPTION
PBI: https://trello.com/c/jPe9PnBi/308-3-sles15-p1-1083887-zero-size-disks-not-able-to-find-the-scsi-disks-while-trying-to-install-sles-15-on-vmax-luns

* Devices with zero-size are excluded to be used in Proposal and Partitioner. 
* Fixed tests to avoid creation of zero-size devices or partitions.
* Adapted yaml reader/writer to properly manage zero-size devices.
* Bonus: yaml reader/writer tests are re-written in a more rspec way. 
