### PR TITLE
Limit ESP to min size on aarch64 (bsc#1119318)

### DIFF
--- a/doc/boot-requirements.md
+++ b/doc/boot-requirements.md
@@ -133,14 +133,13 @@
 			- **requires to mount the existing firmware partition at /boot/vc**
 		- and there is no firmware partition in the system
 			- **only requires to use the existing EFI partition**
-- when proposing an new EFI partition
+- when proposing a new EFI partition
 	- **requires /boot/efi to be a non-encrypted vfat partition**
 	- **requires /boot/efi to be close enough to the beginning of disk**
 	- when aiming for the recommended size
-		- **requires /boot/efi to be exactly 500 MiB large (enough for several operating systems)**
+		- **requires /boot/efi to be exactly 256 MiB large (always FAT32 min size)**
 	- when aiming for the minimal size
-		- **requires it to be at least 256 MiB (min size for FAT32 in drives with 4-KiB-per-sector)**
-		- **requires it to be at most 500 MiB (enough space for several operating systems)**
+		- **requires /boot/efi to be exactly 256 MiB large (always FAT32 min size)**
 
 ## needed partitions in a S/390 system
 - trying to install in a FBA DASD disk
@@ -258,7 +257,7 @@
 			- **requires /boot to be at least 200 MiB large**
 		- when aiming for the minimal size
 			- **requires /boot to be at least 100 MiB large**
-	- when proposing an new GRUB partition
+	- when proposing a new GRUB partition
 		- **requires it to have the correct id**
 		- **requires it to be a non-encrypted partition**
 		- when aiming for the recommended size
@@ -267,14 +266,11 @@
 		- when aiming for the minimal size
 			- **requires it to be at least 2 MiB (Grub2 stages 1+2 and needed Grub modules)**
 			- **requires it to be at most 8 MiB (anything bigger would mean wasting space)**
-	- when proposing an new EFI partition
+	- when proposing a new EFI partition
 		- **requires /boot/efi to be a non-encrypted vfat partition**
 		- **requires /boot/efi to be close enough to the beginning of disk**
-		- if aarch64
-			- ** requires /boot/efi to always have the min size (256 MiB for FAT32 min size)**
-		- for all other architectures
-			- when aiming for the recommended size
-				- **requires /boot/efi to be exactly 500 MiB large (enough for several operating systems)**
-			- when aiming for the minimal size
-				- **requires it to be at least 256 MiB (min size for FAT32 in drives with 4-KiB-per-sector)**
-				- **requires it to be at most 500 MiB (enough space for several operating systems)**
+		- when aiming for the recommended size
+			- **requires /boot/efi to be exactly 500 MiB large (enough for several operating systems)**
+		- when aiming for the minimal size
+			- **requires it to be at least 256 MiB (min size for FAT32 in drives with 4-KiB-per-sector)**
+			- **requires it to be at most 500 MiB (enough space for several operating systems)**

--- a/doc/boot-requirements.md
+++ b/doc/boot-requirements.md
@@ -270,8 +270,11 @@
 	- when proposing an new EFI partition
 		- **requires /boot/efi to be a non-encrypted vfat partition**
 		- **requires /boot/efi to be close enough to the beginning of disk**
-		- when aiming for the recommended size
-			- **requires /boot/efi to be exactly 500 MiB large (enough for several operating systems)**
-		- when aiming for the minimal size
-			- **requires it to be at least 256 MiB (min size for FAT32 in drives with 4-KiB-per-sector)**
-			- **requires it to be at most 500 MiB (enough space for several operating systems)**
+		- if aarch64
+			- ** requires /boot/efi to always have the min size (256 MiB for FAT32 min size)**
+		- for all other architectures
+			- when aiming for the recommended size
+				- **requires /boot/efi to be exactly 500 MiB large (enough for several operating systems)**
+			- when aiming for the minimal size
+				- **requires it to be at least 256 MiB (min size for FAT32 in drives with 4-KiB-per-sector)**
+				- **requires it to be at most 500 MiB (enough space for several operating systems)**

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb  4 15:54:13 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Limit ESP to min size on aarch64 (bsc#1119318)
+- 4.1.51
+
+-------------------------------------------------------------------
 Thu Jan 31 12:35:36 UTC 2019 - jlopez@suse.com
 
 - Partitioner: properly show Flash-only Bcache devices.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.50
+Version:	4.1.51
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/boot_requirements_strategies/uefi.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/uefi.rb
@@ -23,6 +23,8 @@ require "y2storage/boot_requirements_strategies/base"
 require "y2storage/partition_id"
 require "y2storage/filesystems/type"
 
+Yast.import "Arch"
+
 module Y2Storage
   module BootRequirementsStrategies
     # Strategy to calculate boot requirements in UEFI systems
@@ -99,7 +101,17 @@ module Y2Storage
 
       # @return [VolumeSpecification]
       def efi_volume
-        @efi_volume ||= volume_specification_for("/boot/efi")
+        if @efi_volume.nil?
+          @efi_volume = volume_specification_for("/boot/efi")
+          limit_volume_size_to_min(@efi_volume) if Yast::Arch.aarch64 # bsc#1119318
+        end
+        @efi_volume
+      end
+
+      def limit_volume_size_to_min(vol)
+        vol.max_size = vol.min_size
+        vol.desired_size = vol.min_size
+        vol
       end
 
       # @return [Planned::Partition]

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -69,13 +69,24 @@ require_relative "support/storage_helpers"
 RSpec.configure do |c|
   c.include Yast::RSpec::StorageHelpers
 
-  # Y2Packager is not loaded in tests to avoid cyclic dependencies with
-  # yast-installation package at build time. Here, all usage of Y2Packager
-  # is mocked.
   c.before do
+    # Y2Packager is not loaded in tests to avoid cyclic dependencies with
+    # yast-installation package at build time. Here, all usage of Y2Packager
+    # is mocked.
     stub_const("Y2Packager::Repository", double("Y2Packager::Repository"))
     allow(Y2Packager::Repository).to receive(:all).and_return([])
+
     allow(Y2Storage::DumpManager.instance).to receive(:dump)
+
+    if respond_to?(:architecture) # Match mocked architecture in Arch module
+      # In a test, define a symbol :architecture accordingly:
+      #   let(:architecture) { :aarch64 }
+      allow(Yast::Arch).to receive(:x86_64).and_return(architecture == :x86_64)
+      allow(Yast::Arch).to receive(:i386).and_return(architecture == :i386)
+      allow(Yast::Arch).to receive(:ppc).and_return(architecture == :ppc)
+      allow(Yast::Arch).to receive(:s390).and_return(architecture == :s390)
+      allow(Yast::Arch).to receive(:aarch64).and_return(architecture == :aarch64)
+    end
   end
 
   # Some tests use ProposalSettings#new_for_current_product to initialize

--- a/test/support/proposed_partitions_examples.rb
+++ b/test/support/proposed_partitions_examples.rb
@@ -88,7 +88,7 @@ RSpec.shared_examples "proposed GRUB partition" do
   end
 end
 
-RSpec.shared_examples "proposed EFI partition" do
+RSpec.shared_examples "proposed EFI partition basics" do
   using Y2Storage::Refinements::SizeCasts
 
   let(:target) { nil }
@@ -102,6 +102,10 @@ RSpec.shared_examples "proposed EFI partition" do
   it "requires /boot/efi to be close enough to the beginning of disk" do
     expect(efi_part.max_start_offset).to eq 2.TiB
   end
+end
+
+RSpec.shared_examples "flexible size EFI partition" do
+  using Y2Storage::Refinements::SizeCasts
 
   context "when aiming for the recommended size" do
     let(:target) { :desired }
@@ -121,6 +125,28 @@ RSpec.shared_examples "proposed EFI partition" do
 
     it "requires it to be at most 500 MiB (enough space for several operating systems)" do
       expect(efi_part.max).to eq 500.MiB
+    end
+  end
+end
+
+RSpec.shared_examples "minimalistic EFI partition" do
+  using Y2Storage::Refinements::SizeCasts
+
+  context "when aiming for the recommended size" do
+    let(:target) { :desired }
+
+    it "requires /boot/efi to be exactly 256 MiB large (always FAT32 min size)" do
+      expect(efi_part.min_size).to eq 256.MiB
+      expect(efi_part.max_size).to eq 256.MiB
+    end
+  end
+
+  context "when aiming for the minimal size" do
+    let(:target) { :min }
+
+    it "requires /boot/efi to be exactly 256 MiB large (always FAT32 min size)" do
+      expect(efi_part.min_size).to eq 256.MiB
+      expect(efi_part.max_size).to eq 256.MiB
     end
   end
 end

--- a/test/y2storage/autoinst_profile/drive_section_test.rb
+++ b/test/y2storage/autoinst_profile/drive_section_test.rb
@@ -417,13 +417,12 @@ describe Y2Storage::AutoinstProfile::DriveSection do
       let(:dev) { device("sdd") }
 
       before do
-        allow(Yast::Arch).to receive(:s390).and_return s390
         allow(dev).to receive(:udev_full_paths)
           .and_return ["/dev/disk/by-path/1", "/dev/disk/by-path/2"]
       end
 
       context "in s390" do
-        let(:s390) { true }
+        let(:architecture) { :s390 }
 
         it "initializes #device to the udev path of the device" do
           section = described_class.new_from_storage(dev)
@@ -432,7 +431,7 @@ describe Y2Storage::AutoinstProfile::DriveSection do
       end
 
       context "in a non-s390 architecture" do
-        let(:s390) { false }
+        let(:architecture) { :x86_64 }
 
         it "initializes #device to the kernel name of the device" do
           section = described_class.new_from_storage(dev)

--- a/test/y2storage/boot_requirements_checker_aarch64_test.rb
+++ b/test/y2storage/boot_requirements_checker_aarch64_test.rb
@@ -49,6 +49,5 @@ describe Y2Storage::BootRequirementsChecker do
     end
 
     include_context "plain UEFI"
-
   end
 end

--- a/test/y2storage/boot_requirements_checker_raspi_test.rb
+++ b/test/y2storage/boot_requirements_checker_raspi_test.rb
@@ -190,14 +190,15 @@ describe Y2Storage::BootRequirementsChecker do
       include_context "Raspberry Pi partitions"
     end
 
-    context "when proposing an new EFI partition" do
+    context "when proposing a new EFI partition" do
       let(:efi_part) { find_vol("/boot/efi", checker.needed_partitions(target)) }
       # FIXME: Default values to ensure proposal of EFI partition
       let(:sda_partitions) { [] }
       let(:sdb_partitions) { [] }
       let(:efi_partitions) { [] }
 
-      include_examples "proposed EFI partition"
+      include_examples "proposed EFI partition basics"
+      include_examples "minimalistic EFI partition"
     end
   end
 end

--- a/test/y2storage/boot_requirements_checker_x86_test.rb
+++ b/test/y2storage/boot_requirements_checker_x86_test.rb
@@ -233,7 +233,7 @@ describe Y2Storage::BootRequirementsChecker do
         include_examples "proposed boot partition"
       end
 
-      context "when proposing an new GRUB partition" do
+      context "when proposing a new GRUB partition" do
         let(:grub_part) { find_vol(nil, checker.needed_partitions(target)) }
         # Default values to ensure a GRUB partition
         let(:boot_ptable_type) { :gpt }
@@ -243,13 +243,15 @@ describe Y2Storage::BootRequirementsChecker do
         include_examples "proposed GRUB partition"
       end
 
-      context "when proposing an new EFI partition" do
+      context "when proposing a new EFI partition" do
         let(:efi_part) { find_vol("/boot/efi", checker.needed_partitions(target)) }
+        let(:desired_efi_part) { find_vol("/boot/efi", checker.needed_partitions(:desired)) }
         # Default values to ensure proposal of EFI partition
         let(:efiboot) { true }
         let(:efi_partitions) { [] }
 
-        include_examples "proposed EFI partition"
+        include_examples "proposed EFI partition basics"
+        include_examples "flexible size EFI partition"
       end
     end
   end

--- a/test/y2storage/disk_analyzer_test.rb
+++ b/test/y2storage/disk_analyzer_test.rb
@@ -43,10 +43,9 @@ describe Y2Storage::DiskAnalyzer do
 
       context "for disks with some Windows in a PC system" do
         let(:scenario) { "windows-pc-gpt" }
+        let(:architecture) { :x86_64 }
 
         before do
-          allow(Yast::Arch).to receive(:x86_64).and_return true
-
           # A bit ugly mock, but what we want to achieve is to simulate that one of available
           # windows partitions cannot be properly detected due an Storage exception (bsc#1101979).
           allow_any_instance_of(::Storage::BlkFilesystem).to receive(:detect_content_info) do |fs|
@@ -67,10 +66,7 @@ describe Y2Storage::DiskAnalyzer do
     end
 
     context "in a non-PC system" do
-      before do
-        allow(Yast::Arch).to receive(:x86_64).and_return false
-        allow(Yast::Arch).to receive(:i386).and_return false
-      end
+      let(:architecture) { :s390 }
 
       it "returns an empty array" do
         expect(analyzer.windows_partitions.empty?).to eq(true)
@@ -80,13 +76,13 @@ describe Y2Storage::DiskAnalyzer do
 
   describe "#installed_systems" do
     before do
-      allow(Yast::Arch).to receive(:x86_64).and_return true
       allow_any_instance_of(::Storage::BlkFilesystem).to receive(:detect_content_info)
         .and_return(content_info)
       allow_any_instance_of(Y2Storage::ExistingFilesystem).to receive(:release_name)
         .and_return release_name
     end
 
+    let(:architecture) { :x86_64 }
     let(:content_info) { double("::Storage::ContentInfo", windows?: true) }
 
     let(:release_name) { "openSUSE" }

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -396,11 +396,7 @@ describe Y2Storage::Filesystems::Btrfs do
     end
 
     context "when a subvolume spec is not for the current arch" do
-      before do
-        allow(Yast::Arch).to receive(:x86_64).and_return(true)
-        allow(Yast::Arch).to receive(:s390).and_return(false)
-      end
-
+      let(:architecture) { :x86_64 }
       let(:spec1) { Y2Storage::SubvolSpecification.new("foo") }
       let(:spec2) { Y2Storage::SubvolSpecification.new("bar", archs: ["s390"]) }
 

--- a/test/y2storage/proposal/autoinst_devices_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_planner_test.rb
@@ -51,10 +51,6 @@ describe Y2Storage::Proposal::AutoinstDevicesPlanner do
     # Do not read from running system
     allow(Yast::ProductFeatures).to receive(:GetSection).with("partitioning").and_return(nil)
 
-    allow(Yast::Arch).to receive(:x86_64).and_return(architecture == :x86_64)
-    allow(Yast::Arch).to receive(:i386).and_return(architecture == :i386)
-    allow(Yast::Arch).to receive(:ppc).and_return(architecture == :ppc)
-    allow(Yast::Arch).to receive(:s390).and_return(architecture == :s390)
     Y2Storage::VolumeSpecification.clear_cache
   end
 

--- a/test/y2storage/subvol_specification_test.rb
+++ b/test/y2storage/subvol_specification_test.rb
@@ -26,13 +26,6 @@ require "y2storage"
 Yast.import "Arch"
 
 describe Y2Storage::SubvolSpecification do
-  before do
-    allow(Yast::Arch).to receive(:x86_64).and_return(architecture == :x86_64)
-    allow(Yast::Arch).to receive(:i386).and_return(architecture == :i386)
-    allow(Yast::Arch).to receive(:ppc).and_return(architecture == :ppc)
-    allow(Yast::Arch).to receive(:s390).and_return(architecture == :s390)
-  end
-
   let(:architecture) { :x86_64 }
 
   subject { Y2Storage::SubvolSpecification.new(path, archs: archs) }


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1119318

## Trello

https://trello.com/c/vjCvQuGp/650-1-sles15-sp1-p2-1119318-installer-suggest-way-too-big-uefi-esp

## Problem

The UEFI ESP partition was considered much too large on aarch64. Small flash storage (16 GiB SD cards etc.) are quite common for RasPI, and using 512 MiB on such a device only for the ESP consumes a considerable part of the available storage already.

## Fix

Limit the size of that partition to the minimum on that architecture.