### PR TITLE
do not include 'Partition' in partition type names

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Oct 30 13:38:10 UTC 2018 - snwint@suse.com
+
+- do not include 'Partition' in partition type names
+
+-------------------------------------------------------------------
 Fri Oct 26 11:37:48 UTC 2018 - snwint@suse.com
 
 - allow creation of partitions starting before 1 MiB in expert

--- a/src/lib/y2storage/partition_id.rb
+++ b/src/lib/y2storage/partition_id.rb
@@ -36,24 +36,25 @@ module Y2Storage
     NOT_ALLOW_FORMAT = [LVM, RAID, ESP, PREP, BIOS_BOOT, UNKNOWN].freeze
     private_constant :NOT_ALLOW_FORMAT
 
+    # Do not include 'Partition' in the name.
     TRANSLATIONS = {
-      BIOS_BOOT.to_i          => N_("BIOS Boot Partition"),
-      DIAG.to_i               => N_("Diagnostics Partition"),
+      BIOS_BOOT.to_i          => N_("BIOS Boot"),
+      DIAG.to_i               => N_("Diagnostics"),
       DOS12.to_i              => N_("DOS12"),
       DOS16.to_i              => N_("DOS16"),
       DOS32.to_i              => N_("DOS32"),
-      ESP.to_i                => N_("EFI System Partition"),
+      ESP.to_i                => N_("EFI System"),
       EXTENDED.to_i           => N_("Extended"),
       IRST.to_i               => N_("Intel Rapid Start"),
       LINUX.to_i              => N_("Linux Native"),
       LVM.to_i                => N_("Linux LVM"),
-      MICROSOFT_RESERVED.to_i => N_("Microsoft Reserved Partition"),
+      MICROSOFT_RESERVED.to_i => N_("Microsoft Reserved"),
       NTFS.to_i               => N_("NTFS"),
-      PREP.to_i               => N_("PReP Boot Partition"),
+      PREP.to_i               => N_("PReP Boot"),
       RAID.to_i               => N_("Linux RAID"),
       SWAP.to_i               => N_("Linux Swap"),
       UNKNOWN.to_i            => N_("Unknown"),
-      WINDOWS_BASIC_DATA.to_i => N_("Windows Data Partition")
+      WINDOWS_BASIC_DATA.to_i => N_("Windows Data")
     }.freeze
     private_constant :TRANSLATIONS
 


### PR DESCRIPTION
Rather add 'Partition' explicitly if really needed. This way it's possible
to use the partition type in texts consistently.

The understanding is that 'XXX partition' and 'partition of type XXX' should
both be legible terms.