### PR TITLE
WIP: Limit volume label length and permitted characters

### DIFF
--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -256,6 +256,8 @@ module Y2Partitioner
 
       def init
         self.value = filesystem.label
+        Yast::UI.ChangeWidget(Id(widget_id), :ValidChars, valid_chars)
+        Yast::UI.ChangeWidget(Id(widget_id), :InputMaxLength, input_max_length)
       end
 
       # Validates uniqueness of the given label. The presence of the label is also
@@ -334,6 +336,21 @@ module Y2Partitioner
       # Sets the focus into this widget
       def focus
         Yast::UI.SetFocus(Id(widget_id))
+      end
+
+      # Return the valid characters for this input field
+      #
+      # @return [String]
+      def valid_chars
+        filesystem.type.label_valid_chars
+      end
+
+      # Return the maximum length of the input (the number of characters) for
+      # this input field
+      #
+      # @return [Integer]
+      def input_max_length
+        filesystem.max_labelsize
       end
     end
 

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -50,6 +50,12 @@ module Y2Storage
       CODEPAGE_OPTIONS = ["codepage="].freeze
       DEFAULT_CODEPAGE = "437".freeze
 
+      # Base for valid characters (as a string): "ABC...XYZabc...xyz012..89"
+      ALPHANUM = ["A".."Z", "a".."z", "0".."9"].flat_map(&:to_a).join.freeze
+
+      # Fallback for valid characters for a volume label
+      LABEL_VALID_CHARS = ALPHANUM + "-_."
+
       # Hash with the properties of several filesystem types.
       #
       # Keys are the symbols representing the types and values are hashes that
@@ -60,6 +66,8 @@ module Y2Storage
       #   (do not include "defaults" here!)
       # - `:default_partition_id` for the partition id that fits better with
       #   the corresponding filesystem type.
+      # - `:label_valid_chars` (optional) for a string (not a regexp!) containing
+      #   the valid characters for the filesystem label. Fallback: LABEL_VALID_CHARS
       #
       # Not all combinations of filesystem types and properties are represented,
       # default values are used for missing information.
@@ -380,6 +388,16 @@ module Y2Storage
         default = PartitionId::LINUX
         return default unless properties
         properties[:default_partition_id] || default
+      end
+
+      # Valid characters for labels for this filesystem type
+      #
+      # @return [String]
+      def label_valid_chars
+        properties = PROPERTIES[to_sym]
+        default = LABEL_VALID_CHARS
+        return default unless properties
+        properties[:label_valid_chars] || default
       end
 
       # Add the required codepage number according to the current locale to

--- a/test/y2storage/filesystems/type_test.rb
+++ b/test/y2storage/filesystems/type_test.rb
@@ -231,4 +231,27 @@ describe Y2Storage::Filesystems::Type do
       end
     end
   end
+
+  describe "label_valid_chars" do
+    it "contains alphanumeric characters" do
+      chars = Y2Storage::Filesystems::Type::EXT2.label_valid_chars
+      expect(chars).to match(/ABCDEFG/)
+      expect(chars).to match(/xyz/)
+      expect(chars).to match(/789/)
+    end
+
+    it "contains some non-alphanumeric characters" do
+      chars = Y2Storage::Filesystems::Type::EXT2.label_valid_chars
+      expect(chars).to include("-")
+      expect(chars).to include("_")
+      expect(chars).to include(".")
+    end
+
+    it "does not contain any whitespace" do
+      chars = Y2Storage::Filesystems::Type::EXT2.label_valid_chars
+      expect(chars).not_to include(" ")
+      expect(chars).not_to include("\t")
+      expect(chars).not_to include("\n")
+    end
+  end
 end


### PR DESCRIPTION
_**Superseded by https://github.com/yast/yast-storage-ng/pull/654**_

https://trello.com/c/pVvQMTRq/313-2-sles15-p3-1084867-installer-does-not-handle-xfs-label-length-limitations

This limits what a user can enter for volume labels:

- The length of the volume label
- The permitted characters

The length is provided by libstorage-ng directly with `BlkFilesystem::max_labelsize()`.

There is no such counterpart for the permitted characters, so this was added to `Filesystem::Type` on the yast-storage-ng Ruby level.

We could provide a different set of characters for each filesystem, and this is actually prepared in this PR, but so far it does what was requested in the PBI: Keep it simple.

We now restrict it to `A..Za..z0..9` and some very few special characters: `-_.` (minus, underscore, period) which all filesystem types appear to support. No weird non-ASCII characters since those volume labels have to work with system tools that all might have their specific restrictions. Some filesystem types may allow a little bit more, but that does not mean that we are required to let the user enter that here.

This PR uses widget properties of the underlying UI InputField widget that handles this directly, so there is no need for any error popups: The user simply cannot enter more than the permitted amount of characters, and he also cannot enter any characters that are not permitted.