### PR TITLE
Fix partitioner client bug

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 25 16:07:46 UTC 2018 - jlopez@suse.com
+
+- Partitioner: fix bug after confirming changes in a running system
+  (related to bsc#1086892).
+- 4.0.164
+
+-------------------------------------------------------------------
 Tue Apr 24 09:15:14 UTC 2018 - jlopez@suse.com
 
 - Partitioner: do not validate setup just after rescanning

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.163
+Version:        4.0.164
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/clients/main.rb
+++ b/src/lib/y2partitioner/clients/main.rb
@@ -86,7 +86,7 @@ module Y2Partitioner
       #
       # @return [Dialogs::Main]
       def partitioner_dialog
-        Dialogs::Main.new(storage_manager.probed, storage_manager.staging)
+        @partitioner_dialog ||= Dialogs::Main.new(storage_manager.probed, storage_manager.staging)
       end
 
       # Popup to alert the user about using the Partitioner

--- a/test/y2partitioner/clients/main_test.rb
+++ b/test/y2partitioner/clients/main_test.rb
@@ -83,11 +83,14 @@ describe Y2Partitioner::Clients::Main do
         let(:storage_setup) { true }
 
         before do
-          allow(Y2Partitioner::Dialogs::Main).to receive(:new).and_return(partitioner_dialog)
+          allow(Y2Partitioner::Dialogs::Main).to receive(:new)
+            .and_return(partitioner_dialog, other_partitioner_dialog)
           allow(partitioner_dialog).to receive(:run).and_return(partitioner_result)
         end
 
         let(:partitioner_dialog) { instance_double(Y2Partitioner::Dialogs::Main) }
+
+        let(:other_partitioner_dialog) { instance_double(Y2Partitioner::Dialogs::Main) }
 
         let(:partitioner_result) { nil }
 
@@ -112,7 +115,7 @@ describe Y2Partitioner::Clients::Main do
             let(:allow_commit) { true }
 
             it "commits the changes" do
-              expect(storage_manager).to receive(:"staging=")
+              expect(storage_manager).to receive(:"staging=").with(device_graph)
               # this also blocks the real #commit call
               expect(storage_manager).to receive(:commit)
 


### PR DESCRIPTION
Partitioner was failing after confirming changes in a running system.

The bug was introduced with PR#610. See also https://trello.com/c/VjBb7Jxy/347-2-sles15-p3-1086892-slex15loc-yastalllangsuntranslated-modify-the-disks-confirmation-pop-up-after-finishing-changes-in-expert-pa