### PR TITLE
Support for compound actions with newlines

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 31 13:34:48 UTC 2018 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Format the new multi-line compound actions correctly (bsc#1085134)
+- 4.1.29
+
+-------------------------------------------------------------------
 Tue Oct 30 13:38:10 UTC 2018 - snwint@suse.com
 
 - do not include 'Partition' in partition type names

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.28
+Version:	4.1.29
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/actions_presenter.rb
+++ b/src/lib/y2storage/actions_presenter.rb
@@ -49,7 +49,8 @@ module Y2Storage
     # @return [Yast::Term]
     def to_html
       items = general_actions_items + subvolume_actions_items
-      Yast::HTML.Para(html_list(items))
+      html = Yast::HTML.Para(html_list(items))
+      html.gsub("\n", "<br>")
     end
 
     # Whether the event can be managed by the presenter

--- a/test/y2storage/actions_presenter_test.rb
+++ b/test/y2storage/actions_presenter_test.rb
@@ -32,6 +32,7 @@ describe Y2Storage::ActionsPresenter do
   let(:ca_create_device) { instance_double(Y2Storage::CompoundAction) }
   let(:ca_delete_subvol) { instance_double(Y2Storage::CompoundAction) }
   let(:ca_create_subvol) { instance_double(Y2Storage::CompoundAction) }
+  let(:ca_multi_line)    { instance_double(Y2Storage::CompoundAction) }
 
   before do
     allow(ca_delete_device).to receive(:delete?).and_return(true)
@@ -49,6 +50,10 @@ describe Y2Storage::ActionsPresenter do
     allow(ca_create_subvol).to receive(:delete?).and_return(false)
     allow(ca_create_subvol).to receive(:device_is?).with(:btrfs_subvolume).and_return(true)
     allow(ca_create_subvol).to receive(:sentence).and_return("create subvolume action")
+
+    allow(ca_multi_line).to receive(:delete?).and_return(false)
+    allow(ca_multi_line).to receive(:device_is?).with(:btrfs_subvolume).and_return(false)
+    allow(ca_multi_line).to receive(:sentence).and_return("multi\nline\naction")
   end
 
   describe "#update_status" do
@@ -72,9 +77,9 @@ describe Y2Storage::ActionsPresenter do
   end
 
   describe "#to_html" do
-    let(:compound_actions) { [ca_create_device, ca_delete_device] }
+    let(:compound_actions) { [ca_create_device, ca_delete_device, ca_multi_line] }
 
-    context "when there is not an actiongraph" do
+    context "when there is no actiongraph" do
       let(:actiongraph) { nil }
 
       it "returns an empty html list" do
@@ -91,6 +96,11 @@ describe Y2Storage::ActionsPresenter do
       it "presents delete actions first" do
         expect(subject.to_html)
           .to include "<ul><li><b>delete device action</b></li><li>create device action</li>"
+      end
+
+      it "formats newlines in actions correctly" do
+        expect(subject.to_html)
+          .to include "<li>multi<br>line<br>action</li>"
       end
 
       context "when there are no subvolume actions" do


### PR DESCRIPTION
Replace a newline `\n` in a compound action with the proper HTML line break `<br>` to show a newline where one is meant to be.

See also the example actions in https://github.com/openSUSE/libstorage-ng/pull/585 :

    Create bcache /dev/bcache0 on /dev/sda (2.00 TiB) for /data with ext4
    /dev/bcache0 is cached by /dev/sdf (128.00 MiB)

    Create encrypted bcache /dev/bcache1 on /dev/sdb (512.00 GiB) for /home with xfs
    /dev/bcache1 is cached by /dev/sdg (160.00 MiB)

    Create RAID6 /dev/md0 (1023.75 GiB) for /data with ext4
    from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB), /dev/sdc (512.00 GiB), /dev/sdd (512.00 GiB)
