### PR TITLE
use "Partition Table" instead of "Disk Label" (bsc#1070570)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -3,7 +3,7 @@ Wed Jul 25 21:41:48 CEST 2018 - aschnell@suse.com
 
 - use "Partition Table" instead of "Disk Label" in expert
   partitioner (bsc#1070570)
-- 4.0.200
+- 4.1.0
 
 -------------------------------------------------------------------
 Mon Jul 23 13:55:03 UTC 2018 - snwint@suse.com

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 25 21:41:48 CEST 2018 - aschnell@suse.com
+
+- use "Partition Table" instead of "Disk Label" in expert
+  partitioner (bsc#1070570)
+- 4.0.200
+
+-------------------------------------------------------------------
 Mon Jul 23 13:55:03 UTC 2018 - snwint@suse.com
 
 - document XEN guest setup for testing (bsc#1085134)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.0.200
+Version:	4.1.0
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.199
+Version:	4.0.200
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/widgets/blk_device_attributes.rb
+++ b/src/lib/y2partitioner/widgets/blk_device_attributes.rb
@@ -150,7 +150,7 @@ module Y2Partitioner
 
         # TRANSLATORS: partition table type information, where %s is replaced by
         # a partition table type (e.g., GPT, MS-DOS)
-        format(_("Disk Label: %s"), label)
+        format(_("Partition Table: %s"), label)
       end
 
       # Information about the filesystem type

--- a/src/lib/y2partitioner/widgets/help.rb
+++ b/src/lib/y2partitioner/widgets/help.rb
@@ -31,8 +31,8 @@ module Y2Partitioner
 
         device:           N_("<b>Device</b> shows the kernel name of the\ndevice."),
 
-        disk_label:       N_("<b>Disk Label</b> shows the partition table\ntype of the disk, " \
-              "e.g <tt>MSDOS</tt> or <tt>GPT</tt>."),
+        disk_label:       N_("<b>Partition Table</b> shows the partition table\ntype of the disk, " \
+              "e.g <tt>MS-DOS</tt> or <tt>GPT</tt>."),
 
         encrypted:        N_("<b>Encrypted</b> shows whether the device is\nencrypted."),
 


### PR DESCRIPTION
For https://trello.com/c/0ygAghdd/15-sles15-p3-1070570-yast-partitioner-names-the-partition-table-disk-label.