### PR TITLE
Do not crash when mount point is not defined

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May  9 08:21:50 UTC 2018 - igonzalezsosa@suse.com
+
+- AutoYaST: do not crash when size is set to 'auto' for a partition
+  without a mount point (bsc#1092414).
+- 4.0.178
+
+-------------------------------------------------------------------
 Tue May  8 15:34:19 UTC 2018 - shundhammer@suse.com
 
 - Add note to YAML files for devices not supported in YAML

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.177
+Version:        4.0.178
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/proposal/autoinst_devices_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_planner.rb
@@ -262,6 +262,7 @@ module Y2Storage
       # @param mount [String] Mount point
       # @return [Hash]
       def subvolume_attrs_for(mount)
+        return {} if mount.nil?
         spec = VolumeSpecification.for(mount)
         return {} if spec.nil?
         { subvolumes_prefix: spec.btrfs_default_subvolume, subvolumes: spec.subvolumes }

--- a/src/lib/y2storage/proposal/autoinst_size_parser.rb
+++ b/src/lib/y2storage/proposal/autoinst_size_parser.rb
@@ -50,7 +50,8 @@ module Y2Storage
       # @param mount_point [String] Mount point
       # @param min         [DiskSize] Minimal size
       # @param max         [DiskSize] Maximal size
-      # @return [AutoinstSize] Object containing information about size
+      # @return [AutoinstSize,nil] Object containing information about size; nil if size
+      #   specification is "auto" and no predefined values were found.
       #
       # @see AutoinstSize
       def parse(size_spec, mount_point, min, max)
@@ -111,6 +112,7 @@ module Y2Storage
 
       # @return [nil,Array<DiskSize>]
       def auto_sizes_for(mount_point)
+        return nil if mount_point.nil?
         spec = VolumeSpecification.for(mount_point, proposal_settings: proposal_settings)
         return nil if spec.nil?
 

--- a/test/y2storage/proposal/autoinst_devices_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_planner_test.rb
@@ -422,15 +422,16 @@ describe Y2Storage::Proposal::AutoinstDevicesPlanner do
       end
     end
 
-    context "using Btrfs for root" do
+    context "using Btrfs" do
       let(:partitioning_array) do
         [{
           "device" => "/dev/sda", "use" => "all",
-          "enable_snapshots" => snapshots, "partitions" => [root_spec, home_spec]
+          "enable_snapshots" => snapshots, "partitions" => partitions
         }]
       end
       let(:home_spec) { { "mount" => "/home", "filesystem" => "btrfs" } }
       let(:root_spec) { { "mount" => "/", "filesystem" => "btrfs", "subvolumes" => subvolumes } }
+      let(:partitions) { [root_spec, home_spec] }
       let(:snapshots) { false }
 
       let(:devices) { planner.planned_devices(drives_map) }
@@ -597,6 +598,16 @@ describe Y2Storage::Proposal::AutoinstDevicesPlanner do
 
         it "does not plan any subvolume" do
           expect(root.subvolumes).to eq([])
+        end
+      end
+
+      context "when no mount point is defined" do
+        let(:partitions) { [root_spec, not_mounted_spec] }
+        let(:not_mounted_spec) { { "mount" => nil, "filesystem" => "btrfs" } }
+        let(:not_mounted) { devices.find { |d| d.mount_point.nil? } }
+
+        it "does not plan any subvolume" do
+          expect(not_mounted.subvolumes).to eq([])
         end
       end
     end

--- a/test/y2storage/proposal/autoinst_size_parser_test.rb
+++ b/test/y2storage/proposal/autoinst_size_parser_test.rb
@@ -100,9 +100,15 @@ describe Y2Storage::Proposal::AutoinstSizeParser do
       context "and there are no volumes defined in the control file" do
         let(:subvolumes) { [] }
 
-        it "sets min and max values to nil" do
+        it "returns nil" do
           expect(parser.parse("auto", "/srv", MIN, MAX)).to be_nil
         end
+      end
+    end
+
+    context "when size is nil" do
+      it "returns nil" do
+        expect(parser.parse("auto", nil, MIN, MAX)).to be_nil
       end
     end
   end


### PR DESCRIPTION
Fixes bsc#1092414. This problem happens when the mount point is not defined and size is set to 'auto' or filesystem_type is set to :btrfs.