### PR TITLE
Partitioner: fix heading strings and comments

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 13 14:44:32 UTC 2018 - ancor@suse.com
+
+- Partitioner: fixed some strings that contained mistakes about
+  format and/or internationalization.
+
+-------------------------------------------------------------------
 Fri Aug 10 11:56:40 UTC 2018 - ancor@suse.com
 
 - Fixed the warning about overwriting a manually edited partition

--- a/src/lib/y2partitioner/widgets/pages/disk.rb
+++ b/src/lib/y2partitioner/widgets/pages/disk.rb
@@ -71,6 +71,7 @@ module Y2Partitioner
             Left(
               HBox(
                 Image(icon, ""),
+                # TRANSLATORS: Heading. String followed by device name of hard disk
                 Heading(format(_("Hard Disk: %s"), disk.name))
               )
             ),

--- a/src/lib/y2partitioner/widgets/pages/disks.rb
+++ b/src/lib/y2partitioner/widgets/pages/disks.rb
@@ -62,8 +62,8 @@ module Y2Partitioner
             Left(
               HBox(
                 Image(icon, ""),
-                # TRANSLATORS: Heading. String followed by name of partition
-                Heading(_("Hard Disks "))
+                # TRANSLATORS: Heading
+                Heading(_("Hard Disks"))
               )
             ),
             table,

--- a/src/lib/y2partitioner/widgets/pages/partition.rb
+++ b/src/lib/y2partitioner/widgets/pages/partition.rb
@@ -64,7 +64,7 @@ module Y2Partitioner
               HBox(
                 Image(icon, ""),
                 # TRANSLATORS: Heading. String followed by name of partition
-                Heading(format(_("Partition: "), @partition.name))
+                Heading(format(_("Partition: %s"), @partition.name))
               )
             ),
             PartitionDescription.new(@partition),

--- a/src/lib/y2partitioner/widgets/pages/stray_blk_device.rb
+++ b/src/lib/y2partitioner/widgets/pages/stray_blk_device.rb
@@ -57,7 +57,9 @@ module Y2Partitioner
             Left(
               HBox(
                 Image(icon, ""),
-                Heading(device.name)
+                # TRANSLATORS: Heading for a generic storage device
+                # TRANSLATORS: String followed by name of the storage device
+                Heading(format(_("Device: %s"), device.name))
               )
             ),
             BlkDeviceDescription.new(device),


### PR DESCRIPTION
Some stuff found during https://trello.com/c/EqN6jm0m/172-5-sles15-p3-1085134-cannot-install-when-using-xen-virtual-partitions-xvda1xvda2 that was not worth fixing in the SLE-15-GA branch due to i18n overhead.