### PR TITLE
Allow to use disk as a RAID member

### DIFF
--- a/src/lib/y2storage/planned/can_be_md_member.rb
+++ b/src/lib/y2storage/planned/can_be_md_member.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2018] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -19,10 +19,23 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2storage/planned/can_be_encrypted"
-require "y2storage/planned/can_be_formatted"
-require "y2storage/planned/can_be_mounted"
-require "y2storage/planned/can_be_pv"
-require "y2storage/planned/can_be_md_member"
-require "y2storage/planned/can_be_resized"
-require "y2storage/planned/has_size"
+module Y2Storage
+  module Planned
+    # Mixin for planned devices that can act as MD RAID member
+    # @see Planned::Device
+    module CanBeMdMember
+      # @return [String] name of the MD array to which this partition should
+      #   be added
+      attr_accessor :raid_name
+
+      # Initializations of the mixin, to be called from the class constructor.
+      def initialize_can_be_md_member
+      end
+
+      # Checks whether the device represents an MD RAID member
+      def md_member?
+        !raid_name.nil?
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/planned/disk.rb
+++ b/src/lib/y2storage/planned/disk.rb
@@ -34,6 +34,7 @@ module Y2Storage
       include Planned::CanBeMounted
       include Planned::CanBeEncrypted
       include Planned::CanBePv
+      include Planned::CanBeMdMember
       include MatchVolumeSpec
 
       # @return [Array<Planned::Partition>] List of planned partitions
@@ -46,6 +47,7 @@ module Y2Storage
         initialize_can_be_mounted
         initialize_can_be_encrypted
         initialize_can_be_pv
+        initialize_can_be_md_member
 
         @partitions = []
       end

--- a/src/lib/y2storage/planned/partition.rb
+++ b/src/lib/y2storage/planned/partition.rb
@@ -37,6 +37,7 @@ module Y2Storage
       include Planned::CanBeMounted
       include Planned::CanBeEncrypted
       include Planned::CanBePv
+      include Planned::CanBeMdMember
       include MatchVolumeSpec
 
       # @return [PartitionId] id of the partition. If nil, the final id is
@@ -59,10 +60,6 @@ module Y2Storage
       # @return [Boolean] whether the partition must be primary
       attr_accessor :primary
 
-      # @return [String] name of the MD array to which this partition should
-      #   be added
-      attr_accessor :raid_name
-
       # Constructor.
       #
       # @param mount_point [string] See {#mount_point}
@@ -74,6 +71,7 @@ module Y2Storage
         initialize_can_be_mounted
         initialize_can_be_encrypted
         initialize_can_be_pv
+        initialize_can_be_md_member
 
         @mount_point = mount_point
         @filesystem_type = filesystem_type

--- a/src/lib/y2storage/planned/stray_blk_device.rb
+++ b/src/lib/y2storage/planned/stray_blk_device.rb
@@ -35,6 +35,7 @@ module Y2Storage
       include Planned::CanBeMounted
       include Planned::CanBeEncrypted
       include Planned::CanBePv
+      include Planned::CanBeMdMember
       include MatchVolumeSpec
 
       # Constructor.
@@ -44,6 +45,7 @@ module Y2Storage
         initialize_can_be_mounted
         initialize_can_be_encrypted
         initialize_can_be_pv
+        initialize_can_be_md_member
       end
 
       # @see Device.to_string_attrs

--- a/src/lib/y2storage/proposal/autoinst_devices_creator.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_creator.rb
@@ -155,7 +155,6 @@ module Y2Storage
       # @return [Array<Array<Planned::Md>, Array<Planned::Md>, CreatorResult>]
       def process_mds(planned_devices, devs_to_reuse, creator_result)
         mds_to_reuse, mds_to_create = planned_devices.mds.partition(&:reuse?)
-        # TODO: currently it is not possible to use full disks in a RAID
         devs_to_reuse_in_md = reusable_by_md(devs_to_reuse)
         creator_result.merge!(create_mds(mds_to_create, creator_result, devs_to_reuse_in_md))
         mds_to_reuse.each { |i| i.reuse!(creator_result.devicegraph) }
@@ -304,9 +303,7 @@ module Y2Storage
       # @param planned_devices [Planned::DevicesCollection] collection of planned devices
       # @return [Array<Planned::Device>]
       def reusable_by_md(planned_devices)
-        planned_devices.select do |dev|
-          dev.is_a?(Planned::StrayBlkDevice) || dev.is_a?(Planned::Partition)
-        end
+        planned_devices.select { |d| d.respond_to?(:raid_name) }
       end
     end
   end

--- a/src/lib/y2storage/proposal/autoinst_disk_device_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_disk_device_planner.rb
@@ -85,6 +85,7 @@ module Y2Storage
         planned_disk = Y2Storage::Planned::Disk.new
         device_config(planned_disk, part, drive)
         planned_disk.lvm_volume_group_name = part.lvm_group
+        planned_disk.raid_name = part.raid_name
         add_device_reuse(planned_disk, drive.device, part)
 
         [planned_disk]

--- a/test/y2storage/planned/can_be_md_member_test.rb
+++ b/test/y2storage/planned/can_be_md_member_test.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::Planned::CanBeMdMember do
+
+  # Dummy class to test the mixin
+  class MdMemberDevice < Y2Storage::Planned::Device
+    include Y2Storage::Planned::CanBeMdMember
+
+    def initialize
+      super
+      initialize_can_be_md_member
+    end
+  end
+
+  subject(:planned) { MdMemberDevice.new }
+
+  describe "#md_member?" do
+    context "when the device has a RAID name" do
+      before do
+        planned.raid_name = "/dev/md0"
+      end
+
+      it "returns true" do
+        expect(planned.md_member?).to eq(true)
+      end
+    end
+
+    context "when the device does not have a RAID name" do
+      it "returns false" do
+        expect(planned.md_member?).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR extends #754 so a disk can be used as a MD RAID too. In the image below you can see a `raid0` which uses `5GiB` from `vda1` and the whole `vdb` disk (20GiB).

![use-disk-as-md-member](https://user-images.githubusercontent.com/15836/46358017-fcc7a280-c65d-11e8-962c-4871c362b767.png)