### PR TITLE
Show specific error messages when resizing partitions

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 26 09:41:25 UTC 2018 - shundhammer@suse.com
+
+- Partitioner: Report detailed reasons why resizing is not possible
+  (fate#318196)
+- 4.0.140
+
+-------------------------------------------------------------------
 Mon Mar 26 09:02:11 UTC 2018 - ancor@suse.com
 
 - Partitioner: fixed an error that was causing filesystems to be

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -26,12 +26,12 @@ Source:		%{name}-%{version}.tar.bz2
 # Yast2::FsSnapshots.configure_on_install=
 Requires:	yast2 >= 4.0.24
 Requires:	yast2-ruby-bindings
-# BlkFilesystem::supports_shrink() / _grow()
-Requires:	libstorage-ng-ruby >= 3.3.191
+# ResizeInfo::reasons() and RB_ enum
+Requires:	libstorage-ng-ruby >= 3.3.198
 
 BuildRequires:	update-desktop-files
-# BlkFilesystem::supports_shrink() / _grow()
-BuildRequires:	libstorage-ng-ruby >= 3.3.191
+# ResizeInfo::reasons() and RB_ enum
+BuildRequires:	libstorage-ng-ruby >= 3.3.198
 BuildRequires:	yast2-ruby-bindings
 BuildRequires:	yast2-devtools
 # yast2-xml dependency is added by yast2 but ignored in the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -12,11 +12,11 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via  http://bugs.opensuse.org/
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.139
+Version:        4.0.140
 Release:	0
 BuildArch:	noarch
 

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -12,7 +12,7 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via  http://bugs.opensuse.org/
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
 Name:		yast2-storage-ng

--- a/src/lib/y2partitioner/actions/resize_blk_device.rb
+++ b/src/lib/y2partitioner/actions/resize_blk_device.rb
@@ -30,6 +30,7 @@ module Y2Partitioner
   module Actions
     # Action for resizing a partition or an LVM logical volume
     class ResizeBlkDevice
+      include Yast::Logger
       include Yast::I18n
 
       # Constructor
@@ -77,7 +78,6 @@ module Y2Partitioner
 
         # Only first error is shown
         Yast::Popup.Error(errors.first)
-
         false
       end
 
@@ -90,7 +90,7 @@ module Y2Partitioner
          cannot_be_resized_error].compact
       end
 
-      # Error when trying to resize an used device
+      # Error when trying to resize a used device
       #
       # @note A device is being used when it forms part of an LVM or MD RAID.
       #
@@ -117,15 +117,16 @@ module Y2Partitioner
       end
 
       # Error when the device cannot be resized
-      #
-      # TODO: Distinguish the reason why it is not possible to resize, for example:
-      # * extended partition with committed logical partitions
+      # This might be a multi-line message reporting more than one reason.
       #
       # @return [String, nil] nil if the device can be resized.
       def cannot_be_resized_error
         return nil if device.resize_info.resize_ok?
 
-        _("This device cannot be resized.")
+        log.warn("Can't resize #{device.name}: #{device.resize_info.reasons}")
+        msg_lines = [_("This device cannot be resized:"), ""]
+        msg_lines.concat(device.resize_info.reason_texts)
+        msg_lines.join("\n")
       end
     end
   end

--- a/src/lib/y2storage/resize_info.rb
+++ b/src/lib/y2storage/resize_info.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "y2storage/storage_class_wrapper"
+require "yast/i18n"
 
 module Y2Storage
   # Information about the possibility of resizing a given device
@@ -32,7 +33,32 @@ module Y2Storage
   # This is a wrapper for Storage::ResizeInfo
   class ResizeInfo
     include StorageClassWrapper
+    include Yast::I18n
+    extend Yast::I18n
     wrap_class Storage::ResizeInfo
+
+    # rubocop:disable Metrics/LineLength
+    REASON_TEXTS =
+      {
+        RB_RESIZE_NOT_SUPPORTED_BY_DEVICE:       N_("Resizing is not supported by this device."),
+        RB_MIN_MAX_ERROR:                        N_("Combined limitations of partition and filesystem prevent resizing."),
+        RB_SHRINK_NOT_SUPPORTED_BY_FILESYSTEM:   N_("This filesystem does not support shrinking."),
+        RB_GROW_NOT_SUPPORTED_BY_FILESYSTEM:     N_("This filesystem does not support growing."),
+        RB_FILESYSTEM_INCONSISTENT:              N_("Filesystem consistency check failed."),
+        RB_MIN_SIZE_FOR_FILESYSTEM:              N_("This filesystem already has the minimum possible size."),
+        RB_MAX_SIZE_FOR_FILESYSTEM:              N_("This filesystem already has the maximum possible size."),
+        RB_FILESYSTEM_FULL:                      N_("The filesystem is full."),
+        RB_NO_SPACE_BEHIND_PARTITION:            N_("There is no space behind this partition."),
+        RB_MIN_SIZE_FOR_PARTITION:               N_("This partition already has the minimum possible size."),
+        RB_EXTENDED_PARTITION:                   N_("Extended partitions cannot be resized."),
+        RB_ON_IMPLICIT_PARTITION_TABLE:          N_("The partition on an implicit partition table cannot be resized."),
+        RB_SHRINK_NOT_SUPPORTED_FOR_LVM_LV_TYPE: N_("Shrinking of this type of LVM logical volumes is not supported."),
+        RB_RESIZE_NOT_SUPPORTED_FOR_LVM_LV_TYPE: N_("Resizing of this type of LVM logical volumes is not supported."),
+        RB_NO_SPACE_IN_LVM_VG:                   N_("No space left in the LVM volume group."),
+        RB_MIN_SIZE_FOR_LVM_LV:                  N_("The LVM logical volume already has the minimum possible size."),
+        RB_MAX_SIZE_FOR_LVM_LV_THIN:             N_("The LVM thin logical volume already has the masimum size.")
+      }.freeze
+    # rubocop:enable Metrics/LineLength
 
     # @!method resize_ok?
     #   @return [Boolean] whether is possible to resize the device
@@ -53,5 +79,75 @@ module Y2Storage
     #
     #   @return [DiskSize]
     storage_forward :max_size, as: "DiskSize"
+
+    # @!method reason_bits
+    #   Reasons blocking a resize as OR'ed bits.
+    #   In most cases, using 'reasons' will be more convenient.
+    #
+    #   @return [Integer]
+    storage_forward :reason_bits, to: :reasons
+
+    # Return the list of resizer blocker reasons known to libstorage.
+    # This uses introspection to find all constants starting with RB_
+    # in the ::Storage (libstorage) namespace.
+    #
+    # @return [Array<Symbol>] feature list
+    #
+    def libstorage_resize_blockers
+      rb_reasons = ::Storage.constants.select { |c| c.to_s.start_with?("RB_") }
+      # Sort by the constants' numeric value in ascending order
+      rb_reasons.sort_by { |r| ::Storage.const_get(r) }
+    end
+
+    # One reason blocking a resize in (translated) text form.
+    #
+    # @return [String]
+    #
+    def reason_text(blocker_reason)
+      textdomain "storage"
+      text = REASON_TEXTS[blocker_reason]
+      return _("Unknown reason") if text.nil?
+      _(text)
+    end
+
+    # Reasons blocking a resize as an array of symbols such as
+    # :RB_MIN_SIZE_FOR_FILESYSTEM etc.; see also FreeInfo.h in libstorage-ng.
+    #
+    # @return [Array<Symbol>]
+    #
+    def reasons
+      libstorage_resize_blockers.each_with_object([]) do |rb, reasons|
+        reasons << rb if reason?(rb)
+      end
+    end
+
+    # Reasons blocking a resize in text form.
+    #
+    # @return [Array<String>]
+    #
+    def reason_texts
+      reasons.map { |rb| reason_text(rb) }
+    end
+
+    # Return the bitmask for a resize blocker. This looks up a constant in the
+    # ::Storage (libstorage) namespace with that name (one of the enum values
+    # in ResizeInfo.h). If there is no constant with that name (i.e., the
+    # feature is unknown to libstorage), this will throw a NameError.
+    #
+    # @param  blocker_reason [Symbol] RB_*
+    # @return [Integer] bitmask for that feature
+    #
+    def bitmask(blocker_reason)
+      ::Storage.const_get(blocker_reason)
+    end
+
+    # Check if one particular blocker reason is set in the current reasons.
+    #
+    # @return [Boolean]
+    #
+    def reason?(blocker_reason)
+      mask = bitmask(blocker_reason)
+      (reason_bits & mask) == mask
+    end
   end
 end

--- a/src/lib/y2storage/resize_info.rb
+++ b/src/lib/y2storage/resize_info.rb
@@ -56,7 +56,7 @@ module Y2Storage
         RB_RESIZE_NOT_SUPPORTED_FOR_LVM_LV_TYPE: N_("Resizing of this type of LVM logical volumes is not supported."),
         RB_NO_SPACE_IN_LVM_VG:                   N_("No space left in the LVM volume group."),
         RB_MIN_SIZE_FOR_LVM_LV:                  N_("The LVM logical volume already has the minimum possible size."),
-        RB_MAX_SIZE_FOR_LVM_LV_THIN:             N_("The LVM thin logical volume already has the masimum size.")
+        RB_MAX_SIZE_FOR_LVM_LV_THIN:             N_("The LVM thin logical volume already has the maximum size.")
       }.freeze
     # rubocop:enable Metrics/LineLength
 

--- a/test/support/proposal_context.rb
+++ b/test/support/proposal_context.rb
@@ -61,7 +61,8 @@ RSpec.shared_context "proposal" do
   let(:disk_analyzer) { Y2Storage::DiskAnalyzer.new(fake_devicegraph) }
   let(:storage_arch) { instance_double("::Storage::Arch") }
   let(:resize_info) do
-    instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 40.GiB, max_size: 800.GiB)
+    instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 40.GiB, max_size: 800.GiB,
+      reasons: 0, reason_texts: [])
   end
 
   let(:settings_format) { :legacy }

--- a/test/y2partitioner/actions/resize_blk_device_test.rb
+++ b/test/y2partitioner/actions/resize_blk_device_test.rb
@@ -39,9 +39,11 @@ describe Y2Partitioner::Actions::ResizeBlkDevice do
 
   let(:resize_info) do
     instance_double(Y2Storage::ResizeInfo,
-      resize_ok?: can_resize,
-      min_size:   min_size,
-      max_size:   max_size)
+      resize_ok?:   can_resize,
+      min_size:     min_size,
+      max_size:     max_size,
+      reasons:      0,
+      reason_texts: ["Unspecified"])
   end
   let(:can_resize) { nil }
   let(:min_size) { 100.KiB }

--- a/test/y2partitioner/dialogs/blk_device_resize_test.rb
+++ b/test/y2partitioner/dialogs/blk_device_resize_test.rb
@@ -53,9 +53,11 @@ describe Y2Partitioner::Dialogs::BlkDeviceResize do
 
   let(:resize_info) do
     instance_double(Y2Storage::ResizeInfo,
-      resize_ok?: true,
-      min_size:   10.MiB,
-      max_size:   100.GiB)
+      resize_ok?:   true,
+      min_size:     10.MiB,
+      max_size:     100.GiB,
+      reasons:      0,
+      reason_texts: ["Unspecified"])
   end
 
   subject { described_class.new(partition) }
@@ -154,9 +156,11 @@ describe Y2Partitioner::Dialogs::BlkDeviceResize do
 
     let(:resize_info) do
       instance_double(Y2Storage::ResizeInfo,
-        resize_ok?: true,
-        min_size:   min_size,
-        max_size:   max_size)
+        resize_ok?:   true,
+        min_size:     min_size,
+        max_size:     max_size,
+        reasons:      0,
+        reason_texts: ["Unspecified"])
     end
 
     let(:current_widget) { max_size_widget }

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -258,7 +258,8 @@ describe Y2Storage::AutoinstProposal do
       let(:resize_ok) { true }
       let(:resize_info) do
         instance_double(
-          Y2Storage::ResizeInfo, min_size: 512.MiB, max_size: 245.GiB, resize_ok?: resize_ok
+          Y2Storage::ResizeInfo, min_size: 512.MiB, max_size: 245.GiB, resize_ok?: resize_ok,
+            reasons: 0, reason_texts: []
         )
       end
 
@@ -426,7 +427,8 @@ describe Y2Storage::AutoinstProposal do
 
       let(:resize_info) do
         instance_double(
-          Y2Storage::ResizeInfo, min_size: 512.MiB, max_size: 2.GiB, resize_ok?: true
+          Y2Storage::ResizeInfo, min_size: 512.MiB, max_size: 2.GiB, resize_ok?: true,
+            reasons: 0, reason_texts: []
         )
       end
 

--- a/test/y2storage/device_test.rb
+++ b/test/y2storage/device_test.rb
@@ -89,7 +89,10 @@ describe Y2Storage::Device do
 
   describe "#can_resize?" do
     subject(:device) { Y2Storage::Partition.find_by_name(fake_devicegraph, "/dev/sda1") }
-    let(:resize_info) { double(Y2Storage::ResizeInfo, resize_ok?: resize_ok) }
+    let(:resize_info) do
+      double(Y2Storage::ResizeInfo, resize_ok?: resize_ok,
+        reasons: 0, reason_texts: [])
+    end
 
     before { allow(device).to receive(:detect_resize_info).and_return resize_info }
 

--- a/test/y2storage/lvm_lv_test.rb
+++ b/test/y2storage/lvm_lv_test.rb
@@ -86,7 +86,11 @@ describe Y2Storage::LvmLv do
   describe "#resize" do
     before { allow(lv).to receive(:detect_resize_info).and_return resize_info }
 
-    let(:resize_info) { double(Y2Storage::ResizeInfo, resize_ok?: ok, min_size: min, max_size: max) }
+    let(:resize_info) do
+      double(Y2Storage::ResizeInfo, resize_ok?: ok,
+        min_size: min, max_size: max,
+        reasons: 0, reason_texts: [])
+    end
     let(:ok) { true }
     let(:min) { 1.GiB }
     let(:max) { 5.GiB }

--- a/test/y2storage/partition_test.rb
+++ b/test/y2storage/partition_test.rb
@@ -197,7 +197,11 @@ describe Y2Storage::Partition do
 
     before { allow(partition).to receive(:detect_resize_info).and_return resize_info }
 
-    let(:resize_info) { double(Y2Storage::ResizeInfo, resize_ok?: ok, min_size: min, max_size: max) }
+    let(:resize_info) do
+      double(Y2Storage::ResizeInfo, resize_ok?: ok,
+        min_size: min, max_size: max,
+        reasons: 0, reason_texts: [])
+    end
     let(:ok) { true }
     let(:min) { 2.GiB }
     let(:max) { 5.GiB }

--- a/test/y2storage/planned/can_be_resized_test.rb
+++ b/test/y2storage/planned/can_be_resized_test.rb
@@ -39,7 +39,8 @@ describe Y2Storage::Planned::CanBeResized do
   let(:resize_ok) { true }
 
   let(:resize_info) do
-    instance_double(Y2Storage::ResizeInfo, min_size: 5.GiB, max_size: 9.GiB, resize_ok?: resize_ok)
+    instance_double(Y2Storage::ResizeInfo, min_size: 5.GiB, max_size: 9.GiB, resize_ok?: resize_ok,
+      reasons: 0, reason_texts: [])
   end
 
   before do

--- a/test/y2storage/proposal/autoinst_devices_creator_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_creator_test.rb
@@ -241,13 +241,15 @@ describe Y2Storage::Proposal::AutoinstDevicesCreator do
 
       let(:info_sda1) do
         instance_double(
-          Y2Storage::ResizeInfo, min_size: 1.GiB, max_size: 250.GiB, resize_ok?: true
+          Y2Storage::ResizeInfo, min_size: 1.GiB, max_size: 250.GiB, resize_ok?: true,
+          reasons: 0, reason_texts: []
         )
       end
 
       let(:info_sda2) do
         instance_double(
-          Y2Storage::ResizeInfo, min_size: 1.GiB, max_size: 52.GiB, resize_ok?: true
+          Y2Storage::ResizeInfo, min_size: 1.GiB, max_size: 52.GiB, resize_ok?: true,
+          reasons: 0, reason_texts: []
         )
       end
 
@@ -295,13 +297,15 @@ describe Y2Storage::Proposal::AutoinstDevicesCreator do
 
       let(:info_lv1) do
         instance_double(
-          Y2Storage::ResizeInfo, min_size: 1.GiB, max_size: 250.GiB, resize_ok?: true
+          Y2Storage::ResizeInfo, min_size: 1.GiB, max_size: 250.GiB, resize_ok?: true,
+          reasons: 0, reason_texts: []
         )
       end
 
       let(:info_lv2) do
         instance_double(
-          Y2Storage::ResizeInfo, min_size: 1.GiB, max_size: 52.GiB, resize_ok?: true
+          Y2Storage::ResizeInfo, min_size: 1.GiB, max_size: 52.GiB, resize_ok?: true,
+          reasons: 0, reason_texts: []
         )
       end
 

--- a/test/y2storage/proposal/space_maker_test.rb
+++ b/test/y2storage/proposal/space_maker_test.rb
@@ -403,7 +403,8 @@ describe Y2Storage::Proposal::SpaceMaker do
     context "with one disk containing a Windows partition and no Linux ones" do
       let(:scenario) { "windows-pc" }
       let(:resize_info) do
-        instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 730.GiB, max_size: 800.GiB)
+        instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 730.GiB, max_size: 800.GiB,
+          reasons: 0, reason_texts: [])
       end
       let(:windows_partitions) { [partition_double("/dev/sda1")] }
 
@@ -599,7 +600,8 @@ describe Y2Storage::Proposal::SpaceMaker do
     context "if there are two Windows partitions" do
       let(:scenario) { "double-windows-pc" }
       let(:resize_info) do
-        instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 50.GiB, max_size: 800.GiB)
+        instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 50.GiB, max_size: 800.GiB,
+          reasons: 0, reason_texts: [])
       end
       let(:windows_partitions) do
         [
@@ -740,7 +742,8 @@ describe Y2Storage::Proposal::SpaceMaker do
     context "when some volumes have disk restrictions" do
       let(:scenario) { "mixed_disks" }
       let(:resize_info) do
-        instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 50.GiB, max_size: 800.GiB)
+        instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 50.GiB, max_size: 800.GiB,
+          reasons: 0, reason_texts: [])
       end
       let(:windows_partitions) { [partition_double("/dev/sda1")] }
       let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, disk: "/dev/sda") }

--- a/test/y2storage/proposal_scenarios_x86_test.rb
+++ b/test/y2storage/proposal_scenarios_x86_test.rb
@@ -105,7 +105,8 @@ describe Y2Storage::GuidedProposal do
       let(:scenario) { "windows-pc-50GiB-gpt" }
       let(:windows_partitions) { [partition_double("/dev/sda1")] }
       let(:resize_info) do
-        instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 1.GiB, max_size: 50.GiB)
+        instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 1.GiB, max_size: 50.GiB,
+          reasons: 0, reason_texts: [])
       end
 
       # essential part of the example: Windows partition has been resized

--- a/test/y2storage/resize_info_test.rb
+++ b/test/y2storage/resize_info_test.rb
@@ -85,4 +85,11 @@ describe Y2Storage::ResizeInfo do
       expect(no_msg).to be_empty
     end
   end
+
+  describe "#REASON_TEXTS" do
+    it "has only messages for reasons known to libstorage" do
+      orphans = described_class::REASON_TEXTS.keys - subject.libstorage_resize_blockers
+      expect(orphans).to be_empty
+    end
+  end
 end

--- a/test/y2storage/resize_info_test.rb
+++ b/test/y2storage/resize_info_test.rb
@@ -1,0 +1,88 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+describe Y2Storage::ResizeInfo do
+  # We can't use fake_scenario here and then let libstorage-ng create a real
+  # ResizeInfo object because this would actually try to access the partitions
+  # and filesystems and thus throw errors, so we need to create an empty one
+  # and wrap it into its Y2Storage wrapper class.
+  subject { Y2Storage::ResizeInfo.new(Storage::ResizeInfo.new(resize_ok, rb_reasons)) }
+  let(:resize_ok) { false }
+  let(:rb_reasons) { Storage::RB_FILESYSTEM_FULL | Storage::RB_MIN_MAX_ERROR }
+
+  describe "#new" do
+    it "does not crash and burn" do
+      expect(subject.class).to be == Y2Storage::ResizeInfo
+      expect(subject.resize_ok?).to be resize_ok
+      expect(subject.reason_bits).to be == rb_reasons
+    end
+  end
+
+  describe "#libstorage_resize_blockers" do
+    it "has content" do
+      resize_blockers = subject.libstorage_resize_blockers
+      expect(resize_blockers).to include(:RB_FILESYSTEM_FULL, :RB_EXTENDED_PARTITION)
+    end
+  end
+
+  describe "#reason_bits" do
+    it "sets the correct reason bits" do
+      expect(subject.reason_bits).to be == rb_reasons
+    end
+  end
+
+  describe "#reasons" do
+    it "has the correct reasons" do
+      expect(subject.reasons).to eq [:RB_MIN_MAX_ERROR, :RB_FILESYSTEM_FULL]
+    end
+  end
+
+  describe "#reason?" do
+    it "has the correct reasons" do
+      expect(subject.reason?(:RB_MIN_MAX_ERROR)).to be true
+      expect(subject.reason?(:RB_FILESYSTEM_FULL)).to be true
+      expect(subject.reason?(:RB_EXTENDED_PARTITION)).to be false
+    end
+  end
+
+  describe "#reason_texts" do
+    it "has the correct messages" do
+      texts = subject.reason_texts
+      expect(texts.size).to be == 2
+      expect(texts[0]).to match(/combined limitations/i)
+      expect(texts[1]).to match(/filesystem.*full/i)
+    end
+  end
+
+  describe "#reason_text" do
+    it "has a message for every known reason in libstorage_resize_blockers" do
+      no_msg = subject.libstorage_resize_blockers.select do |reason|
+        text = subject.reason_text(reason)
+        text.nil? || text =~ /Unknown reason/i
+      end
+      expect(no_msg).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/lD8N7IET/200-5-partitioner-show-specific-error-messages-when-resizing-partitions

Blog post: https://github.com/yast/yast.github.io/issues/147#issuecomment-375342963

This PR wraps the new resize blocker reasons from libstorage-ng to provide human-readable error messages for all the individual reasons that block a resize operation: 

There might be more than one problem at the same time. We want to show the user all of them, or at least all that make sense; it's no use to show him just one, and once he managed to fix that one, he might find out that there are more, so all his efforts (which might involve data loss due to deleting partitions and/for filesystems) were still in vain.

The first part of this uses introspection to look up constants starting with `RB_` and convert them to Ruby symbols for much better readability, and later to translated texts. The Ruby symbols might come handy some day to check for various common combinations of reasons that can be summarized in other ways that are better to understand, or where we might want to suppress some of the reasons that might tend to confuse the user.

![resize-error-reasons-01](https://user-images.githubusercontent.com/11538225/37778569-8acb43c8-2dea-11e8-9cc7-d63efe64430b.png)

![resize-error-reasons-02](https://user-images.githubusercontent.com/11538225/37778575-929ad0a0-2dea-11e8-946c-b3b076c3c43d.png)

![resize-error-reasons-03](https://user-images.githubusercontent.com/11538225/37778579-9592261e-2dea-11e8-81fb-8a7772b16ade.png)
