### PR TITLE
Centralize path comparison in MountPoint

### DIFF
--- a/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
@@ -320,9 +320,8 @@ module Y2Storage
       # @return [Filesystems::Base, nil] nil if there is no filesystem to be
       #   mounted there
       def filesystem_for_mountpoint(path)
-        cleanpath = Pathname.new(path).cleanpath
         devicegraph.filesystems.find do |fs|
-          fs.mount_path && Pathname.new(fs.mount_path).cleanpath == cleanpath
+          fs.mount_point && fs.mount_point.path?(path)
         end
       end
 

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -186,6 +186,17 @@ module Y2Storage
       in_etc_fstab?
     end
 
+    # Whether the given path is equivalent to {#path}
+    #
+    # This method is more robust than a simple string comparison, since it takes
+    # into account trailing slashes and similar potential problems.
+    #
+    # @param other_path [String, Pathname]
+    # @return [Boolean]
+    def path?(other_path)
+      Pathname.new(other_path).cleanpath == Pathname.new(path).cleanpath
+    end
+
   protected
 
     def types_for_is

--- a/src/lib/y2storage/setup_checker.rb
+++ b/src/lib/y2storage/setup_checker.rb
@@ -149,9 +149,8 @@ module Y2Storage
     # @return [Boolean]
     def nfs?(volume)
       return false unless volume.mount_point
-      vol_path = Pathname.new(volume.mount_point).cleanpath
       devicegraph.nfs_mounts.any? do |nfs|
-        nfs.mount_point && Pathname.new(nfs.mount_path).cleanpath == vol_path
+        nfs.mount_point && nfs.mount_point.path?(volume.mount_point)
       end
     end
 


### PR DESCRIPTION
This is just something I realized while working on https://trello.com/c/F1oQeriK/377-1-sles15-p1-1090752-internal-error-undefined-method-mbrgap-for-nilnilclass

Now that we have a `MountPoint`class, there is a clear responsible for comparing paths and there is no need to fiddle with `Pathname` everywhere.

Cleaner code and the testsuite still passes.