### PR TITLE
Rudimentary support in YAML writer for unknown device types (RAID, multipath, NFS)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May  8 15:34:19 UTC 2018 - shundhammer@suse.com
+
+- Add note to YAML files for devices not supported in YAML
+  (part of fate#318196)
+- 4.0.177
+
+-------------------------------------------------------------------
 Mon May  7 16:39:49 UTC 2018 - shundhammer@suse.com
 
 - Dump devicegraphs and actions in better strategic places

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.176
+Version:        4.0.177
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -442,20 +442,6 @@ module Y2Storage
       { "subvolume" => content }
     end
 
-    # Return YAML for any unsupported objects in a devicegraph.
-    # Right now this is limited to block devices; this might change in the
-    # future.
-    #
-    # @param devicegraph [Devicegraph]
-    # @return [Hash]
-    def yaml_unsupported(devicegraph)
-      content = []
-      unsupported_devices(devicegraph).each { |device| content << yaml_unsupported_device(device) }
-      return nil if content.empty?
-
-      { "unsupported" => content }
-    end
-
     # Return YAML for one unsupported device.
     #
     # @param  device [Device]

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -470,12 +470,28 @@ module Y2Storage
     end
 
     # Return all unsupported devices in a devicegraph. Right now this is
-    # limited to block devices.
+    # limited to block devices and non-block-filesystem filesystems like NFS.
     #
     # @param devicegraph [Devicegraph]
     # @return [Array<Device>]
     def unsupported_devices(devicegraph)
+      unsupported_blk_devices(devicegraph) + non_blk_filesystem_filesystems(devicegraph)
+    end
+
+    # Return all unsupported block devices in a devicegraph.
+    #
+    # @param devicegraph [Devicegraph]
+    # @return [Array<Device>]
+    def unsupported_blk_devices(devicegraph)
       BlkDevice.all(devicegraph).reject { |d| supported_blk_device?(d) }
+    end
+
+    # Return all unsupported filesystems in a devicegraph.
+    #
+    # @param devicegraph [Devicegraph]
+    # @return [Array<Device>]
+    def non_blk_filesystem_filesystems(devicegraph)
+      devicegraph.filesystems.reject { |fs| fs.is?(:blk_filesystem) }
     end
 
     # Check if a block device is supported by the YAML writer.

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -444,12 +444,12 @@ module Y2Storage
 
     # Return YAML for one unsupported device.
     #
-    # @param  device [Device]
+    # @param device [Device]
     # @return [Hash]
     def yaml_unsupported_device(device)
       content = {}
       content["type"] = device.class.to_s
-      content["name"] = device.name
+      content["name"] = device.name if device.respond_to?(:name)
       content["support"] = "unsupported in YAML - check XML"
 
       { "unsupported_device" => content }

--- a/test/y2storage/yaml_writer_test.rb
+++ b/test/y2storage/yaml_writer_test.rb
@@ -477,6 +477,8 @@ describe Y2Storage::YamlWriter do
     context "when the devicegraph contains objects not yet supported in YAML" do
       before do
         fake_scenario(scenario)
+        fs = Y2Storage::Filesystems::Nfs.create(fake_devicegraph, "server", "/path")
+        fs.create_mount_point("/nfs_mount")
       end
       let(:scenario) { "empty-dm_raids.xml" }
 
@@ -489,6 +491,10 @@ describe Y2Storage::YamlWriter do
           - unsupported_device:
               type: Y2Storage::DmRaid
               name: "/dev/mapper/isw_ddgdcbibhd_test2"
+              support: unsupported in YAML - check XML
+          - unsupported_device:
+              type: Y2Storage::Filesystems::Nfs
+              name: server:/path
               support: unsupported in YAML - check XML)
       end
 
@@ -506,7 +512,7 @@ describe Y2Storage::YamlWriter do
       end
 
       it "generates the expected yaml content" do
-        described_class.write(staging, io)
+        described_class.write(fake_devicegraph, io)
         expect(plain_content(relevant_part(io.string))).to eq(plain_content(expected_result))
       end
     end


### PR DESCRIPTION
https://trello.com/c/w14Rh3JY/378-1-yaml-writer-inform-about-missing-stuff

For device types (more exactly: for block devices) where we don't have proper support in our YAML reader / writer, add at least a section to the YAML output that shows that there is something so the XML file can be used for more details.

Sample output:

```yaml
- disk:
    name: "/dev/sdc"
    size: 32 GiB
    block_size: 0.5 KiB
    io_size: 0 B
    min_grain: 1 MiB
    align_ofs: 0 B
- unsupported_device:
    type: Y2Storage::DmRaid
    name: "/dev/mapper/isw_ddgdcbibhd_test1"
    support: unsupported in YAML - check XML
- unsupported_device:
    type: Y2Storage::DmRaid
    name: "/dev/mapper/isw_ddgdcbibhd_test2"
    support: unsupported in YAML - check XML
- unsupported_device:
    type: Y2Storage::Filesystems::Nfs
    name: server:/path
    support: unsupported in YAML - check XML
```

## Notice

Right now, the YAML reader can**not** read such a file; it will be rejected because of those `unsupported_device` entries.  IMHO this is desired, but it is debatable if we should extend the YAML reader so it can at least ignore that part. OTOH this might be unsafe for some use cases.