### PR TITLE
Allow to create bcache without caching set

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  7 15:53:28 UTC 2019 - jlopez@suse.com
+
+- Partitioner: allow to create bcache devices without a caching
+  set (part of fate#325346).
+- 4.1.54
+
+-------------------------------------------------------------------
 Wed Feb  6 11:54:41 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Partitioner: when running standalone (in an installed system)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.53
+Version:	4.1.54
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/actions/add_bcache.rb
+++ b/src/lib/y2partitioner/actions/add_bcache.rb
@@ -36,8 +36,8 @@ module Y2Partitioner
         textdomain "storage"
       end
 
-      # Runs dialogs for adding a bcache and also modify device graph if user confirm
-      # the dialog.
+      # Runs a dialog for adding a bcache and also modifies the device graph if the user
+      # confirms the dialog.
       #
       # @return [Symbol] :back, :finish
       def run

--- a/src/lib/y2partitioner/actions/add_bcache.rb
+++ b/src/lib/y2partitioner/actions/add_bcache.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -24,34 +24,57 @@ require "y2partitioner/dialogs/bcache"
 require "y2partitioner/device_graphs"
 require "y2storage/bcache"
 
-Yast.import "Popup"
-
 module Y2Partitioner
   module Actions
-    # Action following click on Add Bcache button.
+    # Action for adding a bcache device
     class AddBcache
-      # Runs dialogs for adding bcache and also modify device graph if user confirm that dialog.
+      # Runs dialogs for adding a bcache and also modify device graph if user confirm
+      # the dialog.
+      #
+      # @return [Symbol] :finish
       def run
-        dialog = Dialogs::Bcache.new(usable_blk_devices, usable_blk_devices + existing_caches)
+        dialog = Dialogs::Bcache.new(suitable_backing_devices, suitable_caching_devices)
 
         create_device(dialog) if dialog.run == :next
+
         :finish
       end
 
     private
 
-      # Creates device according to user input to dialog.
-      # @return [void]
+      # Creates a bcache device according to the user input
+      #
+      # @param dialog [Dialogs::Bcache]
       def create_device(dialog)
         backing = dialog.backing_device
-        raise "Invalid result #{dialog.inspect}. Backing not found." unless backing
 
-        caching = dialog.caching_device
-        raise "Invalid result #{dialog.inspect}. Caching not found." unless caching
+        raise "Invalid result #{dialog.inspect}. Backing not found." unless backing
 
         bcache = backing.create_bcache(Y2Storage::Bcache.find_free_name(device_graph))
 
-        set_options(bcache, dialog.options)
+        apply_options(bcache, dialog.options)
+
+        attach(bcache, dialog.caching_device) if dialog.caching_device
+      end
+
+      # Applies options to the bcache device
+      #
+      # Right now, the dialog only allows to indicate the cache mode.
+      #
+      # @param bcache [Y2Storage::Bcache]
+      # @param options [Hash<Symbol, Object>]
+      def apply_options(bcache, options)
+        options.each_pair do |key, value|
+          bcache.public_send(:"#{key}=", value)
+        end
+      end
+
+      # Attaches the selected caching to the bcache
+      #
+      # @param bcache [Y2Storage::Bcache]
+      # @param caching [Y2Storage::BcacheCset, Y2Storage::BlkDevice, nil]
+      def attach(bcache, caching)
+        return if caching.nil?
 
         if !caching.is?(:bcache_cset)
           caching.remove_descendants
@@ -61,19 +84,29 @@ module Y2Partitioner
         bcache.attach_bcache_cset(caching)
       end
 
-      def set_options(bcache, options)
-        options.each_pair do |key, value|
-          bcache.public_send(:"#{key}=", value)
-        end
-      end
-
-      # Device graph on which action operates
+      # Device graph in which the action operates on
+      #
       # @return [Y2Storage::Devicegraph]
       def device_graph
         DeviceGraphs.instance.current
       end
 
-      # returns block devices that can be used for backing or caching device
+      # Suitable devices to be used as backing device
+      #
+      # @return [Array<Y2Storage::BlkDevice>]
+      def suitable_backing_devices
+        usable_blk_devices
+      end
+
+      # Suitable devices to be used for caching
+      #
+      # @return [Array<Y2Storage::BcacheCset, Y2Storage::BlkDevice>]
+      def suitable_caching_devices
+        existing_caches + usable_blk_devices
+      end
+
+      # Block devices that can be used as backing or caching device
+      #
       # @return [Array<Y2Storage::BlkDevice>]
       def usable_blk_devices
         device_graph.blk_devices.select do |dev|
@@ -85,7 +118,8 @@ module Y2Partitioner
         end
       end
 
-      # returns existing caches for bcache.
+      # Currently existing caching sets
+      #
       # @return [Array<Y2Storage::BcacheCset>]
       def existing_caches
         device_graph.bcache_csets

--- a/src/lib/y2partitioner/actions/delete_bcache.rb
+++ b/src/lib/y2partitioner/actions/delete_bcache.rb
@@ -61,7 +61,7 @@ module Y2Partitioner
 
       # Deletes the indicated Bcache (see {DeleteDevice#device})
       def delete
-        log.info "deleting bcache raid #{device}"
+        log.info "deleting bcache #{device}"
         device_graph.remove_bcache(device)
       end
 
@@ -89,7 +89,7 @@ module Y2Partitioner
         )
       end
 
-      # Checks if there is only single bcache cset used by this bcache, so it will be delited
+      # Checks if there is only single bcache cset used by this bcache, so it will be deleted
       def single_bcache_cset?
         device.bcache_cset && device.bcache_cset.bcaches.size == 1
       end

--- a/src/lib/y2partitioner/dialogs/bcache.rb
+++ b/src/lib/y2partitioner/dialogs/bcache.rb
@@ -109,7 +109,7 @@ module Y2Partitioner
 
         # Device selected in widget
         #
-        # Only rely on this value when the dialog succeed and {#store} is called.
+        # Only rely on this value when the dialog succeeded and {#store} is called.
         #
         # @return [Y2Storage::BlkDevice, Y2Storage::BcacheCset]
         attr_reader :result
@@ -118,7 +118,7 @@ module Y2Partitioner
         #
         # @param bcache [Y2Storage::Bcache, nil] existing bcache or nil if it is a new one.
         # @param devices [Array<Y2Storage::BlkDevice, Y2Storage::BcacheCset>] possible devices
-        #   that can be used as backing device.
+        #   that can be used as backing or caching device.
         def initialize(bcache, devices)
           textdomain "storage"
 
@@ -138,7 +138,7 @@ module Y2Partitioner
 
       private
 
-        # sid of the device that is initally selected
+        # sid of the device that is initially selected
         #
         # @return [String, nil]
         def default_sid
@@ -205,8 +205,8 @@ module Y2Partitioner
           format(
             _("<p>" \
                 "<b>%{label}</b> is the device that will be used as backing device for bcache." \
-                "It will define the available space of bcache. " \
-                "The Device will be formatted so any previous content will be wiped out." \
+                "It will define the size of the resulting bcache device. " \
+                "The device will be formatted so any previous content will be wiped out." \
               "</p>"),
             label: label
           )
@@ -269,7 +269,7 @@ module Y2Partitioner
             _("<p>" \
                 "<b>%{label}</b> is the device that will be used as caching device for bcache." \
                 "It should be faster and usually is smaller than the backing device, " \
-                "but it is not required. The device will be formatted so any previous " \
+                "but that is not strictly required. The device will be formatted so any previous " \
                 "content will be wiped out." \
               "</p>" \
               "<p>" \
@@ -300,7 +300,7 @@ module Y2Partitioner
       class CacheModeSelector < CWM::ComboBox
         # Cache mode selected in widget
         #
-        # Only rely on this value when the dialog succeed and {#store} is called.
+        # Only rely on this value when the dialog succeeded and {#store} is called.
         attr_reader :result
 
         # Constructor

--- a/src/lib/y2partitioner/dialogs/bcache.rb
+++ b/src/lib/y2partitioner/dialogs/bcache.rb
@@ -212,25 +212,29 @@ module Y2Partitioner
           )
         end
 
+        # Validates the selected value
+        #
+        # An error popup is shown when the backing device and the caching device are
+        # the same.
+        #
         # @macro seeAbstractWidget
+        # @raise [RuntimeError] if no device has been selected.
+        #
+        # @return [Boolean]
         def validate
           log.info "selected value #{value.inspect}"
-          # value can be empty string if there is no items
-          if value.nil? || value.empty?
-            Yast2::Popup.show(
-              _("Empty backing device is not yet supported"),
-              headline: _("Cannot Create Bcache")
-            )
-            return false
-          elsif value == caching.value
-            Yast2::Popup.show(
-              _("Backing and Caching devices cannot be identical."),
-              headline: _("Cannot Create Bcache")
-            )
-            return false
-          else
-            true
-          end
+
+          # Value can be an empty string if there is no items
+          raise "Empty backing device is not supported" if value.nil? || value.empty?
+
+          return true if value != caching.value
+
+          Yast2::Popup.show(
+            _("Backing and Caching devices cannot be identical."),
+            headline: _("Cannot Create Bcache")
+          )
+
+          false
         end
 
       private

--- a/src/lib/y2partitioner/dialogs/bcache.rb
+++ b/src/lib/y2partitioner/dialogs/bcache.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -28,20 +28,22 @@ require "y2partitioner/dialogs/base"
 
 module Y2Partitioner
   module Dialogs
-    # Form to set the backing and caching device for a Bcache device
-
-    # Part of {Actions::AddBcache}.
+    # Bcache dialog
+    #
+    # Used by {Actions::AddBcache}.
     class Bcache < Base
-      # @param suitable_backing [Array<Y2Storage::BlkDevice>] devices that can be used for backing
+      # Constructor
+      #
+      # @param suitable_backing [Array<Y2Storage::BlkDevice>] devices that can be used for backing.
       # @param suitable_caching [Array<Y2Storage::BlkDevice, Y2Storage::BcacheCset>]
-      #   devices that can be used for caching
-      # @param device [Y2Storage::Bcache] existing Bcache device or nil if it is a new one.
+      #   devices that can be used for caching.
+      # @param device [Y2Storage::Bcache] existing bcache device or nil if it is a new one.
       def initialize(suitable_backing, suitable_caching, device = nil)
         textdomain "storage"
 
-        @caching = CachingDevice.new(device, suitable_caching)
-        @backing = BackingDevice.new(device, suitable_backing, @caching)
-        @cache_mode = CacheMode.new(device)
+        @caching = CachingDeviceSelector.new(device, suitable_caching)
+        @backing = BackingDeviceSelector.new(device, suitable_backing, @caching)
+        @cache_mode = CacheModeSelector.new(device)
       end
 
       # @macro seeDialog
@@ -66,19 +68,28 @@ module Y2Partitioner
         )
       end
 
-      # Selected caching device. Undefined if result of dialog is not `:next`
+      # Selected caching device
+      #
+      # Undefined if result of dialog is not `:next`.
+      #
       # @return [Y2Storage::BlkDevice, Y2Storage::BcacheCset]
       def caching_device
         @caching.result
       end
 
-      # Selected backing device. Undefined if result of dialog is not `:next`
+      # Selected backing device
+      #
+      # Undefined if result of dialog is not `:next`
+      #
       # @return [Y2Storage::BlkDevice]
       def backing_device
         @backing.result
       end
 
       # Bcache options
+      #
+      # Undefined if result of dialog is not `:next`
+      #
       # @return [Hash<Symbol, Object>]
       def options
         {
@@ -86,17 +97,95 @@ module Y2Partitioner
         }
       end
 
-      # Widget to select the backing device
-      class BackingDevice < CWM::ComboBox
-        # @param device [Y2Storage::BlkDevice, nil] existing backing device or nil if it is a new bcache.
-        # @param devices [Array<Y2Storage::BlkDevice>] possible devices that can be used as backing
-        #   device for the Bcache.
-        # @param caching [Y2Partitioner::Dialogs::Bcache::CachingDevice] reference to caching widget.
-        #   Used to check that caching and backing devices are not identical.
-        def initialize(device, devices, caching)
+      # Base class for widgets to select a device
+      #
+      # @see BackingDeviceSelector, CachingDeviceSelector
+      class DeviceSelector < CWM::ComboBox
+        # @return [Y2Storage::Bcache]
+        attr_reader :bcache
+
+        # @return [Array<Y2Storage::BlkDevice, Y2Storage::BcacheCset>]
+        attr_reader :devices
+
+        # Device selected in widget
+        #
+        # Only rely on this value when the dialog succeed and {#store} is called.
+        #
+        # @return [Y2Storage::BlkDevice, Y2Storage::BcacheCset]
+        attr_reader :result
+
+        # Constructor
+        #
+        # @param bcache [Y2Storage::Bcache, nil] existing bcache or nil if it is a new one.
+        # @param devices [Array<Y2Storage::BlkDevice, Y2Storage::BcacheCset>] possible devices
+        #   that can be used as backing device.
+        def initialize(bcache, devices)
           textdomain "storage"
-          @device = device
+
+          @bcache = bcache
           @devices = devices
+        end
+
+        # @macro seeAbstractWidget
+        def init
+          self.value = default_sid
+        end
+
+        # @macro seeAbstractWidget
+        def store
+          @result = selected_device
+        end
+
+      private
+
+        # sid of the device that is initally selected
+        #
+        # @return [String, nil]
+        def default_sid
+          return nil unless default_device
+
+          default_device.sid.to_s
+        end
+
+        # The first avilable device is selected by default
+        #
+        # @return [Y2Storage::BlkDevice, Y2Storage::BcacheCset, nil] nil if there is no
+        #   devices to select.
+        def default_device
+          devices.first
+        end
+
+        # Selected device
+        #
+        # @return [Y2Storage::BlkDevice, nil] nil if no device has been selected
+        def selected_device
+          return nil if value.nil? || value.empty?
+
+          devices.find { |d| d.sid == value.to_i }
+        end
+
+        def item_for_device(device)
+          label = device.is?(:bcache_cset) ? device.display_name : device.name
+
+          [device.sid.to_s, label]
+        end
+      end
+
+      # Widget to select the backing device
+      class BackingDeviceSelector < DeviceSelector
+        # @return [Y2Storage::BlkDevice, Y2Storage::BcacheCset]
+        attr_reader :caching
+
+        # Constructor
+        #
+        # @param bcache [Y2Storage::Bcache, nil] existing bcache or nil if it is a new one.
+        # @param devices [Array<Y2Storage::BlkDevice>] possible devices that can be used as
+        #   backing device.
+        # @param caching [Y2Partitioner::Dialogs::Bcache::CachingDeviceSelector] reference to
+        #   caching widget. Used to check that caching and backing devices are not identical.
+        def initialize(bcache, devices, caching)
+          super(bcache, devices)
+
           @caching = caching
         end
 
@@ -107,34 +196,20 @@ module Y2Partitioner
 
         # @macro seeItemsSelection
         def items
-          @devices.map do |dev|
-            [dev.sid.to_s, dev.name]
-          end
+          devices.map { |d| item_for_device(d) }
         end
 
         # @macro seeAbstractWidget
         def help
-          "<p>" +
-            # TRANSLATORS: %s stands for name of option
-            format(_(
-                     "%s is the device that will be used as backing device for bcache." \
-                     "It will define the available space of bcache. " \
-                     "The Device will be formatted so any previous content will be wiped out."
-            ), "<b>" + label + "</b>") +
-            "</p>"
-        end
-
-        # @macro seeAbstractWidget
-        def init
-          return unless @device
-
-          self.value = @device.sid.to_s
-        end
-
-        # @macro seeAbstractWidget
-        def store
-          val = value
-          @result = @devices.find { |d| d.sid == val.to_i }
+          # TRANSLATORS: %{label} is replaced by the label of the option to select a backing device.
+          format(
+            _("<p>" \
+                "<b>%{label}</b> is the device that will be used as backing device for bcache." \
+                "It will define the available space of bcache. " \
+                "The Device will be formatted so any previous content will be wiped out." \
+              "</p>"),
+            label: label
+          )
         end
 
         # @macro seeAbstractWidget
@@ -147,7 +222,7 @@ module Y2Partitioner
               headline: _("Cannot Create Bcache")
             )
             return false
-          elsif value == @caching.value
+          elsif value == caching.value
             Yast2::Popup.show(
               _("Backing and Caching devices cannot be identical."),
               headline: _("Cannot Create Bcache")
@@ -158,22 +233,19 @@ module Y2Partitioner
           end
         end
 
-        # returns device selected in widget. Only when dialog succeed and store is called.
-        # Otherwise undefined
-        attr_reader :result
+      private
+
+        # When the bcache exists, its backing device should be the default device.
+        # Otherwise, the first available device is the default one.
+        def default_device
+          return bcache.backing_device if bcache
+
+          super
+        end
       end
 
       # Widget to select the caching device
-      class CachingDevice < CWM::ComboBox
-        # @param device [Y2Storage::BcacheCset,nil] existing caching device or nil if it is a new bcache
-        # @param devices [Array<Y2Storage::BlkDevice,Y2Storage::BcacheCset>] possible devices that can be
-        #   used as caching device for the Bcache
-        def initialize(device, devices)
-          textdomain "storage"
-          @device = device
-          @devices = devices
-        end
-
+      class CachingDeviceSelector < DeviceSelector
         # @macro seeAbstractWidget
         def label
           _("Caching Device")
@@ -181,53 +253,59 @@ module Y2Partitioner
 
         # @macro seeItemsSelection
         def items
-          @devices.map do |dev|
-            case dev
-            when Y2Storage::BcacheCset
-              [dev.sid.to_s, dev.display_name]
-            else
-              [dev.sid.to_s, dev.name]
-            end
-          end
+          items = devices.map { |d| item_for_device(d) }
+
+          items.prepend(item_for_non_device)
         end
 
         # @macro seeAbstractWidget
         def help
-          "<p>" +
-            # TRANSLATORS: %s stands for name of option
-            format(_(
-                     "%s is the device that will be used as caching device for bcache." \
-                     "It should be faster and usually is smaller than the backing device, " \
-                     "but it is not required. " \
-                     "The device will be formatted so any previous content will be wiped out."
-            ), "<b>" + label + "</b>") +
-            "</p>"
+          # TRANSLATORS: %{label} is replaced by the label of the option to select a caching device.
+          format(
+            _("<p>" \
+                "<b>%{label}</b> is the device that will be used as caching device for bcache." \
+                "It should be faster and usually is smaller than the backing device, " \
+                "but it is not required. The device will be formatted so any previous " \
+                "content will be wiped out." \
+              "</p>" \
+              "<p>" \
+                "If you are thinking about using bcache later, it is recommended to setup " \
+                "your slow devices as bcache backing devices without a cache. You can " \
+                "add a caching device later." \
+              "</p>"),
+            label: label
+          )
         end
 
-        # @macro seeAbstractWidget
-        def init
-          return unless @device
+      private
 
-          self.value = @device.sid.to_s
+        def item_for_non_device
+          ["", _("Without caching")]
         end
 
-        # @macro seeAbstractWidget
-        def store
-          val = value
-          @result = @devices.find { |d| d.sid == val.to_i }
-        end
+        # When the bcache exists, its caching set should be the default device.
+        # Otherwise, the first available device is the default one.
+        def default_device
+          return bcache.bcache_cset if bcache && bcache.bcache_cset
 
-        # returns device selected in widget. Only when dialog succeed and store is called.
-        # Otherwise undefined
-        attr_reader :result
+          super
+        end
       end
 
       # Widget to select the cache mode
-      class CacheMode < CWM::ComboBox
-        # @param device [Y2Storage::Bcache,nil] existing caching device or nil if it is a new bcache
-        def initialize(device)
+      class CacheModeSelector < CWM::ComboBox
+        # Cache mode selected in widget
+        #
+        # Only rely on this value when the dialog succeed and {#store} is called.
+        attr_reader :result
+
+        # Constructor
+        #
+        # @param bcache [Y2Storage::Bcache, nil] existing bcache or nil if it is a new one
+        def initialize(bcache)
           textdomain "storage"
-          @device = device
+
+          @bcache = bcache
         end
 
         # @macro seeAbstractWidget
@@ -243,41 +321,39 @@ module Y2Partitioner
         end
 
         # @macro seeAbstractWidget
+        #
         # @see https://en.wikipedia.org/wiki/Cache_(computing)#Writing_policies
         def help
-          "<p>" +
-            # TRANSLATORS: %s stands for name of option
-            format(_(
-                     "%s is the operating mode for bcache. " \
-                     "There are currently four supported modes.<ul> " \
-                     "<li><i>Writethrough</i> reading operations are cached, writing is done " \
-                     "in parallel to both devices. No data is lost in case of failure of " \
-                     "the caching device. This is the default mode.</li>" \
-                     "<li><i>Writeback</i> both reading and writing operations are cached. " \
-                     "This result in better performance when writing.</li>" \
-                     "<li><i>Writearound</i> reading is cached, new content is " \
-                     "written only to the backing device.</li>" \
-                     "<li><i>None</i> means cache is neither used for reading nor for writing. " \
-                     "This is useful mainly for temporarily disabling the cache before any big " \
-                     "sequential read or write, otherwise that would result in intensive " \
-                     "overwriting on the cache device.</li>"
-            ), "<b>" + label + "</b>") +
-            "</p>"
+          # TRANSLATORS: %{label} is replaced by the label of the option to select a cache mode.
+          format(
+            _("<p>" \
+                "<b>%{label}</b> is the operating mode for bcache. " \
+                "There are currently four supported modes.<ul> " \
+                "<li><i>Writethrough</i> reading operations are cached, writing is done " \
+                "in parallel to both devices. No data is lost in case of failure of " \
+                "the caching device. This is the default mode.</li>" \
+                "<li><i>Writeback</i> both reading and writing operations are cached. " \
+                "This result in better performance when writing.</li>" \
+                "<li><i>Writearound</i> reading is cached, new content is " \
+                "written only to the backing device.</li>" \
+                "<li><i>None</i> means cache is neither used for reading nor for writing. " \
+                "This is useful mainly for temporarily disabling the cache before any big " \
+                "sequential read or write, otherwise that would result in intensive " \
+                "overwriting on the cache device.</li>" \
+              "</p>"),
+            label: label
+          )
         end
 
         # @macro seeAbstractWidget
         def init
-          self.value = (@device ? @device.cache_mode : Y2Storage::CacheMode::WRITETHROUGH).to_sym.to_s
+          self.value = (@bcache ? @bcache.cache_mode : Y2Storage::CacheMode::WRITETHROUGH).to_sym.to_s
         end
 
         # @macro seeAbstractWidget
         def store
           @result = Y2Storage::CacheMode.find(value.to_sym)
         end
-
-        # returns device selected in widget. Only when dialog succeed and store is called.
-        # Otherwise undefined
-        attr_reader :result
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/bcache_add_button.rb
+++ b/src/lib/y2partitioner/widgets/bcache_add_button.rb
@@ -41,8 +41,8 @@ module Y2Partitioner
       # @macro seeAbstractWidget
       # @see Actions::AddBcache
       def handle
-        Actions::AddBcache.new.run
-        :redraw
+        res = Actions::AddBcache.new.run
+        res == :finish ? :redraw : nil
       end
     end
   end

--- a/test/y2partitioner/actions/add_bcache_test.rb
+++ b/test/y2partitioner/actions/add_bcache_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -21,50 +21,107 @@
 # find current contact information at www.suse.com.
 
 require_relative "../test_helper"
+
 require "y2partitioner/device_graphs"
 require "y2partitioner/actions/add_bcache"
 require "y2partitioner/dialogs/bcache"
 
 describe Y2Partitioner::Actions::AddBcache do
-  let(:dialog) do
-    Y2Partitioner::Dialogs::Bcache.new(
-      fake_devicegraph.blk_devices,
-      fake_devicegraph.blk_devices
-    )
-  end
-
-  let(:selected_backing) { fake_devicegraph.blk_devices.find { |d| d.name == "/dev/sda1" } }
-  let(:selected_caching) { fake_devicegraph.blk_devices.find { |d| d.name == "/dev/sdc" } }
-  let(:options) { { cache_mode: Y2Storage::CacheMode::WRITEBACK } }
-
   subject { described_class.new }
 
   before do
-    devicegraph_stub("empty_disks.yml")
-    my_dialog = dialog
-    allow(Y2Partitioner::Dialogs::Bcache).to receive(:new).and_return(my_dialog)
+    devicegraph_stub(scenario)
+
+    allow_any_instance_of(Y2Partitioner::Dialogs::Bcache).to receive(:run)
+      .and_return(dialog_result)
+
+    allow_any_instance_of(Y2Partitioner::Dialogs::Bcache).to receive(:backing_device)
+      .and_return(selected_backing)
+
+    allow_any_instance_of(Y2Partitioner::Dialogs::Bcache).to receive(:caching_device)
+      .and_return(selected_caching)
+
+    allow_any_instance_of(Y2Partitioner::Dialogs::Bcache).to receive(:options)
+      .and_return(selected_options)
   end
 
+  let(:scenario) { "empty_disks.yml" }
+
+  let(:dialog_result) { nil }
+
+  let(:selected_backing) { fake_devicegraph.find_by_name("/dev/sda1") }
+
+  let(:selected_caching) { nil }
+
+  let(:selected_options) { { cache_mode: Y2Storage::CacheMode::WRITEBACK } }
+
   describe "#run" do
-    before do
-      allow(dialog).to receive(:run).and_return :next
-      allow(dialog).to receive(:backing_device).and_return(selected_backing)
-      allow(dialog).to receive(:caching_device).and_return(selected_caching)
-      allow(dialog).to receive(:options).and_return(options)
+    let(:bcache) { fake_devicegraph.find_by_name("/dev/bcache0") }
+
+    shared_examples "create new bcache" do
+      it "creates a new bcache device" do
+        expect(fake_devicegraph.bcaches).to be_empty
+
+        subject.run
+
+        expect(bcache).to_not be_nil
+        expect(bcache.is?(:bcache)).to eq(true)
+      end
+
+      it "sets the selected cache mode" do
+        subject.run
+
+        expect(bcache.cache_mode).to eq(selected_options[:cache_mode])
+      end
     end
 
-    it "returns :finish" do
-      expect(subject.run).to eq :finish
+    context "when the dialog is accepted" do
+      let(:dialog_result) { :next }
+
+      context "and a caching device was selected in the dialog" do
+        let(:selected_caching) { fake_devicegraph.find_by_name("/dev/sdc") }
+
+        include_examples "create new bcache"
+
+        it "attaches the selected caching device" do
+          subject.run
+
+          expect(bcache.bcache_cset).to_not be_nil
+          expect(bcache.bcache_cset.blk_devices.first).to eq(selected_caching)
+        end
+
+        it "returns :finish" do
+          expect(subject.run).to eq :finish
+        end
+      end
+
+      context "when no caching device was selected in the dialog" do
+        let(:selected_caching) { nil }
+
+        include_examples "create new bcache"
+
+        it "does not attach a caching device" do
+          subject.run
+
+          expect(bcache.bcache_cset).to be_nil
+        end
+
+        it "returns :finish" do
+          expect(subject.run).to eq :finish
+        end
+      end
     end
 
-    it "creates a new bcache device" do
-      bcaches = fake_devicegraph.bcaches
-      expect(bcaches.size).to eq 0
+    context "when the dialog is discarded" do
+      it "does not create a new bcache" do
+        subject.run
 
-      subject.run
+        expect(fake_devicegraph.bcaches).to be_empty
+      end
 
-      bcaches = fake_devicegraph.bcaches
-      expect(bcaches.size).to eq 1
+      it "returns :finish" do
+        expect(subject.run).to eq :finish
+      end
     end
   end
 end

--- a/test/y2partitioner/widgets/bcache_add_button_test.rb
+++ b/test/y2partitioner/widgets/bcache_add_button_test.rb
@@ -30,19 +30,36 @@ describe Y2Partitioner::Widgets::BcacheAddButton do
 
   before do
     devicegraph_stub("bcache1.xml")
-    allow(Y2Partitioner::Actions::AddBcache).to receive(:new).and_return(double(run: :finish))
+
+    allow(Y2Partitioner::Actions::AddBcache).to receive(:new)
+      .and_return(double(run: action_result))
   end
+
+  let(:action_result) { :finish }
 
   include_examples "CWM::PushButton"
 
   describe "#handle" do
-    it "starts an AddBcache action" do
-      expect(Y2Partitioner::Actions::AddBcache).to receive(:new).and_return(double(run: :finish))
+    it "starts an action to create a bcache device" do
+      expect(Y2Partitioner::Actions::AddBcache).to receive(:new)
+
       button.handle
     end
 
-    it "returns :redraw" do
-      expect(button.handle).to eq :redraw
+    context "if the action returns :finish" do
+      let(:action_result) { :finish }
+
+      it "returns :redraw" do
+        expect(button.handle).to eq(:redraw)
+      end
+    end
+
+    context "if the action does not return :finish" do
+      let(:action_result) { :back }
+
+      it "returns nil" do
+        expect(button.handle).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

Bcache devices can be created without an associated caching set. In fact, this is a recommended practice if you are thinking about using bcache later. The idea is to setup all your slow devices as bcache backing devices without a cache, and you can choose to add a caching device later.

The Expert Partitioner needs to be adapted to allow bcache creation without a caching set.

- https://jira.suse.de/browse/SLE-4329
- https://trello.com/c/GMjxjMJC/654-3-allow-to-create-a-bcache-without-cset

## Solution

The widget to select the caching set now has a new option: "Without caching". 

## Testing

* Added unit tests.
* Manually tested.

## Screenshots

Option to not select caching device

![virtualbox_opensuse tumbleweed_07_02_2019_15_59_47](https://user-images.githubusercontent.com/1112304/52424227-74687b00-2af1-11e9-879f-4919dbcac1fa.png)

Error when there are no suitable backing devices

![virtualbox_opensuse tumbleweed_08_02_2019_09_50_30](https://user-images.githubusercontent.com/1112304/52471476-e4761000-2b88-11e9-9b6e-eac9d10853d2.png)

Added help

![virtualbox_opensuse tumbleweed_08_02_2019_10_02_39](https://user-images.githubusercontent.com/1112304/52471465-dde79880-2b88-11e9-86a1-fc329f030db2.png)



