### PR TITLE
Partitioner: handle legacy entries which use nfs4

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Apr 10 16:21:04 UTC 2018 - ancor@suse.com
+
+- Partitioner: make possible for the embedded yast2-nfs-client to
+  access the vfstype field of fstab, so it can detect and correct
+  legacy NFS entries (bsc#1088426).
+- 4.0.152
+
+-------------------------------------------------------------------
 Tue Apr 10 10:59:32 UTC 2018 - jlopez@suse.com
 
 - Update dependency with libstorage-ng (ensure lock system).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -27,12 +27,12 @@ Source:		%{name}-%{version}.tar.bz2
 Requires:	yast2 >= 4.0.61
 # for AbortException and handle direct abort
 Requires:	yast2-ruby-bindings >= 4.0.6
-# System lock
-Requires:	libstorage-ng-ruby >= 3.3.204
+# Setter and getter for MountPoint#mount_type
+Requires:	libstorage-ng-ruby >= 3.3.209
 
 BuildRequires:	update-desktop-files
-# System lock
-BuildRequires:	libstorage-ng-ruby >= 3.3.204
+# Setter and getter for MountPoint#mount_type
+BuildRequires:	libstorage-ng-ruby >= 3.3.209
 BuildRequires:	yast2-ruby-bindings
 BuildRequires:	yast2-devtools
 # yast2-xml dependency is added by yast2 but ignored in the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.151
+Version:        4.0.152
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -116,6 +116,14 @@ module Y2Storage
     #   default mount options only contain the subvol for btrfs subvolumes.
     storage_forward :set_default_mount_options, to: :default_mount_options=
 
+    # @!attribute mount_type
+    #   Filesystem type used to mount the device, as specified in fstab and/or
+    #   in the mount command.
+    #
+    #   @return [Filesystems::Type]
+    storage_forward :mount_type, as: "Filesystems::Type"
+    storage_forward :mount_type=
+
     # @!method in_etc_fstab?
     #   Whether the mount point is present (probed devicegraph) or
     #   will be present (staging devicegraph) in /etc/fstab


### PR DESCRIPTION
Communicate properly with the embedded yast2-nfs-client so legacy entries using `nfs4` in the vfstype field can be detected and corrected.

This depends on https://github.com/openSUSE/libstorage-ng/pull/510 (I will add the dependency as soon as that gets merged).

![nfs4-in-partitioner](https://user-images.githubusercontent.com/3638289/38566492-14b1ffc0-3ce4-11e8-8aaf-c237b2e1e3ff.png)
