### PR TITLE
Fix bug # for 4.0.215 changelog.

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -8,7 +8,7 @@ Tue Dec  4 15:07:42 UTC 2018 - jlopez@suse.com
 -------------------------------------------------------------------
 Wed Nov 14 15:15:04 CET 2018 - schubi@suse.de
 
-- SkipListValue.size_k returns the correct value (bsc#1115508).
+- SkipListValue.size_k returns the correct value (bsc#1115507).
 - 4.0.215
 
 -------------------------------------------------------------------


### PR DESCRIPTION
The fix in #799 listed the correct bug ID in the git commit but the wrong one in the RPM changelog.  I noticed this when I updated a Leap 15.0 machine and the summary for the wrong bug was shown in the patch info.

PR for master branch forthcoming, as it doesn't seem possible to submit both branches at once.