### PR TITLE
do not use removed function IconPath anymore (bsc#1119699)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Dec 18 12:02:57 CET 2018 - aschnell@suse.com
+
+- do not use removed function IconPath anymore (bsc#1119699)
+- 4.1.42
+
+-------------------------------------------------------------------
 Tue Dec 11 10:36:52 UTC 2018 - jlopez@suse.com
 
 - Hardening execution of system commands (part of bsc#1118291).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.41
+Version:	4.1.42
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/confirm_recursive_delete.rb
+++ b/src/lib/y2partitioner/confirm_recursive_delete.rb
@@ -61,13 +61,10 @@ module Y2Partitioner
     # @param button_term [Yast::UI::Term]
     # @return [Boolean]
     def fancy_question(headline, label_before, rich_text, label_after, button_term)
-      display_info = Yast::UI.GetDisplayInfo || {}
-      has_image_support = display_info["HasImageSupport"]
-
       layout = VBox(
         VSpacing(0.4),
         HBox(
-          has_image_support ? Top(Image(Yast::Icon.IconPath("question"))) : Empty(),
+          Top(Yast::Icon.Simple("question")),
           HSpacing(1),
           VBox(
             Left(Heading(headline)),


### PR DESCRIPTION
The function IconPath was simply removed without adapting existing code.

I still not get an icon, but that seems to be theme related (e.g. bsc #1119688).
