### PR TITLE
Better error handling if no storage proposal possible

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr  5 15:30:57 UTC 2018 - shundhammer@suse.com
+
+- Better error handling if no storage proposal is possible
+  (bsc#1064677)
+- 4.0.147
+
+-------------------------------------------------------------------
 Tue Apr  3 13:26:50 UTC 2018 - jlopez@suse.com
 
 - Recover method #exists_in_probed? (bsc#1087818).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.146
+Version:        4.0.147
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -52,7 +52,9 @@ module Y2Storage
           log.info "Proposal dialog: return :next with #{proposal} and #{devicegraph}"
           super
         else
-          Yast::Report.Error(_("Cannot continue"))
+          msg = _("Cannot continue without a valid storage setup.") + "\n"
+          msg += _("Please use \"Guided Setup\" or \"Expert Partitioner\".")
+          Yast::Report.Error(msg)
         end
       end
 


### PR DESCRIPTION
Better handling if the storage proposal just is "No proposal possible":

https://trello.com/c/1FvORDWg/315-2-sles15-p3-1064677-build-3101-internal-error-in-installer-on-click-on-booting-in-installation-summary-after-creating-invalid-pa

This affects the automatic proposal as well as the guided setup.

The error handling was always there, but the message was not really informative: "Cannot continue" does not give the user any hint what to do. So basically this just improves the error message:

![cannot-continue-verbose](https://user-images.githubusercontent.com/11538225/38375937-b3e89b26-38f7-11e8-910c-d87a69ac31aa.png)

The expert partitioner has its own error handling which presents errors to the user, but the user can decide to override any error and continue regardless.