### PR TITLE
Use passno=2 for extX systems mounted in non-root paths

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  3 15:46:27 UTC 2018 - ancor@suse.com
+
+- Set fs_passno to 2 for ext2/3/4 filesystems assigned to non-root
+  mount points (bsc#1078703).
+- 4.0.172
+
+-------------------------------------------------------------------
 Thu May  3 15:12:09 UTC 2018 - shundhammer@suse.com
 
 - Don't require rspec/mocks (not present in inst-sys)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.171
+Version:        4.0.172
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/test/y2storage/mount_point_test.rb
+++ b/test/y2storage/mount_point_test.rb
@@ -101,9 +101,9 @@ describe Y2Storage::MountPoint do
         end
 
         context "and later reassigned to another path" do
-          it "is set to 0" do
+          it "is set to 2" do
             mount_point.path = "/var"
-            expect(mount_point.passno).to eq 0
+            expect(mount_point.passno).to eq 2
           end
         end
       end
@@ -111,8 +111,8 @@ describe Y2Storage::MountPoint do
       context "mounted at a non-root location" do
         let(:path) { "/home" }
 
-        it "is set to 0" do
-          expect(mount_point.passno).to eq 0
+        it "is set to 2" do
+          expect(mount_point.passno).to eq 2
         end
       end
     end


### PR DESCRIPTION
Continuation of https://trello.com/c/yzueuWcq/256-1-propose-correct-better-mount-options-for