### PR TITLE
lower minimal mbr gap size to allow creating unaligned partitions

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Oct 26 11:37:48 UTC 2018 - snwint@suse.com
+
+- allow creation of partitions starting before 1 MiB in expert
+  partitioner
+
+-------------------------------------------------------------------
 Sat Oct 20 22:10:48 WEST 2018 - igonzalezsosa@suse.com
 
 - Fixes and improvements to AutoYaST partitioning:

--- a/src/lib/y2partitioner/actions/create_partition_table.rb
+++ b/src/lib/y2partitioner/actions/create_partition_table.rb
@@ -77,7 +77,10 @@ module Y2Partitioner
       # @param type [Y2Storage::PartitionTables::Type]
       def create_partition_table(type)
         disk.remove_descendants
-        disk.create_partition_table(type)
+        ptable = disk.create_partition_table(type)
+        if ptable.type.is?(:msdos)
+          ptable.minimal_mbr_gap = Y2Storage::DiskSize.B(512)
+        end
         Y2Storage::Filesystems::Btrfs.refresh_subvolumes_shadowing(device_graph)
       end
 

--- a/src/lib/y2partitioner/actions/create_partition_table.rb
+++ b/src/lib/y2partitioner/actions/create_partition_table.rb
@@ -79,6 +79,11 @@ module Y2Partitioner
         disk.remove_descendants
         ptable = disk.create_partition_table(type)
         if ptable.type.is?(:msdos)
+          # The default value is 1 MiB, preventing the creation of a
+          # partition starting at a lower value.
+          # 0.5 KiB is the space used by the partition table itself, you
+          # cannot go below that.
+          # Note that this does not affect partition alignment.
           ptable.minimal_mbr_gap = Y2Storage::DiskSize.B(512)
         end
         Y2Storage::Filesystems::Btrfs.refresh_subvolumes_shadowing(device_graph)


### PR DESCRIPTION
For ms-dos partition tables the default minimal_mbr_gap setting of 1 MiB
prevents creating partitions in the expert partitioner starting at a lower
value (via the region dialog).

Note this is not an issue with gpt, there you can already do this.