### PR TITLE
Windows better resize

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 24 16:44:15 UTC 2019 - ancor@suse.com
+
+- Partitioning proposal: improved the calculation about how much
+  each Windows partition must be resized (bsc#1121286).
+- 4.1.48
+
+-------------------------------------------------------------------
 Wed Jan 23 10:14:20 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Make the storage proposal (i.e. the Guided Setup) easier to

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.47
+Version:	4.1.48
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/partition.rb
+++ b/src/lib/y2storage/partition.rb
@@ -244,6 +244,14 @@ module Y2Storage
       min
     end
 
+    # Distance between the end of the partition and the latest aligned block.
+    # Zero if the end of the partition is aligned.
+    #
+    # @return [DiskSize]
+    def end_overhead
+      region.end_overhead(align_grain)
+    end
+
     # Whether it is an implicit partition
     #
     # @see Y2Storage::PartitionTables::ImplicitPt

--- a/src/lib/y2storage/planned/assigned_space.rb
+++ b/src/lib/y2storage/planned/assigned_space.rb
@@ -153,7 +153,11 @@ module Y2Storage
       #
       # @return [DiskSize]
       def total_missing_size
-        total_needed_size - disk_space.disk_size
+        if disk_space.disk_size >= total_needed_size
+          DiskSize.zero
+        else
+          total_needed_size - disk_space.disk_size
+        end
       end
 
       # Space consumed by the EBR of one logical partition in a given disk

--- a/src/lib/y2storage/planned/partitions_distribution.rb
+++ b/src/lib/y2storage/planned/partitions_distribution.rb
@@ -384,6 +384,7 @@ module Y2Storage
       # @param num [Integer] number of partitions that should be logical
       # @return [Boolean]
       def room_for_logical?(assigned_space, num)
+        return true if assigned_space.disk_space.growing?
         overhead = assigned_space.overhead_of_logical
         assigned_space.extra_size >= overhead * num
       end

--- a/test/data/devicegraphs/windows-pc-gpt-with-gap.yml
+++ b/test/data/devicegraphs/windows-pc-gpt-with-gap.yml
@@ -1,0 +1,23 @@
+---
+- disk:
+    name: /dev/sda
+    size: 800 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size:         20 GiB
+        name:         /dev/sda1
+        id:           windows_basic_data
+        file_system:  ntfs
+        label:        recovery
+
+    - free:
+        size: 50 MiB
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda2
+        id:           windows_basic_data
+        file_system:  ntfs
+        label:        windows

--- a/test/data/devicegraphs/windows_resizing1.yml
+++ b/test/data/devicegraphs/windows_resizing1.yml
@@ -1,0 +1,26 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        size:         200 GiB
+        name:         /dev/sda1
+        file_system:  ext4
+
+    - free:
+        size: 10 GiB
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda2
+        type:         extended
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda5
+        type:         logical
+        file_system:  ntfs
+        label:        windows

--- a/test/data/devicegraphs/windows_resizing2.yml
+++ b/test/data/devicegraphs/windows_resizing2.yml
@@ -1,0 +1,36 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        size:         100 GiB
+        name:         /dev/sda1
+        file_system:  ext2
+
+    - free:
+        size: 10 GiB
+
+    - partition:
+        size:         50 GiB
+        name:         /dev/sda2
+        file_system:  ext3
+
+    - partition:
+        size:         50 GiB
+        name:         /dev/sda3
+        file_system:  ext4
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda4
+        type:         extended
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda5
+        type:         logical
+        file_system:  ntfs
+        label:        windows

--- a/test/y2storage/proposal/space_maker_test.rb
+++ b/test/y2storage/proposal/space_maker_test.rb
@@ -912,5 +912,44 @@ describe Y2Storage::Proposal::SpaceMaker do
           .to raise_error Y2Storage::Error
       end
     end
+
+    context "when a Windows partition needs to be resized" do
+      let(:scenario) { "windows-pc-gpt-with-gap" }
+      let(:resize_info) do
+        instance_double("Y2Storage::ResizeInfo", resize_ok?: true, min_size: 50.GiB, max_size: 780.GiB,
+          reasons: 0, reason_texts: [])
+      end
+      let(:windows_partitions) { [partition_double("/dev/sda2")] }
+      let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 20.GiB) }
+
+      before do
+        allow_any_instance_of(Y2Storage::Partition).to receive(:detect_resize_info)
+          .and_return(resize_info)
+      end
+
+      # This is a regression test. In the past, the gap existing between the
+      # "recovery" and "windows" partitions confused SpaceMaker, which tried to
+      # reduce the Windows less than really needed. As a consequence, SpaceMaker
+      # wrongly concluded that reducing "windows" was not enough and it ended up
+      # deleting it.
+      it "does not delete the Windows partition if resizing is enough" do
+        result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+        devicegraph = result[:devicegraph]
+        expect(devicegraph.partitions.size).to eq 2
+      end
+
+      # This is a regression test. In the past, the end of the resulting partition
+      # was misaligned by -16.5 KiB, something that is mandatory when the
+      # partition extends up to the end of the GPT disk, but that should have been
+      # fixed while resizing it (otherwise we will have two 16.5 KiB gaps after creating
+      # the partitions - the mandatory one that will reappear at the end of the disk
+      # and the one at the end of the partition labeled "windows").
+      it "aligns the new end of the partition" do
+        result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+        ptable = result[:devicegraph].disks.first.partition_table
+        aligned = ptable.partitions.map { |part| part.region.end_aligned?(ptable.align_grain) }
+        expect(aligned).to eq [true, true]
+      end
+    end
   end
 end

--- a/test/y2storage/proposal/space_maker_test.rb
+++ b/test/y2storage/proposal/space_maker_test.rb
@@ -296,7 +296,7 @@ describe Y2Storage::Proposal::SpaceMaker do
             it "resizes Windows partitions to free additional needed space" do
               result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
               expect(result[:devicegraph].partitions).to contain_exactly(
-                an_object_having_attributes(filesystem_label: "windows", size: 200.GiB - 2.MiB)
+                an_object_having_attributes(filesystem_label: "windows", size: 200.GiB - 1.MiB)
               )
             end
           end

--- a/test/y2storage/proposal/space_maker_test.rb
+++ b/test/y2storage/proposal/space_maker_test.rb
@@ -927,7 +927,7 @@ describe Y2Storage::Proposal::SpaceMaker do
           .and_return(resize_info)
       end
 
-      # This is a regression test. In the past, the gap existing between the
+      # Regression test for bsc#1121286. In the past, the gap existing between the
       # "recovery" and "windows" partitions confused SpaceMaker, which tried to
       # reduce the Windows less than really needed. As a consequence, SpaceMaker
       # wrongly concluded that reducing "windows" was not enough and it ended up
@@ -938,7 +938,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         expect(devicegraph.partitions.size).to eq 2
       end
 
-      # This is a regression test. In the past, the end of the resulting partition
+      # Regression test for bsc#1121286. In the past, the end of the resulting partition
       # was misaligned by -16.5 KiB, something that is mandatory when the
       # partition extends up to the end of the GPT disk, but that should have been
       # fixed while resizing it (otherwise we will have two 16.5 KiB gaps after creating


### PR DESCRIPTION
This basically implements https://trello.com/c/gdXTlipJ/288-bug1057436-chapter-three-better-calculation-of-resize-windows

With this, the tests at #816 are all green, which means:

- The resizing calculation is not longer confused by other (probably useless) spaces in the disk. This used to have catastrophic consequences.
- When resizing a Windows with a misaligned end (quite common in GPT), we don keep the misalignment. Instead, we take the opportunity to fix it and avoid the gap.

In addition, the remaining test (most adaptations were done already in #825) is now adapted to the new (more correct) behavior because:

- Windows partitions are not always reduced 1 extra MiB just in case. Only when there is a real misalignment to fix.
- With the previous behavior, when there was a free space >1MiB at the end of a GPT partition, the partition being resized was reduced 16.5KiB more than actually needed (even introducing a misalignment). No matter if that partition was not at the end of the disk. That doesn't happen anymore.