### PR TITLE
continue submitting to SLE15 GA

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,9 @@
 #  To contact SUSE about this file by physical or electronic mail,
 #  you may find current contact information at www.suse.com
 
+# rest of yast is branched, but storage-ng still submitting to GA
+ENV["YAST_SUBMIT"] = "sle15"
+
 require "yast/rake"
 
 # Checking for bug/fate numbers in the changelog does not make sense at this


### PR DESCRIPTION
just small note, after upgrade of yast-rake at https://github.com/yast/yast-rake/pull/53 IBS devel project will be "Devel:YaST:SLE-15" and not "Devel:YaST:Head". But it should not affect auto-submission.