### PR TITLE
Fix/support old md raid ay format

### DIFF
--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -280,15 +280,19 @@ module Y2Storage
       # Method used by {.new_from_storage} to populate the attributes when
       # cloning a MD RAID.
       #
-      # AutoYaST does not support multiple partitions on a MD RAID.
-      #
       # @param md [Y2Storage::Md] RAID
       # @return [Boolean]
       def init_from_md(md)
         @type = :CT_MD
         @device = md.name
-        @partitions = partitions_from_collection([md])
-        @enable_snapshots = enabled_snapshots?([md.filesystem])
+        collection =
+          if md.filesystem
+            [md]
+          else
+            md.partitions
+          end
+        @partitions = partitions_from_collection(collection)
+        @enable_snapshots = enabled_snapshots?(collection.map(&:filesystem).compact)
         @raid_options = RaidOptionsSection.new_from_storage(md)
         @raid_options.raid_name = nil if @raid_options # This element is not supported here
         true

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -126,6 +126,7 @@ module Y2Storage
         @skip_list = SkipListSection.new_from_hashes(hash.fetch("skip_list", []), self)
         if hash["raid_options"]
           @raid_options = RaidOptionsSection.new_from_hashes(hash["raid_options"], self)
+          @raid_options.raid_name = nil # This element is not supported here
         end
       end
 
@@ -289,6 +290,7 @@ module Y2Storage
         @partitions = partitions_from_collection([md])
         @enable_snapshots = enabled_snapshots?([md.filesystem])
         @raid_options = RaidOptionsSection.new_from_storage(md)
+        @raid_options.raid_name = nil if @raid_options # This element is not supported here
         true
       end
 

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -287,10 +287,8 @@ module Y2Storage
       def init_fields_by_type(device)
         if device.is?(:lvm_lv)
           init_lv_fields(device)
-        elsif device.is?(:md)
-          init_md_fields(device)
         elsif device.is?(:disk_device)
-          init_disk_fields(device)
+          init_disk_device_fields(device)
         else
           init_partition_fields(device)
         end
@@ -305,10 +303,10 @@ module Y2Storage
         @raid_name = partition.md.name if partition.md
       end
 
-      def init_disk_fields(disk)
+      def init_disk_device_fields(disk)
         @create = false
         @lvm_group = lvm_group_name(disk)
-        @raid_name = disk.md.name if disk.md
+        @raid_name = disk.md.name if disk.respond_to?(:md) && disk.md
       end
 
       def init_lv_fields(lv)
@@ -318,12 +316,6 @@ module Y2Storage
         @pool = lv.lv_type == LvType::THIN_POOL
         parent = lv.parents.first
         @used_pool = parent.lv_name if lv.lv_type == LvType::THIN && parent.is?(:lvm_lv)
-      end
-
-      def init_md_fields(md)
-        @partition_nr = md.number if md.numeric?
-        @raid_options = RaidOptionsSection.new_from_storage(md)
-        @lvm_group = lvm_group_name(md)
       end
 
       def init_encryption_fields(partition)

--- a/src/lib/y2storage/proposal/autoinst_md_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_md_planner.rb
@@ -73,7 +73,7 @@ module Y2Storage
         device_config(md, part_section, drive)
         md.lvm_volume_group_name = part_section.lvm_group
         add_md_reuse(md, part_section) if part_section.create == false
-        add_raid_options(md, part_section.raid_options)
+        add_raid_options(md, drive.raid_options || part_section.raid_options)
         md
       end
 

--- a/test/y2storage/autoinst_profile/drive_section_test.rb
+++ b/test/y2storage/autoinst_profile/drive_section_test.rb
@@ -66,7 +66,18 @@ describe Y2Storage::AutoinstProfile::DriveSection do
       it "initializes raid options" do
         expect(Y2Storage::AutoinstProfile::RaidOptionsSection).to receive(:new_from_hashes)
           .with(raid_options, Y2Storage::AutoinstProfile::DriveSection)
-        described_class.new_from_hashes(hash)
+          .and_call_original
+        section = described_class.new_from_hashes(hash)
+        expect(section.raid_options.raid_type).to eq("raid0")
+      end
+
+      context "when the raid_name is specified in the raid_options" do
+        let(:raid_options) { { "raid_type" => "raid0" } }
+
+        it "ignores the raid_name element" do
+          section = described_class.new_from_hashes(hash)
+          expect(section.raid_options.raid_name).to be_nil
+        end
       end
     end
 

--- a/test/y2storage/autoinst_profile/partition_section_test.rb
+++ b/test/y2storage/autoinst_profile/partition_section_test.rb
@@ -196,30 +196,6 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
           .and_return(raid_options)
       end
 
-      it "initializes #raid_options" do
-        expect(Y2Storage::AutoinstProfile::RaidOptionsSection).to receive(:new_from_storage)
-          .with(md).and_return(raid_options)
-        expect(described_class.new_from_storage(md).raid_options).to eq(raid_options)
-      end
-
-      context "when it is not a named RAID" do
-        let(:numeric?) { true }
-
-        it "initializes #partition_nr to the RAID number" do
-          section = described_class.new_from_storage(md)
-          expect(section.partition_nr).to eq(md.number)
-        end
-      end
-
-      context "when it is a named RAID" do
-        let(:numeric?) { false }
-
-        it "does not initialize #partition_nr" do
-          section = described_class.new_from_storage(md)
-          expect(section.partition_nr).to be_nil
-        end
-      end
-
       context "when it is used as an LVM physical volume" do
         let(:lvm_vg) { instance_double(Y2Storage::LvmVg, basename: "vg0") }
         let(:lvm_pv) do

--- a/test/y2storage/proposal/autoinst_md_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_md_planner_test.rb
@@ -41,7 +41,7 @@ describe Y2Storage::Proposal::AutoinstMdPlanner do
 
     let(:raid) do
       {
-        "device" => "/dev/md2", "raid_options" => raid_options, "disklabel" => disklabel,
+        "device" => device, "raid_options" => raid_options, "disklabel" => disklabel,
         "partitions" => [home_spec]
       }
     end
@@ -55,6 +55,8 @@ describe Y2Storage::Proposal::AutoinstMdPlanner do
     end
 
     let(:disklabel) { nil }
+
+    let(:device) { "/dev/md2" }
 
     it "returns a planned RAID with the given device name" do
       md = planner.planned_devices(drive).first
@@ -148,9 +150,7 @@ describe Y2Storage::Proposal::AutoinstMdPlanner do
     end
 
     context "when using a named RAID" do
-      let(:raid_options) do
-        { "raid_name" => "/dev/md/data", "raid_type" => "raid5" }
-      end
+      let(:device) { "/dev/md/data" }
 
       it "uses the name instead of a number" do
         md = planner.planned_devices(drive).first

--- a/test/y2storage/proposal/autoinst_md_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_md_planner_test.rb
@@ -47,10 +47,7 @@ describe Y2Storage::Proposal::AutoinstMdPlanner do
     end
 
     let(:home_spec) do
-      {
-        "mount" => "/home", "filesystem" => "xfs", "size" => "max", "partition_nr" => 1,
-        "raid_options" => raid_options
-      }
+      { "mount" => "/home", "filesystem" => "xfs", "size" => "max", "partition_nr" => 1 }
     end
 
     let(:raid_options) do
@@ -106,6 +103,21 @@ describe Y2Storage::Proposal::AutoinstMdPlanner do
       it "does not set the partition table type" do
         md = planner.planned_devices(drive).first
         expect(md.ptable_type).to be_nil
+      end
+
+      context "and RAID options are not specified at drive level" do
+        let(:raid_options) { nil }
+        let(:home_spec) do
+          {
+            "mount" => "/home", "filesystem" => "xfs", "size" => "max", "partition_nr" => 1,
+            "raid_options" => { "raid_type" => "raid5" }
+          }
+        end
+
+        it "reads options from the partition section" do
+          md = planner.planned_devices(drive).first
+          expect(md.md_level).to eq(Y2Storage::MdLevel::RAID5)
+        end
       end
     end
 


### PR DESCRIPTION
Fix support for the old way of specifying RAID devices.

```xml
<drive>
  <device>/dev/md</device>
  <partitions config:type="list">
    <partition> <!-- /dev/md0 -->
      <partition_nr config:type="integer">0</partition_nr>
      <filesystem config:type="symbol">xfs</filesystem>
      <format config:type="boolean">true</format>
      <mount>/home</mount>
      <raid_options>
        <raid_type>raid1</raid_type>
      </raid_options>
    </partition>

    <partition> <!-- /dev/md1 -->
      <partition_nr config:type="integer">1</partition_nr>
      <filesystem config:type="symbol">xfs</filesystem>
      <format config:type="boolean">true</format>
      <mount>/srv</mount>
      <raid_options>
        <raid_type>raid1</raid_type>
      </raid_options>
    </partition>
  </partitions>
</drive>
```