### PR TITLE
Hide windows actions if there are no windows partitions

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 22 21:45:06 UTC 2018 - knut.anderssen@suse.com
+
+- Partitioner: Hide the "what to do" selector for windows
+  partitions if there are no windows partitions (bsc#1055646)
+- 4.1.9
+
+-------------------------------------------------------------------
 Wed Aug 22 16:56:53 CEST 2018 - schubi@suse.de
 
 - Switched license in spec file from SPDX2 to SPDX3 format.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.8
+Version:	4.1.9
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/dialogs/guided_setup/select_root_disk.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_root_disk.rb
@@ -55,8 +55,7 @@ module Y2Storage
             VBox(
               root_selection_widget,
               VSpacing(1),
-              windows_action_widget,
-              VSpacing(1),
+              *(activate_windows_actions? ? [windows_action_widget, VSpacing(1)] : [Empty()]),
               linux_delete_mode_widget,
               VSpacing(1),
               other_delete_mode_widget
@@ -143,8 +142,7 @@ module Y2Storage
           widget = settings.root_device || :any_disk
           widget_update(widget, true)
 
-          widget_update(:windows_action, windows_action)
-          widget_update(:windows_action, activate_windows_actions?, attr: :Enabled)
+          widget_update(:windows_action, windows_action) if activate_windows_actions?
 
           widget_update(:linux_delete_mode, settings.linux_delete_mode)
           widget_update(:linux_delete_mode, activate_linux_delete_mode?, attr: :Enabled)
@@ -160,6 +158,12 @@ module Y2Storage
           settings.linux_delete_mode = widget_value(:linux_delete_mode)
           settings.other_delete_mode = widget_value(:other_delete_mode)
 
+          update_windows_settings if activate_windows_actions?
+        end
+
+      private
+
+        def update_windows_settings
           case widget_value(:windows_action)
           when :not_modify
             settings.resize_windows = false
@@ -175,8 +179,6 @@ module Y2Storage
             settings.windows_delete_mode = :all
           end
         end
-
-      private
 
         def candidate_disks
           return @candidate_disks if @candidate_disks

--- a/test/support/guided_setup_context.rb
+++ b/test/support/guided_setup_context.rb
@@ -31,6 +31,13 @@ Yast.import "Report"
 RSpec.shared_context "guided setup requirements" do
   include Yast::UIShortcuts
 
+  def term_with_id(regexp, content)
+    content.nested_find do |nested|
+      next unless nested.is_a?(Yast::Term)
+      nested.params.any? { |i| i.is_a?(Yast::Term) && i.value == :id && regexp.match?(i.params.first) }
+    end
+  end
+
   def expect_select(id, value = true)
     expect(Yast::UI).to receive(:ChangeWidget).once.with(Id(id), :Value, value)
   end


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/VnLlG6Lp/13-sles15-p2-1055646-storageng-guided-setup-select-hard-disks-what-to-do-with-windows)
- [Bugzilla](https://bugzilla.suse.com/show_bug.cgi?id=1055646)

## No windows partition present

![nowindowspartitions](https://user-images.githubusercontent.com/7056681/44519583-52a34500-a6c5-11e8-8043-2fe540716418.png)

## Windows partition is present
![withwindowspartitions](https://user-images.githubusercontent.com/7056681/44522361-2d670480-a6ce-11e8-82ef-597e31d8304e.png)
