### PR TITLE
 Better wording for failed proposal (to mitigate bsc#1089274)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Apr 13 10:56:19 UTC 2018 - ancor@suse.com
+
+- More informative message displayed when the proposal failed with
+  some given settings, so it doesn't sound like a definitive error
+  (related to bsc#1089274).
+- 4.0.154
+
+-------------------------------------------------------------------
 Tue Apr 10 16:24:16 UTC 2018 - jlopez@suse.com
 
 - Partitioner: fix creation of default BTRFS subvolume

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.153
+Version:        4.0.154
 Release:	0
 BuildArch:	noarch
 

--- a/src/lib/y2storage/clients/partitions_proposal.rb
+++ b/src/lib/y2storage/clients/partitions_proposal.rb
@@ -134,9 +134,9 @@ module Y2Storage
           "preformatted_proposal" => nil,
           "links"                 => [],
           "language_changed"      => false,
-          "warning"               => _("No proposal possible"),
+          "warning"               => _("No proposal possible with the current settings"),
           "warning_level"         => :blocker,
-          "label_proposal"        => [_("No proposal possible")]
+          "label_proposal"        => [_("No proposal possible with the current settings")]
         }
       end
 

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -113,7 +113,18 @@ module Y2Storage
         content = if devicegraph
           @actions_presenter.to_html
         else
-          Yast::HTML.Para(Yast::HTML.Colorize(_("No proposal possible."), "red"))
+          Yast::HTML.Para(
+            _(
+              "It was not possible to automatically propose a partitioning layout " \
+              "based on the current settings."
+            )
+          ) +
+          Yast::HTML.Para(
+            _(
+              "Please, use \"Guided Setup\" to adjust the proposal settings or " \
+              "\"Expert Partitioner\" to create a custom layout."
+            )
+          )
         end
 
         RichText(Id(:summary), content)

--- a/test/y2storage/dialogs/proposal_test.rb
+++ b/test/y2storage/dialogs/proposal_test.rb
@@ -137,7 +137,7 @@ describe Y2Storage::Dialogs::Proposal do
         it "displays an error message" do
           # We don't break the event loop, so there is a second call to UserInput
           expect(Yast::Wizard).to receive(:SetContents) do |_title, content|
-            expect(content.to_s).to include "No proposal possible"
+            expect(content.to_s).to include "not possible to automatically propose"
           end
           dialog.run
         end


### PR DESCRIPTION
More info at the bug report and at https://trello.com/c/1eSmpjnE/356-sles15-p1-1089274-build-5626-openqa-test-unable-to-propose-valid-partitioning-an-aarch64-and-s390x

![no_proposal_ncurses](https://user-images.githubusercontent.com/3638289/38731504-c6720dbc-3f1a-11e8-996f-edabc0bec449.png)
