### PR TITLE
Manage Btrfs stuff when importing mount points

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jun 15 14:12:53 UTC 2018 - ancor@suse.com
+
+- Partitioner: honor default subvolumes when importing the root
+  mount point (related to bsc#1078359, bsc#1083851 and fate#318196)
+- Partitioner: honor default snapshots configuration when importing
+  the root mount point (bsc#966637)
+
+-------------------------------------------------------------------
 Thu Jun 14 12:25:37 UTC 2018 - lslezak@suse.cz
 
 - Fixed crash in the error callback when the text contained

--- a/src/lib/y2partitioner/filesystem_role.rb
+++ b/src/lib/y2partitioner/filesystem_role.rb
@@ -115,30 +115,8 @@ module Y2Partitioner
     # @param device [Y2Storage::BlkDevice] device being created and formatted
     # @return [Boolean]
     def snapper?(device)
-      return false if id != :system || device.filesystem_mountpoint.nil?
-
-      spec = Y2Storage::VolumeSpecification.for(device.filesystem_mountpoint)
-      return false unless spec
-
-      snapper_for_spec?(spec, device)
-    end
-
-  protected
-
-    # @see #snapper?
-    #
-    # @param spec [Y2Storage::VolumeSpecification]
-    # @param device [Y2Storage::BlkDevice]
-    def snapper_for_spec?(spec, device)
-      if spec.snapshots
-        if spec.snapshots_configurable # maybe check also disable_order
-          device.size >= spec.min_size_with_snapshots
-        else
-          true
-        end
-      else
-        false
-      end
+      return false if id != :system || device.filesystem.nil?
+      device.filesystem.default_configure_snapper?
     end
   end
 end

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -142,6 +142,26 @@ module Y2Storage
         end
       end
 
+      # Whether it makes sense modify the attribute about snapper configuration
+      #
+      # @see Y2Storage::Filesystems::Btrfs.configure_snapper
+      #
+      # @return [Boolean]
+      def can_configure_snapper?
+        root? && respond_to?(:configure_snapper=)
+      end
+
+      # Volume specification that applies for this filesystem
+      #
+      # @see Y2Storage::VolumeSpecification.for
+      #
+      # @return [Y2Storage::VolumeSpecification, nil] nil if no specification
+      #   matches the filesystem
+      def volume_specification
+        return nil unless mount_point
+        Y2Storage::VolumeSpecification.for(mount_point.path)
+      end
+
     protected
 
       def types_for_is

--- a/src/lib/y2storage/filesystems/btrfs.rb
+++ b/src/lib/y2storage/filesystems/btrfs.rb
@@ -400,6 +400,34 @@ module Y2Storage
         mount_by
       end
 
+      # Default value for #configure_snapper, according to system configuration
+      #
+      # @return [Boolean]
+      def default_configure_snapper?
+        return false unless volume_specification
+
+        # FIXME: this is not ready for multi-device Btrfs (blk_devices.first)
+        volume_specification.snapper_for_device?(blk_devices.first)
+      end
+
+      # Creates the default subvolumes setup for a newly created filesystem,
+      # according to the volumes specification.
+      #
+      # The default subvolume is created first and then the proposed subvolumes are added.
+      #
+      # A proposed subvolume is added only when it does not exist in the filesystem and it
+      # makes sense for the current architecture.
+      #
+      # @see #ensure_default_btrfs_subvolume
+      # @see #add_btrfs_subvolumes
+      def setup_default_btrfs_subvolumes
+        spec = volume_specification
+        return unless spec
+
+        ensure_default_btrfs_subvolume(path: spec.btrfs_default_subvolume)
+        add_btrfs_subvolumes(spec.subvolumes) if spec.subvolumes
+      end
+
     protected
 
       # Removes a subvolume

--- a/src/lib/y2storage/volume_specification.rb
+++ b/src/lib/y2storage/volume_specification.rb
@@ -227,6 +227,7 @@ module Y2Storage
     # this specification to a given block device
     #
     # @param device [Y2Storage::BlkDevice]
+    # @return [Boolean]
     def snapper_for_device?(device)
       if snapshots
         if snapshots_configurable # maybe check also disable_order

--- a/src/lib/y2storage/volume_specification.rb
+++ b/src/lib/y2storage/volume_specification.rb
@@ -223,6 +223,22 @@ module Y2Storage
       end
     end
 
+    # Whether snapper configuration should be activated by default when applying
+    # this specification to a given block device
+    #
+    # @param device [Y2Storage::BlkDevice]
+    def snapper_for_device?(device)
+      if snapshots
+        if snapshots_configurable # maybe check also disable_order
+          device.size >= min_size_with_snapshots
+        else
+          true
+        end
+      else
+        false
+      end
+    end
+
   private
 
     FEATURES = {

--- a/test/y2partitioner/actions/controllers/filesystem_test.rb
+++ b/test/y2partitioner/actions/controllers/filesystem_test.rb
@@ -29,6 +29,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
     allow(Y2Storage::VolumeSpecification).to receive(:for).and_call_original
     allow(Y2Storage::VolumeSpecification).to receive(:for).with("/")
       .and_return(volume_spec)
+    allow(volume_spec).to receive(:subvolumes).and_return subvolumes
   end
 
   let(:scenario) { "mixed_disks_btrfs" }
@@ -42,10 +43,10 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
   let(:dev_name) { "/dev/sda2" }
 
   let(:volume_spec) do
-    instance_double(Y2Storage::VolumeSpecification,
-      btrfs_default_subvolume: default_subvolume,
-      subvolumes:              subvolumes,
-      btrfs_read_only?:        false)
+    Y2Storage::VolumeSpecification.new(
+      "btrfs_default_subvolume" => default_subvolume,
+      "btrfs_read_only"         => false
+    )
   end
 
   let(:default_subvolume) { "" }


### PR DESCRIPTION
Part of https://trello.com/c/S2PrGCQz/388-ostumbleweed-p5-1094924-partition-imported-during-installation-would-all-be-formatted-by-default

Review commit by commit.

Manually tested: works as expected.