### PR TITLE
Remove bcache setters

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Feb  4 15:55:56 UTC 2019 - jlopez@suse.com
+
+- Remove setters for bcache attributes that cannot be permanent
+  saved (writeback_percent and sequential_cutoff).
+- Part of fate#325346.
+- 4.1.52
+
+-------------------------------------------------------------------
 Mon Feb  4 15:54:13 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Limit ESP to min size on aarch64 (bsc#1119318)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.51
+Version:	4.1.52
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/bcache.rb
+++ b/src/lib/y2storage/bcache.rb
@@ -38,7 +38,9 @@ module Y2Storage
     storage_forward :bcache_cset, as: "BcacheCset", check_with: :has_bcache_cset
 
     # @!method type
-    #   @return [BcacheType] type of the Bcache device
+    #   Type of the Bcache device (backed or flash-only)
+    #
+    #   @return [BcacheType]
     storage_forward :type, as: "BcacheType"
 
     # @!method backing_device
@@ -70,27 +72,23 @@ module Y2Storage
     storage_forward :cache_mode, as: "CacheMode"
     storage_forward :cache_mode=
 
-    # @!attribute writeback_percent
+    # @!method writeback_percent
     #   Target percent of dirty pages in writeback mode.
     #
     #   This method does not make sense for Flash-only Bcache devices and its value
-    #   should not be taken into account. If setter is called for a Flash-only Bcache,
-    #   the value will be ignored by libstorage-ng when creating or editing the device.
+    #   should not be taken into account.
     #
     #   @return [Integer]
     storage_forward :writeback_percent
-    storage_forward :writeback_percent=
 
-    # @!attribute sequential_cutoff
+    # @!method sequential_cutoff
     #   Size for cache consider read as sequential and do not cache it.
     #
     #   This method does not make sense for Flash-only Bcache devices and its value
-    #   should not be taken into account. If setter is called for a Flash-only Bcache,
-    #   the value will be ignored by libstorage-ng when creating or editing the device.
+    #   should not be taken into account.
     #
     #   @return [DiskSize]
     storage_forward :sequential_cutoff, as: "DiskSize"
-    storage_forward :sequential_cutoff=
 
     # @!method self.create(devicegraph, name, type = BcacheType::BACKED)
     #   @param devicegraph [Devicegraph]


### PR DESCRIPTION
## Problem

Some setters have been removed from libstorage-ng because `bcache` command has no way to make permanent changes for such attributes (`writeback_percent` and `sequential_cutoff`).

* https://trello.com/c/sdR0Hwi3/607-2-use-the-new-bcache-command-instead-of-make-bcache
* https://fate.suse.com/325346

## Solution

This PR simply adapts the ruby wrappers by removing the setters.




