### PR TITLE
Fix the check about a manual staging (bsc#1055756)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Aug 10 11:56:40 UTC 2018 - ancor@suse.com
+
+- Fixed the warning about overwriting a manually edited partition
+  layout. Now it works even after going back and forth in the
+  installer steps (bsc#1055756).
+- 4.0.204
+
+-------------------------------------------------------------------
 Thu Aug  9 15:43:17 UTC 2018 - ancor@suse.com
 
 - Partitioner: display Xen virtual partitions and allow to format

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.203
+Version:        4.0.204
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
The old fix was not working if the user went back and forth in the installer because the status was tracked in an extra instance variable, instead of checking the already existing variables that are always properly initialized.

See https://github.com/yast/yast-storage-ng/pull/697#discussion_r207894154 for details.