### PR TITLE
Added dumper mocking to not break parallel tests

### DIFF
--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -74,6 +74,7 @@ RSpec.configure do |c|
   c.before do
     stub_const("Y2Packager::Repository", double("Y2Packager::Repository"))
     allow(Y2Packager::Repository).to receive(:all).and_return([])
+    allow(Y2Storage::DumpManager.instance).to receive(:dump)
   end
 
   # Some tests use ProposalSettings#new_for_current_product to initialize

--- a/test/y2storage/dump_manager_test.rb
+++ b/test/y2storage/dump_manager_test.rb
@@ -37,6 +37,10 @@ describe Y2Storage::DumpManager do
     kill_dump_dirs
   end
 
+  before do
+    allow(Y2Storage::DumpManager.instance).to receive(:dump).and_call_original
+  end
+
   subject { described_class.instance }
   let(:probed) { Y2Storage::StorageManager.instance.probed }
   let(:staging) { Y2Storage::StorageManager.instance.staging }


### PR DESCRIPTION
- This is a preparation for the upcoming `parallel_tests` support, fixes a race condition when running several tests in parallel
- Actually fixed by Ancor during the YaST workshop
- The target is SLE15-GA to less diverge from master