### PR TITLE
Fix inconsistent test environment (and improve wording) 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Aug 28 13:27:53 UTC 2018 - ancor@suse.com
+
+- Fixed a wrong unit test.
+
+-------------------------------------------------------------------
 Fri Aug 24 12:43:32 UTC 2018 - mvidner@suse.com
 
 - RAID attributes: include "Active: Yes/No" (bsc#1090010)

--- a/test/y2partitioner/actions/controllers/filesystem_test.rb
+++ b/test/y2partitioner/actions/controllers/filesystem_test.rb
@@ -874,6 +874,9 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
 
     context "and there are subvolumes defined for the given mount point" do
       let(:subvolumes) { Y2Storage::SubvolSpecification.fallback_list }
+      # The default subvolume must be consistent with the list of subvolumes.
+      # The fallback list contains "@" and expects it to be the default.
+      let(:default_subvolume) { "@" }
 
       before do
         # Make sure there is no other mount points
@@ -935,7 +938,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
         include_examples "does nothing"
       end
 
-      context "and the filesystem has no a mount point" do
+      context "and the filesystem has no previous mount point" do
         before do
           device.filesystem.remove_mount_point
         end


### PR DESCRIPTION
To fix the build failure at https://build.opensuse.org/project/show/openSUSE:Factory:Staging:G

It's only failing in master (TW) because the libstorage-ng version in SLE-15 somehow hides the mistake, but I believe it's worth fixing the test also in the SLE-15-GA branch for consistency.