### PR TITLE
allow for numbers > 32 bit in region dialog (bsc#1065258)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 13 13:56:14 UTC 2018 - snwint@suse.com
+
+- allow for numbers > 32 bit in region dialog (bsc#1065258)
+- 4.0.191
+
+-------------------------------------------------------------------
 Tue Jun 12 16:18:40 UTC 2018 - igonzalezsosa@suse.com
 
 - Fix 'Arbitrary Option Value' translation (bsc#1081605).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.190
+Version:        4.0.191
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
libyui's IntField widget works only with 32 bits. Since the major visible
advantage over a plain InputField are the controls allowing to
increase/decrease the value by one - which is not very helpful here - I
think it's fine to use an InputField here.

I've also changed the logic for the min/max values presented: it used to
show the first and last available blocks regardless whether these belong to
the same unused region.  This runs into the problem that in nearly all cases
you run into an error if you just confirm the defaults (for instance the min
value used to be _before_ the first partition).

Instead it now shows the default (largest) region (which is always a valid