### PR TITLE
Fix subvolumes prefix detection when creating a filesystem

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun 11 13:26:54 UTC 2018 - igonzalezsosa@suse.com
+
+- AutoYaST: fix handling of empty Btrfs subvolume prefixes
+  (bsc#1096240).
+- 4.1.188
+
+-------------------------------------------------------------------
 Thu Jun  7 16:13:18 UTC 2018 - jlopez@suse.com
 
 - Added method to update encryption names according to a crypttab

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.187
+Version:        4.0.188
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/filesystems/btrfs.rb
+++ b/src/lib/y2storage/filesystems/btrfs.rb
@@ -360,8 +360,12 @@ module Y2Storage
       # it lives under the #top_level_btrfs_subvolume. Otherwise, an empty
       # string will be taken as the default subvolume name.
       #
+      # If the filesystem does not exists yet, consider the default Btrfs subvolume
+      # (#default_btrfs_subvolume) path as the prefix.
+      #
       # @return [String] Default subvolume name
       def subvolumes_prefix
+        return default_btrfs_subvolume.path unless exists_in_raw_probed?
         children = top_level_btrfs_subvolume.children.reject { |s| snapper_path?(s.path) }
         children.size == 1 ? children.first.path : ""
       end

--- a/src/lib/y2storage/filesystems/btrfs.rb
+++ b/src/lib/y2storage/filesystems/btrfs.rb
@@ -365,7 +365,7 @@ module Y2Storage
       #
       # @return [String] Default subvolume name
       def subvolumes_prefix
-        return default_btrfs_subvolume.path unless exists_in_raw_probed?
+        return default_btrfs_subvolume.path unless exists_in_probed?
         children = top_level_btrfs_subvolume.children.reject { |s| snapper_path?(s.path) }
         children.size == 1 ? children.first.path : ""
       end

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -777,7 +777,7 @@ describe Y2Storage::Filesystems::Btrfs do
     let(:exists?) { true }
 
     before do
-      allow(filesystem).to receive(:exists_in_raw_probed?).and_return(exists?)
+      allow(filesystem).to receive(:exists_in_probed?).and_return(exists?)
     end
 
     context "when there are no subvolumes" do

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -774,6 +774,12 @@ describe Y2Storage::Filesystems::Btrfs do
   end
 
   describe "#subvolumes_prefix" do
+    let(:exists?) { true }
+
+    before do
+      allow(filesystem).to receive(:exists_in_raw_probed?).and_return(exists?)
+    end
+
     context "when there are no subvolumes" do
       let(:dev_name) { "/dev/sda2" }
 
@@ -811,6 +817,21 @@ describe Y2Storage::Filesystems::Btrfs do
           it "returns the parent subvolume path" do
             expect(filesystem.subvolumes_prefix).to eq("@")
           end
+        end
+      end
+
+      context "when the filesystem does not exist yet" do
+        let(:exists?) { false }
+        let(:default_subvolume) do
+          instance_double(Y2Storage::BtrfsSubvolume, path: "@@")
+        end
+
+        before do
+          allow(filesystem).to receive(:default_btrfs_subvolume).and_return(default_subvolume)
+        end
+
+        it "returns the default subvolume path" do
+          expect(filesystem.subvolumes_prefix).to eq("@@")
         end
       end
     end


### PR DESCRIPTION
Fixes [bsc#https://bugzilla.suse.com/show_bug.cgi?id=1096240](https://bugzilla.suse.com/show_bug.cgi?id=1096240).