### PR TITLE
Try to unmount devices for some actions

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Sep 19 13:19:58 UTC 2018 - jlopez@suse.com
+
+- Partitioner: ask for unmounting when deleting a device.
+- Partitioner: ask for unmounting when resizing a device.
+- Part of fate#318196
+- 4.0.212
+
+-------------------------------------------------------------------
 Tue Sep 18 13:00:29 UTC 2018 - jlopez@suse.com
 
 - AutoYaST: Allow to use whole disk as PV by indicating a partition

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -22,8 +22,8 @@ Release:	0
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build
 Source:		%{name}-%{version}.tar.bz2
 
-# CWM::Dialog#abort_handler
-Requires:	yast2 >= 4.0.73
+# CWM::Dialog#next_handler
+Requires:	yast2 >= 4.0.87
 # for AbortException and handle direct abort
 Requires:	yast2-ruby-bindings >= 4.0.6
 # Storage::StrayBlkDevice
@@ -43,8 +43,8 @@ BuildRequires:	yast2-devtools
 # yast2-xml dependency is added by yast2 but ignored in the
 # openSUSE:Factory project config
 BuildRequires:  yast2-xml
-# CWM::Dialog#abort_handler
-BuildRequires:	yast2 >= 4.0.73
+# CWM::Dialog#next_handler
+BuildRequires:	yast2 >= 4.0.87
 # for AbortException and handle direct abort
 BuildRequires:	yast2-ruby-bindings >= 4.0.6
 BuildRequires:	rubygem(yast-rake)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.211
+Version:        4.0.212
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/actions/controllers/blk_device.rb
+++ b/src/lib/y2partitioner/actions/controllers/blk_device.rb
@@ -28,6 +28,10 @@ module Y2Partitioner
     module Controllers
       # This class offers helper methods to perform actions over a block device,
       # for example, to check if its filesystem exists on disk, it is mounted, etc.
+      #
+      # @note Several methods in this class use the term "committed" to refer to the
+      #   device in the system. For example, committed_device would be the real device
+      #   as it is currently in the system (its version in memory could be different).
       class BlkDevice
         # Block device
         #
@@ -41,7 +45,8 @@ module Y2Partitioner
         # @param device [Y2Storage::BlkDevice] it has to be a block device,
         #   (i.e., device#is?(:blk_device) #=> true).
         def initialize(device)
-          raise(TypeError, "param device has to be a block device") unless device.is?(:blk_device)
+          wrong_param = !device.respond_to?(:is?) || !device.is?(:blk_device)
+          raise(TypeError, "param device has to be a block device") if wrong_param
 
           @device = device
         end
@@ -111,7 +116,7 @@ module Y2Partitioner
         #   it does not support mounted shrink.
         #
         # @return [Boolean]
-        def need_unmount_for_shrinking?
+        def unmount_for_shrinking?
           return false unless mounted_committed_filesystem?
 
           !committed_filesystem.supports_mounted_shrink?
@@ -123,7 +128,7 @@ module Y2Partitioner
         #   it does not support mounted grow.
         #
         # @return [Boolean]
-        def need_unmount_for_growing?
+        def unmount_for_growing?
           return false unless mounted_committed_filesystem?
 
           !committed_filesystem.supports_mounted_grow?

--- a/src/lib/y2partitioner/actions/controllers/blk_device.rb
+++ b/src/lib/y2partitioner/actions/controllers/blk_device.rb
@@ -1,0 +1,147 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage"
+require "y2partitioner/device_graphs"
+
+module Y2Partitioner
+  module Actions
+    module Controllers
+      # This class offers helper methods to perform actions over a block device,
+      # for example, to check if its filesystem exists on disk, it is mounted, etc.
+      class BlkDevice
+        # Block device
+        #
+        # @return [Y2Storage::BlkDevice]
+        attr_reader :device
+
+        # Constructor
+        #
+        # @raise [TypeError] if device is not a block device.
+        #
+        # @param device [Y2Storage::BlkDevice] it has to be a block device,
+        #   (i.e., device#is?(:blk_device) #=> true).
+        def initialize(device)
+          raise(TypeError, "param device has to be a block device") unless device.is?(:blk_device)
+
+          @device = device
+        end
+
+        # Whether the current filesystem of the device exists on the system
+        #
+        # @note The device could have a new filesystem that does not match to the real filesystem
+        #   that actually exists on disk (e.g., after formatting the device).
+        #
+        # @return [Boolean]
+        def committed_current_filesystem?
+          return false unless device.formatted?
+
+          committed_filesystem? &&
+            committed_filesystem.sid == device.filesystem.sid
+        end
+
+        # Whether the filesystem of the device exists on the system and it is mounted
+        #
+        # @note The filesystem on system is checked, independently of it matches to the current
+        #   filesystem of the device.
+        #
+        # @return [Boolean]
+        def mounted_committed_filesystem?
+          return false unless committed_filesystem?
+
+          mount_point = committed_filesystem.mount_point
+
+          !mount_point.nil? && mount_point.active?
+        end
+
+        # Whether the device exists on the system
+        #
+        # @return [Boolean] true if the device exists on disk; false otherwise.
+        def committed_device?
+          !committed_device.nil?
+        end
+
+        # Device taken from the system devicegraph
+        #
+        # @return [Y2Storage::BlkDevice, nil] nil if the device does not exist on disk yet.
+        def committed_device
+          @committed_device ||= system_devicegraph.find_device(device.sid)
+        end
+
+        # Whether the committed device is formatted (see {#committed_device})
+        #
+        # @return [Boolean] true if the device exists on disk and it is formatted;
+        #   false otherwise.
+        def committed_filesystem?
+          !committed_filesystem.nil?
+        end
+
+        # Filesystem of the committed device (see {#committed_device})
+        #
+        # @return [Y2Storage::BlkFilesystem, nil] nil if the device does not exist on disk or
+        #   it is not formatted.
+        def committed_filesystem
+          return nil unless committed_device?
+
+          committed_device.filesystem
+        end
+
+        # Whether the device needs to be unmounted to resize it (shrink)
+        #
+        # @note The filesystem must be unmounted when it exists on disk, it is mounted and
+        #   it does not support mounted shrink.
+        #
+        # @return [Boolean]
+        def need_unmount_for_shrinking?
+          return false unless mounted_committed_filesystem?
+
+          !committed_filesystem.supports_mounted_shrink?
+        end
+
+        # Whether the device needs to be unmounted to resize it (grow)
+        #
+        # @note The filesystem must be unmounted when it exists on disk, it is mounted and
+        #   it does not support mounted grow.
+        #
+        # @return [Boolean]
+        def need_unmount_for_growing?
+          return false unless mounted_committed_filesystem?
+
+          !committed_filesystem.supports_mounted_grow?
+        end
+
+      private
+
+        # Devicegraph that represents the current version of the devices in the system
+        #
+        # @note To check whether a filesystem is currently mounted, it must be checked
+        #   in the system devicegraph. When a mount point is "immediate deactivated", the
+        #   mount point is set as inactive only in the system devicegraph.
+        #
+        # @return [Y2Storage::Devicegraph]
+        def system_devicegraph
+          Y2Storage::StorageManager.instance.system
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/actions/resize_blk_device.rb
+++ b/src/lib/y2partitioner/actions/resize_blk_device.rb
@@ -23,6 +23,8 @@ require "yast"
 require "yast/i18n"
 require "y2partitioner/dialogs/blk_device_resize"
 require "y2partitioner/ui_state"
+require "y2partitioner/immediate_unmount"
+require "y2partitioner/actions/controllers/blk_device"
 
 Yast.import "Popup"
 
@@ -32,6 +34,7 @@ module Y2Partitioner
     class ResizeBlkDevice
       include Yast::Logger
       include Yast::I18n
+      include ImmediateUnmount
 
       # Constructor
       #
@@ -40,17 +43,20 @@ module Y2Partitioner
         textdomain "storage"
 
         @device = device
+        @controller = Controllers::BlkDevice.new(device)
+
         UIState.instance.select_row(device)
       end
 
-      # Checks whether it is possible to resize the device, and if so,
-      # the action is performed.
+      # Checks whether it is possible to resize the device, and if so, the action is performed.
+      # It also checks whether the device needs to be unmounted before resizing (e.g., NTFS).
+      # When unmounted device is required, it offers the option for unmounting it.
       #
       # @note An error popup is shown when the device cannot be resized.
       #
       # @return [Symbol, nil]
       def run
-        return :back unless validate
+        return :back unless try_unmount && validate
         resize
       end
 
@@ -59,11 +65,14 @@ module Y2Partitioner
       # @return [Y2Storage::Partition, Y2Storage::LvmLv] device to resize
       attr_reader :device
 
+      # @return [Y2Partitioner::Actions::Controllers::BlkDevice] controller for a block device
+      attr_reader :controller
+
       # Runs the dialog to resize the device
       #
       # @return [Symbol] :finish if the dialog returns :next; dialog result otherwise.
       def resize
-        result = Dialogs::BlkDeviceResize.run(device)
+        result = Dialogs::BlkDeviceResize.run(controller)
 
         result == :next ? :finish : result
       end
@@ -127,6 +136,33 @@ module Y2Partitioner
         msg_lines = [_("This device cannot be resized:"), ""]
         msg_lines.concat(device.resize_info.reason_texts)
         msg_lines.join("\n")
+      end
+
+      # Tries to unmount the device, if it is required.
+      #
+      # It asks the user for immediate unmount the device, see {#immediate_unmount}.
+      #
+      # @return [Boolean] true if it is not required to unmount or the device was correctly
+      #   unmounted; false when user cancels.
+      def try_unmount
+        return true unless need_try_unmount?
+
+        # TRANSLATORS: Note added to the dialog for trying to unmount a device
+        note = _("It is not possible to check whether a NTFS\ncan be resized while it is mounted.")
+
+        immediate_unmount(controller.committed_device, note: note, allow_continue: false)
+      end
+
+      # Whether it is necessary to try unmount
+      #
+      # Unmount is needed when the current filesystem is NTFS, it exists on disk and it is mounted.
+      # NTFS tools require the filesystem be unmounted.
+      #
+      # @return [Boolean]
+      def need_try_unmount?
+        controller.committed_current_filesystem? &&
+          controller.mounted_committed_filesystem? &&
+          controller.committed_filesystem.type.is?(:ntfs)
       end
     end
   end

--- a/src/lib/y2partitioner/actions/resize_blk_device.rb
+++ b/src/lib/y2partitioner/actions/resize_blk_device.rb
@@ -148,7 +148,7 @@ module Y2Partitioner
         return true unless need_try_unmount?
 
         # TRANSLATORS: Note added to the dialog for trying to unmount a device
-        note = _("It is not possible to check whether a NTFS\ncan be resized while it is mounted.")
+        note = _("It is not possible to check whether an NTFS\ncan be resized while it is mounted.")
 
         immediate_unmount(controller.committed_device, note: note, allow_continue: false)
       end

--- a/src/lib/y2partitioner/actions/resize_blk_device.rb
+++ b/src/lib/y2partitioner/actions/resize_blk_device.rb
@@ -148,7 +148,7 @@ module Y2Partitioner
         return true unless need_try_unmount?
 
         # TRANSLATORS: Note added to the dialog for trying to unmount a device
-        note = _("It is not possible to check whether an NTFS\ncan be resized while it is mounted.")
+        note = _("It is not possible to check whether a NTFS\ncan be resized while it is mounted.")
 
         immediate_unmount(controller.committed_device, note: note, allow_continue: false)
       end

--- a/src/lib/y2partitioner/dialogs/blk_device_resize.rb
+++ b/src/lib/y2partitioner/dialogs/blk_device_resize.rb
@@ -219,17 +219,23 @@ module Y2Partitioner
       def try_unmount_for_big_growing
         return true unless big_growing? && controller.mounted_committed_filesystem?
 
-        message = format(
+        message = Yast::Builtins.sformat(
           # TRANSLATORS: Text for the dialog for trying to unmount a device. It is used
-          # when a device is tried to be resized by extending it too much.
-          _("You are extending a mounted filesystem by %{gibs} Gigabyte.\n" \
+          # when a device is tried to be resized by extending it too much. %1 is replaced
+          # by a number that represents the amount of GiB to extend (e.g., 56).
+          _(
+            "You are extending a mounted filesystem by %1 Gigabyte. \n" \
             "This may be quite slow and can take hours. You might possibly want \n" \
             "to consider umounting the filesystem, which will increase speed of \n" \
-            "resize task a lot.\n\n" \
-            "You can try to unmount it now, continue without unmounting or cancel.\n" \
-            "Click Cancel unless you know exactly what you are doing."),
-          gibs: growing_size.to_i / Y2Storage::DiskSize.GiB(1).to_i
+            "resize task a lot."
+          ),
+          growing_size.to_i / Y2Storage::DiskSize.GiB(1).to_i
         )
+
+        message += "\n\n" +
+          # TRANSLATORS: Actions explanation when trying to unmount
+          _("You can try to unmount it now, continue without unmounting or cancel.\n" \
+            "Click Cancel unless you know exactly what you are doing.")
 
         immediate_unmount(controller.committed_device, full_message: message, allow_continue: true)
       end

--- a/src/lib/y2partitioner/dialogs/blk_device_resize.rb
+++ b/src/lib/y2partitioner/dialogs/blk_device_resize.rb
@@ -221,7 +221,7 @@ module Y2Partitioner
 
         message = format(
           # TRANSLATORS: Text for the dialog for trying to unmount a device. It is used
-          # when a device is tried to be resized by growing it more than 1 GiB.
+          # when a device is tried to be resized by extending it too much.
           _("You are extending a mounted filesystem by %{gibs} Gigabyte.\n" \
             "This may be quite slow and can take hours. You might possibly want \n" \
             "to consider umounting the filesystem, which will increase speed of \n" \
@@ -250,7 +250,7 @@ module Y2Partitioner
 
       # Whether the device is going to be growed more than 50 GiB
       #
-      # @note Threshold to consider a big growing is defined in the old code, but there is
+      # @note Threshold to consider a big growing is defined in the old code, but there is not
       #   any kind of explanation:
       #   https://github.com/yast/yast-storage/blob/SLE-12-SP4/src/include/partitioning/ep-dialogs.rb#L1229
       #

--- a/src/lib/y2partitioner/dialogs/blk_device_resize.rb
+++ b/src/lib/y2partitioner/dialogs/blk_device_resize.rb
@@ -248,11 +248,15 @@ module Y2Partitioner
         selected_size > device.size
       end
 
-      # Whether the device is going to be growed more than 1 GiB
+      # Whether the device is going to be growed more than 50 GiB
+      #
+      # @note Threshold to consider a big growing is defined in the old code, but there is
+      #   any kind of explanation:
+      #   https://github.com/yast/yast-storage/blob/SLE-12-SP4/src/include/partitioning/ep-dialogs.rb#L1229
       #
       # @return [Boolean]
       def big_growing?
-        growing? && growing_size > Y2Storage::DiskSize.GiB(1)
+        growing? && growing_size > Y2Storage::DiskSize.GiB(50)
       end
 
       # How much the device is going to be growed

--- a/src/lib/y2partitioner/dialogs/blk_device_resize.rb
+++ b/src/lib/y2partitioner/dialogs/blk_device_resize.rb
@@ -191,7 +191,7 @@ module Y2Partitioner
       # @return [Boolean] true if the device supports mounted shrinking or the device was
       #   correctly unmounted or user decides to continue; false if user cancels.
       def try_unmount_for_shrinking
-        return true unless shrinking? && controller.need_unmount_for_shrinking?
+        return true unless shrinking? && controller.unmount_for_shrinking?
 
         # TRANSLATORS: Note added to the dialog for trying to unmount a device
         note = _("It is not possible to shrink the file system while it is mounted.")
@@ -204,7 +204,7 @@ module Y2Partitioner
       # @return [Boolean] true if the device supports mounted growing or the device was
       #   correctly unmounted or user decides to continue; false if user cancels.
       def try_unmount_for_growing
-        return true unless growing? && controller.need_unmount_for_growing?
+        return true unless growing? && controller.unmount_for_growing?
 
         # TRANSLATORS: Note added to the dialog for trying to unmount a device
         note = _("It is not possible to extend the file system while it is mounted.")

--- a/src/lib/y2partitioner/immediate_unmount.rb
+++ b/src/lib/y2partitioner/immediate_unmount.rb
@@ -22,7 +22,6 @@
 require "yast"
 require "yast/i18n"
 require "yast2/popup"
-require "y2partitioner/device_graphs"
 
 module Y2Partitioner
   # Mixin that offers a dialog to immediate unmount a block device
@@ -32,16 +31,6 @@ module Y2Partitioner
   #   unmount the device and the user is not asked for it. For instance, when a new partition table
   #   is created over a disk and some of its partitions are already mounted.
   module ImmediateUnmount
-    include Yast::Logger
-    include Yast::I18n
-
-  private
-
-    # Sets textdomain
-    def included(_target)
-      textdomain "storage"
-    end
-
     # Shows a Popup dialog to try to unmount the device
     #
     # @param device [Y2Storage::BlkDevice]
@@ -51,123 +40,166 @@ module Y2Partitioner
     #
     # @return [Boolean]
     def immediate_unmount(device, full_message: nil, note: nil, allow_continue: true)
-      loop do
-        case confirm_unmount(device, full_message, note, allow_continue)
-        when :unmount
-          break true if unmount(device)
-        when :continue
-          break true
-        when :cancel
-          break false
+      Unmounter.new(device, full_message, note, allow_continue).unmount
+    end
+
+    # Utility class for immediate unmounting a device
+    class Unmounter
+      include Yast::Logger
+      include Yast::I18n
+
+      # Constructor
+      #
+      # @param device [Y2Storage::BlkDevice]
+      # @param full_message [String, nil] message to show in the dialog (param note would be ignored)
+      # @param note [String, nil] note to add to the generic message (ignored if full_message is used)
+      # @param allow_continue [Boolean] if it should allow to continue without unmounting
+      def initialize(device, full_message, note, allow_continue)
+        textdomain "storage"
+
+        @device = device
+        @full_message = full_message
+        @note = note
+        @allow_continue = allow_continue
+      end
+
+      # Shows a dialog to unmount a device and performs the action if the user selects to unmount
+      #
+      # @return [Boolean] true if the user decides to continue without unmounting (when to continue
+      #   is allowed) or the device was correctly unmounted; false if the user cancels.
+      def unmount
+        loop do
+          case unmount_dialog
+          when :unmount
+            break true if unmount_device
+          when :continue
+            break true
+          when :cancel
+            break false
+          end
         end
       end
-    end
 
-    # Popup dialog for immediate unmounting
-    #
-    # @param device [Y2Storage::BlkDevice]
-    # @param full_message [String, nil] message to show in the dialog (param note would be ignored)
-    # @param note [String, nil] note to add to the generic message (ignored if full_message is used)
-    # @param allow_continue [Boolean] if it should allow to continue without unmounting
-    def confirm_unmount(device, full_message, note, allow_continue)
-      headline = Yast::Label.WarningMsg
+    private
 
-      message = immediate_unmount_message(device, full_message, note, allow_continue)
+      # @return [Y2Storage::BlkDevice]
+      attr_reader :device
 
-      buttons = inmmediate_unmount_buttons(allow_continue)
+      # @return [String, nil] message to show in the dialog (note would be ignored)
+      attr_reader :full_message
 
-      Yast2::Popup.show(message, headline: headline, buttons: buttons, focus: :cancel)
-    end
+      # @return [String, nil] note to add to the generic message (ignored if full_message is used)
+      attr_reader :note
 
-    # Performs the unmount action
-    #
-    # @note An error message is shown when the device cannot be unmounted.
-    #
-    # @param device [Y2Storage::BlkDevice]
-    # @return [Boolean] true if the device was correctly unmounted; false otherwise.
-    def unmount(device)
-      device.mount_point.immediate_deactivate
-      true
-    rescue Storage::Exception => e
-      log.warn "failed to unmount #{device.name}: #{e.what}"
+      # @return [Boolean] if it should allow to continue without unmounting
+      attr_reader :allow_continue
 
-      show_unmount_error(e.what)
-      false
-    end
-
-    # Error popup showed when the device cannot be unmounted
-    #
-    # @param details [String] error details
-    def show_unmount_error(details)
-      # TRANSLATORS: Error message when the device could not be unmounted
-      message = _("The file system could not be unmounted")
-
-      Yast2::Popup.show(message, headline: :error, details: details, buttons: :ok)
-    end
-
-    # Message for the immediate unmount dialog
-    #
-    # @note The message depends on several aspects:
-    #   * If the full_message param is provided, the dialog message is the full_message value.
-    #   * If a note is provided, a generic message is generated including that note.
-    #   * If continue is not allowed, the generic message is properly adjusted.
-    #
-    # @param device [Y2Storage::BlkDevice]
-    # @param full_message [String, nil] message to show in the dialog (param note would be ignored)
-    # @param note [String, nil] note to add to the generic message (ignored if full_message is used)
-    # @param allow_continue [Boolean] if it should allow to continue without unmounting
-    #
-    # @return [String]
-    def immediate_unmount_message(device, full_message, note, allow_continue)
-      return full_message unless full_message.nil?
-
-      path = device.mount_point.path
-
-      note = note.nil? ? "" : "\n" + note
-
-      format(
-        # TRANSLATORS: Generic message when trying to unmount a device. %{path} is replaced
-        # by a mount point path (e.g., /home), %{note} is replaced by a specefic note to clarify
-        # the action and %{options_message} is replaced by an explanation about possible actions
-        # to peform in the dialog.
-        _("The file system is currently mounted on %{path}.%{note}\n\n%{options_message}"),
-        path:            path,
-        note:            note,
-        options_message: immediate_unmount_options_message(allow_continue)
-      )
-    end
-
-    # Part of the generic message that explains the options
-    #
-    # @param allow_continue [Boolean] if it should allow to continue without unmounting
-    # @return [String]
-    def immediate_unmount_options_message(allow_continue)
-      if allow_continue
-        # TRANSLATORS: Actions explanation when continue is allowed.
-        _("You can try to unmount it now, continue without unmounting or cancel.\n" \
-          "In case you decide to continue, the file system will be automatically \n" \
-          "unmounted when all changes are applied. Note that automatic unmount \n" \
-          "could fail and, for this reason, it is recommendable to try to unmount now.\n" \
-          "Click Cancel unless you know exactly what you are doing.")
-      else
-        # TRANSLATORS: Actions explanation when continue is not allowed.
-        _("You can try to unmount it now or cancel.\n" \
-          "Click Cancel unless you know exactly what you are doing.")
+      # Popup dialog for immediate unmounting
+      #
+      # @return [Yast2::Popup]
+      def unmount_dialog
+        Yast2::Popup.show(message, headline: headline, buttons: buttons, focus: :cancel)
       end
-    end
 
-    # Buttons to show for the immediate unmount popup
-    #
-    # @param allow_continue [Boolean] if it should allow to continue without unmounting
-    # @return [Hash<Symbol, String>]
-    def inmmediate_unmount_buttons(allow_continue)
-      buttons = {}
+      # Dialog headline
+      #
+      # @return [String]
+      def headline
+        Yast::Label.WarningMsg
+      end
 
-      buttons[:continue] = Yast::Label.ContinueButton if allow_continue
-      buttons[:cancel] = Yast::Label.CancelButton
-      buttons[:unmount] = _("Unmount")
+      # Message for the unmount dialog
+      #
+      # @note The message depends on several aspects:
+      #   * If full_message was provided, the dialog message is the full_message value.
+      #   * If a note was provided, a generic message is generated including that note.
+      #   * If continue is not allowed, the generic message is properly adjusted.
+      #
+      # @return [String]
+      def message
+        return full_message unless full_message.nil?
 
-      buttons
+        format(
+          # TRANSLATORS: Generic message when trying to unmount a device. %{path} is replaced
+          # by a mount point path (e.g., /home), %{note} is replaced by a specefic note to clarify
+          # the action and %{options_message} is replaced by an explanation about possible actions
+          # to peform in the dialog.
+          _("The file system is currently mounted on %{mount_point}.%{note}\n\n%{options_message}"),
+          mount_point:     mount_point,
+          note:            note_message,
+          options_message: options_message
+        )
+      end
+
+      # Mount point path of the device to unmount
+      #
+      # @return [String]
+      def mount_point
+        device.mount_point.path
+      end
+
+      # Prepare the note to be included in the message
+      #
+      # @return [String]
+      def note_message
+        note.nil? ? "" : "\n" + note
+      end
+
+      # Part of the generic message that explains the options
+      #
+      # @return [String]
+      def options_message
+        if allow_continue
+          # TRANSLATORS: Actions explanation when continue is allowed.
+          _("You can try to unmount it now, continue without unmounting or cancel.\n" \
+            "In case you decide to continue, the file system will be automatically \n" \
+            "unmounted when all changes are applied. Note that automatic unmount \n" \
+            "could fail and, for this reason, it is recommendable to try to unmount now.\n" \
+            "Click Cancel unless you know exactly what you are doing.")
+        else
+          # TRANSLATORS: Actions explanation when continue is not allowed.
+          _("You can try to unmount it now or cancel.\n" \
+            "Click Cancel unless you know exactly what you are doing.")
+        end
+      end
+
+      # Buttons to show for the immediate unmount popup
+      #
+      # @return [Hash<Symbol, String>]
+      def buttons
+        buttons = {}
+
+        buttons[:continue] = Yast::Label.ContinueButton if allow_continue
+        buttons[:cancel] = Yast::Label.CancelButton
+        buttons[:unmount] = _("Unmount")
+
+        buttons
+      end
+
+      # Performs the unmount action
+      #
+      # @note An error message is shown when the device cannot be unmounted.
+      #
+      # @return [Boolean] true if the device was correctly unmounted; false otherwise.
+      def unmount_device
+        device.mount_point.immediate_deactivate
+        true
+      rescue Storage::Exception => e
+        log.warn "failed to unmount #{device.name}: #{e.what}"
+
+        show_unmount_error(e.what)
+        false
+      end
+
+      # Error popup showed when the device cannot be unmounted
+      #
+      # @param details [String] error details
+      def show_unmount_error(details)
+        # TRANSLATORS: Error message when the device could not be unmounted
+        message = _("The file system could not be unmounted")
+
+        Yast2::Popup.show(message, headline: :error, details: details, buttons: :ok)
+      end
     end
   end
 end

--- a/src/lib/y2partitioner/immediate_unmount.rb
+++ b/src/lib/y2partitioner/immediate_unmount.rb
@@ -1,0 +1,173 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast/i18n"
+require "yast2/popup"
+require "y2partitioner/device_graphs"
+
+module Y2Partitioner
+  # Mixin that offers a dialog to immediate unmount a block device
+  #
+  # @note This feature is intended to allow to unmount devices before the commit phase, for example,
+  #   when a device is deleted or resized. But there are serveral scenarios where the actions require
+  #   unmount the device and the user is not asked for it. For instance, when a new partition table
+  #   is created over a disk and some of its partitions are already mounted.
+  module ImmediateUnmount
+    include Yast::Logger
+    include Yast::I18n
+
+  private
+
+    # Sets textdomain
+    def included(_target)
+      textdomain "storage"
+    end
+
+    # Shows a Popup dialog to try to unmount the device
+    #
+    # @param device [Y2Storage::BlkDevice]
+    # @param full_message [String, nil] message to show in the dialog (param note would be ignored)
+    # @param note [String, nil] note to add to the generic message (ignored if full_message is used)
+    # @param allow_continue [Boolean] if it should allow to continue without unmounting
+    #
+    # @return [Boolean]
+    def immediate_unmount(device, full_message: nil, note: nil, allow_continue: true)
+      loop do
+        case confirm_unmount(device, full_message, note, allow_continue)
+        when :unmount
+          break true if unmount(device)
+        when :continue
+          break true
+        when :cancel
+          break false
+        end
+      end
+    end
+
+    # Popup dialog for immediate unmounting
+    #
+    # @param device [Y2Storage::BlkDevice]
+    # @param full_message [String, nil] message to show in the dialog (param note would be ignored)
+    # @param note [String, nil] note to add to the generic message (ignored if full_message is used)
+    # @param allow_continue [Boolean] if it should allow to continue without unmounting
+    def confirm_unmount(device, full_message, note, allow_continue)
+      headline = Yast::Label.WarningMsg
+
+      message = immediate_unmount_message(device, full_message, note, allow_continue)
+
+      buttons = inmmediate_unmount_buttons(allow_continue)
+
+      Yast2::Popup.show(message, headline: headline, buttons: buttons, focus: :cancel)
+    end
+
+    # Performs the unmount action
+    #
+    # @note An error message is shown when the device cannot be unmounted.
+    #
+    # @param device [Y2Storage::BlkDevice]
+    # @return [Boolean] true if the device was correctly unmounted; false otherwise.
+    def unmount(device)
+      device.mount_point.immediate_deactivate
+      true
+    rescue Storage::Exception => e
+      log.warn "failed to unmount #{device.name}: #{e.what}"
+
+      show_unmount_error(e.what)
+      false
+    end
+
+    # Error popup showed when the device cannot be unmounted
+    #
+    # @param details [String] error details
+    def show_unmount_error(details)
+      # TRANSLATORS: Error message when the device could not be unmounted
+      message = _("The file system could not be unmounted")
+
+      Yast2::Popup.show(message, headline: :error, details: details, buttons: :ok)
+    end
+
+    # Message for the immediate unmount dialog
+    #
+    # @note The message depends on several aspects:
+    #   * If the full_message param is provided, the dialog message is the full_message value.
+    #   * If a note is provided, a generic message is generated including that note.
+    #   * If continue is not allowed, the generic message is properly adjusted.
+    #
+    # @param device [Y2Storage::BlkDevice]
+    # @param full_message [String, nil] message to show in the dialog (param note would be ignored)
+    # @param note [String, nil] note to add to the generic message (ignored if full_message is used)
+    # @param allow_continue [Boolean] if it should allow to continue without unmounting
+    #
+    # @return [String]
+    def immediate_unmount_message(device, full_message, note, allow_continue)
+      return full_message unless full_message.nil?
+
+      path = device.mount_point.path
+
+      note = note.nil? ? "" : "\n" + note
+
+      format(
+        # TRANSLATORS: Generic message when trying to unmount a device. %{path} is replaced
+        # by a mount point path (e.g., /home), %{note} is replaced by a specefic note to clarify
+        # the action and %{options_message} is replaced by an explanation about possible actions
+        # to peform in the dialog.
+        _("The file system is currently mounted on %{path}.%{note}\n\n%{options_message}"),
+        path:            path,
+        note:            note,
+        options_message: immediate_unmount_options_message(allow_continue)
+      )
+    end
+
+    # Part of the generic message that explains the options
+    #
+    # @param allow_continue [Boolean] if it should allow to continue without unmounting
+    # @return [String]
+    def immediate_unmount_options_message(allow_continue)
+      if allow_continue
+        # TRANSLATORS: Actions explanation when continue is allowed.
+        _("You can try to unmount it now, continue without unmounting or cancel.\n" \
+          "In case you decide to continue, the file system will be automatically \n" \
+          "unmounted when all changes are applied. Note that automatic unmount \n" \
+          "could fail and, for this reason, it is recommendable to try to unmount now.\n" \
+          "Click Cancel unless you know exactly what you are doing.")
+      else
+        # TRANSLATORS: Actions explanation when continue is not allowed.
+        _("You can try to unmount it now or cancel.\n" \
+          "Click Cancel unless you know exactly what you are doing.")
+      end
+    end
+
+    # Buttons to show for the immediate unmount popup
+    #
+    # @param allow_continue [Boolean] if it should allow to continue without unmounting
+    # @return [Hash<Symbol, String>]
+    def inmmediate_unmount_buttons(allow_continue)
+      buttons = {}
+
+      buttons[:continue] = Yast::Label.ContinueButton if allow_continue
+      buttons[:cancel] = Yast::Label.CancelButton
+      buttons[:unmount] = _("Unmount")
+
+      buttons
+    end
+  end
+end

--- a/src/lib/y2partitioner/immediate_unmount.rb
+++ b/src/lib/y2partitioner/immediate_unmount.rb
@@ -119,16 +119,10 @@ module Y2Partitioner
       def message
         return full_message unless full_message.nil?
 
-        format(
-          # TRANSLATORS: Generic message when trying to unmount a device. %{path} is replaced
-          # by a mount point path (e.g., /home), %{note} is replaced by a specefic note to clarify
-          # the action and %{options_message} is replaced by an explanation about possible actions
-          # to peform in the dialog.
-          _("The file system is currently mounted on %{mount_point}.%{note}\n\n%{options_message}"),
-          mount_point:     mount_point,
-          note:            note_message,
-          options_message: options_message
-        )
+        # TRANSLATORS: Generic message when trying to unmount a device. %1 is replaced
+        # by a mount point path (e.g., /home).
+        Yast::Builtins.sformat(_("The file system is currently mounted on %1."), mount_point) +
+          note_message + "\n\n" + options_message
       end
 
       # Mount point path of the device to unmount
@@ -152,9 +146,6 @@ module Y2Partitioner
         if allow_continue
           # TRANSLATORS: Actions explanation when continue is allowed.
           _("You can try to unmount it now, continue without unmounting or cancel.\n" \
-            "In case you decide to continue, the file system will be automatically \n" \
-            "unmounted when all changes are applied. Note that automatic unmount \n" \
-            "could fail and, for this reason, it is recommended to try to unmount now.\n" \
             "Click Cancel unless you know exactly what you are doing.")
         else
           # TRANSLATORS: Actions explanation when continue is not allowed.

--- a/src/lib/y2partitioner/immediate_unmount.rb
+++ b/src/lib/y2partitioner/immediate_unmount.rb
@@ -154,7 +154,7 @@ module Y2Partitioner
           _("You can try to unmount it now, continue without unmounting or cancel.\n" \
             "In case you decide to continue, the file system will be automatically \n" \
             "unmounted when all changes are applied. Note that automatic unmount \n" \
-            "could fail and, for this reason, it is recommendable to try to unmount now.\n" \
+            "could fail and, for this reason, it is recommended to try to unmount now.\n" \
             "Click Cancel unless you know exactly what you are doing.")
         else
           # TRANSLATORS: Actions explanation when continue is not allowed.

--- a/src/lib/y2partitioner/immediate_unmount.rb
+++ b/src/lib/y2partitioner/immediate_unmount.rb
@@ -23,6 +23,8 @@ require "yast"
 require "yast/i18n"
 require "yast2/popup"
 
+Yast.import "Mode"
+
 module Y2Partitioner
   # Mixin that offers a dialog to immediate unmount a block device
   #
@@ -40,6 +42,10 @@ module Y2Partitioner
     #
     # @return [Boolean]
     def immediate_unmount(device, full_message: nil, note: nil, allow_continue: true)
+      # This check is here to avoid changes in installer behaviour for GA. The dialog for immediate
+      # unmounting will be only shown in normal mode. This check can be removed for SP1.
+      return true unless Yast::Mode.normal
+
       Unmounter.new(device, full_message, note, allow_continue).unmount
     end
 

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -320,7 +320,7 @@ module Y2Storage
     # Mount point of the filesystem
     #
     # @return [Y2Storage::MountPoint, nil] nil if the device is not formatted or its
-    #   filesystem has not mount point.
+    #   filesystem has no mount point.
     def mount_point
       return nil unless formatted?
 

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -317,6 +317,16 @@ module Y2Storage
       remove_descendants
     end
 
+    # Mount point of the filesystem
+    #
+    # @return [Y2Storage::MountPoint, nil] nil if the device is not formatted or its
+    #   filesystem has not mount point.
+    def mount_point
+      return nil unless formatted?
+
+      filesystem.mount_point
+    end
+
     # LVM physical volume defined on top of the device, either directly or
     # through an encryption layer.
     #

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -62,9 +62,17 @@ module Y2Storage
       #   @return [Boolean] whether the filesystem supports shrinking
       storage_forward :supports_shrink?, to: :supports_shrink
 
+      # @!method supports_mounted_shrink?
+      #   @return [Boolean] whether the filesystem supports shrinking while being mounted
+      storage_forward :supports_mounted_shrink?, to: :supports_mounted_shrink
+
       # @!method supports_grow?
       #   @return [Boolean] whether the filesystem supports growing
       storage_forward :supports_grow?, to: :supports_grow
+
+      # @!method supports_mounted_grow?
+      #   @return [Boolean] whether the filesystem supports growing while being mounted
+      storage_forward :supports_mounted_grow?, to: :supports_mounted_grow
 
       # @!attribute mkfs_options
       #   Options to use when calling mkfs during devicegraph commit (if the
@@ -119,7 +127,7 @@ module Y2Storage
         disks.any?(&:in_network?)
       end
 
-      # Check if this filesystem type supports any kind of resize at all,
+      # Checks if this filesystem type supports any kind of resize at all,
       # either shrinking or growing.
       #
       # @return [Boolean]

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -159,6 +159,16 @@ module Y2Storage
     # 	@param value [Boolean]
     storage_forward :active=
 
+    # @!method immediate_deactivate
+    #   Immediately deactivates (unmount) the mount point object. In
+    #   contrast to {#active=} this function acts immediately and does
+    #   not require calling to commit.
+    #
+    #   @note The mount point object must exist in the probed devicegraph.
+    #
+    #   @raise [Storage::Exception] when it cannot be unmounted.
+    storage_forward :immediate_deactivate
+
     # @!method mountable
     #   Gets the mountable of the mount point (filesystem, BTRFS subvolume, etc)
     #

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -37,6 +37,12 @@ Yast.import "Stage"
 module Y2Storage
   # Singleton class to provide access to the libstorage Storage object and
   # to store related state information.
+  #
+  # FIXME: This class exceeds the maximum allowed length (250 lines of code), but
+  # there are quite some code that could be extracted to a new place, mainly all
+  # stuff related to testing (e.g., {#probe_from_yaml}).
+  #
+  # rubocop:disable Metrics/ClassLength
   class StorageManager
     include Yast::Logger
     extend Forwardable
@@ -242,6 +248,15 @@ module Y2Storage
     # @param [Devicegraph] devicegraph to copy
     def staging=(devicegraph)
       copy_to_staging(devicegraph)
+    end
+
+    # System devicegraph
+    #
+    # It is used to perform actions beforme the commit phase (e.g., immediate unmount).
+    #
+    # @return [Y2Storage::Devicegraph]
+    def system
+      @system_graph ||= Devicegraph.new(storage.system)
     end
 
     # Stores the proposal, modifying the staging devicegraph and all the related
@@ -663,6 +678,7 @@ module Y2Storage
         callbacks.retry?
       end
     end
+    # rubocop:enable Metrics/ClassLength
 
     # Logger class for libstorage. This is needed to make libstorage log to the
     # y2log.

--- a/test/y2partitioner/actions/controllers/blk_device_test.rb
+++ b/test/y2partitioner/actions/controllers/blk_device_test.rb
@@ -349,8 +349,8 @@ describe Y2Partitioner::Actions::Controllers::BlkDevice do
     end
   end
 
-  describe "#need_unmount_for_shrinking?" do
-    let(:described_method) { :need_unmount_for_shrinking? }
+  describe "#unmount_for_shrinking?" do
+    let(:described_method) { :unmount_for_shrinking? }
 
     include_examples "checks mounted committed filesystem"
 
@@ -363,7 +363,7 @@ describe Y2Partitioner::Actions::Controllers::BlkDevice do
       end
 
       it "returns true" do
-        expect(controller.need_unmount_for_shrinking?).to eq(true)
+        expect(controller.unmount_for_shrinking?).to eq(true)
       end
     end
 
@@ -376,13 +376,13 @@ describe Y2Partitioner::Actions::Controllers::BlkDevice do
       end
 
       it "returns false" do
-        expect(controller.need_unmount_for_shrinking?).to eq(false)
+        expect(controller.unmount_for_shrinking?).to eq(false)
       end
     end
   end
 
-  describe "#need_unmount_for_growing?" do
-    let(:described_method) { :need_unmount_for_growing? }
+  describe "#unmount_for_growing?" do
+    let(:described_method) { :unmount_for_growing? }
 
     include_examples "checks mounted committed filesystem"
 
@@ -395,7 +395,7 @@ describe Y2Partitioner::Actions::Controllers::BlkDevice do
       end
 
       it "returns true" do
-        expect(controller.need_unmount_for_growing?).to eq(true)
+        expect(controller.unmount_for_growing?).to eq(true)
       end
     end
 
@@ -408,7 +408,7 @@ describe Y2Partitioner::Actions::Controllers::BlkDevice do
       end
 
       it "returns false" do
-        expect(controller.need_unmount_for_growing?).to eq(false)
+        expect(controller.unmount_for_growing?).to eq(false)
       end
     end
   end

--- a/test/y2partitioner/actions/controllers/blk_device_test.rb
+++ b/test/y2partitioner/actions/controllers/blk_device_test.rb
@@ -1,0 +1,415 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2partitioner/actions/controllers/blk_device"
+
+describe Y2Partitioner::Actions::Controllers::BlkDevice do
+  before do
+    devicegraph_stub(scenario)
+  end
+
+  subject(:controller) { described_class.new(device) }
+
+  let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+
+  let(:device) { current_graph.find_by_name(device_name) }
+
+  let(:scenario) { "mixed_disks.yml" }
+
+  def create_partition(disk_name)
+    disk = current_graph.find_by_name(disk_name)
+    slot = disk.partition_table.unused_partition_slots.first
+    part = disk.partition_table.create_partition(
+      slot.name,
+      slot.region,
+      Y2Storage::PartitionType::PRIMARY
+    )
+    part.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
+  end
+
+  describe "#initialize" do
+    context "when the given device is a block device" do
+      let(:device_name) { "/dev/sda" }
+
+      it "does not raise an exception" do
+        expect { described_class.new(device) }.to_not raise_error
+      end
+    end
+
+    context "when the given device is not a blk device" do
+      let(:scenario) { "dos_lvm" }
+      let(:device_name) { "/dev/vg0" }
+
+      it "raises an exception" do
+        expect { described_class.new(device) }.to raise_error(TypeError)
+      end
+    end
+  end
+
+  describe "#committed_current_filesystem?" do
+    context "when the device is not currently formatted" do
+      let(:device_name) { "/dev/sdb7" }
+
+      it "returns false" do
+        expect(controller.committed_current_filesystem?).to eq(false)
+      end
+    end
+
+    context "when the device is currently formatted" do
+      context "but it does not exist on the system yet" do
+        before do
+          create_partition("/dev/sdc")
+        end
+
+        let(:device_name) { "/dev/sdc1" }
+
+        it "returns false" do
+          expect(controller.committed_current_filesystem?).to eq(false)
+        end
+      end
+
+      context "but it is not formatted on system" do
+        let(:device_name) { "/dev/sdb7" }
+
+        before do
+          device.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
+        end
+
+        it "returns false" do
+          expect(controller.committed_current_filesystem?).to eq(false)
+        end
+      end
+
+      context "and it is formatted on system" do
+        let(:device_name) { "/dev/sda2" }
+
+        context "but the current filesystem does not match to the filesystem on system" do
+          before do
+            device.delete_filesystem
+            device.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
+          end
+
+          it "returns false" do
+            expect(controller.committed_current_filesystem?).to eq(false)
+          end
+        end
+
+        context "and the current filesystem matches to the filesystem on system" do
+          it "returns true" do
+            expect(controller.committed_current_filesystem?).to eq(true)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#mounted_committed_filesystem?" do
+    context "when the device does not exist on the system yet" do
+      before do
+        create_partition("/dev/sdc")
+      end
+
+      let(:device_name) { "/dev/sdc1" }
+
+      it "returns false" do
+        expect(controller.mounted_committed_filesystem?).to eq(false)
+      end
+    end
+
+    context "when the device is not formatted on the system" do
+      let(:device_name) { "/dev/sdb7" }
+
+      it "returns false" do
+        expect(controller.mounted_committed_filesystem?).to eq(false)
+      end
+    end
+
+    context "when the device is formatted on the system" do
+      context "and the filesystem on the system has not mount point" do
+        let(:device_name) { "/dev/sdb7" }
+
+        it "returns false" do
+          expect(controller.mounted_committed_filesystem?).to eq(false)
+        end
+      end
+
+      context "and the filesystem on the system has mount point" do
+        let(:device_name) { "/dev/sdb2" }
+
+        before do
+          system_devicegraph = Y2Storage::StorageManager.instance.system
+          part = system_devicegraph.find_by_name(device_name)
+          part.mount_point.active = active
+        end
+
+        context "and the mount point is not active" do
+          let(:active) { false }
+
+          it "returns false" do
+            expect(controller.mounted_committed_filesystem?).to eq(false)
+          end
+        end
+
+        context "and the mount point is active" do
+          let(:active) { true }
+
+          it "returns true" do
+            expect(controller.mounted_committed_filesystem?).to eq(true)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#committed_device?" do
+    context "when the device does not exist on the system yet" do
+      before do
+        create_partition("/dev/sdc")
+      end
+
+      let(:device_name) { "/dev/sdc1" }
+
+      it "returns false" do
+        expect(controller.committed_device?).to eq(false)
+      end
+    end
+
+    context "when the device exists on the system" do
+      let(:device_name) { "/dev/sda1" }
+
+      it "returns true" do
+        expect(controller.committed_device?).to eq(true)
+      end
+    end
+  end
+
+  describe "#committed_device" do
+    context "when the device does not exist on the system yet" do
+      before do
+        create_partition("/dev/sdc")
+      end
+
+      let(:device_name) { "/dev/sdc1" }
+
+      it "returns nil" do
+        expect(controller.committed_device).to be_nil
+      end
+    end
+
+    context "when the device exists on the system" do
+      let(:device_name) { "/dev/sda1" }
+
+      it "returns the device on the system" do
+        expect(controller.committed_device).to be_a(Y2Storage::BlkDevice)
+        expect(controller.committed_device.name).to eq("/dev/sda1")
+
+        system = Y2Storage::StorageManager.instance.system
+
+        expect(controller.committed_device.exists_in_devicegraph?(system)).to eq(true)
+      end
+    end
+  end
+
+  describe "#committed_filesystem?" do
+    context "when the device does not exist on the system yet" do
+      before do
+        create_partition("/dev/sdc")
+      end
+
+      let(:device_name) { "/dev/sdc1" }
+
+      it "returns false" do
+        expect(controller.committed_filesystem?).to eq(false)
+      end
+    end
+
+    context "when the device exists on the system" do
+      context "but it is not formatted" do
+        let(:device_name) { "/dev/sdb7" }
+
+        it "returns false" do
+          expect(controller.committed_filesystem?).to eq(false)
+        end
+      end
+
+      context "and it is formatted" do
+        let(:device_name) { "/dev/sdb2" }
+
+        it "returns true" do
+          expect(controller.committed_filesystem?).to eq(true)
+        end
+      end
+    end
+  end
+
+  describe "#committed_filesystem" do
+    context "when the device does not exist on the system yet" do
+      before do
+        create_partition("/dev/sdc")
+      end
+
+      let(:device_name) { "/dev/sdc1" }
+
+      it "returns nil" do
+        expect(controller.committed_filesystem).to be_nil
+      end
+    end
+
+    context "when the device exists on the system" do
+      context "but it is not formatted" do
+        let(:device_name) { "/dev/sdb7" }
+
+        it "returns nil" do
+          expect(controller.committed_filesystem).to be_nil
+        end
+      end
+
+      context "and it is formatted" do
+        let(:device_name) { "/dev/sdb2" }
+
+        it "returns the filesystem on the system" do
+          expect(controller.committed_filesystem).to be_a(Y2Storage::Filesystems::Base)
+          expect(controller.committed_filesystem.type.is?("btrfs"))
+
+          system = Y2Storage::StorageManager.instance.system
+
+          expect(controller.committed_filesystem.exists_in_devicegraph?(system)).to eq(true)
+        end
+      end
+    end
+  end
+
+  shared_examples "checks mounted committed filesystem" do
+    context "when the device does not exist on the system yet" do
+      before do
+        create_partition("/dev/sdc")
+      end
+
+      let(:device_name) { "/dev/sdc1" }
+
+      it "returns false" do
+        expect(controller.send(described_method)).to eq(false)
+      end
+    end
+
+    context "when the device is not formatted on the system" do
+      let(:device_name) { "/dev/sdb7" }
+
+      it "returns false" do
+        expect(controller.send(described_method)).to eq(false)
+      end
+    end
+
+    context "when the device is formatted on the system" do
+      context "and the filesystem on the system has not mount point" do
+        let(:device_name) { "/dev/sdb7" }
+
+        it "returns false" do
+          expect(controller.send(described_method)).to eq(false)
+        end
+      end
+
+      context "and the filesystem on the system has mount point" do
+        let(:device_name) { "/dev/sdb2" }
+
+        before do
+          system_devicegraph = Y2Storage::StorageManager.instance.system
+          part = system_devicegraph.find_by_name(device_name)
+          part.mount_point.active = active
+        end
+
+        context "and the mount point is not active" do
+          let(:active) { false }
+
+          it "returns false" do
+            expect(controller.send(described_method)).to eq(false)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#need_unmount_for_shrinking?" do
+    let(:described_method) { :need_unmount_for_shrinking? }
+
+    include_examples "checks mounted committed filesystem"
+
+    context "when the committed filesystem does not support to shrink being mounted" do
+      let(:device_name) { "/dev/sdb2" }
+
+      before do
+        allow_any_instance_of(Y2Storage::Filesystems::BlkFilesystem)
+          .to receive(:supports_mounted_shrink?).and_return(false)
+      end
+
+      it "returns true" do
+        expect(controller.need_unmount_for_shrinking?).to eq(true)
+      end
+    end
+
+    context "when the committed filesystem supports to shrink being mounted" do
+      let(:device_name) { "/dev/sdb2" }
+
+      before do
+        allow_any_instance_of(Y2Storage::Filesystems::BlkFilesystem)
+          .to receive(:supports_mounted_shrink?).and_return(true)
+      end
+
+      it "returns false" do
+        expect(controller.need_unmount_for_shrinking?).to eq(false)
+      end
+    end
+  end
+
+  describe "#need_unmount_for_growing?" do
+    let(:described_method) { :need_unmount_for_growing? }
+
+    include_examples "checks mounted committed filesystem"
+
+    context "when the committed filesystem does not support to grow being mounted" do
+      let(:device_name) { "/dev/sdb2" }
+
+      before do
+        allow_any_instance_of(Y2Storage::Filesystems::BlkFilesystem)
+          .to receive(:supports_mounted_grow?).and_return(false)
+      end
+
+      it "returns true" do
+        expect(controller.need_unmount_for_growing?).to eq(true)
+      end
+    end
+
+    context "when the committed filesystem supports to grow being mounted" do
+      let(:device_name) { "/dev/sdb2" }
+
+      before do
+        allow_any_instance_of(Y2Storage::Filesystems::BlkFilesystem)
+          .to receive(:supports_mounted_grow?).and_return(true)
+      end
+
+      it "returns false" do
+        expect(controller.need_unmount_for_growing?).to eq(false)
+      end
+    end
+  end
+end

--- a/test/y2partitioner/actions/resize_blk_device_test.rb
+++ b/test/y2partitioner/actions/resize_blk_device_test.rb
@@ -188,7 +188,7 @@ describe Y2Partitioner::Actions::ResizeBlkDevice do
 
                 it "shows a specific note for unmounting NTFS" do
                   expect(Yast2::Popup).to receive(:show)
-                    .with(/check whether a NTFS/, anything)
+                    .with(/check whether an NTFS/, anything)
                     .and_return(:cancel)
 
                   subject.run

--- a/test/y2partitioner/actions/resize_blk_device_test.rb
+++ b/test/y2partitioner/actions/resize_blk_device_test.rb
@@ -188,7 +188,7 @@ describe Y2Partitioner::Actions::ResizeBlkDevice do
 
                 it "shows a specific note for unmounting NTFS" do
                   expect(Yast2::Popup).to receive(:show)
-                    .with(/check whether an NTFS/, anything)
+                    .with(/check whether a NTFS/, anything)
                     .and_return(:cancel)
 
                   subject.run

--- a/test/y2partitioner/dialogs/blk_device_resize_test.rb
+++ b/test/y2partitioner/dialogs/blk_device_resize_test.rb
@@ -335,17 +335,17 @@ describe Y2Partitioner::Dialogs::BlkDeviceResize do
             end
 
             context "and the device is going to be extended" do
-              let(:selected_size) { 60.1.GiB } # current size is 60 GiB
+              let(:selected_size) { 65.GiB } # current size is 60 GiB
 
               context "and the device supports to extend being mounted" do
                 let(:mounted_grow) { true }
 
-                context "and the device is going to be extended less than 1 GiB" do
+                context "and the device is going to be extended less than 50 GiB" do
                   include_examples "do not unmount"
                 end
 
-                context "and the device is going to be extended more than 1 GiB" do
-                  let(:selected_size) { 62.GiB } # current size is 60 GiB
+                context "and the device is going to be extended more than 50 GiB" do
+                  let(:selected_size) { 150.GiB } # current size is 60 GiB
 
                   it "shows a specific note for extending the device too much" do
                     expect(Yast2::Popup).to receive(:show)

--- a/test/y2partitioner/dialogs/blk_device_resize_test.rb
+++ b/test/y2partitioner/dialogs/blk_device_resize_test.rb
@@ -219,6 +219,11 @@ describe Y2Partitioner::Dialogs::BlkDeviceResize do
           context "but it is not mounted in the system" do
             let(:mounted) { false }
 
+            before do
+              allow(device).to receive(:filesystem).and_return(filesystem)
+              allow(filesystem).to receive(:sid).and_return(-1)
+            end
+
             include_examples "do not unmount"
           end
 

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -112,6 +112,37 @@ describe Y2Storage::BlkDevice do
     end
   end
 
+  describe "#mount_point" do
+    let(:scenario) { "mixed_disks" }
+
+    context "when the device is not formatted" do
+      let(:device_name) { "/dev/sdb7" }
+
+      it "returns nil" do
+        expect(device.mount_point).to be_nil
+      end
+    end
+
+    context "when the device is formatted" do
+      context "and the filesystem does not have mount point" do
+        let(:device_name) { "/dev/sda2" }
+
+        it "returns nil" do
+          expect(device.mount_point).to be_nil
+        end
+      end
+
+      context "and the filesystem has mount point" do
+        let(:device_name) { "/dev/sdb2" }
+
+        it "returns the fielesystem mount point" do
+          expect(device.mount_point).to be_a(Y2Storage::MountPoint)
+          expect(device.mount_point.path).to eq("/")
+        end
+      end
+    end
+  end
+
   describe "#plain_device" do
     context "for a non encrypted device" do
       let(:device_name) { "/dev/sda2" }


### PR DESCRIPTION
PBI: https://trello.com/c/e1TpNp2Y/213-5-partitioner-handle-on-the-fly-unmounting-in-installed-system

Requires https://github.com/yast/yast-yast2/pull/817

NOTE

This PR is intentionally not merged yet. These changes should not be included as Self Update, so we are going to merge [this L3](https://trello.com/c/1icYnFLW/266-l3-sles15-1107298-autoyast-disk-directly-as-pv-doesnt-work) before. Maybe, if we are lucky, we don't get more L3s after merging the code of this PR and so it would not be included in the Self Update. 