### PR TITLE
Partitioner: abort gracefully in installed system (bsc#1123837)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb  6 11:54:41 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Partitioner: when running standalone (in an installed system)
+  abort gracefully if probing fails (bsc#1123837).
+- 4.1.53
+
+-------------------------------------------------------------------
 Mon Feb  4 15:55:56 UTC 2019 - jlopez@suse.com
 
 - Remove setters for bcache attributes that cannot be permanent

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.52
+Version:	4.1.53
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/clients/main.rb
+++ b/src/lib/y2partitioner/clients/main.rb
@@ -51,10 +51,7 @@ module Y2Partitioner
           inhibitors = Y2Storage::Inhibitors.new
           inhibitors.inhibit
 
-          # Quit immediately if probing failed
-          return nil unless storage_manager.probed
-
-          return nil if partitioner_dialog.run != :next
+          return nil if partitioner_dialog.nil? || partitioner_dialog.run != :next
           allow_commit ? commit : forbidden_commit_warning
         ensure
           inhibitors.uninhibit
@@ -96,9 +93,15 @@ module Y2Partitioner
 
       # Partitioner dialog is initalized with the probed and staging devicegraphs
       #
-      # @return [Dialogs::Main]
+      # @return [Dialogs::Main, nil] nil if it was not possible to get the
+      #   devicegraphs (probing failed)
       def partitioner_dialog
-        @partitioner_dialog ||= Dialogs::Main.new(storage_manager.probed, storage_manager.staging)
+        return @partitioner_dialog if @partitioner_dialog
+
+        # Force quitting if probing failed
+        return nil unless storage_manager.probed
+
+        @partitioner_dialog = Dialogs::Main.new(storage_manager.probed, storage_manager.staging)
       end
 
       # Popup to alert the user about using the Partitioner

--- a/src/lib/y2partitioner/clients/main.rb
+++ b/src/lib/y2partitioner/clients/main.rb
@@ -51,6 +51,9 @@ module Y2Partitioner
           inhibitors = Y2Storage::Inhibitors.new
           inhibitors.inhibit
 
+          # Quit immediately if probing failed
+          return nil unless storage_manager.probed
+
           return nil if partitioner_dialog.run != :next
           allow_commit ? commit : forbidden_commit_warning
         ensure

--- a/src/lib/y2partitioner/clients/main.rb
+++ b/src/lib/y2partitioner/clients/main.rb
@@ -98,7 +98,8 @@ module Y2Partitioner
       def partitioner_dialog
         return @partitioner_dialog if @partitioner_dialog
 
-        # Force quitting if probing failed
+        # Force quitting if probing failed, which (with default callbacks) means
+        # the user got an error pop-up and decided to abort.
         return nil unless storage_manager.probed
 
         @partitioner_dialog = Dialogs::Main.new(storage_manager.probed, storage_manager.staging)


### PR DESCRIPTION
See https://trello.com/c/deksXijN/671-3-sles15-sp1-p1-1123837-error-popup-shown-twice-followed-by-an-unhandled-exception