### PR TITLE
fix boot requirements: legacy

### DIFF
--- a/doc/the-boot-partition-and-me.md
+++ b/doc/the-boot-partition-and-me.md
@@ -1,0 +1,83 @@
+## What is the boot partition used for and why would I need one?
+
+
+> #### Notes
+> - In this document only file systems supported by `storage-ng` are considered: btrfs, extX (ext2, ext3, ext4), xfs.
+> - With 'boot partition' a partition mounted at `/boot` (or containing the `/boot` directory directly) is meant.
+>   It is not to be confused with the BIOS GRUB partition, EFI System Partition, or PReP partition.
+> - While this document is basically valid for all architectures (points 1 and 3 in the below list) the focus here is on clarifying the situation
+>   on x86 with legacy BIOS and msdos partition table.
+
+A boot partition is used for three different purposes
+
+1. to hold kernel and initrd using a file system that can be read by grub
+2. to install grub into
+3. to hold the grub environment block (accessible as `/boot/grub2/grubenv` in the file system)
+
+There are different file system requirements for each use case
+
+1. extX, xfs, btrfs
+2. extX, btrfs
+3. readable in grub: extX, xfs, btrfs; writable in grub: extX, xfs
+
+So if you ever need a boot partition, extX would be the file system of choice.
+
+Let's get into detail.
+
+### 1. To hold kernel and initrd
+
+This would be needed in a complex setup where grub otherwise would not be
+able to read the kernel. As grub supports basically everything the only
+reason left would be to avoid entering the decryption key in grub for an
+encrypted boot partition.
+
+### 2. To install grub into
+
+On x86 with a legacy BIOS setup and using a msdos partition table grub
+would normally be installed into free space before the first partition ('mbr gap').
+
+But if the mbr gap is too small grub can alternatively be installed into the
+boot partition and a generic boot loader be put into the mbr to chainload
+grub from the boot partition.
+
+This is a setup discouraged by grub as this embedding of grub into a file
+system via block maps has the drawback that if the grub image files are
+inadvertently moved this would invalidate the block map and break
+grub until `grub2-install` is re-run.
+
+The mbr gap is considered large enough by `storage-ng` if it's at least
+256 KiB. This limit cannot be given exactly as it depends on the number of modules
+grub needs to boot (lvm, raid, encryption, file systems, ...).
+
+The chosen value is comfortably larger than the current real grub
+requirements (around 100 KiB) and much smaller than typical real mbr gap
+values of 1 MiB. Only older disks might have been partitioned with the obsolete
+chs (cylinder) layout in mind and only reserved one track (31.5 KiB) - which is too small for
+our purposes and is caught by our limit.
+
+### 3. To hold the grub environment block
+
+The [grub environment block](https://www.gnu.org/software/grub/manual/grub/grub.html#Environment-block)
+is a 1 KiB block reserved to store environment
+variables to be read and written by grub during the boot process. The block
+is visible as `/boot/grub2/grubenv` in the file system but should be
+accessed only via the `grub2-editenv` command.
+
+Entries can be read and written with `load_env` and `save_env` from grub. The catch
+here is that it can basically always be read but writing is limited to a few file systems
+as grub just does not want to get into trouble accidentally destroying data. Also, writing is
+not supported via lvm, raid, and encryption modules.
+
+The main usage of this block is `grub2-once` that sets a `next_entry`
+variable (boot entry to be used for the next boot). This variable is unset
+during the next boot by systemd in `grub2-once.service`.
+
+`save_env` is **not** used for this and we can live fine with a setup that
+does not allow writing the environment block from grub.
+
+### Conclusion
+
+A boot partition is not needed unless the mbr gap is too small. Because
+
+- we consciously live with the fact that you have to enter the decryption key in grub
+- write access in grub to the environment block is not needed in a typical setup

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 16 14:56:26 UTC 2018 - snwint@suse.com
+
+- adjust boot requirements to handle RAID cases
+- 4.1.33
+
+-------------------------------------------------------------------
 Wed Nov 14 15:15:04 CET 2018 - schubi@suse.de
 
 - SkipListValue.size_k returns the correct value (bsc#1115508).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.32
+Version:	4.1.33
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/rakelib/doc_bootspecs.rake
+++ b/rakelib/doc_bootspecs.rake
@@ -20,8 +20,8 @@
 namespace :doc do
   desc "Build boot requirements spec."
   task :bootspecs do
-    files = Dir["**/test/y2storage/boot_requirements_checker_*_test.rb"]
-    sh "rspec" \
+    files = Dir["**/test/y2storage/boot_requirements_checker_*_test.rb"].sort
+    sh "PARALLEL_TESTS=0 rspec" \
       " --require ./src/tools/md_formatter.rb" \
       " --format MdFormatter" \
       " --out doc/boot-requirements.md" \

--- a/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
@@ -481,9 +481,7 @@ module Y2Storage
       #
       # FIXME: The check is possibly overly strict: currently it enforces
       #   that the disk is a member of a single RAID.
-      #   With BIOS RAIDs that might not be necessary. Also the limitation
-      #   to RAID1 can possibly be dropped there - the question would be how
-      #   grub behaves in this case.
+      #   That might not be necessary.
       #
       # @return [Y2Storage::Md, nil] the RAID device, else nil
       def boot_disk_raid1(device)

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -47,7 +47,8 @@ module Y2Storage
         :root_in_lvm?, :root_in_software_raid?, :encrypted_root?, :btrfs_root?,
         :root_fs_can_embed_grub?,
         :boot_in_lvm?, :boot_in_software_raid?, :encrypted_boot?,
-        :boot_fs_can_embed_grub?, :boot_filesystem_type, :boot_can_embed_grub?
+        :boot_fs_can_embed_grub?, :boot_filesystem_type, :boot_can_embed_grub?,
+        :esp_in_lvm?, :esp_in_software_raid?, :esp_in_software_raid1?, :encrypted_esp?
 
       # Constructor
       #

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -45,7 +45,9 @@ module Y2Storage
       def_delegators :@analyzer,
         :root_filesystem, :boot_disk, :boot_ptable_type?, :free_mountpoint?,
         :root_in_lvm?, :root_in_software_raid?, :encrypted_root?, :btrfs_root?,
-        :boot_in_lvm?, :boot_in_software_raid?, :encrypted_boot?, :boot_filesystem_type
+        :root_fs_can_embed_grub?,
+        :boot_in_lvm?, :boot_in_software_raid?, :encrypted_boot?,
+        :boot_fs_can_embed_grub?, :boot_filesystem_type, :boot_can_embed_grub?
 
       # Constructor
       #

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -59,6 +59,8 @@ module Y2Storage
 
         @devicegraph = devicegraph
         @analyzer = Analyzer.new(devicegraph, planned_devices, boot_disk_name)
+
+        log.info "boot disk: #{boot_disk.inspect}"
       end
 
       # Partitions that should be created to boot the system

--- a/src/lib/y2storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/legacy.rb
@@ -26,9 +26,6 @@ module Y2Storage
   module BootRequirementsStrategies
     # Strategy to calculate the boot requirements in a legacy system (x86 without EFI)
     class Legacy < Base
-      GRUB_SIZE = DiskSize.KiB(256)
-      GRUBENV_SIZE = DiskSize.KiB(1)
-
       def initialize(*args)
         super
         textdomain "storage"
@@ -36,7 +33,6 @@ module Y2Storage
 
       # @see Base#needed_partitions
       def needed_partitions(target)
-        raise Error if grub_in_mbr? && mbr_gap && !valid_mbr_gap?
         planned_partitions = super
         planned_partitions << grub_partition(target) if grub_partition_needed? && grub_partition_missing?
         planned_partitions
@@ -44,14 +40,18 @@ module Y2Storage
 
       # Boot warnings in the current setup
       #
+      # Note that all are just warnings and we don't trigger real errors so far.
+      #
       # @return [Array<SetupError>]
       def warnings
         res = super
 
         if boot_ptable_type?(:gpt)
           res.concat(errors_on_gpt)
-        else
+        elsif boot_ptable_type?(:msdos)
           res.concat(errors_on_msdos)
+        else
+          res.concat(errors_on_plain_disk)
         end
 
         res
@@ -59,15 +59,19 @@ module Y2Storage
 
     protected
 
-      # Whether the MBR gap is big enough
+      # Whether a BIOS GRUB partition will be needed.
       #
-      # @return [Boolean] true if the MBR gap is enough; false otherwise.
-      def valid_mbr_gap?
-        mbr_gap && mbr_gap >= GRUB_SIZE
-      end
-
+      # Note: this is a bit tricky.
+      #
+      # This function is intended to be used in #needed_partitions while
+      # creating a partition proposal. The catch is that when there is no
+      # partition table (yet) it is implicitly assumed that there will be a
+      # gpt created finally - so a grub partition is needed also in this
+      # case.
+      #
+      # @return [Boolean]
       def grub_partition_needed?
-        boot_ptable_type?(:gpt) && grub_part_needed_in_gpt?
+        (boot_ptable_type?(:gpt) || boot_ptable_type?(nil)) && grub_part_needed_in_gpt?
       end
 
       # Given the fact we are trying to boot from a GPT disk, whether a BIOS
@@ -94,39 +98,42 @@ module Y2Storage
       def grub_partition_missing?
         # We don't check if the planned partition is in the boot disk,
         # whoever created it is in control of the details
-        current_devices = analyzer.planned_devices + boot_disk.partitions
+        current_devices = analyzer.planned_devices
+        current_devices += boot_disk.partitions if boot_disk
         current_devices.none? { |d| d.match_volume?(grub_volume) }
       end
 
-      def grub_in_mbr?
-        boot_ptable_type?(:msdos) && !plain_btrfs?
-      end
-
-      def plain_btrfs?
-        btrfs_without_lvm? && btrfs_without_software_raid? && btrfs_without_encryption?
-      end
-
-      def btrfs_without_lvm?
-        btrfs_root? && !root_in_lvm?
-      end
-
-      # Whether the root filesystem is a BTRFS over a software raid
+      # Whether /boot is a plain partition and can embed grub
       #
-      # @return [Boolean] true if it is a BTRFS over a software raid; false otherwise.
-      def btrfs_without_software_raid?
-        btrfs_root? && !root_in_software_raid?
+      # @return [Boolean] true if /boot is a plain partition and can embed grub, else false
+      def boot_can_embed_grub?
+        boot_fs_can_embed_grub? && !(boot_in_lvm? || boot_in_software_raid? || encrypted_boot?)
       end
 
-      def btrfs_without_encryption?
-        btrfs_root? && !encrypted_root?
+      # Whether / is a plain partition and can embed grub
+      #
+      # @return [Boolean] true if / is a plain partition and can embed grub, else false
+      def root_can_embed_grub?
+        root_fs_can_embed_grub? && !(root_in_lvm? || root_in_software_raid? || encrypted_root?)
       end
 
+      # Whether the MBR gap is big enough for grub
+      #
+      # @return [Boolean] true if the MBR gap is big enough for grub, else false
+      def mbr_gap_for_grub?
+        boot_disk.mbr_gap_for_grub?
+      end
+
+      # A separate boot partition is needed if
+      #   - partition table is msdos and
+      #   - the mbr gap is too small for grub and
+      #   - grub can't be embedded into the root file system directly
+      #
+      # Note: this is *not* the bios grub partition.
+      #
+      # @return [Boolean] true if a separate boot partition is needed, else false
       def boot_partition_needed?
-        grub_in_mbr? && valid_mbr_gap? && mbr_gap < GRUB_SIZE + GRUBENV_SIZE
-      end
-
-      def mbr_gap
-        boot_disk.mbr_gap
+        boot_ptable_type?(:msdos) && !mbr_gap_for_grub? && !root_can_embed_grub?
       end
 
       # @return [VolumeSpecification]
@@ -148,13 +155,12 @@ module Y2Storage
         errors = []
 
         if grub_part_needed_in_gpt? && missing_partition_for?(grub_volume)
-          message = _(
-            "There is no partition of type BIOS Boot. " \
-            "For GPT devices it is strongly advised to use a BIOS Boot partition. " \
-            "A setup without such a partition is not supported and may cause " \
-            "problems now or in the future."
-          )
-          errors << SetupError.new(message: message)
+          errors << bios_boot_missing_error
+          errors <<= if boot_can_embed_grub?
+            bad_config_warning
+          else
+            bad_config_error
+          end
         end
 
         errors
@@ -166,22 +172,36 @@ module Y2Storage
       def errors_on_msdos
         errors = []
 
-        if !valid_mbr_gap?
-          errors << mbr_gap_error if !plain_btrfs?
-        elsif boot_partition_needed? && missing_partition_for?(boot_volume)
-          errors << SetupError.new(missing_volume: boot_volume)
+        if !mbr_gap_for_grub?
+          errors <<= mbr_gap_error
+          errors <<= if boot_can_embed_grub?
+            bad_config_warning
+          else
+            bad_config_error
+          end
         end
 
         errors
       end
 
-      # Specific error when the boot disk has not partition table
+      # Boot errors when there's no partition table
+      #
+      # @return [Array<SetupError>]
+      def errors_on_plain_disk
+        errors = []
+
+        errors << no_boot_partition_table_error
+
+        errors
+      end
+
+      # Specific error when the boot disk has no partition table
       #
       # @return [SetupError]
-      def unknown_boot_partition_table_error
+      def no_boot_partition_table_error
         # TRANSLATORS: error message
         error_message = _(
-          "Boot disk has no partition table and it is not possible to boot from it." \
+          "Boot disk has no partition table and it is not possible to boot from it. " \
           "You can fix it by creating a partition table on the boot disk."
         )
         SetupError.new(message: error_message)
@@ -191,9 +211,48 @@ module Y2Storage
       #
       # @return [SetupError]
       def mbr_gap_error
-        # TRANSLATORS: error message
-        error_message = _("MBR gap size is not enough to correctly install bootloader")
+        # TRANSLATORS: error message; %s is a human readable disk size like 256 KiB
+        error_message = format(
+          _(
+            "Not enough space before the first partition to install the bootloader. " \
+            "Leave at least %s."
+          ),
+          PartitionTables::Msdos::MBR_GAP_GRUB_LIMIT
+        )
         SetupError.new(message: error_message)
+      end
+
+      # Specific error when BIOS GRUB partition is missing
+      #
+      # @return [SetupError]
+      def bios_boot_missing_error
+        # TRANSLATORS: %s is a partition type, e.g. "BIOS Boot"
+        message = format(
+          _("A partition of type %s is needed to install the bootloader."),
+          PartitionId::BIOS_BOOT.to_human_string
+        )
+        SetupError.new(message: message)
+      end
+
+      # Specific warning when the current setup is not supported
+      #
+      # @return [SetupError]
+      def bad_config_warning
+        message = _(
+          "Such a setup is not supported and may cause problems " \
+          "with the bootloader now or in the future."
+        )
+        SetupError.new(message: message)
+      end
+
+      # Specific error when we are quite sure the current setup will not work
+      #
+      # @return [SetupError]
+      def bad_config_error
+        message = _(
+          "It will not be possible to install the bootloader."
+        )
+        SetupError.new(message: message)
       end
     end
   end

--- a/src/lib/y2storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/legacy.rb
@@ -71,7 +71,29 @@ module Y2Storage
       #
       # @return [Boolean]
       def grub_partition_needed?
-        (boot_ptable_type?(:gpt) || boot_ptable_type?(nil)) && grub_part_needed_in_gpt?
+        future_boot_ptable_type?(:gpt) && grub_part_needed_in_gpt?
+      end
+
+      # Whether the partition table that will finally be created matches the
+      # given type.
+      #
+      # This is the same as the partition table type if one already exists. Else
+      # the check will be against #preferred_ptable_type.
+      #
+      # FIXME
+      #   It seems that a setup with xen virtual partitions (that are in
+      #   fact disks) also ends up here. In that case no partition table will
+      #   be created (below this case is indicated by boot_disk = nil).
+      #   This looks weird.
+      #
+      # @return [Boolean] true if the partition table matches.
+      def future_boot_ptable_type?(type)
+        return false if boot_disk.nil?
+        if boot_ptable_type?(nil)
+          boot_disk.preferred_ptable_type.is?(type)
+        else
+          boot_ptable_type?(type)
+        end
       end
 
       # Given the fact we are trying to boot from a GPT disk, whether a BIOS

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -167,6 +167,9 @@ module Y2Storage
 
       ZIPL_FILESYSTEMS = [:ext2, :ext3, :ext4, :xfs]
 
+      # filesystems that can embed grub
+      GRUB_FILESYSTEMS = [:ext2, :ext3, :ext4, :btrfs]
+
       private_constant :PROPERTIES, :ROOT_FILESYSTEMS, :HOME_FILESYSTEMS,
         :COMMON_FSTAB_OPTIONS, :EXT_FSTAB_OPTIONS, :LEGACY_ROOT_FILESYSTEMS,
         :LEGACY_HOME_FILESYSTEMS, :ZIPL_FILESYSTEMS, :JOURNAL_OPTIONS,
@@ -214,6 +217,13 @@ module Y2Storage
         ZIPL_FILESYSTEMS.map { |f| find(f) }
       end
 
+      # Allowed filesystems to embed grub
+      #
+      # @return [Array<Filesystems::Type>]
+      def self.grub_filesystems
+        GRUB_FILESYSTEMS.map { |f| find(f) }
+      end
+
       # Check if filesystem is usable as root (mountpoint "/") filesystem.
       #
       # return [Boolean]
@@ -259,6 +269,13 @@ module Y2Storage
       # @return [Boolean]
       def zipl_ok?
         Type.zipl_filesystems.include?(self)
+      end
+
+      # Checks whether this type is usable to embed grub.
+      #
+      # @return [Boolean]
+      def grub_ok?
+        Type.grub_filesystems.include?(self)
       end
 
       # Check if filesystem was usable as home (mountpoint "/home") filesystem.

--- a/src/lib/y2storage/partition_tables/msdos.rb
+++ b/src/lib/y2storage/partition_tables/msdos.rb
@@ -44,6 +44,13 @@ module Y2Storage
       LOWER_MBR_GAP_LIMIT = DiskSize.B(512)
       private_constant :LOWER_MBR_GAP_LIMIT
 
+      # MBR_GAP_GRUB_LIMIT covers the size needed for embedding the grub image.
+      #
+      # The value is not exact (it depends on the grub modules needed to
+      # access the /boot partition [raid, lvm, encryption, ...]) but is
+      # chosen big enough to be on the safe side.
+      MBR_GAP_GRUB_LIMIT = DiskSize.KiB(256)
+
       # @!attribute minimal_mbr_gap
       #   Minimal possible size of the so-called MBR gap. In other words, at
       #   which distance from the start of the disk should the first partition
@@ -77,6 +84,15 @@ module Y2Storage
 
         region1 = partitions.min { |x, y| x.region.start <=> y.region.start }
         region1.region.block_size * region1.region.start
+      end
+
+      # Whether the MBR gap is big enough for grub
+      #
+      # If the mbr_gap is nil this means there are no partitions. This is also ok.
+      #
+      # @return [Boolean] true if the MBR gap is big enough for grub, else false
+      def mbr_gap_for_grub?
+        !mbr_gap || mbr_gap >= MBR_GAP_GRUB_LIMIT
       end
 
       # Sets #{minimal_mbr_gap} to the lower acceptable value

--- a/src/lib/y2storage/partitionable.rb
+++ b/src/lib/y2storage/partitionable.rb
@@ -223,6 +223,18 @@ module Y2Storage
       partition_table.mbr_gap
     end
 
+    # Whether there is a MBR gap big enough for grub
+    #
+    # @see PartitionTables::Msdos#mbr_gap_for_grub?
+    #
+    # @return [Boolean] true if there is a MS-DOS partition table and the mbr gap is big
+    #   enough for grub; else false
+    def mbr_gap_for_grub?
+      return false unless partition_table
+      return false unless partition_table.respond_to?(:mbr_gap_for_grub?)
+      partition_table.mbr_gap_for_grub?
+    end
+
     # Free spaces inside the device
     #
     # @return [Array<FreeDiskSpace>]

--- a/test/support/boot_requirements_context.rb
+++ b/test/support/boot_requirements_context.rb
@@ -58,7 +58,11 @@ RSpec.shared_context "boot requirements" do
       planned_devices:         planned_grub_partitions + planned_prep_partitions,
       max_planned_weight:      0.0,
       boot_fs_can_embed_grub?: embed_grub,
-      root_fs_can_embed_grub?: embed_grub
+      root_fs_can_embed_grub?: embed_grub,
+      esp_in_lvm?:             false,
+      esp_in_software_raid?:   false,
+      esp_in_software_raid1?:  false,
+      encrypted_esp?:          false
     )
   end
 

--- a/test/support/boot_requirements_context.rb
+++ b/test/support/boot_requirements_context.rb
@@ -56,10 +56,13 @@ RSpec.shared_context "boot requirements" do
       planned_prep_partitions: planned_prep_partitions,
       planned_grub_partitions: planned_grub_partitions,
       planned_devices:         planned_grub_partitions + planned_prep_partitions,
-      max_planned_weight:      0.0
+      max_planned_weight:      0.0,
+      boot_fs_can_embed_grub?: embed_grub,
+      root_fs_can_embed_grub?: embed_grub
     )
   end
 
+  let(:embed_grub) { false }
   let(:use_lvm) { false }
   let(:use_raid) { false }
   let(:use_encryption) { false }

--- a/test/y2storage/boot_requirements_checker_aarch64_test.rb
+++ b/test/y2storage/boot_requirements_checker_aarch64_test.rb
@@ -37,14 +37,12 @@ describe Y2Storage::BootRequirementsChecker do
     let(:other_efi_partitions) { [] }
     let(:use_lvm) { false }
     let(:sda_part_table) { pt_msdos }
-    let(:mbr_gap_size) { Y2Storage::DiskSize.zero }
 
     # it's always UEFI
     let(:efiboot) { true }
 
     before do
       allow(storage_arch).to receive(:efiboot?).and_return(efiboot)
-      allow(dev_sda).to receive(:mbr_gap).and_return mbr_gap_size
       allow(dev_sda).to receive(:efi_partitions).and_return efi_partitions
       allow(dev_sda).to receive(:partitions).and_return(efi_partitions)
       allow(dev_sdb).to receive(:efi_partitions).and_return other_efi_partitions

--- a/test/y2storage/boot_requirements_duplicate_test.rb
+++ b/test/y2storage/boot_requirements_duplicate_test.rb
@@ -39,11 +39,11 @@ describe Y2Storage::BootRequirementsChecker do
     let(:other_efi_partitions) { [] }
     let(:use_lvm) { false }
     let(:sda_part_table) { pt_msdos }
-    let(:mbr_gap_size) { Y2Storage::DiskSize.zero }
+    let(:mbr_gap_for_grub?) { false }
 
     before do
       allow(storage_arch).to receive(:efiboot?).and_return(efiboot)
-      allow(dev_sda).to receive(:mbr_gap).and_return mbr_gap_size
+      allow(dev_sda).to receive(:mbr_gap_for_grub?).and_return mbr_gap_for_grub?
       allow(dev_sda).to receive(:grub_partitions).and_return grub_partitions
       allow(dev_sda).to receive(:efi_partitions).and_return efi_partitions
       allow(dev_sda).to receive(:partitions).and_return(grub_partitions + efi_partitions)
@@ -113,7 +113,7 @@ describe Y2Storage::BootRequirementsChecker do
       # Default values to ensure boot is needed
       let(:use_lvm) { true }
       let(:sda_part_table) { pt_msdos }
-      let(:mbr_gap_size) { Y2Storage::DiskSize.KiB(256) }
+      let(:mbr_gap_for_grub?) { false }
 
       before do
         allow(analyzer).to receive(:free_mountpoint?).with("/boot")

--- a/test/y2storage/boot_requirements_errors_test.rb
+++ b/test/y2storage/boot_requirements_errors_test.rb
@@ -90,11 +90,21 @@ describe Y2Storage::BootRequirementsChecker do
 
     RSpec.shared_examples "missing boot partition" do
       it "contains an error for missing boot partition" do
-        expect(checker.warnings.size).to eq(1)
+        expect(checker.warnings.size).to be >= 1
         expect(checker.warnings).to all(be_a(Y2Storage::SetupError))
 
         message = checker.warnings.first.message
-        expect(message).to match(/Missing device for \/boot/)
+        expect(message).to match(/Missing device for \/boot|Not enough space/)
+      end
+    end
+
+    RSpec.shared_examples "missing mbr gap" do
+      it "contains an error for missing/too small mbr gap" do
+        expect(checker.warnings.size).to be >= 1
+        expect(checker.warnings).to all(be_a(Y2Storage::SetupError))
+
+        message = checker.warnings.first.message
+        expect(message).to match(/Not enough space before the first partition/)
       end
     end
 
@@ -210,11 +220,11 @@ describe Y2Storage::BootRequirementsChecker do
             let(:scenario) { "gpt_without_grub" }
 
             it "contains an error for missing grub partition" do
-              expect(checker.warnings.size).to eq(1)
+              expect(checker.warnings.size).to be >= 1
               expect(checker.warnings).to all(be_a(Y2Storage::SetupError))
 
               message = checker.warnings.first.message
-              expect(message).to match(/There is no partition of type BIOS Boot/)
+              expect(message).to match(/partition of type BIOS Boot/)
             end
           end
 
@@ -228,33 +238,31 @@ describe Y2Storage::BootRequirementsChecker do
         context "with a MS-DOS partition table" do
           context "with a too small MBR gap" do
             before do
-              # it have to be set here, as mbr_gap in yml set only minimal size and not real one
-              allow(checker.send(:strategy).boot_disk).to receive(:mbr_gap).and_return(0.KiB)
+              allow(checker.send(:strategy).boot_disk).to receive(:mbr_gap_for_grub?).and_return(false)
             end
 
             context "in a plain btrfs setup" do
               let(:scenario) { "dos_btrfs" }
 
-              include_examples "no errors"
+              include_examples "missing mbr gap"
             end
 
             context "in a not plain btrfs setup" do
               let(:scenario) { "dos_lvm" }
 
               it "contains an error for small MBR gap" do
-                expect(checker.warnings.size).to eq(1)
+                expect(checker.warnings.size).to be >= 1
                 expect(checker.warnings).to all(be_a(Y2Storage::SetupError))
 
                 message = checker.warnings.first.message
-                expect(message).to match(/gap size is not enough/)
+                expect(message).to match(/not enough/i)
               end
             end
           end
 
           context "if the MBR gap is big enough to embed Grub" do
             before do
-              # it have to be set here, as mbr_gap in yml set only minimal size and not real one
-              allow(checker.send(:strategy).boot_disk).to receive(:mbr_gap).and_return(256.KiB)
+              allow(checker.send(:strategy).boot_disk).to receive(:mbr_gap_for_grub?).and_return(true)
             end
 
             context "in a partitions-based setup" do
@@ -263,13 +271,15 @@ describe Y2Storage::BootRequirementsChecker do
               include_examples "no errors"
             end
 
+            # FIXME: doesn't make sense logically anymore
             context "in a LVM-based setup" do
               # examples define own gap
               let(:scenario) { "dos_lvm" }
 
               context "if the MBR gap has additional space for grubenv" do
                 before do
-                  allow(checker.send(:strategy).boot_disk).to receive(:mbr_gap).and_return(260.KiB)
+                  allow(checker.send(:strategy).boot_disk).to receive(:mbr_gap_for_grub?)
+                    .and_return(true)
                 end
 
                 include_examples "no errors"
@@ -277,7 +287,8 @@ describe Y2Storage::BootRequirementsChecker do
 
               context "if the MBR gap has no additional space" do
                 before do
-                  allow(checker.send(:strategy).boot_disk).to receive(:mbr_gap).and_return(256.KiB)
+                  allow(checker.send(:strategy).boot_disk).to receive(:mbr_gap_for_grub?)
+                    .and_return(false)
                 end
 
                 context "if there is no separate /boot" do
@@ -287,7 +298,7 @@ describe Y2Storage::BootRequirementsChecker do
                 context "if there is separate /boot" do
                   let(:scenario) { "dos_lvm_boot_partition" }
 
-                  include_examples "no errors"
+                  include_examples "missing mbr gap"
                 end
               end
             end
@@ -300,7 +311,8 @@ describe Y2Storage::BootRequirementsChecker do
 
               context "if the MBR gap has additional space for grubenv" do
                 before do
-                  allow(checker.send(:strategy).boot_disk).to receive(:mbr_gap).and_return(260.KiB)
+                  allow(checker.send(:strategy).boot_disk).to receive(:mbr_gap_for_grub?)
+                    .and_return(true)
                 end
 
                 include_examples "no errors"
@@ -308,7 +320,8 @@ describe Y2Storage::BootRequirementsChecker do
 
               context "if the MBR gap has no additional space" do
                 before do
-                  allow(checker.send(:strategy).boot_disk).to receive(:mbr_gap).and_return(256.KiB)
+                  allow(checker.send(:strategy).boot_disk).to receive(:mbr_gap_for_grub?)
+                    .and_return(false)
                 end
 
                 context "if there is no separate /boot" do
@@ -318,7 +331,7 @@ describe Y2Storage::BootRequirementsChecker do
                 context "if there is separate /boot" do
                   let(:scenario) { "dos_encrypted_boot_partition" }
 
-                  include_examples "no errors"
+                  include_examples "missing mbr gap"
                 end
               end
 

--- a/test/y2storage/boot_requirements_errors_test.rb
+++ b/test/y2storage/boot_requirements_errors_test.rb
@@ -202,7 +202,7 @@ describe Y2Storage::BootRequirementsChecker do
             expect(checker.warnings).to all(be_a(Y2Storage::SetupError))
 
             message = checker.warnings.first.message
-            expect(message).to match(/\/boot\/efi.*software RAID/)
+            expect(message).to match(/software RAID/)
           end
         end
       end

--- a/test/y2storage/boot_requirements_strategies/analyzer_test.rb
+++ b/test/y2storage/boot_requirements_strategies/analyzer_test.rb
@@ -499,13 +499,17 @@ describe Y2Storage::BootRequirementsStrategies::Analyzer do
     context "if the boot disk contains no partition table" do
       let(:disk_name) { "/dev/sde" }
 
-      it "returns true for GPT (the default proposal type)" do
-        expect(analyzer.boot_ptable_type?(:gpt)).to eq true
+      it "returns false for GPT (the default proposal type)" do
+        expect(analyzer.boot_ptable_type?(:gpt)).to eq false
       end
 
       it "returns false for any other type" do
         expect(analyzer.boot_ptable_type?(:msdos)).to eq false
         expect(analyzer.boot_ptable_type?(:dasd)).to eq false
+      end
+
+      it "returns true for nil" do
+        expect(analyzer.boot_ptable_type?(nil)).to eq true
       end
     end
 

--- a/test/y2storage/disk_test.rb
+++ b/test/y2storage/disk_test.rb
@@ -407,6 +407,38 @@ describe Y2Storage::Disk do
     end
   end
 
+  describe "#mbr_gap_for_grub?" do
+    let(:scenario) { "gpt_and_msdos" }
+
+    def disk(disk_name)
+      Y2Storage::Disk.find_by_name(fake_devicegraph, disk_name)
+    end
+
+    it "returns false for a disk without partition table" do
+      expect(disk("/dev/sde").mbr_gap_for_grub?).to eq false
+    end
+
+    it "returns false for a GPT disk without partitions" do
+      expect(disk("/dev/sdd").mbr_gap_for_grub?).to eq false
+    end
+
+    it "returns false for a GPT disk with partitions" do
+      expect(disk("/dev/sdb").mbr_gap_for_grub?).to eq false
+    end
+
+    it "returns true for a MS-DOS disk without partitions" do
+      expect(disk("/dev/sdc").mbr_gap_for_grub?).to be true
+    end
+
+    it "returns true for a MS-DOS disk with partitions and big enough gap" do
+      expect(disk("/dev/sda").mbr_gap_for_grub?).to be true
+    end
+
+    it "returns false for a MS-DOS disk with partitions and too small gap" do
+      expect(disk("/dev/sdf").mbr_gap_for_grub?).to be false
+    end
+  end
+
   describe "#efi_partitions" do
     let(:scenario) { "gpt_and_msdos" }
 

--- a/test/y2storage/proposal_scenarios_x86_test.rb
+++ b/test/y2storage/proposal_scenarios_x86_test.rb
@@ -47,13 +47,15 @@ describe Y2Storage::GuidedProposal do
       include_examples "all proposed layouts"
     end
 
-    context "in a windows-only PC with 256 KiB of MBR gap" do
+    # FIXME: all these cases work without proposing a separate /boot partition
+    xcontext "in a windows-only PC with 256 KiB of MBR gap" do
       let(:scenario) { "windows-pc-mbr256" }
       include_examples "LVM-based proposed layouts"
       include_examples "partition-based proposed layouts"
     end
 
-    context "in a windows-only PC with 128 KiB of MBR gap" do
+    # FIXME: it raises no exceptions but works like the (old) 256 KiB case above (adding /boot)
+    xcontext "in a windows-only PC with 128 KiB of MBR gap" do
       let(:scenario) { "windows-pc-mbr128" }
 
       context "using LVM" do


### PR DESCRIPTION
WIP
- some test cases are not yet adapted
- the 'whole disk' case gives the wrong warning (due to default = gpt): https://github.com/yast/yast-storage-ng/pull/788/commits/3637f8c8c8a9c21176f5ac4c216bfe9cfe435c79

The logic in the boot requirements check for legacy is a bit broken. So I start by putting things straight.

In the legacy (non-efi) case, using ms-dos partition table, in
https://github.com/yast/yast-storage-ng/blob/master/doc/boot-requirements.md
the entire 'with too small MBR gap' - section can go. It's basically the same as the 'mbr gap too small' part of the lvm/encryption case. I don't see why proposing /boot to embed grub is sometimes good and sometimes bad.

The code now consistently proposes a /boot partition if the mbr gap is too small. No error is raised. This should have near to no practical consequences but we have a number of test cases expecting this.

There's also no difference between 'mbr gap' and 'mbr gap + grub env block' anymore. This caused much of the test case adjustments as 256 KiB is now always ok.

Also, I'm pretty sure this

https://github.com/yast/yast-storage-ng/pull/788/commits/3566cdd1ffa4a6147ecf55718250fa6aed26ba04#diff-85b6d1f00cb4bd77ea48096f7b819477R29

is the wrong way. How to do it better?