### PR TITLE
Fix raid options

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May 11 10:08:24 UTC 2018 - jlopez@suse.com
+
+- Partitioner: allow to select only valid parity algorithms when
+  creating a new MD RAID (bsc#1090182).
+
+-------------------------------------------------------------------
 Fri May 11 07:36:18 UTC 2018 - ancor@suse.com
 
 - Partitioner: "Configure..." button allowing to execute the

--- a/src/lib/y2partitioner/actions/controllers/md.rb
+++ b/src/lib/y2partitioner/actions/controllers/md.rb
@@ -156,6 +156,15 @@ module Y2Partitioner
           md.size
         end
 
+        # Allowed partity algorithms
+        #
+        # Allowed parities depends on the RAID type and the number of devices in the Md RAID
+        #
+        # @return [Array<Y2Storage::MdParity>]
+        def md_parities
+          md.allowed_md_parities
+        end
+
         # Sets the name of the Md device
         #
         # Unlike {Y2Storage::Md#md_name=}, setting the value to nil or empty will
@@ -200,11 +209,12 @@ module Y2Partitioner
 
         # Whether is possible to set the parity configuration for the current Md device
         #
-        # @note Parity algorithm only makes sense for Raid5, Raid6 and Raid10.
+        # @note Parity algorithm only makes sense for Raid5, Raid6 and Raid10, see
+        #   {Y2Storage::Md#allowed_md_parities}
         #
         # @return [Boolean]
         def parity_supported?
-          [:raid5, :raid6, :raid10].include?(md.md_level.to_sym)
+          md.allowed_md_parities.any?
         end
 
         # Minimal number of devices required for the Md object.

--- a/src/lib/y2partitioner/dialogs/md_options.rb
+++ b/src/lib/y2partitioner/dialogs/md_options.rb
@@ -104,7 +104,7 @@ module Y2Partitioner
         end
 
         def items
-          PARITIES.map { |p| [p.to_s, Y2Storage::MdParity.find(p).to_human_string] }
+          @controller.md_parities.map { |p| [p.to_s, Y2Storage::MdParity.find(p).to_human_string] }
         end
 
         # @macro seeAbstractWidget
@@ -116,10 +116,6 @@ module Y2Partitioner
         def store
           @controller.md_parity = Y2Storage::MdParity.find(value)
         end
-
-        PARITIES = [:default, :near_2, :offset_2, :far_2, :near_3, :offset_3, :far_3].freeze
-
-        private_constant :PARITIES
       end
     end
   end

--- a/src/lib/y2partitioner/dialogs/md_options.rb
+++ b/src/lib/y2partitioner/dialogs/md_options.rb
@@ -104,7 +104,7 @@ module Y2Partitioner
         end
 
         def items
-          @controller.md_parities.map { |p| [p.to_s, Y2Storage::MdParity.find(p).to_human_string] }
+          @controller.md_parities.map { |p| [p.to_s, p.to_human_string] }
         end
 
         # @macro seeAbstractWidget

--- a/src/lib/y2storage/md.rb
+++ b/src/lib/y2storage/md.rb
@@ -84,10 +84,22 @@ module Y2Storage
     storage_forward :md_level=
 
     # @!attribute md_parity
-    #   Parity of the MD RAID.
+    #   Parity of the MD RAID, only meaningful for RAID5, RAID6 and RAID10.
+    #
+    #   @note Setting the parity is only meaningful for RAID5, RAID6 and RAID10
+    #       and for MD RAIDs not created on disk yet.
+    #
     #   @return [MdParity]
     storage_forward :md_parity, as: "MdParity"
     storage_forward :md_parity=
+
+    # @!method allowed_md_parities
+    #   Get the allowed parities for the MD RAID. Only meaningful for
+    #   RAID5, RAID6 and RAID10. So far depends on the MD RAID level and
+    #   the number of devices.
+    #
+    #   @return [Array<MdParity>]
+    storage_forward :allowed_md_parities, as: "MdParity"
 
     # @!attribute chunk_size
     #   Chunk size of the MD RAID.

--- a/test/y2partitioner/actions/controllers/md_test.rb
+++ b/test/y2partitioner/actions/controllers/md_test.rb
@@ -648,6 +648,14 @@ describe Y2Partitioner::Actions::Controllers::Md do
     end
   end
 
+  describe "#md_parities" do
+    it "returns the allowed parity algorithms for the Md device" do
+      md = controller.md
+      md.md_level = Y2Storage::MdLevel::RAID10
+      expect(controller.md_parities).to eq(md.allowed_md_parities)
+    end
+  end
+
   describe "#wizard_title" do
     subject(:controller) { described_class.new(md: md) }
 


### PR DESCRIPTION
PBI: https://trello.com/c/wqCTgFxw/368-1-sles15-p2-1090182-build5741storage-ng-layout-not-understood-errors-when-setting-non-default-parity-for-raid5-and-raid10