### PR TITLE
Expose the active flag for MountPoint 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 14 16:43:05 UTC 2018 - ancor@suse.com
+
+- Expose the active flag of the MountPoint class (needed for the
+  definitive fix for bsc#1064437 in modern distributions).
+- 4.0.180
+
+-------------------------------------------------------------------
 Fri May 11 14:05:49 UTC 2018 - igonzalezsosa@suse.com
 
 - Partitioner: check whether required packages are installed

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.179
+Version:        4.0.180
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -145,6 +145,20 @@ module Y2Storage
     #   @return [Boolean]
     storage_forward :in_etc_fstab?
 
+    # @!method active?
+    # 	Whether the mount point is mounted (probed devicegraph) or
+    # 	should be mounted (staging devicegraph)
+    #
+    # 	@return [Boolean]
+    storage_forward :active?
+
+    # @!method active=(value)
+    #
+    # 	Sets the {#active?} flag
+    #
+    # 	@param value [Boolean]
+    storage_forward :active=
+
     # @!method mountable
     #   Gets the mountable of the mount point (filesystem, BTRFS subvolume, etc)
     #


### PR DESCRIPTION
See https://trello.com/c/XQXJVOVl/242-5-port-yast-nfs-client-to-storage-ng

To use storage-ng in yast2-nfs-client we need a more fine-grained control on what gets mounted during a commit, so we need to control the value of the `MountPoint#active?` flag