### PR TITLE
Do not crash during the content info detection

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 19 14:28:22 UTC 2018 - dgonzalez@suse.com
+
+- Do not crash when a partition content info cannot be
+  detected (bsc#1101979).
+- 4.1.18
+
+-------------------------------------------------------------------
 Wed Sep 19 11:43:13 UTC 2018 - jreidinger@suse.com
 
 - Add read-only support for Bcache (fate#325346)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.17
+Version:	4.1.18
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/disk_analyzer.rb
+++ b/src/lib/y2storage/disk_analyzer.rb
@@ -210,6 +210,10 @@ module Y2Storage
 
       log.info("#{partition.name} is a windows partition") if is_win
       is_win
+
+    rescue Storage::Exception
+      log.warn("#{partition.name} content info cannot be detected")
+      false
     end
 
     # Obtain release names of installed systems in a disk.


### PR DESCRIPTION
Related to https://bugzilla.suse.com/show_bug.cgi?id=1101979

> If there is any problem during the content info detection, it will not
be considered as windows partition.