### PR TITLE
Added a Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+
+## Problem
+
+*Short description of the original problem.*
+
+- *Bugzilla link*
+- *openQA link*
+- *Links to other related pull requests*
+
+
+## Solution
+
+*Short description of the fix.*
+
+
+## Testing
+
+- *Added a new unit test*
+- *Tested manually*
+
+
+## Screenshots
+
+*If the fix affects the UI attach some screenshots here.*
+


### PR DESCRIPTION
- Having a pull request template should make the pull requests unified and easier to write.
- It's just a suggested template, feel free add/remove some parts as you need or edit the texts.
- For example some pull requests do not need any screenshot so just remove that section.
- Let's try it in this repository and see how it works. We can later add it to all YaST repositories or drop it if it does not work as expected. :stuck_out_tongue_closed_eyes: 

The rendered template looks like this:

----


## Problem

*Short description of the original problem.*

- *Bugzilla link*
- *openQA link*
- *Links to other related pull requests*


## Fix

*Short description of the fix.*


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

