### PR TITLE
Link to storage client

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 10 14:59:32 UTC 2019 - jlopez@suse.com
+
+- Allow to cancel Guided Setup (bsc#1121442).
+- Link to storage client from installation summary (bsc#1099485).
+- 4.0.217
+
+-------------------------------------------------------------------
 Tue Dec  4 15:07:42 UTC 2018 - jlopez@suse.com
 
 - Partitioner: does not allow to create BTRFS subvolumes with

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.216
+Version:        4.0.217
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/clients/inst_disk_proposal.rb
+++ b/src/lib/y2storage/clients/inst_disk_proposal.rb
@@ -61,7 +61,7 @@ module Y2Storage
       def run
         log.info("BEGIN of inst_disk_proposal")
 
-        until [:back, :next, :abort].include?(@result)
+        until [:back, :cancel, :next, :abort].include?(@result)
           dialog = Dialogs::Proposal.new(@proposal, @devicegraph, excluded_buttons: excluded_buttons)
           @result = dialog.run
           @proposal = dialog.proposal

--- a/test/y2storage/clients/inst_disk_proposal_test.rb
+++ b/test/y2storage/clients/inst_disk_proposal_test.rb
@@ -509,6 +509,21 @@ describe Y2Storage::Clients::InstDiskProposal do
         end
       end
 
+      context "if the guided setup returns :cancel" do
+        before do
+          allow(proposal_dialog).to receive(:devicegraph).and_return(devicegraph)
+          allow(guided_dialog).to receive(:run).and_return :cancel
+        end
+
+        it "opens a new proposal dialog again with the same values" do
+          expect(Y2Storage::Dialogs::Proposal).to receive(:new).once.ordered
+            .and_return(proposal_dialog)
+          expect(Y2Storage::Dialogs::Proposal).to receive(:new).once.ordered
+            .with(proposal, devicegraph, anything).and_return(second_proposal_dialog)
+          client.run
+        end
+      end
+
       context "if the guided setup returns :back" do
         before do
           allow(proposal_dialog).to receive(:devicegraph).and_return(devicegraph)

--- a/test/y2storage/dialogs/guided_setup_test.rb
+++ b/test/y2storage/dialogs/guided_setup_test.rb
@@ -205,6 +205,16 @@ describe Y2Storage::Dialogs::GuidedSetup do
       end
     end
 
+    context "when some dialog is canceled" do
+      before do
+        allow_run_select_scheme { :cancel }
+      end
+
+      it "returns :cancel" do
+        expect(subject.run).to eq(:cancel)
+      end
+    end
+
     context "when some dialog aborts" do
       before do
         allow_run_select_scheme { :abort }


### PR DESCRIPTION
Installation summary links to storage client instead of Expert Partitioner directly. Moreover, the Guided Setup wizard can be now canceled, see https://bugzilla.suse.com/show_bug.cgi?id=1121442.

PBI: https://trello.com/c/53IEUxrB/577-susecaas-platform-4-p2-1099485-caasp-specific-partitioning-warning-dialog-missing-in-storage-ng

~~Requires this be merged: https://github.com/yast/yast-yast2/pull/886~~