### PR TITLE
Limit Bcache Support to x86_64 Arch

### DIFF
--- a/doc/bcache.md
+++ b/doc/bcache.md
@@ -18,3 +18,20 @@ YaST also prevents actions that would trigger such operations. For example, YaST
 editing or resizing an existing bcache device and removing a bcache device that shares
 its caching set. All those actions could imply detaching a cache, which is one of those slow
 and asynchronous processes.
+
+
+### Supported Platforms
+
+Since the SUSE bcache maintainer Coly Li <colyli@suse.com> considers bcache to
+be unreliable on architectures other than x86_64, YaST supports bcache only on
+that architecture.
+
+On other architectures, the installer and the partitioner will post a warning
+if an existing bcache is detected. No bcache operations are offered on those
+architectures.
+
+
+See also
+
+  https://jira.suse.de/browse/SLE-4329?focusedCommentId=918311
+

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 14 12:49:25 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Limit bcache support to x86_64 arch (jsc#SLE-4329)
+- 4.1.58
+
+-------------------------------------------------------------------
 Thu Feb 14 12:19:58 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Guided Setup: improved the disk selection user interface to

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.57
+Version:	4.1.58
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -30,6 +30,7 @@ require "y2partitioner/widgets/pages"
 require "y2partitioner/setup_errors_presenter"
 require "y2storage/setup_checker"
 require "y2storage/used_storage_features"
+require "y2storage/bcache"
 
 Yast.import "UI"
 Yast.import "PackageSystem"
@@ -187,7 +188,7 @@ module Y2Partitioner
           btrfs_items
           # TODO: Bring this back to life - disabled for now (bsc#1078849)
           # unused_items
-        ]
+        ].compact
         CWM::PagerTreeItem.new(page, children: children, icon: Icons::ALL)
       end
 
@@ -238,6 +239,7 @@ module Y2Partitioner
 
       # @return [CWM::PagerTreeItem]
       def bcache_items
+        return nil unless Y2Storage::Bcache.supported?
         devices = device_graph.bcaches
         page = Pages::Bcaches.new(devices, self)
         children = devices.map { |v| disk_items(v, Pages::Bcache) }

--- a/src/lib/y2storage/bcache.rb
+++ b/src/lib/y2storage/bcache.rb
@@ -23,6 +23,8 @@ require "y2storage/storage_class_wrapper"
 require "y2storage/partitionable"
 require "y2storage/bcache_type"
 
+Yast.import "Arch"
+
 module Y2Storage
   # A Bcache device
   #
@@ -125,6 +127,15 @@ module Y2Storage
 
     def inspect
       flash_only? ? flash_only_inspect : backed_inspect
+    end
+
+    # Check if bcache is supported on this platform.
+    # Notice that this is for both bcache and bcache_cset.
+    #
+    # @return [Boolean]
+    def self.supported?
+      # So far, bcache is only supported on x86_64 (JIRA#SLE-4329)
+      Yast::Arch.x86_64
     end
 
   protected

--- a/src/lib/y2storage/devicegraph_sanitizer.rb
+++ b/src/lib/y2storage/devicegraph_sanitizer.rb
@@ -166,7 +166,7 @@ module Y2Storage
       vg.lvm_pvs.any? { |p| p.blk_device.nil? }
     end
 
-    # Errors related to LVM VGs in the given devicegraph
+    # Errors related to bcache in the given devicegraph
     #
     # @param devicegraph [Y2Storage::Devicegraph]
     # @return [Array<DevicegraphSanitizer::Error>]

--- a/test/y2storage/bcache_cset_test.rb
+++ b/test/y2storage/bcache_cset_test.rb
@@ -30,6 +30,7 @@ describe Y2Storage::BcacheCset do
 
   let(:scenario) { "bcache1.xml" }
   let(:bcache_name) { "/dev/bcache0" }
+  let(:architecture) { :x86_64 } # need an architecture where bcache is supported
   subject(:bcache_cset) { Y2Storage::Bcache.find_by_name(fake_devicegraph, bcache_name).bcache_cset }
 
   describe "#blk_devices" do

--- a/test/y2storage/bcache_test.rb
+++ b/test/y2storage/bcache_test.rb
@@ -26,198 +26,232 @@ require "y2storage"
 describe Y2Storage::Bcache do
   using Y2Storage::Refinements::SizeCasts
 
-  before do
-    fake_scenario(scenario)
-  end
+  context "without any devicegraph" do
+    describe ".supported?" do
+      context "on x86_64" do
+        let(:architecture) { :x86_64 }
+        it "returns true (supported)" do
+          expect(described_class.supported?).to be true
+        end
+      end
 
-  let(:scenario) { "bcache2.xml" }
+      context "on ppc" do
+        let(:architecture) { :ppc }
+        it "returns false (not supported)" do
+          expect(described_class.supported?).to be false
+        end
+      end
 
-  let(:bcache_name) { "/dev/bcache0" }
+      context "on aarch64" do
+        let(:architecture) { :aarch64 }
+        it "returns false (not supported)" do
+          expect(described_class.supported?).to be false
+        end
+      end
 
-  subject(:bcache) { Y2Storage::Bcache.find_by_name(fake_devicegraph, bcache_name) }
-
-  describe "#backing_device" do
-    it "returns the backing device" do
-      expect(subject.backing_device).to be_a(Y2Storage::BlkDevice)
-      expect(subject.backing_device.basename).to eq("sdb2")
-    end
-
-    context "when it is a Flash-only bcache" do
-      let(:bcache_name) { "/dev/bcache1" }
-
-      it "returns nil" do
-        expect(subject.backing_device).to be_nil
+      context "on s390" do
+        let(:architecture) { :s390 }
+        it "returns false (not supported)" do
+          expect(described_class.supported?).to be false
+        end
       end
     end
   end
 
-  describe "#bcache_cset" do
-    context "when the bcache is using caching" do
-      let(:bcache_name) { "/dev/bcache0" }
-
-      it "returns the associated caching set" do
-        expect(subject.bcache_cset).to be_a(Y2Storage::BcacheCset)
-        expect(subject.bcache_cset.blk_devices.map(&:basename)).to contain_exactly("sdb1")
-      end
-    end
-
-    context "when the bcache is not using caching" do
-      before do
-        sdb3 = fake_devicegraph.find_by_name("/dev/sdb3")
-        sdb3.create_bcache("/dev/bcache99")
-      end
-
-      let(:bcache_name) { "/dev/bcache99" }
-
-      it "returns nil" do
-        expect(subject.bcache_cset).to be_nil
-      end
-    end
-
-    context "when the bcache is flash-only" do
-      let(:bcache_name) { "/dev/bcache1" }
-
-      it "returns the caching set that holds it" do
-        expect(subject.type).to eq(Y2Storage::BcacheType::FLASH_ONLY)
-
-        expect(subject.bcache_cset).to be_a(Y2Storage::BcacheCset)
-        expect(subject.bcache_cset.blk_devices.map(&:basename)).to contain_exactly("sdb1")
-      end
-    end
-  end
-
-  describe "#attach_bcache_cset" do
+  context "with a bcache in the probed devicegraph" do
     before do
-      described_class.create(fake_devicegraph, bcache_name)
+      fake_scenario(scenario)
     end
 
-    let(:bcache_name) { "/dev/bcache99" }
+    let(:scenario) { "bcache2.xml" }
+    let(:bcache_name) { "/dev/bcache0" }
+    let(:architecture) { :x86_64 } # need an architecture where bcache is supported
 
-    let(:cset) { fake_devicegraph.bcache_csets.first }
+    subject(:bcache) { Y2Storage::Bcache.find_by_name(fake_devicegraph, bcache_name) }
 
-    it "attach a caching set to bcache device" do
-      expect(subject.bcache_cset).to be_nil
+    describe "#backing_device" do
+      it "returns the backing device" do
+        expect(subject.backing_device).to be_a(Y2Storage::BlkDevice)
+        expect(subject.backing_device.basename).to eq("sdb2")
+      end
 
-      subject.attach_bcache_cset(cset)
+      context "when it is a Flash-only bcache" do
+        let(:bcache_name) { "/dev/bcache1" }
 
-      expect(subject.bcache_cset).to eq(cset)
-    end
-
-    context "when the bcache already has an associated caching set" do
-      let(:bcache_name) { "/dev/bcache1" }
-
-      it "raises an exception" do
-        expect { subject.attach_bcache_cset(cset) }.to raise_error(Storage::LogicException)
+        it "returns nil" do
+          expect(subject.backing_device).to be_nil
+        end
       end
     end
 
-    context "when the bcache is flash-only" do
-      let(:bcache_name) { "/dev/bcache1" }
+    describe "#bcache_cset" do
+      context "when the bcache is using caching" do
+        let(:bcache_name) { "/dev/bcache0" }
 
-      it "raises an exception" do
-        expect { subject.attach_bcache_cset(cset) }.to raise_error(Storage::LogicException)
+        it "returns the associated caching set" do
+          expect(subject.bcache_cset).to be_a(Y2Storage::BcacheCset)
+          expect(subject.bcache_cset.blk_devices.map(&:basename)).to contain_exactly("sdb1")
+        end
       end
-    end
-  end
 
-  describe ".find_free_name" do
-    it "returns bcache name that is not used yet" do
-      expect(fake_devicegraph.bcaches.map(&:name)).to_not(
-        include(described_class.find_free_name(fake_devicegraph))
-      )
-    end
-  end
+      context "when the bcache is not using caching" do
+        before do
+          sdb3 = fake_devicegraph.find_by_name("/dev/sdb3")
+          sdb3.create_bcache("/dev/bcache99")
+        end
 
-  describe "#is?" do
-    it "returns true for values whose symbol is :bcache" do
-      expect(bcache.is?(:bcache)).to eq true
-      expect(bcache.is?("bcache")).to eq true
-    end
+        let(:bcache_name) { "/dev/bcache99" }
 
-    it "returns false for a different string like \"Disk\"" do
-      expect(bcache.is?("Disk")).to eq false
-    end
+        it "returns nil" do
+          expect(subject.bcache_cset).to be_nil
+        end
+      end
 
-    it "returns false for different device names like :partition or :filesystem" do
-      expect(bcache.is?(:partition)).to eq false
-      expect(bcache.is?(:filesystem)).to eq false
-    end
+      context "when the bcache is flash-only" do
+        let(:bcache_name) { "/dev/bcache1" }
 
-    it "returns true for a list of names containing :bcache" do
-      expect(bcache.is?(:bcache, :partition)).to eq true
-    end
+        it "returns the caching set that holds it" do
+          expect(subject.type).to eq(Y2Storage::BcacheType::FLASH_ONLY)
 
-    it "returns false for a list of names not containing :bcache" do
-      expect(bcache.is?(:filesystem, :partition)).to eq false
-    end
-  end
-
-  describe "#flash_only?" do
-    context "when the bcache is flash-only" do
-      let(:bcache_name) { "/dev/bcache1" }
-
-      it "returns true" do
-        expect(subject.flash_only?).to eq(true)
+          expect(subject.bcache_cset).to be_a(Y2Storage::BcacheCset)
+          expect(subject.bcache_cset.blk_devices.map(&:basename)).to contain_exactly("sdb1")
+        end
       end
     end
 
-    context "when the bcache is not flash-only" do
-      let(:bcache_name) { "/dev/bcache0" }
-
-      it "returns false" do
-        expect(subject.flash_only?).to eq(false)
-      end
-    end
-  end
-
-  describe "#inspect" do
-    context "when the bcache has an associated caching set" do
-      let(:bcache_name) { "/dev/bcache0" }
-
-      it "includes the caching set info" do
-        expect(subject.inspect).to include("BcacheCset")
-      end
-    end
-
-    context "when the bcache has no associated caching set" do
+    describe "#attach_bcache_cset" do
       before do
-        sdb3 = fake_devicegraph.find_by_name("/dev/sdb3")
-        sdb3.create_bcache(bcache_name)
+        described_class.create(fake_devicegraph, bcache_name)
       end
 
       let(:bcache_name) { "/dev/bcache99" }
 
-      it "does not include the caching set info" do
-        expect(subject.inspect).to_not include("BcacheCset")
-        expect(subject.inspect).to include("without caching set")
+      let(:cset) { fake_devicegraph.bcache_csets.first }
+
+      it "attach a caching set to bcache device" do
+        expect(subject.bcache_cset).to be_nil
+
+        subject.attach_bcache_cset(cset)
+
+        expect(subject.bcache_cset).to eq(cset)
+      end
+
+      context "when the bcache already has an associated caching set" do
+        let(:bcache_name) { "/dev/bcache1" }
+
+        it "raises an exception" do
+          expect { subject.attach_bcache_cset(cset) }.to raise_error(Storage::LogicException)
+        end
+      end
+
+      context "when the bcache is flash-only" do
+        let(:bcache_name) { "/dev/bcache1" }
+
+        it "raises an exception" do
+          expect { subject.attach_bcache_cset(cset) }.to raise_error(Storage::LogicException)
+        end
       end
     end
 
-    context "when the bcache is flash-only" do
-      let(:bcache_name) { "/dev/bcache1" }
-
-      it "includes the caching set info" do
-        expect(subject.inspect).to include("BcacheCset")
-      end
-
-      it "includes the 'flash-only' mark" do
-        expect(subject.inspect).to include("flash-only")
+    describe ".find_free_name" do
+      it "returns bcache name that is not used yet" do
+        expect(fake_devicegraph.bcaches.map(&:name)).to_not(
+          include(described_class.find_free_name(fake_devicegraph))
+        )
       end
     end
-  end
 
-  describe ".all" do
-    it "returns a list of Y2Storage::Bcache objects" do
-      bcaches = Y2Storage::Bcache.all(fake_devicegraph)
-      expect(bcaches).to be_an Array
-      expect(bcaches).to all(be_a(Y2Storage::Bcache))
+    describe "#is?" do
+      it "returns true for values whose symbol is :bcache" do
+        expect(bcache.is?(:bcache)).to eq true
+        expect(bcache.is?("bcache")).to eq true
+      end
+
+      it "returns false for a different string like \"Disk\"" do
+        expect(bcache.is?("Disk")).to eq false
+      end
+
+      it "returns false for different device names like :partition or :filesystem" do
+        expect(bcache.is?(:partition)).to eq false
+        expect(bcache.is?(:filesystem)).to eq false
+      end
+
+      it "returns true for a list of names containing :bcache" do
+        expect(bcache.is?(:bcache, :partition)).to eq true
+      end
+
+      it "returns false for a list of names not containing :bcache" do
+        expect(bcache.is?(:filesystem, :partition)).to eq false
+      end
     end
 
-    it "includes all bcaches in the devicegraph and nothing else" do
-      bcaches = Y2Storage::Bcache.all(fake_devicegraph)
-      expect(bcaches.map(&:basename)).to contain_exactly(
-        "bcache0", "bcache1", "bcache2"
-      )
+    describe "#flash_only?" do
+      context "when the bcache is flash-only" do
+        let(:bcache_name) { "/dev/bcache1" }
+
+        it "returns true" do
+          expect(subject.flash_only?).to eq(true)
+        end
+      end
+
+      context "when the bcache is not flash-only" do
+        let(:bcache_name) { "/dev/bcache0" }
+
+        it "returns false" do
+          expect(subject.flash_only?).to eq(false)
+        end
+      end
+    end
+
+    describe "#inspect" do
+      context "when the bcache has an associated caching set" do
+        let(:bcache_name) { "/dev/bcache0" }
+
+        it "includes the caching set info" do
+          expect(subject.inspect).to include("BcacheCset")
+        end
+      end
+
+      context "when the bcache has no associated caching set" do
+        before do
+          sdb3 = fake_devicegraph.find_by_name("/dev/sdb3")
+          sdb3.create_bcache(bcache_name)
+        end
+
+        let(:bcache_name) { "/dev/bcache99" }
+
+        it "does not include the caching set info" do
+          expect(subject.inspect).to_not include("BcacheCset")
+          expect(subject.inspect).to include("without caching set")
+        end
+      end
+
+      context "when the bcache is flash-only" do
+        let(:bcache_name) { "/dev/bcache1" }
+
+        it "includes the caching set info" do
+          expect(subject.inspect).to include("BcacheCset")
+        end
+
+        it "includes the 'flash-only' mark" do
+          expect(subject.inspect).to include("flash-only")
+        end
+      end
+    end
+
+    describe ".all" do
+      it "returns a list of Y2Storage::Bcache objects" do
+        bcaches = Y2Storage::Bcache.all(fake_devicegraph)
+        expect(bcaches).to be_an Array
+        expect(bcaches).to all(be_a(Y2Storage::Bcache))
+      end
+
+      it "includes all bcaches in the devicegraph and nothing else" do
+        bcaches = Y2Storage::Bcache.all(fake_devicegraph)
+        expect(bcaches.map(&:basename)).to contain_exactly(
+          "bcache0", "bcache1", "bcache2"
+        )
+      end
     end
   end
 end

--- a/test/y2storage/devicegraph_sanitizer_test.rb
+++ b/test/y2storage/devicegraph_sanitizer_test.rb
@@ -71,15 +71,13 @@ describe Y2Storage::DevicegraphSanitizer do
     end
 
     context "with a bcache device in the devicegraph" do
-      let(:scenario) { "bcache2.xml" }
-      let(:devicegraph) { fake_devicegraph }
-      let(:bcache_name) { "/dev/bcache1" }
+      let(:devicegraph) { devicegraph_from("bcache2.xml") }
+      let(:bcache_name) { "/dev/bcache0" }
 
       context "on an architecture that supports bcache (x86_64)" do
         let(:architecture) { :x86_64 }
 
         it "does not contain an error" do
-          fake_scenario(scenario)
           expect(subject.errors).to be_empty
         end
       end
@@ -87,8 +85,13 @@ describe Y2Storage::DevicegraphSanitizer do
       context "on an architecture that does not support bcache (ppc)" do
         let(:architecture) { :ppc }
 
-        it "raises an error" do
-          expect { fake_scenario(scenario) }.to raise_error(Y2Storage::Error)
+        it "contains a bcache-related error" do
+          errors = subject.errors
+          expect(errors).not_to be_empty
+
+          err_devices = errors.map(&:device)
+          bcache = devicegraph.find_by_name(bcache_name)
+          expect(err_devices).to include(bcache)
         end
       end
     end

--- a/test/y2storage/devicegraph_sanitizer_test.rb
+++ b/test/y2storage/devicegraph_sanitizer_test.rb
@@ -69,6 +69,29 @@ describe Y2Storage::DevicegraphSanitizer do
         expect(subject.errors).to be_empty
       end
     end
+
+    context "with a bcache device in the devicegraph" do
+      let(:scenario) { "bcache2.xml" }
+      let(:devicegraph) { fake_devicegraph }
+      let(:bcache_name) { "/dev/bcache1" }
+
+      context "on an architecture that supports bcache (x86_64)" do
+        let(:architecture) { :x86_64 }
+
+        it "does not contain an error" do
+          fake_scenario(scenario)
+          expect(subject.errors).to be_empty
+        end
+      end
+
+      context "on an architecture that does not support bcache (ppc)" do
+        let(:architecture) { :ppc }
+
+        it "raises an error" do
+          expect { fake_scenario(scenario) }.to raise_error(Y2Storage::Error)
+        end
+      end
+    end
   end
 
   describe "#sanitized_devicegraph" do


### PR DESCRIPTION
## Trello

https://trello.com/c/f1pcGKbD/673-3-bcache-in-non-x8664-systems

## JIRA

https://jira.suse.de/browse/SLE-4329

## Problem

Bcache is only really supported (on the kernel and upstream tools side) on a limited range of platforms. Currently, this is only the x86_64 architecture.

## Solution

### Installation / Upgrade and Expert Partitioner in the Installed System

Right after probing, check if bcache is in use (i.e. if there is an existing bcache device).

Probing is safe since this only uses external tools like the `blkid` command and checks for `/sys` etc. paths that the kernel generated.

If there is an existing bcache, but we don't fully support bcache on that architecture, post a warning, but let the user proceed anyway.

This is implemented via the DevicegraphSanitizer which is run over the probed devicegraph to check for problems. Now a new error class for bcache is added if any bcache device is found and the platform does not support bcache.

### Partitioner

Don't offer bcache operations. Don't add the bcache branch to the tree in the partitioner.


## Testing

- Slightly hacked up the code to make the warning appear on my system and tested with "yast2 disk" on my workstation (see screenshot below)

- Checked manually that there is no bcache branch in the partitioner's tree, i.e. no bcache devices or operations are show

- Unit tests

## Screenshots

![bcache-not-supported-warning](https://user-images.githubusercontent.com/11538225/52653957-4ae49080-2ef1-11e9-945e-9b7523bb1b5e.png)

Warning message