### PR TITLE
make bsc#1098594 regression test work on s390

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 26 11:16:27 UTC 2018 - snwint@suse.com
+
+- make bsc#1098594 regression test work on s390
+- 4.0.200
+
+-------------------------------------------------------------------
 Mon Jul 23 13:55:03 UTC 2018 - snwint@suse.com
 
 - document XEN guest setup for testing (bsc#1085134)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.199
+Version:        4.0.200
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -204,7 +204,7 @@ module Y2Storage
         return false if disk.partitions.empty?
 
         @type = :CT_DISK
-        # FIXME: could anyone with knowledge leave a comment why s390 is special here?
+        # s390 prefers udev by-path device names (bsc#591603)
         @device = Yast::Arch.s390 ? disk.udev_full_paths.first : disk.name
         # if disk.udev_full_paths.first is nil go for disk.name anyway
         @device ||= disk.name

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -204,7 +204,10 @@ module Y2Storage
         return false if disk.partitions.empty?
 
         @type = :CT_DISK
+        # FIXME: could anyone with knowledge leave a comment why s390 is special here?
         @device = Yast::Arch.s390 ? disk.udev_full_paths.first : disk.name
+        # if disk.udev_full_paths.first is nil go for disk.name anyway
+        @device ||= disk.name
         @disklabel = disk.partition_table.type.to_s
 
         @partitions = partitions_from_disk(disk)


### PR DESCRIPTION
This fixes the bsc#1098594 regression unit test in [partitioning_section_test.rb](../tree/SLE-15-GA/test/y2storage/autoinst_profile/partitioning_section_test.rb#L105) as otherwise `drive.device` would be nil on s390.