### PR TITLE
Make the package arch dependant

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 23 10:27:04 UTC 2018 - jlopez@suse.com
+
+- Make the package to be architecture dependant to correctly check
+  the current architecture (bsc#1081198).
+- 4.0.161
+
+-------------------------------------------------------------------
 Fri Apr 20 20:27:15 UTC 2018 - igonzalezsosa@suse.com
 
 - AutoYaST: properly handle empty proposals (bsc#1090390).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.160
+Version:        4.0.161
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -18,7 +18,6 @@
 Name:		yast2-storage-ng
 Version:        4.0.160
 Release:	0
-BuildArch:	noarch
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build
 Source:		%{name}-%{version}.tar.bz2


### PR DESCRIPTION
PBI: https://trello.com/c/Xy8pySwj/362-390-bug-reopen-partitioner-settings-mount-by

Needed to use `%ifarch s390` to decide what template to use for `/etc/sysconfig/storage`. This file is needed to decide the default `mount_by` value (and other Partitioner settings).