### PR TITLE
Allow to reuse LUKS devices and MDs

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 26 10:59:42 UTC 2018 - ancor@suse.com
+
+- Ensure the installer adds reused devices to /etc/crypttab and/or
+  /etc/mdadm.conf if needed for booting (bsc#1071350).
+- 4.0.165
+
+-------------------------------------------------------------------
 Wed Apr 25 16:07:46 UTC 2018 - jlopez@suse.com
 
 - Partitioner: fix bug after confirming changes in a running system

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.164
+Version:        4.0.165
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -467,6 +467,7 @@ module Y2Partitioner
           @encrypt = blk_device.encrypted?
 
           restore_mount_point(mount_path, mount_by: mount_by)
+          blk_device.update_etc_status
         end
 
         # Sets options to the current mount point

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -45,6 +45,14 @@ module Y2Storage
     #   @return [Array<Encryption>] all the encryption devices in the given devicegraph
     storage_class_forward :all, as: "Encryption"
 
+    # @!method in_etc_crypttab?
+    #   @return [Boolean] whether the device is included in /etc/crypttab
+    storage_forward :in_etc_crypttab?
+
+    # The setter is intentionally hidden. See similar comment for Md#in_etc_mdadm
+    storage_forward :storage_in_etc_crypttab=, to: :in_etc_crypttab=
+    private :storage_in_etc_crypttab=
+
     # @see BlkDevice#plain_device
     def plain_device
       blk_device
@@ -65,10 +73,21 @@ module Y2Storage
       "cr_#{device.basename}"
     end
 
+    # @see Device#in_etc?
+    # @see #in_etc_crypttab?
+    def in_etc?
+      in_etc_crypttab?
+    end
+
   protected
 
     def types_for_is
       super << :encryption
+    end
+
+    # @see Device#update_etc_attributes
+    def assign_etc_attribute(value)
+      self.storage_in_etc_crypttab = value
     end
   end
 end

--- a/src/lib/y2storage/md.rb
+++ b/src/lib/y2storage/md.rb
@@ -107,10 +107,18 @@ module Y2Storage
     #   @return [Boolean] whether the MD RAID is included in /etc/mdadm.conf
     storage_forward :in_etc_mdadm?
 
-    # @!method in_etc_mdadm=(value)
-    #   @see #in_etc_mdadm?
-    #   @param value [Boolean]
-    storage_forward :in_etc_mdadm=
+    # The setter is intentionally hidden to avoid interferences with the
+    # #update_etc_status mechanism. If we decide to expose the setter, it would
+    # make sense to implement it like this:
+    #
+    #   def in_etc_mdadm=(value)
+    #     self.etc_status_autoset = false
+    #     self.storage_in_etc_mdadm = value
+    #     update_parents_etc_status
+    #     value
+    #   end
+    storage_forward :storage_in_etc_mdadm=, to: :in_etc_mdadm=
+    private :storage_in_etc_mdadm=
 
     # @!method minimal_number_of_devices
     #   Minimal number of devices required by the RAID.
@@ -274,6 +282,12 @@ module Y2Storage
       self.name = "/dev/md/#{new_name}"
     end
 
+    # @see Device#in_etc?
+    # @see #in_etc_mdadm?
+    def in_etc?
+      in_etc_mdadm?
+    end
+
   protected
 
     # Holders connecting the MD Raid to its component block devices in the
@@ -298,6 +312,11 @@ module Y2Storage
       types << :raid if software_defined?
       types << :software_raid if software_defined?
       types
+    end
+
+    # @see Device#update_etc_attributes
+    def assign_etc_attribute(value)
+      self.storage_in_etc_mdadm = value
     end
   end
 end

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -143,11 +143,17 @@ module Y2Storage
     #   @return [Filesystems::Base]
     storage_forward :filesystem, as: "Filesystems::Base"
 
-    # Wheter the mount point is root
+    # Whether the mount point is root
     #
     # @return [Boolean]
     def root?
       path == ROOT_PATH.to_s
+    end
+
+    # @see Device#in_etc?
+    # @see #in_etc_fstab
+    def in_etc?
+      in_etc_fstab?
     end
 
   protected

--- a/src/lib/y2storage/mountable.rb
+++ b/src/lib/y2storage/mountable.rb
@@ -36,14 +36,11 @@ module Y2Storage
     #   @return [Array<Mountable>] all mountable devices in the devicegraph
     storage_class_forward :all, as: "Mountable"
 
-    # @!method create_mount_point(path)
-    #   @param path [String]
-    #   @return [MountPoint]
-    storage_forward :create_mount_point, as: "MountPoint"
+    storage_forward :storage_create_mount_point, to: :create_mount_point, as: "MountPoint"
+    private :storage_create_mount_point
 
-    # @!method remove_mount_point
-    #   @raise [Storage::Exception] if the mountable has no mount point
-    storage_forward :remove_mount_point
+    storage_forward :storage_remove_mount_point, to: :remove_mount_point
+    private :storage_create_mount_point
 
     # @!method mount_point
     #   @return [MountPoint]
@@ -108,6 +105,24 @@ module Y2Storage
     def root?
       return false if mount_point.nil?
       mount_point.root?
+    end
+
+    # Creates a mount point object for the device
+    #
+    # @param path [String]
+    # @return [MountPoint]
+    def create_mount_point(path)
+      mp = storage_create_mount_point(path)
+      update_etc_status
+      mp
+    end
+
+    # Removes the mount point object associated to the device
+    #
+    # @raise [Storage::Exception] if the mountable has no mount point
+    def remove_mount_point
+      storage_remove_mount_point
+      update_etc_status
     end
   end
 end

--- a/test/data/devicegraphs/subvolumes-and-empty-md.xml
+++ b/test/data/devicegraphs/subvolumes-and-empty-md.xml
@@ -410,7 +410,7 @@
         <block-size>512</block-size>
       </region>
       <dm-table-name>cr_sda5</dm-table-name>
-      <in-etc-crypttab>true</in-etc-crypttab>
+      <in-etc-crypttab>false</in-etc-crypttab>
       <uuid></uuid>
     </Luks>
     <Md>
@@ -426,6 +426,7 @@
         <optimal-io-size>1048576</optimal-io-size>
       </topology>
       <range>256</range>
+      <in-etc-mdadm>false</in-etc-mdadm>
       <md-level>RAID0</md-level>
     </Md>
   </Devices>

--- a/test/y2storage/in_etc_test.rb
+++ b/test/y2storage/in_etc_test.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+describe Y2Storage::Device do
+  before { fake_scenario("subvolumes-and-empty-md.xml") }
+
+  describe "#update_etc_status" do
+    let(:md) { fake_devicegraph.find_by_name("/dev/md/strip0") }
+    let(:encryption) { fake_devicegraph.find_by_name("/dev/mapper/cr_sda5") }
+
+    # Creates a filesystem and mount point in the RAID
+    def create_mount_point
+      fs = md.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
+      fs.create_mount_point("/mnt")
+    end
+
+    context "when a new mount point is created" do
+      it "sets in_etc_crypttab and in_etc_mdadm to true in the underlying devices" do
+        expect(md.in_etc_mdadm?).to eq false
+        expect(encryption.in_etc_crypttab?).to eq false
+
+        create_mount_point
+
+        expect(md.in_etc_mdadm?).to eq true
+        expect(encryption.in_etc_crypttab?).to eq true
+      end
+    end
+
+    context "when a mount point is removed" do
+      context "if the /etc flags were automatically set by the mount point creation" do
+        before { create_mount_point }
+
+        it "restores the false values for in_etc_crypttab and in_etc_mdadm" do
+          expect(md.in_etc_mdadm?).to eq true
+          expect(encryption.in_etc_crypttab?).to eq true
+
+          md.filesystem.remove_mount_point
+
+          expect(md.in_etc_mdadm?).to eq false
+          expect(encryption.in_etc_crypttab?).to eq false
+        end
+      end
+
+      context "if the /etc flags were already true before creating the mount point" do
+        before do
+          md.to_storage_value.in_etc_mdadm = true
+          encryption.to_storage_value.in_etc_crypttab = true
+          create_mount_point
+        end
+
+        it "keeps the original true values for in_etc_crypttab and in_etc_mdadm" do
+          expect(md.in_etc_mdadm?).to eq true
+          expect(encryption.in_etc_crypttab?).to eq true
+
+          md.filesystem.remove_mount_point
+
+          expect(md.in_etc_mdadm?).to eq true
+          expect(encryption.in_etc_crypttab?).to eq true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
PR for https://trello.com/c/bM0mB7r9/146-3-storage-ng-set-inetcfstab-inetccrypttab-and-inetcmdadm

Tested manually and it works, as can be seen here (the action for adding it to cryptab is added and, thus, the system boots):
![in_etc_crypttab](https://user-images.githubusercontent.com/3638289/39195268-c2e5d570-47df-11e8-8ad1-b5dada80ba3e.png)