### PR TITLE
AutoYaST: fix exporting of BIOS RAIDs (bsc#1098594)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 18 11:38:39 UTC 2018 - ancor@suse.com
+
+- AutoYaST: export BIOS RAID devices correctly (bsc#1098594).
+- 4.0.197
+
+-------------------------------------------------------------------
 Mon Jul 16 16:26:28 UTC 2018 - ancor@suse.com
 
 - AutoYaST: do not crash when reusing partitions on non-disk

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.196
+Version:        4.0.197
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -151,7 +151,7 @@ module Y2Storage
       #   <drive> section, like a disk, a DASD or an LVM volume group.
       # @return [Boolean] if attributes were successfully read; false otherwise.
       def init_from_device(device)
-        if device.is?(:md)
+        if device.is?(:software_raid)
           init_from_md(device)
         elsif device.is?(:lvm_vg)
           init_from_vg(device)

--- a/src/lib/y2storage/autoinst_profile/partitioning_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partitioning_section.rb
@@ -83,7 +83,7 @@ module Y2Storage
       def self.new_from_storage(devicegraph)
         result = new
         # TODO: consider also NFS and TMPFS
-        devices = devicegraph.md_raids + devicegraph.lvm_vgs + devicegraph.disk_devices
+        devices = devicegraph.software_raids + devicegraph.lvm_vgs + devicegraph.disk_devices
         result.drives = devices.each_with_object([]) do |dev, array|
           drive = DriveSection.new_from_storage(dev)
           array << drive if drive

--- a/test/y2partitioner/clients/main_test.rb
+++ b/test/y2partitioner/clients/main_test.rb
@@ -116,6 +116,11 @@ describe Y2Partitioner::Clients::Main do
 
           before do
             allow(partitioner_dialog).to receive(:device_graph).and_return(device_graph)
+
+            allow(Yast::Execute).to receive(:locally!)
+              .with("/sbin/udevadm", any_args)
+            allow(Yast::Execute).to receive(:locally!)
+              .with("/usr/lib/YaST2/bin/mask-systemd-units", any_args)
           end
 
           let(:device_graph) { instance_double(Y2Storage::Devicegraph) }

--- a/test/y2storage/autoinst_profile/partitioning_section_test.rb
+++ b/test/y2storage/autoinst_profile/partitioning_section_test.rb
@@ -62,42 +62,61 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
   end
 
   describe ".new_from_storage" do
-    let(:devicegraph) do
-      instance_double(
-        Y2Storage::Devicegraph, disk_devices: disks, lvm_vgs: [vg], md_raids: [md]
-      )
-    end
-    let(:disks) { [disk, dasd] }
-    let(:disk) { instance_double(Y2Storage::Disk) }
-    let(:dasd) { instance_double(Y2Storage::Dasd) }
-    let(:vg) { instance_double(Y2Storage::LvmVg) }
-    let(:md) { instance_double(Y2Storage::Md) }
+    describe "using doubles for the devicegraph and the subsections" do
+      let(:devicegraph) do
+        instance_double(
+          Y2Storage::Devicegraph, disk_devices: disks, lvm_vgs: [vg], md_raids: [md]
+        )
+      end
+      let(:disks) { [disk, dasd] }
+      let(:disk) { instance_double(Y2Storage::Disk) }
+      let(:dasd) { instance_double(Y2Storage::Dasd) }
+      let(:vg) { instance_double(Y2Storage::LvmVg) }
+      let(:md) { instance_double(Y2Storage::Md) }
 
-    before do
-      allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
-        .with(disk).and_return(disk_section)
-      allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
-        .with(dasd).and_return(dasd_section)
-      allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
-        .with(vg).and_return(vg_section)
-      allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
-        .with(md).and_return(md_section)
+      before do
+        allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
+          .with(disk).and_return(disk_section)
+        allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
+          .with(dasd).and_return(dasd_section)
+        allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
+          .with(vg).and_return(vg_section)
+        allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
+          .with(md).and_return(md_section)
+      end
+
+      it "returns a new PartitioningSection object" do
+        expect(described_class.new_from_storage(devicegraph)).to be_a(described_class)
+      end
+
+      it "creates an entry in #drives for every relevant VG, disk and DASD" do
+        section = described_class.new_from_storage(devicegraph)
+        expect(section.drives).to eq([md_section, vg_section, disk_section, dasd_section])
+      end
+
+      it "ignores irrelevant drives" do
+        allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
+          .with(disk).and_return(nil)
+        section = described_class.new_from_storage(devicegraph)
+        expect(section.drives).to eq([md_section, vg_section, dasd_section])
+      end
     end
 
-    it "returns a new PartitioningSection object" do
-      expect(described_class.new_from_storage(devicegraph)).to be_a(described_class)
-    end
+    # Regression test for bug#1098594, BIOS RAIDs were exported as
+    # software-defined ones
+    context "with a BIOS MD RAID in the system" do
+      before do
+        fake_scenario("bug_1098594.xml")
+      end
 
-    it "creates an entry in #drives for every relevant VG, disk and DASD" do
-      section = described_class.new_from_storage(devicegraph)
-      expect(section.drives).to eq([md_section, vg_section, disk_section, dasd_section])
-    end
+      it "creates only one entry in #drives, of type CT_DISK, for the BIOS RAID" do
+        section = described_class.new_from_storage(fake_devicegraph)
+        expect(section.drives.size).to eq 1
 
-    it "ignores irrelevant drives" do
-      allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
-        .with(disk).and_return(nil)
-      section = described_class.new_from_storage(devicegraph)
-      expect(section.drives).to eq([md_section, vg_section, dasd_section])
+        drive = section.drives.first
+        expect(drive.device).to eq "/dev/md/Volume0_0"
+        expect(drive.type).to eq :CT_DISK
+      end
     end
   end
 

--- a/test/y2storage/autoinst_profile/partitioning_section_test.rb
+++ b/test/y2storage/autoinst_profile/partitioning_section_test.rb
@@ -65,7 +65,7 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
     describe "using doubles for the devicegraph and the subsections" do
       let(:devicegraph) do
         instance_double(
-          Y2Storage::Devicegraph, disk_devices: disks, lvm_vgs: [vg], md_raids: [md]
+          Y2Storage::Devicegraph, disk_devices: disks, lvm_vgs: [vg], software_raids: [md]
         )
       end
       let(:disks) { [disk, dasd] }


### PR DESCRIPTION
Second part of https://trello.com/c/BEBfAZTf/142-1-p2-1098594-support-for-bios-defined-md-in-autoyast

It also includes a commit to add a mock that was missing in the testsuite (it was trying to fiddle with udevadm).