### PR TITLE
Tests for PartitionsDistributionCalculator#resizing_size

### DIFF
--- a/test/data/devicegraphs/windows-pc-gpt-with-gap.yml
+++ b/test/data/devicegraphs/windows-pc-gpt-with-gap.yml
@@ -1,0 +1,23 @@
+---
+- disk:
+    name: /dev/sda
+    size: 800 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size:         20 GiB
+        name:         /dev/sda1
+        id:           windows_basic_data
+        file_system:  ntfs
+        label:        recovery
+
+    - free:
+        size: 50 MiB
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda2
+        id:           windows_basic_data
+        file_system:  ntfs
+        label:        windows

--- a/test/data/devicegraphs/windows_resizing1.yml
+++ b/test/data/devicegraphs/windows_resizing1.yml
@@ -1,0 +1,26 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        size:         200 GiB
+        name:         /dev/sda1
+        file_system:  ext4
+
+    - free:
+        size: 10 GiB
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda2
+        type:         extended
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda5
+        type:         logical
+        file_system:  ntfs
+        label:        windows

--- a/test/data/devicegraphs/windows_resizing2.yml
+++ b/test/data/devicegraphs/windows_resizing2.yml
@@ -1,0 +1,36 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        size:         100 GiB
+        name:         /dev/sda1
+        file_system:  ext2
+
+    - free:
+        size: 10 GiB
+
+    - partition:
+        size:         50 GiB
+        name:         /dev/sda2
+        file_system:  ext3
+
+    - partition:
+        size:         50 GiB
+        name:         /dev/sda3
+        file_system:  ext4
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda4
+        type:         extended
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda5
+        type:         logical
+        file_system:  ntfs
+        label:        windows

--- a/test/y2storage/proposal/space_maker_test.rb
+++ b/test/y2storage/proposal/space_maker_test.rb
@@ -912,5 +912,44 @@ describe Y2Storage::Proposal::SpaceMaker do
           .to raise_error Y2Storage::Error
       end
     end
+
+    context "when a Windows partition needs to be resized" do
+      let(:scenario) { "windows-pc-gpt-with-gap" }
+      let(:resize_info) do
+        instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 50.GiB, max_size: 780.GiB,
+          reasons: 0, reason_texts: [])
+      end
+      let(:windows_partitions) { [partition_double("/dev/sda2")] }
+      let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 20.GiB) }
+
+      before do
+        allow_any_instance_of(Y2Storage::Partition).to receive(:detect_resize_info)
+          .and_return(resize_info)
+      end
+
+      # This is a regression test. In the past, the gap existing between the
+      # "recovery" and "windows" partitions confused SpaceMaker, which tried to
+      # reduce the Windows less than really needed. As a consequence, SpaceMaker
+      # wrongly concluded that reducing "windows" was not enough and it ended up
+      # deleting it.
+      it "does not delete the Windows partition if resizing is enough" do
+        result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+        devicegraph = result[:devicegraph]
+        expect(devicegraph.partitions.size).to eq 2
+      end
+
+      # This is a regression test. In the past, the end of the resulting partition
+      # was misaligned by -16.5 KiB, something that is mandatory when the
+      # partition extends up to the end of the GPT disk, but that should have been
+      # fixed while resizing it (otherwise we will have two 16.5 KiB gaps after creating
+      # the partitions - the mandatory one that will reappear at the end of the disk
+      # and the one at the end of the partition labeled "windows").
+      it "aligns the new end of the partition" do
+        result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+        ptable = result[:devicegraph].disks.first.partition_table
+        aligned = ptable.partitions.map { |part| part.region.end_aligned?(ptable.align_grain) }
+        expect(aligned).to eq [true, true]
+      end
+    end
   end
 end


### PR DESCRIPTION
See https://trello.com/c/gdXTlipJ/288-bug1057436-chapter-three-better-calculation-of-resize-windows

These tests proves that there are several situations in which the over-simplistic logic to calculate how much a partition must be reduced leads to Windows been reduced less than needed... which can have very bad consequences.

In fact, the current simplistic logic (labeled as temporary but never improved so far) only works reliably when there are no other spaces in the disk, apart from the one we are planning to create by resizing.

