### PR TITLE
[WIP] Cache downcasting map

### DIFF
--- a/src/lib/y2storage/storage_class_wrapper.rb
+++ b/src/lib/y2storage/storage_class_wrapper.rb
@@ -231,15 +231,11 @@ module Y2Storage
       # @param object [Object] storage object to be wrapped
       def downcasted_new(object)
         @downcast_class_names.each do |class_name|
-          klass = StorageClassWrapper.class_for(class_name)
-          storage_class = klass.storage_class
+          map = StorageClassWrapper.downcast_map(class_name)
 
-          underscored = StorageClassWrapper.underscore(storage_class.name.split("::").last)
-          check_method = :"#{underscored}?"
-          cast_method = :"to_#{underscored}"
-          next unless Storage.public_send(check_method, object)
+          next unless Storage.public_send(map[:check_method], object)
 
-          return klass.downcasted_new(Storage.send(cast_method, object))
+          return map[:class].downcasted_new(Storage.send(map[:cast_method], object))
         end
         new(object)
       end
@@ -286,6 +282,26 @@ module Y2Storage
 
       def underscore(camel_case_name)
         camel_case_name.gsub(/(.)([A-Z])/, '\1_\2').downcase
+      end
+
+      # Internal method to optimize downcasted_new
+      def downcast_map(class_name)
+        @downcast_map ||= {}
+
+        return @downcast_map[class_name] if @downcast_map[class_name]
+
+        klass = StorageClassWrapper.class_for(class_name)
+        storage_class = klass.storage_class
+
+        underscored = StorageClassWrapper.underscore(storage_class.name.split("::").last)
+        check_method = :"#{underscored}?"
+        cast_method = :"to_#{underscored}"
+
+        @downcast_map[class_name] =  {
+            class: klass,
+            check_method: check_method,
+            cast_method: cast_method
+          }
       end
 
     private


### PR DESCRIPTION
Measurement ( done by accumulating Time.now difference ) from simple start of module is that without cache it took

0.29208857400000154 seconds in this method with original implementation
and 0.07035962099999996 when cache is involved. Reason is huge number of
calls.