### PR TITLE
support full disk devices as lvm pv in autoyast profile (bsc#1107298)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 18 13:00:29 UTC 2018 - jlopez@suse.com
+
+- AutoYaST: Allow to use whole disk as PV by indicating a partition
+  with number 0 (bsc#1107298).
+- 4.0.211
+
+-------------------------------------------------------------------
 Thu Sep  6 11:45:19 UTC 2018 - jreidinger@suse.com
 
 - Add asterisk to mount points that is not active and also write it

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.210
+Version:        4.0.211
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/planned/has_size.rb
+++ b/src/lib/y2storage/planned/has_size.rb
@@ -89,7 +89,11 @@ module Y2Storage
         # @return [Array] list containing devices with an adjusted value
         #     for Planned::HasSize#size
         def distribute_space(devices, space_size, rounding: nil, align_grain: nil, end_alignment: false)
-          raise RuntimeError if space_size < DiskSize.sum(devices.map(&:min))
+          needed_size = DiskSize.sum(devices.map(&:min))
+          if space_size < needed_size
+            log.error "not enough space: needed #{needed_size}, available #{space_size}"
+            raise RuntimeError
+          end
 
           rounding ||= align_grain
           rounding ||= DiskSize.new(1)

--- a/src/lib/y2storage/planned/stray_blk_device.rb
+++ b/src/lib/y2storage/planned/stray_blk_device.rb
@@ -29,6 +29,10 @@ module Y2Storage
     # Specification for a Y2Storage::StrayBlkDevice object to be processed
     # during the AutoYaST proposals
     #
+    # FIXME: When a disk device is used as PV (indicated as partition with number 0
+    # in the autoyast profile), a Stray Block Device is planned for it. Think about
+    # a better solution (maybe by creating a Planned::PV ?).
+    #
     # @see Device
     class StrayBlkDevice < Device
       include Planned::CanBeFormatted

--- a/src/lib/y2storage/planned/stray_blk_device.rb
+++ b/src/lib/y2storage/planned/stray_blk_device.rb
@@ -34,6 +34,7 @@ module Y2Storage
       include Planned::CanBeFormatted
       include Planned::CanBeMounted
       include Planned::CanBeEncrypted
+      include Planned::CanBePv
       include MatchVolumeSpec
 
       # Constructor.
@@ -42,6 +43,7 @@ module Y2Storage
         initialize_can_be_formatted
         initialize_can_be_mounted
         initialize_can_be_encrypted
+        initialize_can_be_pv
       end
 
       # @see Device.to_string_attrs

--- a/src/lib/y2storage/proposal/autoinst_devices_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_planner.rb
@@ -124,6 +124,9 @@ module Y2Storage
       # @note The part argument is used when we emulate the sle12 behavior to
       #   have partition 0 mean the full disk.
       def planned_for_full_disk(drive, part)
+        # FIXME: When a disk device is used as PV (indicated as partition with number 0
+        # in the autoyast profile), a Stray Block Device is planned for it. Think about
+        # a better solution (maybe by creating a Planned::PV ?).
         planned = Y2Storage::Planned::StrayBlkDevice.new
         device_config(planned, part, drive)
         planned.lvm_volume_group_name = part.lvm_group

--- a/test/support/storage_helpers.rb
+++ b/test/support/storage_helpers.rb
@@ -112,6 +112,11 @@ module Yast
         add_planned_attributes(md, attrs)
       end
 
+      def planned_stray_blk_device(attrs = {})
+        device = Y2Storage::Planned::StrayBlkDevice.new
+        add_planned_attributes(device, attrs)
+      end
+
       def add_planned_attributes(device, attrs)
         attrs = attrs.dup
 

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -496,13 +496,15 @@ describe Y2Storage::AutoinstProposal do
     context "when partition_nr=0 is used to specify a whole disk as PV" do
       let(:partitioning) do
         [
-          { "device" => "/dev/sda", "initialize" => true, "disklabel" => "msdos",
+          {
+            "device" => "/dev/sda", "initialize" => true, "disklabel" => "msdos",
             "partitions" => [
               "create" => true, "filesystem" => :ext4, "format" => true,
               "mount" => "/boot", "size" => "1G"
             ]
           },
-          { "device" => "/dev/sdb", "initialize" => true, "disklabel" => "msdos",
+          {
+            "device" => "/dev/sdb", "initialize" => true, "disklabel" => "msdos",
             "partitions" => [
               # Undocumented feature: use a single partition with number zero
               # and create=false as a way to associate the device to an LVM VG
@@ -511,7 +513,8 @@ describe Y2Storage::AutoinstProposal do
               "mountby" => :device, "partition_id" => 142
             ]
           },
-          { "device" => "/dev/foo_vg", "type" => :CT_LVM,
+          {
+            "device" => "/dev/foo_vg", "type" => :CT_LVM,
             "initialize" => true, "disklabel" => "msdos",
             "partitions" => [
               "create" => true, "format" => true, "lvm_name" => "bar_lv",

--- a/test/y2storage/proposal/autoinst_devices_creator_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_creator_test.rb
@@ -201,6 +201,22 @@ describe Y2Storage::Proposal::AutoinstDevicesCreator do
         end
       end
 
+      context "reusing a disk device as physical volume" do
+        let(:scenario) { "windows-linux-free-pc" }
+        let(:pv) do
+          planned_stray_blk_device(lvm_volume_group_name: "vg0", reuse_name: "/dev/sda")
+        end
+
+        it "adds the whole disk device as physical volume to the volume group" do
+          result = creator.populated_devicegraph([pv, vg], ["/dev/sda"])
+          devicegraph = result.devicegraph
+          vg = devicegraph.lvm_vgs.first
+          pv = vg.lvm_pvs.first
+          expect(pv).to_not be_nil
+          expect(pv.blk_device.name).to eq("/dev/sda")
+        end
+      end
+
       context "when creating more than one volume group" do
         let(:pv1) { planned_partition(lvm_volume_group_name: "vg1", min_size: 5.GiB) }
 


### PR DESCRIPTION
This allows partition 0 to stand as an alias for the full disk.