### PR TITLE
Run the unit tests in parallel

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage/
 .yardoc/
 doc/autodocs
 *.pot
+tmp/parallel_runtime_rspec.log

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,1 @@
+--format progress --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun 12 13:11:07 UTC 2018 - lslezak@suse.cz
+
+- Use parallel_tests to speed up running the unit tests
+  (bsc#1094875), active only in SLE15-SP1/Leap-15.1
+
+-------------------------------------------------------------------
 Tue Jun 12 08:40:48 UTC 2018 - ancor@suse.com
 
 - Better auto-generated names for encryption devices:

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -47,6 +47,10 @@ BuildRequires:	yast2 >= 4.0.73
 BuildRequires:	yast2-ruby-bindings >= 4.0.6
 BuildRequires:	rubygem(yast-rake)
 BuildRequires:	rubygem(rspec)
+# speed up the tests in SLE15-SP1+
+%if 0%{?sle_version} >= 150100
+BuildRequires:	rubygem(parallel_tests)
+%endif
 # communicate with udisks
 BuildRequires:	rubygem(ruby-dbus)
 PreReq:         %fillup_prereq

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -53,8 +53,9 @@ if ENV["COVERAGE"]
   # track all ruby files under src
   SimpleCov.track_files("#{SRC_PATH}/lib/**/*.rb")
 
-  # use coveralls for on-line code coverage reporting at Travis CI
-  if ENV["TRAVIS"]
+  # use coveralls for on-line code coverage reporting at Travis CI,
+  # coverage in parallel tests is handled directly by the "test:unit" task
+  if ENV["TRAVIS"] && !ENV["PARALLEL_TEST_GROUPS"]
     require "coveralls"
     SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
       SimpleCov::Formatter::HTMLFormatter,


### PR DESCRIPTION
Speed up the unit tests by running them in parallel using the [parallel_tests](https://github.com/grosser/parallel_tests) gem.

- The local speed up is about `npcu`-times, i.e. with quad core CPU the speed up is about 4x (on my machine with HT enabled the speed up is ~4.4x)
- The Travis speed up is about 1.4x (4min15s -> 3min7s), the [Travis doc](https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System) says the worker has ~1.5CPU power. That's still quite a good improvement...
- This will speed up also build in OBS, the workers use `-smp 8` or even `-smp 16` KVM option, the speed up should be significant there
- This is SLE15-GA compatible change, it does not change anything in SLE15-GA, only the SLE15-SP1/Leap15.1 will be affected
- I have already submitted the required Ruby gems to Factory: [rubygem-parallel](https://build.opensuse.org/request/show/615280), [rubygem-parallel_tests](https://build.opensuse.org/request/show/615279), I'll do that for SLE15-SP1 as well...

## AI lslezak :smiley: 

- [x] Submit the gems to SP1
- [ ] Write a documentation how to use parallel_tests and parallel Travis