### PR TITLE
SpaceMaker: avoid two passes if not needed (bug#1057436) 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 23 10:14:20 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Make the storage proposal (i.e. the Guided Setup) easier to
+  debug (bsc#1057436).
+- 4.1.47
+
+-------------------------------------------------------------------
 Wed Jan 23 10:11:58 CET 2019 - aschnell@suse.com
 
 - do not include nil in package list of used storage features

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.46
+Version:	4.1.47
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/proposal/partitions_distribution_calculator.rb
+++ b/src/lib/y2storage/proposal/partitions_distribution_calculator.rb
@@ -142,11 +142,13 @@ module Y2Storage
       # missing LVM part in the free spaces
       def impossible?(planned_partitions, free_spaces)
         needed = DiskSize.sum(planned_partitions.map(&:min))
+        log.info "#impossible? - initially needed: #{needed}"
         if lvm?
           # Let's assume the best possible case - if we need to create a PV it
           # will be only one
           pvs_to_create = 1
           needed += lvm_space_to_make(pvs_to_create)
+          log.info "#impossible? with LVM - needed: #{needed}"
         end
         needed > available_space(free_spaces)
       end

--- a/src/lib/y2storage/proposal/space_maker.rb
+++ b/src/lib/y2storage/proposal/space_maker.rb
@@ -246,6 +246,9 @@ module Y2Storage
       # @param disk_name [String, nil] optional disk name to restrict operations to
       #
       def resize_and_delete(planned_partitions, keep, lvm_helper, disk_name: nil)
+        # Note that only the execution with disk_name == nil is the final one.
+        # In other words, if disk_name contains something, it means there will
+        # be at least a subsequent call to the method.
         log.info "Resize and delete. disk_name: #{disk_name}, planned partitions:"
         planned_partitions.each do |p|
           log.info "  mount: #{p.mount_point}, disk: #{p.disk}, min: #{p.min}, max: #{p.max}"

--- a/test/data/devicegraphs/output/windows-pc-50GiB-gpt-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-50GiB-gpt-sep-home.yml
@@ -9,7 +9,7 @@
     partition_table: gpt
     partitions:
     - partition:
-        size: 36171759.5 KiB (34.50 GiB)
+        size: 35324 MiB
         name: "/dev/sda1"
         type: primary
         id: windows_basic_data

--- a/test/data/devicegraphs/output/windows-pc-50GiB-gpt.yml
+++ b/test/data/devicegraphs/output/windows-pc-50GiB-gpt.yml
@@ -9,7 +9,7 @@
     partition_table: gpt
     partitions:
     - partition:
-        size: 8382447.5 KiB (7.99 GiB)
+        size: 8186 MiB
         name: "/dev/sda1"
         type: primary
         id: windows_basic_data

--- a/test/data/devicegraphs/output/windows-pc-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-enc-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 745469 MiB
+        size: 745470 MiB
         name: /dev/sda1
         id: 0x7
         file_system: ntfs
@@ -25,7 +25,7 @@
           password: '12345678'
 
     - partition:
-        size: 12291 MiB
+        size: 12290 MiB
         name: "/dev/sda4"
         type: extended
         id: extended
@@ -43,7 +43,7 @@
           password: '12345678'
 
     - partition:
-        size: 10241 MiB
+        size: 10 GiB
         name: "/dev/sda6"
         type: logical
         id: linux

--- a/test/data/devicegraphs/output/windows-pc-enc.yml
+++ b/test/data/devicegraphs/output/windows-pc-enc.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 755711 MiB
+        size: 738 GiB
         name: /dev/sda1
         id: 0x7
         file_system: ntfs
@@ -34,9 +34,6 @@
           type: luks
           name: "/dev/mapper/cr_sda4"
           password: '12345678'
-
-    - free:
-        size: 1 MiB
 
     - partition:
         size: unlimited

--- a/test/data/devicegraphs/output/windows-pc-gpt-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-enc-sep-home.yml
@@ -6,14 +6,14 @@
     partitions:
 
     - partition:
-        size: 745467 MiB
+        size: 745468 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 5 MiB
+        size: 4 MiB
         name: "/dev/sda3"
         id: bios_boot
 

--- a/test/data/devicegraphs/output/windows-pc-gpt-enc.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-enc.yml
@@ -6,14 +6,14 @@
     partitions:
 
     - partition:
-        size: 755707 MiB
+        size: 755708 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 5 MiB
+        size: 4 MiB
         name: "/dev/sda3"
         id: bios_boot
 

--- a/test/data/devicegraphs/output/windows-pc-gpt-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-sep-home.yml
@@ -6,14 +6,14 @@
     partitions:
 
     - partition:
-        size: 745467 MiB
+        size: 745468 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 5 MiB
+        size: 4 MiB
         name: "/dev/sda3"
         id: bios_boot
 

--- a/test/data/devicegraphs/output/windows-pc-gpt.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt.yml
@@ -6,14 +6,14 @@
     partitions:
 
     - partition:
-        size: 755707 MiB
+        size: 755708 MiB
         name: /dev/sda1
         id: windows_basic_data
         file_system: ntfs
         label: windows
 
     - partition:
-        size: 5 MiB
+        size: 4 MiB
         name: "/dev/sda3"
         id: bios_boot
 

--- a/test/data/devicegraphs/output/windows-pc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-sep-home.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 745469 MiB
+        size: 745470 MiB
         name: /dev/sda1
         id: 0x7
         file_system: ntfs
@@ -21,7 +21,7 @@
         mount_point: "/"
 
     - partition:
-        size: 12291 MiB
+        size: 12290 MiB
         name: "/dev/sda4"
         type: extended
         id: extended
@@ -35,7 +35,7 @@
         mount_point: swap
 
     - partition:
-        size: 10241 MiB
+        size: 10 GiB
         name: "/dev/sda6"
         type: logical
         id: linux

--- a/test/data/devicegraphs/output/windows-pc.yml
+++ b/test/data/devicegraphs/output/windows-pc.yml
@@ -6,7 +6,7 @@
     partitions:
 
     - partition:
-        size: 755711 MiB
+        size: 738 GiB
         name: /dev/sda1
         id: 0x7
         file_system: ntfs
@@ -26,9 +26,6 @@
         id: swap
         file_system: swap
         mount_point: swap
-
-    - free:
-       size: 1 MiB
 
     - partition:
         size: unlimited


### PR DESCRIPTION
See https://trello.com/c/0ZARc9rP/602-1-bug1057436-chapter-two-avoid-two-passes-if-not-needed

Review by commit.

The **second commit** adapts the test in a way that is equivalent to the adaptations found in https://github.com/yast/yast-storage-ng/pull/822. That's because this pull request mitigates the effect of some problems of the original `PartitionsDistributionCalculator.#resizing_size` that are fixed in that other PR. To be precise, this "hides" the following problems described in the other pull request

- Windows partitions are reduced 1 extra MiB if there is some space in the disk. That is done just in case, even if there is no real misalignment to fix. With two passes, the first resizing introduced that space, so the second one added the extra MiB.
- When there is a free space >1MiB at the end of a GPT partition, the partition being resized is reduced 16.5KiB more than actually needed (even introducing a misalignment). Again, the first resizing introduced such space, so the second one was affected by the extra 16.5KiB.

As said, #822 really fixes those problems in `PartitionsDistributionCalculator.#resizing_size`, the current PR only hides then in the tests because it avoids calling the method more than strictly needed.

The **third and fourth commits** are there only to make debugging easier (based on experience).
