### PR TITLE
Fixed crash in the error callback when passing UTF-8 string from libstorage-ng (bsc#1096758)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 14 12:25:37 UTC 2018 - lslezak@suse.cz
+
+- Fixed crash in the error callback when the text contained
+  non-ASCII characters in the translated message (bsc#1096758)
+- 4.0.192
+
+-------------------------------------------------------------------
 Wed Jun 13 13:56:14 UTC 2018 - snwint@suse.com
 
 - allow for numbers > 32 bit in region dialog (bsc#1065258)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.191
+Version:        4.0.192
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/callbacks/libstorage_callback.rb
+++ b/src/lib/y2storage/callbacks/libstorage_callback.rb
@@ -42,6 +42,11 @@ module Y2Storage
       # user with information about every single step. Libstorage-ng is
       # already writing that information to the YaST logs.
       #
+      # @param message [String] message text (in the ASCII-8BIT encoding!,
+      #   see https://sourceforge.net/p/swig/feature-requests/89/,
+      #   it is recommended to force it to the UTF-8 encoding before
+      #   doing anything with the string to avoid the Encoding::CompatibilityError
+      #   exception!)
       # See Storage::Callbacks#message in libstorage-ng
       def message(message); end
 
@@ -57,11 +62,16 @@ module Y2Storage
       # See Storage::Callbacks#error in libstorage-ng
       #
       # @param message [String] error title coming from libstorage-ng
-      # @param what [String] details coming from libstorage-ng
+      #   (in the ASCII-8BIT encoding! see https://sourceforge.net/p/swig/feature-requests/89/)
+      # @param what [String] details coming from libstorage-ng (in the ASCII-8BIT encoding!)
       # @return [Boolean] true will make libstorage-ng ignore the error, false
       #   will result in a libstorage-ng exception
       def error(message, what)
         textdomain "storage"
+        # force the UTF-8 encoding to avoid Encoding::CompatibilityError exception (bsc#1096758)
+        message.force_encoding("UTF-8")
+        what.force_encoding("UTF-8")
+
         log.info "libstorage-ng reported an error, asking the user whether to continue"
         log.info "Error details. Message: #{message}. What: #{what}."
 

--- a/test/y2storage/callbacks/callbacks_examples.rb
+++ b/test/y2storage/callbacks/callbacks_examples.rb
@@ -29,6 +29,19 @@ RSpec.shared_examples "general #error examples" do
     subject.error("the message", "the what")
   end
 
+  # SWIG returns ASCII-8BIT encoded strings even if they contain UTF-8 characters
+  # see https://sourceforge.net/p/swig/feature-requests/89/
+  it "handles ASCII-8BIT encoded messages with UTF-8 characters" do
+    expect(Yast::Report).to receive(:yesno_popup) do |message, options|
+      expect(message).to include "🍺"
+      expect(options[:details]).to include "🍻"
+    end
+    subject.error(
+      "testing UTF-8 message: 🍺".force_encoding("ASCII-8BIT"),
+      "details: 🍻".force_encoding("ASCII-8BIT")
+    )
+  end
+
   context "with an unknown error" do
     let(:what) { "Some error\nexit code:\n 2." }
 


### PR DESCRIPTION
The strings received from libstorage have ASCII-8BIT encoding which makes troubles when it contains UTF-8 characters. Processing such strings might result in the `Encoding::CompatibilityError` exception.

See https://bugzilla.suse.com/show_bug.cgi?id=1096758