### PR TITLE
Removed workaround in tests

### DIFF
--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -31,8 +31,8 @@ Requires:	yast2-ruby-bindings >= 4.0.6
 Requires:	libstorage-ng-ruby >= 3.3.209
 
 BuildRequires:	update-desktop-files
-# Setter and getter for MountPoint#mount_type
-BuildRequires:	libstorage-ng-ruby >= 3.3.209
+# MountPoint#mount_type in the XML format
+BuildRequires:	libstorage-ng-ruby >= 3.3.210
 BuildRequires:	yast2-ruby-bindings
 BuildRequires:	yast2-devtools
 # yast2-xml dependency is added by yast2 but ignored in the

--- a/test/data/devicegraphs/nfs1.xml
+++ b/test/data/devicegraphs/nfs1.xml
@@ -11,6 +11,7 @@
       <sid>43</sid>
       <path>/test1</path>
       <mount-by>device</mount-by>
+      <mount-type>nfs</mount-type>
       <active>false</active>
       <in-etc-fstab>true</in-etc-fstab>
       <freq>0</freq>
@@ -29,6 +30,7 @@
       <sid>45</sid>
       <path>/test2</path>
       <mount-by>device</mount-by>
+      <mount-type>nfs</mount-type>
       <mount-options>rw,relatime,vers=3,rsize=65536,wsize=65536</mount-options>
       <active>true</active>
       <in-etc-fstab>false</in-etc-fstab>

--- a/test/y2partitioner/widgets/pages/nfs_mounts_test.rb
+++ b/test/y2partitioner/widgets/pages/nfs_mounts_test.rb
@@ -28,8 +28,6 @@ require "y2partitioner/widgets/pages"
 describe Y2Partitioner::Widgets::Pages::NfsMounts do
   before do
     devicegraph_stub("nfs1.xml")
-    # Workaround. Will not be needed as soon as the xml format includes MountPoint#mount_type
-    device_graph.filesystems.each { |fs| fs.mount_point.mount_type = Y2Storage::Filesystems::Type::NFS }
   end
 
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }


### PR DESCRIPTION
This depends on https://github.com/openSUSE/libstorage-ng/pull/511 being merged and a new docker image being available with the new XML format.