### PR TITLE
do not include nil in package list of used storage features for FC devices (bsc#1122781)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 23 10:11:58 CET 2019 - aschnell@suse.com
+
+- do not include nil in package list of used storage features
+  for FC devices (bsc#1122781)
+- 4.1.46
+
+-------------------------------------------------------------------
 Thu Jan 17 13:46:54 UTC 2019 - ancor@suse.com
 
 - Specific error pop-up for exceptions raised while calculating the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-storage-ng
 #
-# Copyright (c) 2018 SUSE LLC.
+# Copyright (c) 2019 SUSE LLC.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.45
+Version:	4.1.46
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/used_storage_features.rb
+++ b/src/lib/y2storage/used_storage_features.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2016-2017] SUSE LLC
+# Copyright (c) [2016-2017,2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -43,7 +43,7 @@ module Y2Storage
     # Configurable part starts here
     #
     # Software packages required for storage features.
-    # Any map value may be a string, a list of strings, or 'nil'.
+    # Any map value may be a string or a list of strings.
     #
     # Packages that are part of a minimal installation (e.g., "util-linux")
     # are not listed here.
@@ -82,7 +82,7 @@ module Y2Storage
         # Data transport methods
         UF_ISCSI:         "open-iscsi",
         UF_FCOE:          "fcoe-utils",
-        UF_FC:            nil,
+        UF_FC:            [],
 
         # Other
         UF_QUOTA:         "quota",

--- a/test/y2storage/used_storage_features_test.rb
+++ b/test/y2storage/used_storage_features_test.rb
@@ -2,7 +2,7 @@
 #
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017,2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -87,6 +87,21 @@ describe Y2Storage::UsedStorageFeatures do
     it "requires exactly the expected storage-related packages" do
       expect(subject.feature_packages)
         .to contain_exactly("btrfsprogs", "e2fsprogs", "ntfs-3g", "ntfsprogs", "xfsprogs")
+    end
+  end
+
+  context "Created with a XML devicegraph containing FC devices" do
+    before { fake_scenario(scenario) }
+    let(:scenario) { "empty-dasd-and-multipath.xml" }
+    subject { described_class.new(fake_devicegraph) }
+
+    it "has exactly the expected storage features" do
+      expect(subject.collect_features).to contain_exactly(:UF_FC, :UF_FCOE, :UF_MULTIPATH)
+    end
+
+    it "requires exactly the expected storage-related packages" do
+      expect(subject.feature_packages)
+        .to contain_exactly("device-mapper", "multipath-tools", "fcoe-utils")
     end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/OkmGMBQG/632-sle15-sp1-1122781-p1-installer-throws-error-message-after-selection-of-multipath-disk-on-sles-15-sp1-beta2.