### PR TITLE
[WIP] [RFC] Allows to use a random encryption pwd when filesystem support it

### DIFF
--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -343,7 +343,7 @@ module Y2Partitioner
             enc = blk_device.create_encryption(name)
 
             if random_password
-              enc.password_file = '/dev/urandom' # FIXME
+              enc.password_file = "/dev/urandom" # FIXME
             else
               enc.password = encrypt_password
             end

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -342,8 +342,11 @@ module Y2Partitioner
             name = Y2Storage::Encryption.dm_name_for(blk_device)
             enc = blk_device.create_encryption(name)
 
+            # FIXME: extract this to its own method. Also, pay attention to the hardcoded value for
+            # password_file, which for now is here only to test until a final decision about how to do it
+            # better will be taken.
             if random_password
-              enc.password_file = "/dev/urandom" # FIXME
+              enc.password_file = "/dev/urandom"
             else
               enc.password = encrypt_password
             end

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -57,6 +57,9 @@ module Y2Partitioner
         # @return [String] Password for the encryption device
         attr_accessor :encrypt_password
 
+        # @return [Boolean] Whether the device should use a random password every boot
+        attr_accessor :random_password
+
         # Name of the plain device
         #
         # @see #blk_device
@@ -338,7 +341,12 @@ module Y2Partitioner
           if to_be_encrypted?
             name = Y2Storage::Encryption.dm_name_for(blk_device)
             enc = blk_device.create_encryption(name)
-            enc.password = encrypt_password
+
+            if random_password
+              enc.password_file = '/dev/urandom' # FIXME
+            else
+              enc.password = encrypt_password
+            end
           elsif blk_device.encrypted? && !encrypt
             blk_device.remove_encryption
           end

--- a/src/lib/y2partitioner/widgets/encrypt_password.rb
+++ b/src/lib/y2partitioner/widgets/encrypt_password.rb
@@ -99,9 +99,13 @@ module Y2Partitioner
           RadioButtonGroup(
             Id(:pwd_type),
             VBox(
-              Left(RadioButton(Id(:manual_pwd), _("Ask for password on boot to mount the swap"), true)),
+              Left(
+                RadioButton(Id(:manual_pwd), _("Ask for password on boot to mount the swap"), true)
+              ),
               password_fields,
-              Left(RadioButton(Id(:random_pwd), _("Auto-generate a new &random password on every boot"))),
+              Left(
+                RadioButton(Id(:random_pwd), _("Auto-generate a new &random password on every boot"))
+              )
             )
           )
         )
@@ -143,11 +147,11 @@ module Y2Partitioner
             "</p>\n"
           )
         else
-        _(
-          "<p>\n" \
-            "You will need to enter your encryption password.\n" \
-          "</p>\n"
-        )
+          _(
+            "<p>\n" \
+              "You will need to enter your encryption password.\n" \
+            "</p>\n"
+          )
         end
       end
 

--- a/src/lib/y2partitioner/widgets/encrypt_password.rb
+++ b/src/lib/y2partitioner/widgets/encrypt_password.rb
@@ -15,33 +15,25 @@ module Y2Partitioner
       end
 
       # @macro seeAbstractWidget
-      def help
-        # help text for cryptofs
-        _(
-          "<p>\n" \
-            "You will need to enter your encryption password.\n" \
-          "</p>\n" \
-          "<p>\n" \
-            "If the encrypted file system does not contain any system file and therefore is\n" \
-            "not needed for the update, you may select <b>Skip</b>. In this case, the\n" \
-            "file system is not accessed during update.\n" \
-          "</p>\n"
-        )
-      end
-
-      # @macro seeAbstractWidget
       def validate
-        msg = checker.error_msg(pw1, pw2)
-        return true unless msg
+        return true if random_password?
 
-        Yast::Report.Error(msg)
+        error_msg = checker.error_msg(pw1, pw2)
+        return true unless error_msg
+
+        Yast::Report.Error(error_msg)
         Yast::UI.SetFocus(Id(:pw1))
+
         false
       end
 
       # @macro seeAbstractWidget
       def store
-        @controller.encrypt_password = pw1
+        if random_password?
+          @controller.random_password = true
+        else
+          @controller.encrypt_password = pw1
+        end
       end
 
       # @macro seeAbstractWidget
@@ -56,27 +48,15 @@ module Y2Partitioner
           MarginBox(
             1.45,
             0.5,
-            VBox(
-              Password(
-                Id(:pw1),
-                Opt(:hstretch),
-                # Label: get password for user root
-                # Please use newline if label is longer than 40 characters
-                _("&Enter a Password for your File System:"),
-                ""
-              ),
-              Password(
-                Id(:pw2),
-                Opt(:hstretch),
-                # Label: get same password again for verification
-                # Please use newline if label is longer than 40 characters
-                _("Reenter the Password for &Verification:"),
-                ""
-              ),
-              VSpacing(0.5)
-            )
+            form_content
           )
         )
+      end
+
+      # @macro seeAbstractWidget
+      def help
+        # help text for cryptofs
+        help_encryption_password + help_skip
       end
 
     private
@@ -92,6 +72,94 @@ module Y2Partitioner
       # @return [String]
       def pw2
         Yast::UI.QueryWidget(Id(:pw2), :Value)
+      end
+
+      # @return [Boolean]
+      def random_password_allowed?
+        @random_password_allowed ||= @controller.filesystem_type.to_sym == :swap
+      end
+
+      # @return [Boolean]
+      def random_password?
+        return false unless random_password_allowed?
+
+        Yast::UI::QueryWidget(Id(:pwd_type), :Value) == :random_pwd
+      end
+
+      def form_content
+        if random_password_allowed?
+          extended_content
+        else
+          password_fields
+        end
+      end
+
+      def extended_content
+        VBox(
+          RadioButtonGroup(
+            Id(:pwd_type),
+            VBox(
+              Left(RadioButton(Id(:manual_pwd), _("Ask for password on boot to mount the swap"), true)),
+              password_fields,
+              Left(RadioButton(Id(:random_pwd), _("Auto-generate a new &random password on every boot"))),
+            )
+          )
+        )
+      end
+
+      def password_fields
+        MarginBox(
+          1.45,
+          0.5,
+          VBox(
+            Password(
+              Id(:pw1),
+              Opt(:hstretch),
+              # Label: get password for user root
+              # Please use newline if label is longer than 40 characters
+              _("&Enter a Password for your File System:"),
+              ""
+            ),
+            Password(
+              Id(:pw2),
+              Opt(:hstretch),
+              # Label: get same password again for verification
+              # Please use newline if label is longer than 40 characters
+              _("Reenter the Password for &Verification:"),
+              ""
+            ),
+            VSpacing(0.5)
+          )
+        )
+      end
+
+      # @return [String]
+      def help_encryption_password
+        if random_password_allowed?
+          _(
+            "<p>\n" \
+              "You will need to enter your encryption password or allow to system\n" \
+              "auto-generate a new random password on every boot.\n" \
+            "</p>\n"
+          )
+        else
+        _(
+          "<p>\n" \
+            "You will need to enter your encryption password.\n" \
+          "</p>\n"
+        )
+        end
+      end
+
+      # @return [String]
+      def help_skip
+        _(
+          "<p>\n" \
+            "If the encrypted file system does not contain any system file and therefore is\n" \
+            "not needed for the update, you may select <b>Skip</b>. In this case, the\n" \
+            "file system is not accessed during update.\n" \
+          "</p>\n"
+        )
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/encrypt_password.rb
+++ b/src/lib/y2partitioner/widgets/encrypt_password.rb
@@ -142,7 +142,7 @@ module Y2Partitioner
         if random_password_allowed?
           _(
             "<p>\n" \
-              "You will need to enter your encryption password or allow to system\n" \
+              "You will need to enter your encryption password or allow system to\n" \
               "auto-generate a new random password on every boot.\n" \
             "</p>\n"
           )

--- a/src/lib/y2partitioner/widgets/encrypt_password.rb
+++ b/src/lib/y2partitioner/widgets/encrypt_password.rb
@@ -74,6 +74,12 @@ module Y2Partitioner
         Yast::UI.QueryWidget(Id(:pw2), :Value)
       end
 
+      # Checks if is allowed to use random passwords
+      #
+      # NOTE: for now, only Swap filesystem allows this kind of encryption method because its content is
+      # not needed after a shutdown and can be reinitialized on boot-up. For other filesystems does not
+      # make sense since data will be lost.
+      #
       # @return [Boolean]
       def random_password_allowed?
         @random_password_allowed ||= @controller.filesystem_type.to_sym == :swap

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -87,15 +87,15 @@ module Y2Storage
     #
     # @return [String]
     def password_file
-      @password_file
+      @password_file || "/dev/urandom"
     end
 
     # Sets the absolute path to a file containing the encryption password
     #
     # @param filename [String] absolute path to the file
     def password_file=(filename)
-      log.error("Not implemented yet: assigning #{filename} as file for the password in crypttab")
       # @password_file = filename
+      log.error("Not implemented yet: assigning #{filename} as file for the password in crypttab")
     end
 
   protected

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -27,6 +27,8 @@ module Y2Storage
   #
   # This is a wrapper for Storage::Encryption
   class Encryption < BlkDevice
+    include Yast::Logger
+
     wrap_class Storage::Encryption
 
     # @!method blk_device
@@ -77,6 +79,23 @@ module Y2Storage
     # @see #in_etc_crypttab?
     def in_etc?
       in_etc_crypttab?
+    end
+
+    # Returns the absolute path to a file containing the encryption password
+    #
+    # To be used as a third field in the crypttab file
+    #
+    # @return [String]
+    def password_file
+      @password_file
+    end
+
+    # Sets the absolute path to a file containing the encryption password
+    #
+    # @param filename [String] absolute path to the file
+    def password_file=(filename)
+      log.error("Not implemented yet: assigning #{filename} as file for the password in crypttab")
+      # @password_file = filename
     end
 
   protected

--- a/test/y2partitioner/widgets/encrypt_password_test.rb
+++ b/test/y2partitioner/widgets/encrypt_password_test.rb
@@ -29,10 +29,11 @@ describe Y2Partitioner::Widgets::EncryptPassword do
 
   include_examples "CWM::AbstractWidget"
 
-  let(:controller) { double("FilesystemController", blk_device_name: "/dev/sda1") }
+  let(:controller) { double("FilesystemController", blk_device_name: "/dev/sda1", filesystem_type: filesystem_type ) }
   let(:pw1) { "password1" }
   let(:pw2) { "password2" }
   let(:password_checker) { Y2Storage::EncryptPasswordChecker.new }
+  let(:filesystem_type) { Y2Storage::Filesystems::Type::VFAT }
 
   before do
     allow(Y2Storage::EncryptPasswordChecker).to receive(:new).and_return(password_checker)
@@ -47,6 +48,16 @@ describe Y2Partitioner::Widgets::EncryptPassword do
       expect(pw1).to_not be_nil
       pw2 = contents.nested_find { |i| i.is_a?(Yast::Term) && i.params == [:pw2] }
       expect(pw2).to_not be_nil
+    end
+
+    context "when the filesystem supports random passwords" do
+      let(:filesystem_type) { Y2Storage::Filesystems::Type::SWAP }
+
+      it "includes also a radio button group to select the passsword type" do
+        contents = widget.contents
+        pw_type = contents.nested_find { |i| i.is_a?(Yast::Term) && i.params == [:pwd_type] }
+        expect(pw_type).to_not be_nil
+      end
     end
   end
 
@@ -82,11 +93,25 @@ describe Y2Partitioner::Widgets::EncryptPassword do
         widget.validate
       end
     end
-  end
 
-  describe "#help" do
-    it "returns a string" do
-      expect(widget.help).to be_a(String)
+    context "when the filesystem supports random passwords" do
+      let(:filesystem_type) { Y2Storage::Filesystems::Type::SWAP }
+
+      context "and random password was selected" do
+        it "does not check password if random password is selected" do
+           allow(Yast::UI).to receive(:QueryWidget).with(Id(:pwd_type), :Value).and_return(:random_pwd)
+           expect(password_checker).to_not receive(:error_msg)
+           widget.validate
+        end
+      end
+
+      context "and password is given" do
+        it "checkes password if random IS NOT selected" do
+           allow(Yast::UI).to receive(:QueryWidget).with(Id(:pwd_type), :Value).and_return(:manual_pwd)
+           expect(password_checker).to receive(:error_msg)
+           widget.validate
+        end
+      end
     end
   end
 
@@ -95,12 +120,55 @@ describe Y2Partitioner::Widgets::EncryptPassword do
       expect(controller).to receive(:encrypt_password=).with(pw1)
       widget.store
     end
+
+    context "when the filesystem supports random passwords" do
+      let(:filesystem_type) { Y2Storage::Filesystems::Type::SWAP }
+
+      context "and random password was selected" do
+        before do
+          allow(Yast::UI).to receive(:QueryWidget).with(Id(:pwd_type), :Value).and_return(:random_pwd)
+        end
+
+        it "does not assign password to the controller" do
+          allow(controller).to receive(:random_password=)
+          expect(controller).to_not receive(:encrypt_password=)
+          widget.store
+        end
+
+        it "sets controller#random_password to true" do
+          expect(controller).to receive(:random_password=).with(true)
+          widget.store
+        end
+      end
+
+      context "and password is given" do
+        it "assigns password to the controller" do
+          allow(Yast::UI).to receive(:QueryWidget).with(Id(:pwd_type), :Value).and_return(:manual_pwd)
+          expect(controller).to receive(:encrypt_password=).with(pw1)
+          widget.store
+        end
+      end
+    end
   end
 
   describe "#cleanup" do
     it "cleans up the password checker" do
       expect(password_checker).to receive(:tear_down)
       widget.cleanup
+    end
+  end
+
+  describe "#help" do
+    it "returns a string" do
+      expect(widget.help).to be_a(String)
+    end
+
+    context "when the filesystem supports random passwords" do
+      let(:filesystem_type) { Y2Storage::Filesystems::Type::SWAP }
+
+      it "contains information about random password option" do
+        expect(widget.help).to include('auto-generate', 'random')
+      end
     end
   end
 end

--- a/test/y2partitioner/widgets/encrypt_password_test.rb
+++ b/test/y2partitioner/widgets/encrypt_password_test.rb
@@ -29,11 +29,14 @@ describe Y2Partitioner::Widgets::EncryptPassword do
 
   include_examples "CWM::AbstractWidget"
 
-  let(:controller) { double("FilesystemController", blk_device_name: "/dev/sda1", filesystem_type: filesystem_type ) }
   let(:pw1) { "password1" }
   let(:pw2) { "password2" }
   let(:password_checker) { Y2Storage::EncryptPasswordChecker.new }
   let(:filesystem_type) { Y2Storage::Filesystems::Type::VFAT }
+
+  let(:controller) do
+    double("FilesystemController", blk_device_name: "/dev/sda1", filesystem_type: filesystem_type)
+  end
 
   before do
     allow(Y2Storage::EncryptPasswordChecker).to receive(:new).and_return(password_checker)
@@ -99,17 +102,17 @@ describe Y2Partitioner::Widgets::EncryptPassword do
 
       context "and random password was selected" do
         it "does not check password if random password is selected" do
-           allow(Yast::UI).to receive(:QueryWidget).with(Id(:pwd_type), :Value).and_return(:random_pwd)
-           expect(password_checker).to_not receive(:error_msg)
-           widget.validate
+          allow(Yast::UI).to receive(:QueryWidget).with(Id(:pwd_type), :Value).and_return(:random_pwd)
+          expect(password_checker).to_not receive(:error_msg)
+          widget.validate
         end
       end
 
       context "and password is given" do
         it "checkes password if random IS NOT selected" do
-           allow(Yast::UI).to receive(:QueryWidget).with(Id(:pwd_type), :Value).and_return(:manual_pwd)
-           expect(password_checker).to receive(:error_msg)
-           widget.validate
+          allow(Yast::UI).to receive(:QueryWidget).with(Id(:pwd_type), :Value).and_return(:manual_pwd)
+          expect(password_checker).to receive(:error_msg)
+          widget.validate
         end
       end
     end
@@ -167,7 +170,7 @@ describe Y2Partitioner::Widgets::EncryptPassword do
       let(:filesystem_type) { Y2Storage::Filesystems::Type::SWAP }
 
       it "contains information about random password option" do
-        expect(widget.help).to include('auto-generate', 'random')
+        expect(widget.help).to include("auto-generate", "random")
       end
     end
   end


### PR DESCRIPTION
Hi there!

This PR tries to resolve the bug related to encryption of swap partitions [(see it at bugzilla#1088641)](https://bugzilla.suse.com/show_bug.cgi?id=1088641),  allowing user to set the encryption password as random when filesystem supports it.

I am opening it as a request for comments because I need your feedback, opinion, and hints to finish it and, at least in this case, it seems to me a better way that shooting questions in the IRC channel. I mean, at this point maybe async feedback is a better choice.

So, let me to leave right here some questions, doubts or alternatives that I thought for which I want to know your feedback about them.

* Regarding `#finish` method in Filesystem controller, I am not happy at all with nested conditionals. I tried to extract the creation of encryption to a separated method, but it looks a little weird to have the creation in a dedicated method and the deletion directly inside the conditional. Even more, this approach continues growing the length of controller, which has a `TODO` suggesting to split and reduce it.

  An alternative could be to move the logic inside `to_be_encrypted?` branch to a new `#set_encryption` method at [BlkDevice model](https://github.com/yast/yast-storage-ng/blob/7d909a43f606a257437fa34afbe24bb09b99d332/src/lib/y2storage/blk_device.rb#L32), but I am not sure if it should be within the scope of this PR or not. In addition, I must admit that I do not know if that could collide or overlap with the [`create_encryption` factory method](https://github.com/yast/yast-storage-ng/blob/7d909a43f606a257437fa34afbe24bb09b99d332/src/lib/y2storage/fake_device_factory.rb#L542) since there are few lines doing exactly the same. Thoughts?

* I simulated the API to add the path to the password file to the crypttab in `Y2Storage::Encryption` class, adding temporary `password_file` and `password_file=` methods. Here is where I think I need the @joseivanlopez's help, as was said in the IRC channel last Friday. Isn't it?

* I am not sure if breaking the help string in two different parts is a good idea or, instead, a problem for translators.

Remember that UI was discussed in the IRC channel last Friday, when I proposed both, one [using a checkbox](https://paste.opensuse.org/29804956) and [this with radio buttons]( https://paste.opensuse.org/14479832).

Thanks in advance :)