### PR TITLE
Proper partitioner checks for root on NFS (bsc#1090752)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 27 15:23:05 UTC 2018 - ancor@suse.com
+
+- Partitioner: fixed checks when the root filesystem is NFS
+  (bsc#1090752).
+- 4.0.169
+
+-------------------------------------------------------------------
 Fri Apr 27 12:57:25 UTC 2018 - jreidinger@suse.com
 
 - add method to check if system has any disk device (bsc#1090753)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.168
+Version:        4.0.169
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/boot_requirements_checker.rb
+++ b/src/lib/y2storage/boot_requirements_checker.rb
@@ -112,7 +112,9 @@ module Y2Storage
       return @strategy unless @strategy.nil?
 
       klass =
-        if arch.efiboot?
+        if nfs_root?
+          BootRequirementsStrategies::NfsRoot
+        elsif arch.efiboot?
           BootRequirementsStrategies::UEFI
         elsif arch.s390?
           BootRequirementsStrategies::ZIPL
@@ -123,6 +125,13 @@ module Y2Storage
           BootRequirementsStrategies::Legacy
         end
       @strategy = klass.new(devicegraph, planned_devices, boot_disk_name)
+    end
+
+    # Whether the root filesystem is NFS
+    #
+    # @return [Boolean]
+    def nfs_root?
+      devicegraph.nfs_mounts.any? { |i| i.mount_point && i.mount_point.root? }
     end
   end
 end

--- a/src/lib/y2storage/boot_requirements_strategies/nfs_root.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/nfs_root.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2015] SUSE LLC
+# Copyright (c) [2018] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -19,8 +19,17 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2storage/boot_requirements_strategies/legacy"
-require "y2storage/boot_requirements_strategies/uefi"
-require "y2storage/boot_requirements_strategies/prep"
-require "y2storage/boot_requirements_strategies/zipl"
-require "y2storage/boot_requirements_strategies/nfs_root"
+require "y2storage/boot_requirements_strategies/base"
+
+module Y2Storage
+  module BootRequirementsStrategies
+    # Strategy to calculate the boot requirements for a system in which the root
+    # filesystem is an NFS share.
+    #
+    # This actually checks nothing on top of the basic checks of the base class,
+    # users installing on top of NFS are supposed to know what they are doing and
+    # are on their own.
+    class NfsRoot < Base
+    end
+  end
+end

--- a/test/support/boot_requirements_context.rb
+++ b/test/support/boot_requirements_context.rb
@@ -82,6 +82,7 @@ RSpec.shared_context "boot requirements" do
     allow(storage_arch).to receive(:s390?).and_return(architecture == :s390)
 
     allow(devicegraph).to receive(:disk_devices).and_return [dev_sda, dev_sdb]
+    allow(devicegraph).to receive(:nfs_mounts).and_return []
 
     allow(analyzer).to receive(:boot_ptable_type?) { |type| type == boot_ptable_type }
     # Assume the needed partitions are not already planned in advance

--- a/test/y2storage/boot_requirements_errors_test.rb
+++ b/test/y2storage/boot_requirements_errors_test.rb
@@ -643,5 +643,38 @@ describe Y2Storage::BootRequirementsChecker do
         end
       end
     end
+
+    context "using NFS for the root filesystem" do
+      before do
+        fs = Y2Storage::Filesystems::Nfs.create(fake_devicegraph, "server", "/path")
+        fs.create_mount_point("/")
+      end
+
+      context "in a diskless system" do
+        let(:scenario) { "nfs1.xml" }
+
+        # Regression test for bug#1090752
+        it "does not crash" do
+          expect { checker.warnings }.to_not raise_error
+          expect { checker.errors }.to_not raise_error
+        end
+
+        it "returns no warnings or errors" do
+          expect(checker.warnings).to be_empty
+          expect(checker.errors).to be_empty
+        end
+      end
+
+      context "in a system with local disks" do
+        let(:scenario) { "empty_hard_disk_50GiB" }
+
+        # This used to consider the local disk as the one to boot from, so it
+        # reported wrong errors assuming "/" was going to be there.
+        it "returns no warnings or errors" do
+          expect(checker.warnings).to be_empty
+          expect(checker.errors).to be_empty
+        end
+      end
+    end
   end
 end

--- a/test/y2storage/setup_checker_test.rb
+++ b/test/y2storage/setup_checker_test.rb
@@ -243,6 +243,18 @@ describe Y2Storage::SetupChecker do
       end
     end
 
+    context "when a mandatory product volume is mounted as NFS" do
+      before do
+        fs = Y2Storage::Filesystems::Nfs.create(fake_devicegraph, "server", "/path")
+        fs.mount_path = "/"
+      end
+
+      it "does not include an error for that volume" do
+        expect(subject.product_warnings)
+          .to_not include(an_object_having_attributes(missing_volume: root_volume))
+      end
+    end
+
     context "when all mandatory product volumes are present in the system" do
       let(:product_volumes) { [root_volume, home_volume] }
 


### PR DESCRIPTION
See https://trello.com/c/F1oQeriK/377-1-sles15-p1-1090752-internal-error-undefined-method-mbrgap-for-nilnilclass

The reporter found this crash installing on NFS-root in a diskless system
![crash](https://user-images.githubusercontent.com/3638289/39370537-746d3d40-4a3f-11e8-83ea-0d80adc81e17.png)

Additionally, while writing the unit tests I found the boot requirement checks also misbehaved if there were local disks combined with root in NFS, just in a different way.

This PR adds fixes and unit tests for both situations.

Even after fixing the crash, the SetupChecker was still reporting this warning.
![wrong-warning](https://user-images.githubusercontent.com/3638289/39370545-7b9c85b2-4a3f-11e8-8605-617e744ea6c8.png)

Now that should also be fixed with the latest commit (added after the first approval of this PR). Everything up to that point tested manually in a diskless system and in a disk with a local disk (in addition to the NFS mount).

BUT, at the moment of writing bootloader fails if the user decides to continue. That's, of course, another story.