### PR TITLE
Make disable_order affect all configurable aspects of the volume

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Apr  9 19:44:44 UTC 2018 - ancor@suse.com
+
+- Fixed the disable_order property of control.xml. Now it affects
+  all the configurable aspects of the volume, as documented
+  (related to bsc#1078495).
+- 4.0.150
+
+-------------------------------------------------------------------
 Mon Apr  9 10:14:12 UTC 2018 - jlopez@suse.com
 
 - Add system lock to avoid several processes using the storage

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.149
+Version:        4.0.150
 Release:	0
 BuildArch:	noarch
 


### PR DESCRIPTION
The behavior was intentionally implemented in a different way to what was documented at https://github.com/yast/yast-storage-ng/blob/master/doc/old_and_new_proposal.md

Now code and documentation match.