### PR TITLE
Handle lock system

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Apr  9 10:14:12 UTC 2018 - jlopez@suse.com
+
+- Add system lock to avoid several process using the storage stack
+  when a process is already using it with write access.
+- Part of fate#318196.
+- 4.0.149
+
+-------------------------------------------------------------------
 Mon Apr  9 09:14:12 UTC 2018 - ancor@suse.com
 
 - Force UTF-8 encoding for (most) strings coming from libstorage-ng

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Mon Apr  9 10:14:12 UTC 2018 - jlopez@suse.com
 
-- Add system lock to avoid several process using the storage stack
-  when a process is already using it with write access.
+- Add system lock to avoid several processes using the storage
+  stack when a process is already using it with read-write access.
 - Part of fate#318196.
 - 4.0.149
 

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.148
+Version:        4.0.149
 Release:	0
 BuildArch:	noarch
 

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -25,7 +25,8 @@ Source:		%{name}-%{version}.tar.bz2
 
 # Yast::Report.yesno_popup
 Requires:	yast2 >= 4.0.61
-Requires:	yast2-ruby-bindings
+# for AbortException and handle direct abort
+Requires:	yast2-ruby-bindings >= 4.0.6
 # ResizeInfo::reasons() and RB_ enum
 Requires:	libstorage-ng-ruby >= 3.3.198
 
@@ -39,6 +40,8 @@ BuildRequires:	yast2-devtools
 BuildRequires:  yast2-xml
 # Yast::Report.yesno_popup
 BuildRequires:	yast2 >= 4.0.61
+# for AbortException and handle direct abort
+BuildRequires:	yast2-ruby-bindings >= 4.0.6
 BuildRequires:	rubygem(yast-rake)
 BuildRequires:	rubygem(rspec)
 PreReq:         %fillup_prereq

--- a/src/clients/partitioner_testing.rb
+++ b/src/clients/partitioner_testing.rb
@@ -5,6 +5,11 @@ require "yast"
 require "y2partitioner/clients/main"
 require "y2storage"
 
+# Uncomment next line and run the file with root privileges to test system lock
+# exit unless Y2Storage::StorageManager.setup(mode: :rw)
+
+Y2Storage::StorageManager.create_test_instance
+
 arg = Yast::WFM.Args.first
 case arg
 when /.ya?ml$/

--- a/src/clients/partitioner_testing.rb
+++ b/src/clients/partitioner_testing.rb
@@ -5,7 +5,7 @@ require "yast"
 require "y2partitioner/clients/main"
 require "y2storage"
 
-# Uncomment next line and run the file with root privileges to test system lock
+# Comment next line and run the file with root privileges to test system lock
 Y2Storage::StorageManager.create_test_instance
 
 arg = Yast::WFM.Args.first

--- a/src/clients/partitioner_testing.rb
+++ b/src/clients/partitioner_testing.rb
@@ -6,17 +6,15 @@ require "y2partitioner/clients/main"
 require "y2storage"
 
 # Uncomment next line and run the file with root privileges to test system lock
-# exit unless Y2Storage::StorageManager.setup(mode: :rw)
-
 Y2Storage::StorageManager.create_test_instance
 
 arg = Yast::WFM.Args.first
 case arg
 when /.ya?ml$/
-  Y2Storage::StorageManager.instance.probe_from_yaml(arg)
+  Y2Storage::StorageManager.instance(mode: :rw).probe_from_yaml(arg)
 when /.xml$/
   # note: support only xml device graph, not xml output of probing commands
-  Y2Storage::StorageManager.instance.probe_from_xml(arg)
+  Y2Storage::StorageManager.instance(mode: :rw).probe_from_xml(arg)
 else
   raise "Invalid testing parameter #{arg}, expecting foo.yml or foo.xml."
 end

--- a/src/lib/y2partitioner/clients/main.rb
+++ b/src/lib/y2partitioner/clients/main.rb
@@ -35,9 +35,16 @@ module Y2Partitioner
       extend Yast::Logger
 
       # Run the client
+      #
+      # It tries to initialize the storage object with read-write access mode.
+      #
+      # @see Y2Storage::StorageManager.setup
+      #
       # @param allow_commit [Boolean] can we pass the point of no return
       def self.run(allow_commit: true)
         textdomain "storage"
+
+        return nil unless Y2Storage::StorageManager.setup(mode: :rw)
 
         smanager = Y2Storage::StorageManager.instance
         dialog = Dialogs::Main.new

--- a/src/lib/y2storage/callbacks/initialize.rb
+++ b/src/lib/y2storage/callbacks/initialize.rb
@@ -21,8 +21,8 @@
 
 require "yast"
 require "yast/i18n"
-require "yast2/popup"
 
+Yast.import "Report"
 Yast.import "Mode"
 Yast.import "Label"
 
@@ -73,11 +73,11 @@ module Y2Storage
 
         buttons = { yes: _("Retry"), no: abort_button_label }
 
-        answer = Yast2::Popup.show(message, headline: headline, buttons: buttons)
+        answer = Yast::Report.yesno_popup(message, headline: headline, buttons: buttons)
 
         log.info "User answer: #{answer}"
 
-        answer == :yes
+        answer
       end
 
     private

--- a/src/lib/y2storage/callbacks/initialize.rb
+++ b/src/lib/y2storage/callbacks/initialize.rb
@@ -71,9 +71,10 @@ module Y2Storage
 
         headline = _("Accessing the storage subsystem failed")
 
-        buttons = { yes: _("Retry"), no: abort_button_label }
-
-        answer = Yast::Report.yesno_popup(message, headline: headline, buttons: buttons)
+        answer = Yast::Report.yesno_popup(message,
+          headline: headline,
+          buttons:  buttons,
+          focus:    focus_button)
 
         log.info "User answer: #{answer}"
 
@@ -107,6 +108,22 @@ module Y2Storage
       # @return [String]
       def abort_button_label
         Yast::Mode.installation ? Yast::Label.AbortInstallationButton : Yast::Label.AbortButton
+      end
+
+      # Buttons to retry or abort
+      #
+      # @return [Hash<Symbol, String>]
+      def buttons
+        { yes: _("Retry"), no: abort_button_label }
+      end
+
+      # Button with focus by default
+      #
+      # @note For AutoYaST, default must be :no to avoid constantly retry.
+      #
+      # @return [Symbol] :yes, :no
+      def focus_button
+        Yast::Mode.auto ? :no : :yes
       end
     end
   end

--- a/src/lib/y2storage/callbacks/initialize.rb
+++ b/src/lib/y2storage/callbacks/initialize.rb
@@ -69,7 +69,7 @@ module Y2Storage
             )
           end
 
-        headline = _("Accessing the storage subsystem failed")
+        headline = _("Accessing the Storage Subsystem Failed")
 
         answer = Yast::Report.yesno_popup(message,
           headline: headline,

--- a/src/lib/y2storage/callbacks/initialize.rb
+++ b/src/lib/y2storage/callbacks/initialize.rb
@@ -1,0 +1,111 @@
+# encoding: utf-8
+
+# Copyright (c) 2018 SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast/i18n"
+require "yast2/popup"
+
+Yast.import "Mode"
+Yast.import "Label"
+
+module Y2Storage
+  module Callbacks
+    # Class to implement callbacks used when initializing the storage instance
+    class Initialize
+      include Yast
+      include Yast::Logger
+      include Yast::I18n
+
+      # Constructor
+      #
+      # @param error [Storage::LockException]
+      def initialize(error)
+        textdomain "storage"
+
+        @error = error
+      end
+
+      # Callback to ask the user whether to retry or abort when the storage lock
+      # cannot be acquired.
+      #
+      # @return [Boolean] true if the user decides to retry.
+      def retry?
+        log.info "Storage subsystem is locked by process #{locker_pid}, asking to user whether to retry"
+
+        if locker_name
+          message = format(
+            # TRANSLATORS: %{name} is replaced by the name of a process (e.g., yast2)
+            # and %{pid} by the pid of a process (e.g., 5032).
+            _("The storage subsystem is locked by the application \"%{name}\" (%{pid})."),
+            name: locker_name,
+            pid:  locker_pid
+          )
+        else
+          message = _("The storage subsystem is locked by an unknown application.")
+        end
+
+        message << "\n"
+        message << _("You must quit that application before you can continue.")
+        message << "\n\n"
+        message << _("Would you like to abort or try again?")
+
+        headline = _("Accessing the storage subsystem failed")
+
+        buttons = { yes: _("Retry"), no: abort_button_label }
+
+        answer = Yast2::Popup.show(message, headline: headline, buttons: buttons)
+
+        log.info "User answer: #{answer}"
+
+        answer == :yes
+      end
+
+    private
+
+      # @return [Storage::LockException]
+      attr_reader :error
+
+      # ID of the current process that has the lock
+      #
+      # @return [Integer]
+      def locker_pid
+        error.locker_pid
+      end
+
+      # Name of the current process that has the lock
+      #
+      # @return [String, nil] nil if the process is unknown.
+      def locker_name
+        full_path = Yast::SCR.Read(path(".target.symlink"), "/proc/#{locker_pid}/exe")
+        return nil unless full_path
+
+        full_path.split("/").last
+      end
+
+      # Label for the abort button displayed by {#retry?}
+      #
+      # @return [String]
+      def abort_button_label
+        Yast::Mode.installation ? Yast::Label.AbortInstallationButton : Yast::Label.AbortButton
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/callbacks/initialize.rb
+++ b/src/lib/y2storage/callbacks/initialize.rb
@@ -50,22 +50,24 @@ module Y2Storage
       def retry?
         log.info "Storage subsystem is locked by process #{locker_pid}, asking to user whether to retry"
 
-        if locker_name
-          message = format(
-            # TRANSLATORS: %{name} is replaced by the name of a process (e.g., yast2)
-            # and %{pid} by the pid of a process (e.g., 5032).
-            _("The storage subsystem is locked by the application \"%{name}\" (%{pid})."),
-            name: locker_name,
-            pid:  locker_pid
-          )
-        else
-          message = _("The storage subsystem is locked by an unknown application.")
-        end
-
-        message << "\n"
-        message << _("You must quit that application before you can continue.")
-        message << "\n\n"
-        message << _("Would you like to abort or try again?")
+        message =
+          if locker_name
+            format(
+              # TRANSLATORS: %{name} is replaced by the name of a process (e.g., yast2)
+              # and %{pid} by the pid of a process (e.g., 5032).
+              _("The storage subsystem is locked by the application \"%{name}\" (%{pid}).\n" \
+                "You must quit that application before you can continue.\n\n" \
+                "Would you like to abort or try again?"),
+              name: locker_name,
+              pid:  locker_pid
+            )
+          else
+            _(
+              "The storage subsystem is locked by an unknown application.\n" \
+              "You must quit that application before you can continue.\n\n" \
+              "Would you like to abort or try again?"
+            )
+          end
 
         headline = _("Accessing the storage subsystem failed")
 

--- a/src/lib/y2storage/exceptions.rb
+++ b/src/lib/y2storage/exceptions.rb
@@ -38,4 +38,7 @@ module Y2Storage
   # A device was not found
   class DeviceNotFoundError < Error
   end
+  # Requested access mode is incompatible with current mode
+  class AccessModeError < Error
+  end
 end

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -490,7 +490,7 @@ module Y2Storage
         mode ||= default_storage_mode
         Y2Storage::StorageManager.instance(mode: mode, callbacks: callbacks)
         true
-      rescue Storage::LockException
+      rescue Yast::AbortException
         false
       end
 
@@ -510,7 +510,7 @@ module Y2Storage
       # @raise [AccessModeError] if the requested mode is incompatible with the
       #   already created instance (i.e., current instance is ro but rw is requested).
       #
-      # @raise [Storage::LockException] if the storage lock cannot be acquired and
+      # @raise [Yast::AbortException] if the storage lock cannot be acquired and
       #   the user decides to abort.
       #
       # @param mode [Symbol, nil] :ro, :rw. If nil, a default mode is used, see
@@ -544,7 +544,7 @@ module Y2Storage
       # With the default callbacks, the user is asked whether to retry or abort
       # when lock cannot be acquired.
       #
-      # @raise [Storage::LockException] if lock cannot be acquired and the user
+      # @raise [Yast::AbortException] if lock cannot be acquired and the user
       #   decides to abort.
       #   Several process can access in read-only mode at the same time, but only
       #   one process can access in read-write mode. If a process is accessing in
@@ -560,7 +560,7 @@ module Y2Storage
         log.info "Creating Storage object"
         @instance = new(environment)
       rescue Storage::LockException => error
-        raise error unless retry_create_instance?(error, callbacks)
+        raise Yast::AbortException unless retry_create_instance?(error, callbacks)
         retry
       end
 

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -482,6 +482,11 @@ module Y2Storage
       # @return [Boolean] true if the storage instance was correctly created for
       #   the given mode; false otherwise.
       def setup(mode: nil, callbacks: nil)
+        # In case of mode is not given, it is necessary to initialize it with the
+        # default mode due to {.instance} without mode returns the current storage
+        # instance. In some cases, the current instance might not be valid for the
+        # default mode (e.g., current is read-only but {.setup} is called without
+        # mode during installation).
         mode ||= default_storage_mode
         Y2Storage::StorageManager.instance(mode: mode, callbacks: callbacks)
         true

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -595,7 +595,7 @@ module Y2Storage
       #
       # @return [Symbol] :ro, :rw
       def default_storage_mode
-        Yast::Mode.installation || Yast::Mode.autoinst ? :rw : :ro
+        Yast::Mode.installation ? :rw : :ro
       end
 
       # Checks whether the current instance can be used for the requested access mode

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -472,8 +472,8 @@ module Y2Storage
       # With the default callbacks, the user is asked whether to retry or abort
       # when lock cannot be acquired.
       #
-      # @raise [Error] if the requested mode is incompatible with the already
-      #   created instance (i.e., current instance is ro but rw is requested).
+      # @raise [AccessModeError] if the requested mode is incompatible with the
+      #   already created instance (i.e., current instance is ro but rw is requested).
       #
       # @param mode [Symbol, nil] :ro, :rw. If nil, a default mode is used, see
       #   {.default_storage_mode}.
@@ -507,8 +507,8 @@ module Y2Storage
       # @see .create_test_instance if you just need to create an instance that
       #   ensures not real hardware probing, even calling to #probe.
       #
-      # @raise [Error] if the requested mode is incompatible with the already
-      #   created instance (i.e., current instance is ro but rw is requested).
+      # @raise [AccessModeError] if the requested mode is incompatible with the
+      #   already created instance (i.e., current instance is ro but rw is requested).
       #
       # @raise [Storage::LockException] if the storage lock cannot be acquired and
       #   the user decides to abort.
@@ -525,7 +525,8 @@ module Y2Storage
 
         if @instance
           return @instance if valid_instance?(mode)
-          raise Error, "Unexpected storage mode: current is #{@instance.mode}, requested is #{mode}"
+          raise AccessModeError,
+            "Unexpected storage mode: current is #{@instance.mode}, requested is #{mode}"
         else
           read_only = mode == :ro
           create_instance(Storage::Environment.new(read_only), callbacks)

--- a/test/y2partitioner/clients/main_test.rb
+++ b/test/y2partitioner/clients/main_test.rb
@@ -23,7 +23,7 @@ describe Y2Partitioner::Clients::Main do
         expect(subject.run).to be_nil
       end
 
-      it "does not run the client" do
+      it "does not run the dialog" do
         expect(Y2Partitioner::Dialogs::Main).to_not receive(:new)
         subject.run
       end

--- a/test/y2partitioner/clients/main_test.rb
+++ b/test/y2partitioner/clients/main_test.rb
@@ -14,7 +14,22 @@ describe Y2Partitioner::Clients::Main do
       Y2Storage::StorageManager.create_test_instance
     end
 
-    describe "when committing is allowed" do
+    context "when storage system cannot be initialized as read-write" do
+      before do
+        allow(Y2Storage::StorageManager).to receive(:setup).with(mode: :rw).and_return(false)
+      end
+
+      it "returns nil" do
+        expect(subject.run).to be_nil
+      end
+
+      it "does not run the client" do
+        expect(Y2Partitioner::Dialogs::Main).to_not receive(:new)
+        subject.run
+      end
+    end
+
+    context "when committing is allowed" do
       it "asks, and commits when confirmed" do
         smanager = Y2Storage::StorageManager.instance
 
@@ -27,7 +42,7 @@ describe Y2Partitioner::Clients::Main do
       end
     end
 
-    describe "when commitig is disallowed" do
+    context "when commitig is disallowed" do
       it "tells so, and does not commit" do
         smanager = Y2Storage::StorageManager.instance
 

--- a/test/y2storage/callbacks/initialize_test.rb
+++ b/test/y2storage/callbacks/initialize_test.rb
@@ -1,6 +1,7 @@
+#!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017-2018] SUSE LLC
+# Copyright (c) [2018] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -19,8 +20,27 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require_relative "../spec_helper"
 require "y2storage/callbacks/initialize"
-require "y2storage/callbacks/activate"
-require "y2storage/callbacks/probe"
-require "y2storage/callbacks/sanitize"
-require "y2storage/callbacks/commit"
+
+describe Y2Storage::Callbacks::Initialize do
+  subject(:callbacks) { described_class.new(error) }
+
+  let(:error) { instance_double(Storage::LockException, locker_pid: 0) }
+
+  describe "#retry?" do
+    it "displays the lock error message" do
+      expect(Yast2::Popup).to receive(:show) do |message|
+        expect(message).to match(/storage subsystem is locked/)
+      end
+      subject.retry?
+    end
+
+    it "asks the user whether to retry and returns the answer" do
+      allow(Yast2::Popup).to receive(:show).and_return(:yes, :yes, :no)
+      expect(subject.retry?).to eq(true)
+      expect(subject.retry?).to eq(true)
+      expect(subject.retry?).to eq(false)
+    end
+  end
+end

--- a/test/y2storage/callbacks/initialize_test.rb
+++ b/test/y2storage/callbacks/initialize_test.rb
@@ -30,14 +30,14 @@ describe Y2Storage::Callbacks::Initialize do
 
   describe "#retry?" do
     it "displays the lock error message" do
-      expect(Yast2::Popup).to receive(:show) do |message|
+      expect(Yast::Report).to receive(:yesno_popup) do |message|
         expect(message).to match(/storage subsystem is locked/)
       end
       subject.retry?
     end
 
     it "asks the user whether to retry and returns the answer" do
-      allow(Yast2::Popup).to receive(:show).and_return(:yes, :yes, :no)
+      allow(Yast::Report).to receive(:yesno_popup).and_return(true, true, false)
       expect(subject.retry?).to eq(true)
       expect(subject.retry?).to eq(true)
       expect(subject.retry?).to eq(false)

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -122,7 +122,7 @@ describe Y2Storage::StorageManager do
         end
 
         it "raises an error" do
-          expect { described_class.setup(mode: mode) }.to raise_error(Y2Storage::Error)
+          expect { described_class.setup(mode: mode) }.to raise_error(Y2Storage::AccessModeError)
         end
       end
     end

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -40,8 +40,16 @@ describe Y2Storage::StorageManager do
       end
 
       context "and storage system is not locked" do
+        before do
+          # Mocking #new because it is not possible to create a lock without root privileges
+          allow(Storage::Storage).to receive(:new).and_return(storage)
+          allow(storage).to receive(:default_mount_by=)
+        end
+
+        let(:storage) { instance_double(Storage::Storage) }
+
         it "creates a new storage instance" do
-          expect(Storage::Storage).to receive(:new).and_call_original
+          expect(Storage::Storage).to receive(:new)
           described_class.setup
         end
 
@@ -107,7 +115,7 @@ describe Y2Storage::StorageManager do
         let(:mode) { :rw }
 
         before do
-          # To properly test it, the enviroment should be created with another
+          # To properly test it, the environment should be created with another
           # probe mode, but for that, root privileges are required. So, here we
           # simply mock #test_instance?
           allow(described_class).to receive(:test_instance?).and_return(false)
@@ -260,7 +268,7 @@ describe Y2Storage::StorageManager do
         let(:mode) { :rw }
 
         before do
-          # To properly test it, the enviroment should be created with another
+          # To properly test it, the environment should be created with another
           # probe mode, but for that, root privileges are required. So, here we
           # simply mock #test_instance?
           allow(described_class).to receive(:test_instance?).and_return(false)
@@ -308,6 +316,14 @@ describe Y2Storage::StorageManager do
     end
 
     context "if the storage system is not locked" do
+      before do
+        # Mocking #new because it is not possible to create a lock without root privileges
+        allow(Storage::Storage).to receive(:new).and_return(storage)
+        allow(storage).to receive(:default_mount_by=)
+      end
+
+      let(:storage) { instance_double(Storage::Storage) }
+
       it "creates a new storage instance" do
         initial_instance = described_class.instance
         new_instance = described_class.create_instance
@@ -322,7 +338,6 @@ describe Y2Storage::StorageManager do
         allow(Storage::Storage).to receive(:new).and_raise(lock_error)
 
         allow(Y2Storage::Callbacks::Initialize).to receive(:new).and_return(callbacks)
-
         allow(callbacks).to receive(:retry?).and_return(*retry_answers)
       end
 

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -212,8 +212,8 @@ describe Y2Storage::StorageManager do
               .and_return(false)
           end
 
-          it "raises a lock exception" do
-            expect { subject }.to raise_error(Storage::LockException)
+          it "raises an abort exception" do
+            expect { subject }.to raise_error(Yast::AbortException)
           end
         end
       end
@@ -348,8 +348,8 @@ describe Y2Storage::StorageManager do
       context "and the user decides to abort" do
         let(:retry_answers) { [false] }
 
-        it "raises a lock exception" do
-          expect { described_class.create_instance }.to raise_error(Storage::LockException)
+        it "raises an abort exception" do
+          expect { described_class.create_instance }.to raise_error(Yast::AbortException)
         end
       end
 
@@ -358,7 +358,7 @@ describe Y2Storage::StorageManager do
 
         it "retries the creation of the instance" do
           expect(described_class).to receive(:new).exactly(3).times.and_call_original
-          expect { described_class.create_instance }.to raise_error(Storage::LockException)
+          expect { described_class.create_instance }.to raise_error(Yast::AbortException)
         end
       end
     end


### PR DESCRIPTION
PBI: https://trello.com/c/jItiacnG/335-readd-system-wide-lock-in-libstorage-ng

Notes for reviewers:
* [These changes](https://github.com/yast/yast-ruby-bindings/pull/215) in `yast-ruby-bindings`are required for this PR.
* Clients from other packages using storage-ng do not need to be adapted. With the default callbacks, an `AbortException` is raised if the user aborts and the process will finish.

* codeclimate is complaining for a couple of methods (high complexity), but it seems difficult to improve them without a less readable way.
* Class StorageManager starts to be too large, and codeclimate also detects it. Another class to lighten up in future.