### PR TITLE
SpaceMaker: refactor the code to be more flexible

### DIFF
--- a/src/lib/y2storage/proposal/partition_killer.rb
+++ b/src/lib/y2storage/proposal/partition_killer.rb
@@ -154,7 +154,7 @@ module Y2Storage
         partitions_to_delete.select! { |p| disks.include?(p.partitionable.name) } if disks
         target_partitions = partitions_to_delete.map { |p| find_partition(p.sid) }.compact
         log.info "These LVM partitions will be deleted: #{target_partitions.map(&:name)}"
-        target_partitions.map { |p| delete_partition(p) }
+        target_partitions.map { |p| delete_partition(p) }.flatten
       end
 
       # Checks whether the partition is part of a volume group

--- a/src/lib/y2storage/proposal/space_maker.rb
+++ b/src/lib/y2storage/proposal/space_maker.rb
@@ -377,7 +377,7 @@ module Y2Storage
 
       # Sid of the next partition to be resized by {#resize_and_delete}
       #
-      # @return [Partition]
+      # @return [Integer, nil] nil if no partition should be resized
       def next_partition_to_resize
         log.info("Looking for Windows partitions to resize")
 


### PR DESCRIPTION
First step for https://trello.com/c/DVQH3p2n/397-8-bug1057436-improve-confusing-spacemaker-strategy-fate325885-preserve-irst-partitions-in-guided-proposal

This basically implements what is described at https://github.com/yast/yast-storage-ng/blob/master/doc/space_maker_improve_strategy.md

Please don't be too picky about name or level of documentation of internal methods. The next step would be to adapt them in order to support IRST and similar stuff.

It's much easier to review commit by commit.