### PR TITLE
Run parallel jobs at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,16 @@ before_install:
     # list the installed packages (just for easier debugging)
   - docker run --rm -it yast-storage-ng-image rpm -qa | sort
 
+# define jobs running in parallel to speed up the build
+env:
+  # only the unit tests
+  - CMD='yast-travis-ruby -o tests'
+  # only rubocop
+  - CMD='yast-travis-ruby -o rubocop'
+  # the rest, -y uses "rake check:doc" instead of plain "yardoc"
+  - CMD='yast-travis-ruby -y -x tests -x rubocop'
+
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-storage-ng-image yast-travis-ruby
-  - docker run -it yast-storage-ng-image rake check:doc
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-storage-ng-image $CMD


### PR DESCRIPTION
- Speed up the build by splitting the work into separate jobs
- Run "yardoc" only once (was run two times, by `yast-travis-ruby` and then by `rake check:doc` here)
- Originally the Travis build time was 8-10 minutes, with this change the build is finished in less than 4 minutes (see [this](https://travis-ci.org/yast/yast-storage-ng/builds/389591445) and [this](https://travis-ci.org/yast/yast-storage-ng/builds/389597728) build)
- See the [related change in the Docker script](https://github.com/yast/docker-yast-ruby/pull/25)

As this only touches the `.travis.yml` file which is not packaged into the final RPM it is safe to include it also in the SLE15 branch.