### PR TITLE
WIP: Dump devicegraphs to YAML and XML

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 27 15:23:05 UTC 2018 - ancor@suse.com
+
+- Partitioner: fixed checks when the root filesystem is NFS
+  (bsc#1090752).
+- 4.0.169
+
+-------------------------------------------------------------------
 Fri Apr 27 12:57:25 UTC 2018 - jreidinger@suse.com
 
 - add method to check if system has any disk device (bsc#1090753)

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 27 12:57:25 UTC 2018 - jreidinger@suse.com
+
+- add method to check if system has any disk device (bsc#1090753)
+- 4.0.168
+
+-------------------------------------------------------------------
 Fri Apr 27 11:15:20 UTC 2018 - ancor@suse.com
 
 - Set fs_passno to 1 for ext2/3/4 root filesystems (bsc#1078703).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.168
+Version:        4.0.169
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.167
+Version:        4.0.168
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -26,12 +26,12 @@ Source:		%{name}-%{version}.tar.bz2
 Requires:	yast2 >= 4.0.61
 # for AbortException and handle direct abort
 Requires:	yast2-ruby-bindings >= 4.0.6
-# Proper handling of EBR in PartitionTable#unused_partition_slots
-Requires:	libstorage-ng-ruby >= 3.3.215
+# function light_probe
+Requires:	libstorage-ng-ruby >= 3.3.254
 
 BuildRequires:	update-desktop-files
-# Proper handling of EBR in PartitionTable#unused_partition_slots
-BuildRequires:	libstorage-ng-ruby >= 3.3.215
+# function light_probe
+BuildRequires:	libstorage-ng-ruby >= 3.3.254
 BuildRequires:	yast2-ruby-bindings
 BuildRequires:	yast2-devtools
 # yast2-xml dependency is added by yast2 but ignored in the

--- a/src/lib/y2partitioner/widgets/summary_text.rb
+++ b/src/lib/y2partitioner/widgets/summary_text.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "cwm"
 require "y2storage/actions_presenter"
+require "y2storage/dump_manager"
 require "y2partitioner/device_graphs"
 
 Yast.import "HTML"
@@ -94,6 +95,9 @@ module Y2Partitioner
       def calculate_actions
         actiongraph = current_graph.actiongraph
         @actions = Y2Storage::ActionsPresenter.new(actiongraph)
+        Y2Storage::DumpManager.dump(current_graph, "partitioner")
+        Y2Storage::DumpManager.dump(@actions)
+        @actions
       end
 
       # Updates the value of {#packages}

--- a/src/lib/y2storage/actions_presenter.rb
+++ b/src/lib/y2storage/actions_presenter.rb
@@ -21,6 +21,7 @@
 
 require "yast"
 require "y2storage"
+require "y2storage/dump_manager"
 
 Yast.import "HTML"
 
@@ -97,6 +98,14 @@ module Y2Storage
         file.puts
         file.puts(to_s)
       end
+    end
+
+    # Dump the actions to a plain text file.
+    #
+    # @param file_base_name [String] File base name to use.
+    #   Leave this empty to use a generated name.
+    def dump(file_base_name = nil)
+      DumpManager.dump(self, file_base_name)
     end
 
   protected

--- a/src/lib/y2storage/actions_presenter.rb
+++ b/src/lib/y2storage/actions_presenter.rb
@@ -72,6 +72,33 @@ module Y2Storage
       actiongraph.nil? || actiongraph.empty?
     end
 
+    # Plain text representation
+    #
+    # @return [String] multi-line text
+    def to_s
+      lines = actions_to_text(general_actions)
+      subvolume_lines = actions_to_text(subvolume_actions)
+
+      if !subvolume_lines.empty?
+        lines << ""
+        lines.append(subvolume_lines)
+      end
+
+      return "Nothing to do" if lines.empty?
+      lines.join("\n")
+    end
+
+    # Save the actions to a plain text file
+    #
+    # @param filename [String]
+    def save(filename)
+      File.open(filename, "w") do |file|
+        file.puts(Time.now.to_s)
+        file.puts
+        file.puts(to_s)
+      end
+    end
+
   protected
 
     attr_reader :actiongraph
@@ -92,13 +119,11 @@ module Y2Storage
     end
 
     def general_actions_items
-      actions = sort_actions(general_actions)
-      actions_to_items(actions)
+      actions_to_items(general_actions)
     end
 
     def subvolume_actions_items
-      actions = sort_actions(subvolume_actions)
-
+      actions = subvolume_actions
       return [] if actions.empty?
 
       event = toggle_subvolumes_event
@@ -115,12 +140,14 @@ module Y2Storage
 
     def general_actions
       return [] if actiongraph.nil?
-      actiongraph.compound_actions.select { |a| !a.device_is?(:btrfs_subvolume) }
+      actions = actiongraph.compound_actions.select { |a| !a.device_is?(:btrfs_subvolume) }
+      sort_actions(actions)
     end
 
     def subvolume_actions
       return [] if actiongraph.nil?
-      actiongraph.compound_actions.select { |a| a.device_is?(:btrfs_subvolume) }
+      actions = actiongraph.compound_actions.select { |a| a.device_is?(:btrfs_subvolume) }
+      sort_actions(actions)
     end
 
     def sort_actions(actions)
@@ -134,6 +161,10 @@ module Y2Storage
 
     def action_to_item(action)
       action.delete? ? Yast::HTML.Bold(action.sentence) : action.sentence
+    end
+
+    def actions_to_text(actions)
+      actions.map(&:sentence)
     end
 
     def html_list(items)

--- a/src/lib/y2storage/boot_requirements_checker.rb
+++ b/src/lib/y2storage/boot_requirements_checker.rb
@@ -112,7 +112,9 @@ module Y2Storage
       return @strategy unless @strategy.nil?
 
       klass =
-        if arch.efiboot?
+        if nfs_root?
+          BootRequirementsStrategies::NfsRoot
+        elsif arch.efiboot?
           BootRequirementsStrategies::UEFI
         elsif arch.s390?
           BootRequirementsStrategies::ZIPL
@@ -123,6 +125,13 @@ module Y2Storage
           BootRequirementsStrategies::Legacy
         end
       @strategy = klass.new(devicegraph, planned_devices, boot_disk_name)
+    end
+
+    # Whether the root filesystem is NFS
+    #
+    # @return [Boolean]
+    def nfs_root?
+      devicegraph.nfs_mounts.any? { |i| i.mount_point && i.mount_point.root? }
     end
   end
 end

--- a/src/lib/y2storage/boot_requirements_strategies/nfs_root.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/nfs_root.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2015] SUSE LLC
+# Copyright (c) [2018] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -19,8 +19,17 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2storage/boot_requirements_strategies/legacy"
-require "y2storage/boot_requirements_strategies/uefi"
-require "y2storage/boot_requirements_strategies/prep"
-require "y2storage/boot_requirements_strategies/zipl"
-require "y2storage/boot_requirements_strategies/nfs_root"
+require "y2storage/boot_requirements_strategies/base"
+
+module Y2Storage
+  module BootRequirementsStrategies
+    # Strategy to calculate the boot requirements for a system in which the root
+    # filesystem is an NFS share.
+    #
+    # This actually checks nothing on top of the basic checks of the base class,
+    # users installing on top of NFS are supposed to know what they are doing and
+    # are on their own.
+    class NfsRoot < Base
+    end
+  end
+end

--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -61,9 +61,6 @@ module Y2Storage
       # @return [Boolean] true if everything went fine, false if the user
       #   decided to abort
       def commit
-        manager.probed.save(Yast::Directory.logdir + "/inst-probed_devicegraph.xml")
-        manager.staging.save(Yast::Directory.logdir + "/inst-staging_devicegraph.xml")
-
         manager.rootprefix = Yast::Installation.destdir
         return false unless manager.commit(force_rw: true)
 

--- a/src/lib/y2storage/clients/partitions_proposal.rb
+++ b/src/lib/y2storage/clients/partitions_proposal.rb
@@ -24,6 +24,7 @@
 require "yast"
 require "y2storage"
 require "y2storage/actions_presenter"
+require "y2storage/dump_manager"
 require "installation/proposal_client"
 require "y2partitioner/dialogs/main"
 
@@ -114,6 +115,8 @@ module Y2Storage
           staging = storage_manager.staging
           actiongraph = staging ? staging.actiongraph : nil
           self.actions_presenter = ActionsPresenter.new(actiongraph)
+          Y2Storage::DumpManager.dump(staging)
+          Y2Storage::DumpManager.dump(actions_presenter)
         end
       end
 

--- a/src/lib/y2storage/devicegraph.rb
+++ b/src/lib/y2storage/devicegraph.rb
@@ -24,6 +24,7 @@ require "tempfile"
 require "y2storage/actiongraph"
 require "y2storage/blk_device"
 require "y2storage/disk"
+require "y2storage/dump_manager"
 require "y2storage/fake_device_factory"
 require "y2storage/filesystems/base"
 require "y2storage/filesystems/blk_filesystem"
@@ -436,6 +437,15 @@ module Y2Storage
       # Do not wait for garbage collector and delete the file right away
       file.close
       file.unlink
+    end
+
+    # Dump the devicegraph to both XML and YAML.
+    #
+    # @param file_base_name [String] File base name to use.
+    #   Leave this empty to use a generated name ("01-staging-01",
+    #   "02-staging", ...).
+    def dump(file_base_name = nil)
+      DumpManager.dump(self, file_base_name)
     end
 
   private

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -23,6 +23,7 @@ require "yast"
 require "ui/installation_dialog"
 require "y2storage"
 require "y2storage/actions_presenter"
+require "y2storage/dump_manager"
 
 Yast.import "HTML"
 
@@ -52,6 +53,9 @@ module Y2Storage
         propose! if proposal && !proposal.proposed?
         actiongraph = @devicegraph ? @devicegraph.actiongraph : nil
         @actions_presenter = ActionsPresenter.new(actiongraph)
+
+        DumpManager.dump(devicegraph, "proposal")
+        DumpManager.dump(@actions_presenter)
       end
 
       def next_handler

--- a/src/lib/y2storage/dump_manager.rb
+++ b/src/lib/y2storage/dump_manager.rb
@@ -1,0 +1,327 @@
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "singleton"
+require "fileutils"
+require "yast"
+require "rspec/mocks"
+require "y2storage/devicegraph"
+require "y2storage/actions_presenter"
+require "y2storage/storage_manager"
+
+Yast.import "Mode"
+
+module Y2Storage
+  # Helper class to manage XML and YAML devicegraph dumps.
+  # Most of this is handling log rotation.
+  # This is a singleton class; use DumpManager.instance for all methods.
+  class DumpManager
+    include Singleton
+    include Yast::Logger
+
+    # The number of old dump directories to keep.
+    # This is in addition to the current one.
+    KEEP_OLD_DUMP_DIRS = 3
+
+    def initialize
+      @initialized = false
+    end
+
+    # Kill (recursively remove) all dump directories.
+    def kill_all_dump_dirs
+      Dir.glob(base_dir + "/storage*").each { |dir| FileUtils.remove_dir(dir) }
+    end
+
+    # Reset the dump directories: Rotate any old ones, create a new one and
+    # start numbering devicegraph dump files from zero.
+    def reset
+      rotate_dump_dirs
+      ensure_dump_dir
+      @prefix = "00"
+      @initialized = true
+    end
+
+    # Dump a devicegraph or the actions from an ActionsPresenter to file in
+    # human-readable format.
+    #
+    # If 'file_base_name' is specified, this is used. If it is nil, for
+    # devicegraphs an appropriate name based on its role (probed, staging) is
+    # generated, for actions, it is "actions".
+    #
+    # In any case, use a numbered prefix to make the sequence of files clear,
+    # and use the appropriate suffix (filename extension) depending on type.
+    #
+    # This will typically result in something like this:
+    #
+    #   01-probed.xml
+    #   01-probed.yml
+    #   02-staging.xml
+    #   02-staging.yml
+    #   03-staging.xml
+    #   03-staging.yml
+    #   04-actions.txt
+    #   05-committed.xml
+    #   05-committed.yml
+    #
+    # The directory to use is chosen according to the YaST mode (installation
+    # vs. installed system), and the directories are cleared (installation) or
+    # rotated (installed system) for each program invocation.
+    #
+    # @param dump_obj[Y2Storage::Devicegraph|Y2Storage::ActionsPresenter]
+    # @param file_base_name [String|nil] File base name to use.
+    #
+    # @return file base name with numeric prefix actually used
+    #   ("01-probed", "02-staging", ...)
+    #
+    def dump(dump_obj, file_base_name = nil)
+      return nil if dump_obj.nil?
+
+      if dump_obj.is_a?(Y2Storage::Devicegraph)
+        dump_devicegraph(dump_obj, file_base_name)
+      elsif dump_obj.is_a?(Y2Storage::ActionsPresenter)
+        dump_actions(dump_obj, file_base_name)
+      elsif dump_obj.is_a?(RSpec::Mocks::InstanceVerifyingDouble) ||
+          dump_obj.is_a?(RSpec::Mocks::Double)
+        log.warn("Not dumping #{dump_obj.class}")
+      else
+        raise ArgumentError, "Unsupported type to dump: #{dump_obj.class}"
+      end
+    end
+
+    # Class method for dumping (for convenience).
+    # See Y2Storage::DumpManager.dump
+    def self.dump(dump_obj, file_base_name = nil)
+      instance.dump(dump_obj, file_base_name)
+    end
+
+    # Dump a devicegraph to both XML and YAML.
+    #
+    # Use the specified name as the file base name or, if not specified,
+    # generate a name based on the role of the devicegraph (probed,
+    # staging). In any case, use a numbered prefix to make the sequence of
+    # files clear, and use the appropriate suffix (filename extension)
+    # depending on type.
+    #
+    # @param devicegraph [Y2Storage::Devicegraph] devicegraph to dump
+    # @param file_base_name [String|nil] File base name to use.
+    #
+    # @return file base name with numeric prefix actually used
+    #   ("01-probed", "02-staging", ...)
+    #
+    def dump_devicegraph(devicegraph, file_base_name = nil)
+      file_base_name ||= devicegraph_dump_name(devicegraph)
+      dump_internal(devicegraph, file_base_name) do |file_base_path|
+        devicegraph.save(file_base_path + ".xml")
+        YamlWriter.write(devicegraph, file_base_path + ".yml")
+      end
+    end
+
+    # Dump actions from an ActionsPresenter. This works very much like dumping
+    # the devicegraph.
+    #
+    # @param actions_presenter [ActionsPresenter]
+    # @param file_base_name [String|nil] File base name to use.
+    #
+    # @return file base name with numeric prefix actually used
+    #
+    def dump_actions(actions_presenter, file_base_name = nil)
+      file_base_name ||= "actions"
+      dump_internal(actions_presenter, file_base_name) do |file_path|
+        actions_presenter.save(file_path + ".txt")
+      end
+    end
+
+    # Get a suitable name for dumping for well-known devicegraphs.
+    #
+    # @return [String]
+    def devicegraph_dump_name(devicegraph)
+      return nil if devicegraph.nil?
+      return "probed"  if devicegraph.equal?(StorageManager.instance.probed)
+      return "staging" if devicegraph.equal?(StorageManager.instance.staging)
+      "devicegraph"
+    end
+
+    # Return true if this is some installation mode: installation, update,
+    # AutoYaST.
+    #
+    # @return [Boolean]
+    def installation?
+      Yast::Mode.installation || Yast::Mode.auto || Yast::Mode.update
+    end
+
+    # Return a suitable name for the devicegraph dump directory
+    # depending on the YaST mode (installation / installed system).
+    #
+    # @return [String] directory name with full path
+    def dump_dir
+      dir = installation? ? "storage-inst" : "storage"
+      base_dir + "/" + dir
+    end
+
+    # Return the base directory to put the dump directories in.
+    #
+    # @return [String] directory name with full path
+    def base_dir
+      if running_as_root?
+        Yast::Directory.logdir
+      else
+        Dir.home + "/.y2storage"
+      end
+    end
+
+    # Rotate the dump directories, depending on current YaST mode:
+    #
+    # During installation (or update or AutoYaST), clear and remove any old
+    # /var/log/YaST2/storage-inst directory.
+    #
+    # In the installed system, keep a number of old dump directories, remove
+    # any older ones in /var/log/YaST2, and rename the ones to keep:
+    #
+    #   rm -rf storage-03
+    #   mv storage-02 storage-03
+    #   mv storage-01 storage-02
+    #   mv storage    storage-01
+    #
+    # This will NOT create any new dump directory.
+    def rotate_dump_dirs
+      # Intentionally not calling ensure_initialized here:
+      # that would rotate the dump dirs twice.
+      return unless File.exist?(base_dir)
+      if installation?
+        kill_old_dump_dirs([File.basename(dump_dir)])
+      else
+        dump_dirs = old_dump_dirs.sort
+        keep_dirs = dump_dirs.shift(KEEP_OLD_DUMP_DIRS)
+        kill_old_dump_dirs(dump_dirs)
+        keep_dirs.reverse.each { |dir| rename_old_dump_dir(dir) }
+      end
+    end
+
+  private
+
+    # Lazy initialisation and create initial dump dir
+    def ensure_initialized
+      lazy_init
+      ensure_dump_dir
+    end
+
+    # Lazy initialisation.
+    def lazy_init
+      return if @initialized
+      @initialized = true
+      log.info("Devicegraph dump directory: #{dump_dir}")
+      reset
+    end
+
+    # Return the next numeric prefix for the numbered devicegraph files.
+    # Each call to this increments the number.
+    #
+    # @return [String]
+    def next_prefix
+      ensure_initialized
+      @prefix = @prefix.next
+      @prefix + "-"
+    end
+
+    # Common part for all dump methods.
+    # Call this with a code block that does the actual dumping:
+    #
+    #   dump_internal(obj, "base") { |path| obj.save(path + ".xyz") }
+    #
+    # @param dump_obj [Object] object to dump
+    # @param file_base_name [String]
+    # @param block [Block] code block that does the actual dumping
+    #
+    # @return file base name with numeric prefix actually used
+    #
+    def dump_internal(dump_obj, file_base_name, &block)
+      return nil if dump_obj.nil?
+      return nil unless block_given?
+
+      ensure_initialized
+      short_name = next_prefix + file_base_name
+      file_base_path = dump_dir + "/" + short_name
+
+      dump_class = dump_obj.class.to_s.gsub("Y2Storage::", "")
+      log.info("Dumping #{dump_class} to #{short_name}")
+
+      block.call(file_base_path)
+      short_name # "01-probed", "02-staging", ...
+    end
+
+    # Return the old devicegraph dump directories for the installed system
+    # currently found in base_dir: ["storage", "storage-01", "storage-02", ...]
+    #
+    # @return [Array<String>] directory names without path
+    def old_dump_dirs
+      Dir.entries(base_dir).select do |entry|
+        entry.start_with?("storage") && entry != "storage-inst"
+      end
+    end
+
+    # Make sure the current dump directory (and possibly all its parents) is
+    # created.
+    def ensure_dump_dir
+      FileUtils.mkdir_p(dump_dir)
+    end
+
+    def clear_dump_dir
+      remove_dir(dump_dir) if File.exist?(dump_dir)
+      ensure_dump_dir
+    end
+
+    # Rename an old dump directory according to this schema:
+    #
+    #   mv storage-02 storage-03
+    #   mv storage-01 storage-02
+    #   mv storage    storage-01
+    #
+    # @param old_name [String] old directory name (without path)
+    def rename_old_dump_dir(old_name)
+      new_name =
+        if old_name =~ /[0-9]+$/
+          old_name.next
+        else
+          old_name + "-01"
+        end
+      log.info("Rotating devicegraph dump dir #{old_name} to #{new_name}")
+      File.rename(base_dir + "/" + old_name, base_dir + "/" + new_name)
+    end
+
+    # Kill (recursively remove) old dump directories.
+    #
+    # @param dump_dirs [Array<String>] directory names (without path) to remove
+    def kill_old_dump_dirs(dump_dirs)
+      dump_dirs.each do |dir|
+        next unless File.exist?(base_dir + "/" + dir)
+        log.info("Removing old devicegraph dump dir #{dir}")
+        FileUtils.remove_dir(base_dir + "/" + dir)
+      end
+    end
+
+    # Check if this process is running with root privileges
+    #
+    # @return [Boolean]
+    def running_as_root?
+      Process.euid == 0
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/base.rb
+++ b/src/lib/y2storage/proposal/base.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "y2storage/storage_manager"
 require "y2storage/disk_analyzer"
+require "y2storage/dump_manager"
 require "y2storage/exceptions"
 require "abstract_method"
 
@@ -77,6 +78,7 @@ module Y2Storage
         result = calculate_proposal
         return result if devices.nil? || devices.empty?
         log.info("Proposed devicegraph:\n\n#{devices.to_str}\n")
+        DumpManager.dump(devices, "proposed")
         result
       end
 

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -339,6 +339,29 @@ module Y2Storage
       environment.read_only? ? :ro : :rw
     end
 
+    # Whether there is any device in the system that may be used to install a
+    # system.
+    #
+    # This method does not check sizes or any other property of the devices.
+    # It performs a very simple check and returns true if there is any device
+    # of one of the acceptable types (basically disks or DASDs).
+    #
+    # It will never trigger a hardware probing. The method works even if
+    # such probing has not been performed yet.
+    #
+    # @return [Boolean]
+    def devices_for_installation?
+      if probed?
+        !probed.disk_devices.empty?
+      else
+        begin
+          Storage.light_probe
+        rescue Storage::Exception
+          false
+        end
+      end
+    end
+
   private
 
     # Value of #staging_revision right after executing the latest libstorage

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -25,6 +25,7 @@ require "y2storage/fake_device_factory"
 require "y2storage/devicegraph"
 require "y2storage/devicegraph_sanitizer"
 require "y2storage/disk_analyzer"
+require "y2storage/dump_manager"
 require "y2storage/callbacks"
 require "y2storage/hwinfo_reader"
 require "y2storage/sysconfig_storage"
@@ -183,6 +184,7 @@ module Y2Storage
       @storage.probe(probe_callbacks)
       probed_performed
       sanitize_probed(sanitize_callbacks)
+      DumpManager.dump(@probed_graph)
       true
     rescue Storage::Exception, Error
       false
@@ -299,6 +301,7 @@ module Y2Storage
 
       # Save committed devicegraph into logs
       log.info("Committed devicegraph\n#{staging.to_xml}")
+      DumpManager.dump(staging, "committed")
 
       storage.commit(commit_options, callbacks)
       @committed = true

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -58,9 +58,13 @@ module Y2Storage
     def write(devicegraph, yaml_file)
       device_tree = yaml_device_tree(devicegraph)
       if yaml_file.respond_to?(:write)
+        # No timestamp if it's not a file
         yaml_file.write(device_tree.to_yaml)
       else
-        File.open(yaml_file, "w") { |file| file.write(device_tree.to_yaml) }
+        File.open(yaml_file, "w") do |file|
+          write_timestamp(file)
+          file.write(device_tree.to_yaml)
+        end
       end
     end
 
@@ -78,6 +82,14 @@ module Y2Storage
     end
 
   private
+
+    # Write a human-readable timestamp to a file.
+    #
+    # @param file [File]
+    def write_timestamp(file)
+      return unless file.respond_to?(:puts)
+      file.puts("# #{Time.now}")
+    end
 
     # Top level devices that will be converted to yaml format
     #

--- a/test/support/boot_requirements_context.rb
+++ b/test/support/boot_requirements_context.rb
@@ -82,6 +82,7 @@ RSpec.shared_context "boot requirements" do
     allow(storage_arch).to receive(:s390?).and_return(architecture == :s390)
 
     allow(devicegraph).to receive(:disk_devices).and_return [dev_sda, dev_sdb]
+    allow(devicegraph).to receive(:nfs_mounts).and_return []
 
     allow(analyzer).to receive(:boot_ptable_type?) { |type| type == boot_ptable_type }
     # Assume the needed partitions are not already planned in advance

--- a/test/y2storage/boot_requirements_errors_test.rb
+++ b/test/y2storage/boot_requirements_errors_test.rb
@@ -643,5 +643,38 @@ describe Y2Storage::BootRequirementsChecker do
         end
       end
     end
+
+    context "using NFS for the root filesystem" do
+      before do
+        fs = Y2Storage::Filesystems::Nfs.create(fake_devicegraph, "server", "/path")
+        fs.create_mount_point("/")
+      end
+
+      context "in a diskless system" do
+        let(:scenario) { "nfs1.xml" }
+
+        # Regression test for bug#1090752
+        it "does not crash" do
+          expect { checker.warnings }.to_not raise_error
+          expect { checker.errors }.to_not raise_error
+        end
+
+        it "returns no warnings or errors" do
+          expect(checker.warnings).to be_empty
+          expect(checker.errors).to be_empty
+        end
+      end
+
+      context "in a system with local disks" do
+        let(:scenario) { "empty_hard_disk_50GiB" }
+
+        # This used to consider the local disk as the one to boot from, so it
+        # reported wrong errors assuming "/" was going to be there.
+        it "returns no warnings or errors" do
+          expect(checker.warnings).to be_empty
+          expect(checker.errors).to be_empty
+        end
+      end
+    end
   end
 end

--- a/test/y2storage/clients/inst_prepdisk_test.rb
+++ b/test/y2storage/clients/inst_prepdisk_test.rb
@@ -55,16 +55,6 @@ describe Y2Storage::Clients::InstPrepdisk do
         client.run
       end
 
-      it "saves probed devicegraph to a xml log file" do
-        expect(storage_manager.probed).to receive(:save).with(/.*probed.*.xml/)
-        client.run
-      end
-
-      it "saves staging devicegraph to a xml log file" do
-        expect(storage_manager.staging).to receive(:save).with(/.*staging.*.xml/)
-        client.run
-      end
-
       it "returns :next if everything goes fine" do
         expect(client.run).to eq :next
       end

--- a/test/y2storage/dump_manager_test.rb
+++ b/test/y2storage/dump_manager_test.rb
@@ -1,0 +1,251 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) 2016 SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage/dump_manager"
+
+describe Y2Storage::DumpManager do
+  before(:all) do
+    fake_scenario("mixed_disks")
+    # DumpManager is a singleton which might be used by previous unit tests,
+    # so let's reset it to a well-defined state to make sure the dump dir
+    # numbers start with -01 again.
+    described_class.instance.reset
+  end
+
+  after(:all) do
+    # Comment this out for debugging to keep the dump files after running the tests
+    kill_dump_dirs
+  end
+
+  subject { described_class.instance }
+  let(:probed) { Y2Storage::StorageManager.instance.probed }
+  let(:staging) { Y2Storage::StorageManager.instance.staging }
+
+  def populate_dump_dir(dir, marker = nil)
+    FileUtils.mkdir_p(base_dir + "/" + dir)
+    FileUtils.touch(base_dir + "/" + dir + "/" + marker) if marker
+  end
+
+  def populate_full
+    kill_dump_dirs
+    populate_dump_dir("storage-inst", "marker-inst")
+    populate_dump_dir("storage", "marker-00")
+    populate_dump_dir("storage-01", "marker-01")
+    populate_dump_dir("storage-02", "marker-02")
+    populate_dump_dir("storage-03", "marker-03")
+  end
+
+  def dir?(dir)
+    File.exist?(base_dir + "/" + dir)
+  end
+
+  def marker?(dir, marker)
+    File.exist?(base_dir + "/" + dir + "/" + marker)
+  end
+
+  def dump?(name)
+    base_name = dump_dir + "/" + name
+    File.exist?(base_name + ".xml") && File.exist?(base_name + ".yml")
+  end
+
+  def kill_dump_dirs
+    Dir.glob(base_dir + "/storage*").each { |dir| FileUtils.remove_dir(dir) }
+  end
+
+  def base_dir
+    Process.euid == 0 ? "/var/log/YaST2" : Dir.home + "/.y2storage"
+  end
+
+  def dump_dir_list
+    return [] unless File.exist?(base_dir)
+    Dir.glob(base_dir + "/storage*").sort
+  end
+
+  describe "#instance" do
+    it "does not crash and burn" do
+      expect(subject).not_to be_nil
+    end
+  end
+
+  context "In the installed system" do
+    before(:all) do
+      fake_scenario("mixed_disks")
+    end
+
+    let(:dump_dir) { base_dir + "/storage" }
+
+    describe "#installation?" do
+      it "returns false" do
+        expect(subject.installation?).to be false
+      end
+    end
+
+    describe "#base_dir" do
+      it "returns the correct base directory" do
+        expect(subject.base_dir).to eq base_dir
+      end
+    end
+
+    describe "#dump_dir" do
+      it "uses 'storage' as the dump dir" do
+        expect(subject.dump_dir).to eq dump_dir
+      end
+    end
+
+    describe "#kill_all_dump_dirs" do
+      it "leaves only the base dir" do
+        populate_full
+        # Check preconditions
+        expect(dump_dir_list.size).to be == 5
+        expect(dir?("storage")).to be true
+        expect(dir?("storage-01")).to be true
+
+        subject.kill_all_dump_dirs
+        expect(dump_dir_list.empty?).to be true
+        expect(File.exist?(base_dir)).to be true
+      end
+    end
+
+    describe "#rotate_dump_dirs" do
+      it "Rotates the most recent 3 directories" do
+        populate_full
+        subject.rotate_dump_dirs
+        expect(marker?("storage-03", "marker-02")).to be true
+        expect(marker?("storage-02", "marker-01")).to be true
+        expect(marker?("storage-01", "marker-00")).to be true
+        expect(marker?("storage-inst", "marker-inst")).to be true
+        expect(dir?("storage")).to be false
+      end
+
+      it "Rotates one more" do
+        subject.rotate_dump_dirs
+        # storage-04 might sound surprising, but rotating the directories once
+        # more without creating the one that just rotated out (storage-01) should
+        # still leave us with 3 old dump directories, so it's now storage-04..02.
+        expect(marker?("storage-04", "marker-02")).to be true
+        expect(marker?("storage-03", "marker-01")).to be true
+        expect(marker?("storage-02", "marker-00")).to be true
+        expect(dir?("storage-01")).to be false
+        expect(marker?("storage-inst", "marker-inst")).to be true
+        expect(dir?("storage")).to be false
+      end
+    end
+
+    describe "#devicegraph_dump_name" do
+      it "Can handle a nil devicegraph" do
+        expect(subject.devicegraph_dump_name(nil)).to be_nil
+      end
+
+      it "Returns 'probed' for the probed devicegraph" do
+        expect(subject.devicegraph_dump_name(probed)).to eq "probed"
+      end
+
+      it "Returns 'staging' for the staging devicegraph" do
+        expect(subject.devicegraph_dump_name(probed)).to eq "probed"
+      end
+
+      it "Returns 'devicegraph' for anything else" do
+        expect(subject.devicegraph_dump_name(Object.new)).to eq "devicegraph"
+      end
+    end
+
+    describe "#dump" do
+      it "Can handle a nil object" do
+        expect(subject.dump(nil)).to be_nil
+      end
+
+      it "Correctly dumps the probed devicegraph" do
+        expect(dir?("storage")).to be false
+        expect(subject.dump(probed)).to eq "01-probed"
+        expect(dump?("01-probed")).to be true
+      end
+
+      it "Correctly dumps the staging devicegraph" do
+        expect(subject.dump(staging)).to eq "02-staging"
+        expect(dump?("02-staging")).to be true
+        expect(dump?("01-probed")).to be true
+      end
+
+      it "Correctly dumps the staging devicegraph again" do
+        expect(subject.dump(staging)).to eq "03-staging"
+        expect(dump?("03-staging")).to be true
+        expect(dump?("02-staging")).to be true
+        expect(dump?("01-probed")).to be true
+      end
+
+      it "Correctly dumps the staging devicegraph again to a specified name" do
+        expect(subject.dump(staging, "committed")).to eq "04-committed"
+        expect(dump?("04-committed")).to be true
+        expect(dump?("03-staging")).to be true
+        expect(dump?("02-staging")).to be true
+        expect(dump?("01-probed")).to be true
+      end
+
+      it "Correctly dumps an ActionsPresenter" do
+        expect(subject.dump(Y2Storage::ActionsPresenter.new(nil))).to eq "05-actions"
+        expect(File.exist?(base_dir + "/storage/05-actions.txt")).to be true
+      end
+
+      it "Rejects unknown types" do
+        expect { subject.dump(Object.new) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  context "During installation" do
+    let(:dump_dir) { base_dir + "/storage-inst" }
+
+    before(:each) do
+      allow(Yast::Mode).to receive(:installation).and_return(true)
+    end
+
+    describe "#reset" do
+      # It's a singleton - we need to reset it now for Mode.installation to
+      # take effect
+      it "clears storage-inst/" do
+        subject.reset
+        expect(dir?("storage-inst")).to be true
+        expect(marker?("storage-inst", "marker-inst")).to be false
+      end
+
+      it "leaves storage/, storage-03/, ... alone" do
+        expect(marker?("storage", "01-probed.yml")).to be true
+        expect(marker?("storage", "03-staging.yml")).to be true
+        expect(marker?("storage", "04-committed.yml")).to be true
+        expect(marker?("storage-03", "marker-01")).to be true
+      end
+    end
+
+    describe "#dump_dir" do
+      it "uses 'storage-inst' as the dump dir" do
+        expect(subject.dump_dir).to eq dump_dir
+      end
+    end
+
+    describe "#installation?" do
+      it "returns true" do
+        expect(subject.installation?).to be true
+      end
+    end
+  end
+end

--- a/test/y2storage/setup_checker_test.rb
+++ b/test/y2storage/setup_checker_test.rb
@@ -243,6 +243,18 @@ describe Y2Storage::SetupChecker do
       end
     end
 
+    context "when a mandatory product volume is mounted as NFS" do
+      before do
+        fs = Y2Storage::Filesystems::Nfs.create(fake_devicegraph, "server", "/path")
+        fs.mount_path = "/"
+      end
+
+      it "does not include an error for that volume" do
+        expect(subject.product_warnings)
+          .to_not include(an_object_having_attributes(missing_volume: root_volume))
+      end
+    end
+
     context "when all mandatory product volumes are present in the system" do
       let(:product_volumes) { [root_volume, home_volume] }
 

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -970,4 +970,27 @@ describe Y2Storage::StorageManager do
       end
     end
   end
+
+  describe "#devices_for_installation?" do
+    context "system is already probed" do
+      before { fake_scenario("gpt_and_msdos") }
+      it "returns true if there is any diskk device" do
+        expect(subject.devices_for_installation?).to eq true
+      end
+    end
+
+    context "system is not yet probed" do
+      it "returns result of libstorage method light_probe" do
+        expect(::Storage).to receive(:light_probe).and_return true
+
+        expect(subject.devices_for_installation?).to eq true
+      end
+
+      it "returns false if libstorage raise exception" do
+        expect(::Storage).to receive(:light_probe).and_raise(::Storage::Exception)
+
+        expect(subject.devices_for_installation?).to eq false
+      end
+    end
+  end
 end

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -974,8 +974,14 @@ describe Y2Storage::StorageManager do
   describe "#devices_for_installation?" do
     context "system is already probed" do
       before { fake_scenario("gpt_and_msdos") }
-      it "returns true if there is any diskk device" do
+      it "returns true if there is any disk device" do
         expect(subject.devices_for_installation?).to eq true
+      end
+
+      it "returns false if there is no local disk device" do
+        fake_scenario("nfs1.xml")
+
+        expect(subject.devices_for_installation?).to eq false
       end
     end
 


### PR DESCRIPTION
https://trello.com/c/hvI17ITA/155-2-storageng-log-the-final-partitioning

This will dump device and action graphs to file at appropriate places during installation and in the installed system (when the partitioner is used).

During installation, it will create a directory `storage-inst` below `/var/log/YaST2` for those files; in the installed system, it will create a directory `storage` and rotate any previous such directory to keep at most 3 old ones of them:

- storage  (for the current files)
- storage-01  (for the last older ones)
- storage-02  (for even older ones)
- storage-03  (for even older ones)

For each program start (of the partitioner), those directories are rotated.

For the installation, it's always just `storage-inst`; any previous directory by that same name will be deleted and recreated. This can only happen anyway when somebody does an ssh installation and aborts and restarts YaST, so any old files there (in the inst-sys!) are irrelevant.

`storage-inst` in the inst-sys needs to be copied to the target (this will be a separate PR against yast-installation) and picked up by `save_y2logs` (which will collect everything in `/var/log/YaST` anyway.

If YaST is running as non-root, those directories are created below `~/.y2storage/` to avoid cluttering the user's home directory too much (but this affects mostly us YaST developers starting tests).

In each of those directories, files are created to record the devicegraphs (and, at strategic points, also the actions):

- 01-probed.xml
- 01-probed.yml
- 02-proposed.xml
- 02-proposed.yml
- 03-actions.txt
- 04-partitioner.xml
- 04-partitioner.yml
- 05-actions.txt
- 06-committed.xml
- 07-committed.yml

When the user changes proposal parameters or keeps entering and leaving the partitioner, there might be more of those; one pair of XML and YAML files each time, and whenever actions are shown to the user, also the actions.