### PR TITLE
Hot fix: Don't require rspec/mocks (not in inst-sys)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  3 15:12:09 UTC 2018 - shundhammer@suse.com
+
+- Don't require rspec/mocks (not present in inst-sys)
+  (part of fate#318196)
+- 4.0.171
+
+-------------------------------------------------------------------
 Wed May  2 12:55:09 UTC 2018 - shundhammer@suse.com
 
 - Dump devicegraph and actions to separate human readable files

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.170
+Version:        4.0.171
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/dump_manager.rb
+++ b/src/lib/y2storage/dump_manager.rb
@@ -22,7 +22,6 @@
 require "singleton"
 require "fileutils"
 require "yast"
-require "rspec/mocks"
 require "y2storage/devicegraph"
 require "y2storage/actions_presenter"
 require "y2storage/storage_manager"
@@ -100,8 +99,7 @@ module Y2Storage
         dump_devicegraph(dump_obj, file_base_name)
       elsif dump_obj.is_a?(Y2Storage::ActionsPresenter)
         dump_actions(dump_obj, file_base_name)
-      elsif dump_obj.is_a?(RSpec::Mocks::InstanceVerifyingDouble) ||
-          dump_obj.is_a?(RSpec::Mocks::Double)
+      elsif mocked_object?(dump_obj)
         log.warn("Not dumping #{dump_obj.class}")
       else
         raise ArgumentError, "Unsupported type to dump: #{dump_obj.class}"
@@ -324,6 +322,17 @@ module Y2Storage
     # @return [Boolean]
     def running_as_root?
       Process.euid == 0
+    end
+
+    # Check if an object is some kind of rspec mocked object
+    # (double or instance_double)
+    #
+    # @return [Boolean]
+    def mocked_object?(obj)
+      return false unless defined?(RSpec::Mocks::Double)
+      return true if obj.is_a?(RSpec::Mocks::Double)
+      return false unless defined?(RSpec::Mocks::InstanceVerifyingDouble)
+      obj.is_a?(RSpec::Mocks::InstanceVerifyingDouble)
     end
   end
 end


### PR DESCRIPTION
Imo and Ivan found out (independently) that the inst-sys doesn't provide rspec/mocks, so it was necessary to change that check for mocked objects.