### PR TITLE
Guided Setup: improve disk selection screen

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 14 12:19:58 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Guided Setup: improved the disk selection user interface to
+  properly support scenarios with many disks (bsc#1123688).
+- 4.1.57
+
+-------------------------------------------------------------------
 Thu Feb 14 10:49:47 CET 2019 - aschnell@suse.com
 
 - AutoYaST: save device_order for MD RAIDs (bsc#1083542)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.56
+Version:	4.1.57
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/dialogs/guided_setup/base.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/base.rb
@@ -73,11 +73,13 @@ module Y2Storage
         end
 
         # Disk label used by dialogs.
-        # name, size and installed systems, for example:
-        #   "/dev/sda, 10GiB, Windows, OpenSUSE"
+        # name, size, [USB] and installed systems, for example:
+        #   "/dev/sda, 10.00 GiB, Windows, OpenSUSE"
+        #   "/dev/sdb, 8.00 GiB, USB"
         # @return [String]
         def disk_label(disk)
           data = [disk.name, disk.size.to_human_string]
+          data += disk_type_labels(disk)
           data += analyzer.installed_systems(disk)
           data.join(", ")
         end
@@ -122,6 +124,35 @@ module Y2Storage
         # Helper to set widget value
         def widget_update(id, value, attr: :Value)
           Yast::UI.ChangeWidget(Id(id), attr, value)
+        end
+
+        # Labels to help indentifying some kind of disks, like USB ones
+        #
+        # @see #disk_label
+        #
+        # @param disk [BlkDevice]
+        # @return [Array<String>]
+        def disk_type_labels(disk)
+          return [] unless disk.respond_to?(:transport)
+
+          trans = transport_label(disk.transport)
+          trans.empty? ? [] : [trans]
+        end
+
+        # Label for the given transport to be displayed in the dialogs
+        #
+        # @see #disk_type_labels
+        #
+        # @param transport [DataTransport]
+        # @return [String] empty string if the transport is not worth mentioning
+        def transport_label(transport)
+          if transport.is?(:usb)
+            _("USB")
+          elsif transport.is?(:sbp)
+            _("IEEE 1394")
+          else
+            ""
+          end
         end
       end
     end

--- a/src/lib/y2storage/dialogs/guided_setup/select_disks.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_disks.rb
@@ -46,31 +46,29 @@ module Y2Storage
 
       protected
 
+        # Maximum number of disks the user is allowed to select
         MAX_DISKS = 3
+
+        # Maximum number of disks that can be displayed at the same time with
+        # the default interface. If that number is exceeded an alternative
+        # interface with scroll is displayed.
+        DISKS_WITHOUT_SCROLL = 10
 
         def dialog_title
           _("Select Hard Disk(s)")
         end
 
         def dialog_content
-          HSquash(
-            VBox(
-              Left(Label(_("Select one or more (max %d) hard disks") % MAX_DISKS)),
-              VSpacing(0.3),
-              *all_disks.map { |d| disk_widget(d) }
-            )
-          )
-        end
-
-        def disk_widget(disk)
-          Left(CheckBox(Id(disk.name), disk_label(disk)))
+          items = all_disks.map { |d| [d.name, disk_label(d)] }
+          label = _("Select one or more (max %d) hard disks") % MAX_DISKS
+          disks_widget.content(label, items)
         end
 
         def initialize_widgets
           default_selected = settings.candidate_devices || []
           default_selected = default_selected.map { |d| analyzer.device_by_name(d) }
           default_selected = all_disks if default_selected.empty?
-          default_selected.first(MAX_DISKS).each { |d| widget_update(d.name, true) }
+          disks_widget.select(default_selected.first(MAX_DISKS).map(&:name))
         end
 
         def update_settings!
@@ -96,11 +94,91 @@ module Y2Storage
         end
 
         def selected_disks
-          all_disks.select { |d| widget_value(d.name) }
+          all_disks.select { |d| disks_widget.selected?(d.name) }
         end
 
         def all_disks
           analyzer.candidate_disks
+        end
+
+        # Widget used to display and select the list of disks
+        #
+        # @return [DisksWidget, ScrollableDisksWidget]
+        def disks_widget
+          @disks_widget ||=
+            if all_disks.size > DISKS_WITHOUT_SCROLL
+              ScrollableDisksWidget.new
+            else
+              DisksWidget.new
+            end
+        end
+
+        # Auxiliary internal class to draw and query the list of disks in the
+        # default case
+        class DisksWidget
+          include Yast::UIShortcuts
+
+          # @see SelectDisks#content
+          #
+          # @param label [String] heading of the widget
+          # @param items [Array<Array<String>>] list of pairs (id, description)
+          def content(label, items)
+            HSquash(
+              VBox(
+                Left(Label(label)),
+                VSpacing(0.3),
+                *items.map { |item| disk_widget(item) }
+              )
+            )
+          end
+
+          # @see SelectDisks#initialize_widgets
+          def select(ids)
+            ids.each { |id| Yast::UI.ChangeWidget(Id(id), :Value, true) }
+          end
+
+          # @see SelectDisks#selected_disks
+          def selected?(id)
+            Yast::UI.QueryWidget(Id(id), :Value)
+          end
+
+        protected
+
+          # @see #content
+          def disk_widget(item)
+            Left(CheckBox(Id(item.first), item.last))
+          end
+        end
+
+        # Auxiliary internal class to draw and query the list of disks when
+        # there are so many disks that the default widget cannot deal with it
+        class ScrollableDisksWidget
+          include Yast::UIShortcuts
+
+          # @see SelectDisks#content
+          #
+          # @param label [String] heading of the widget
+          # @param items [Array<Array<String>>] list of pairs (id, description)
+          def content(label, items)
+            MarginBox(
+              2, 1,
+              MultiSelectionBox(
+                Id(:disks),
+                label,
+                items.map { |item| Item(Id(item.first), item.last) }
+              )
+            )
+          end
+
+          # @see SelectDisks#initialize_widgets
+          def select(ids)
+            Yast::UI.ChangeWidget(Id(:disks), :SelectedItems, ids)
+          end
+
+          # @see SelectDisks#selected_disks
+          def selected?(id)
+            Yast::UI.QueryWidget(Id(:disks), :SelectedItems).include?(id)
+          end
         end
       end
     end

--- a/src/lib/y2storage/dialogs/guided_setup/select_disks.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_disks.rb
@@ -118,7 +118,7 @@ module Y2Storage
         class DisksWidget
           include Yast::UIShortcuts
 
-          # @see SelectDisks#content
+          # @see SelectDisks#dialog_content
           #
           # @param label [String] heading of the widget
           # @param items [Array<Array<String>>] list of pairs (id, description)
@@ -155,7 +155,7 @@ module Y2Storage
         class ScrollableDisksWidget
           include Yast::UIShortcuts
 
-          # @see SelectDisks#content
+          # @see SelectDisks#dialog_content
           #
           # @param label [String] heading of the widget
           # @param items [Array<Array<String>>] list of pairs (id, description)


### PR DESCRIPTION
## Problem

The screen to select the disks to run the Guided Setup is unusable if there are more than 20 disks to choose from. See

| nCurses       | Qt           |
| ------------- |-------------|
| ![current-curses-30](https://gist.githubusercontent.com/ancorgs/67dcd8a52debd95496137a1cd5bacf6f/raw/734b565d7757b79f47f94f504051f25fcbbe2395/current-curses-30.png) | ![current-qt-30](https://gist.githubusercontent.com/ancorgs/67dcd8a52debd95496137a1cd5bacf6f/raw/734b565d7757b79f47f94f504051f25fcbbe2395/current-qt-30.png) |

In addition, we wanted to take the opportunity to improve the descriptions of the disk. For example, there is nothing to identify external disks like USB.

## Links

- [bsc#1123688](https://bugzilla.suse.com/show_bug.cgi?id=1123688) about unusable screen with many disks
- [Gist discussing the options to fix it](https://gist.github.com/ancorgs/67dcd8a52debd95496137a1cd5bacf6f)
- [Main card in trello](https://trello.com/c/K19cS3aj/)
- [Additional card in Trello](https://trello.com/c/yCnFY5eQ/) for the bug report

## Solution

This pull request implements two changes so far.

- Adding the transport to the description only for USB and IEEE 1394 devices
- Using MultiSelectionBox if there are more than 10 disks to chose from. With 10 or fewer disks, the current UI is still used.

## Testing

- Added unit tests to verify the improved labels and to ensure both versions of the UI are covered by automated tests (since the scrollable version will be used very seldom).

## Screenshots

With more than 10 disks.

| nCurses       | Qt           |
| ------------- |-------------|
| ![curses-30](https://user-images.githubusercontent.com/3638289/52714760-03b2da00-2f9b-11e9-9d3d-0d969eda7881.png) | ![qt-30](https://user-images.githubusercontent.com/3638289/52714765-08778e00-2f9b-11e9-9215-96080f8c5d32.png)

With less than 10 disks (nothing changed, only "USB" or "IEEE 1394" added).

| nCurses       | Qt           |
| ------------- |-------------|
| ![curses-5](https://user-images.githubusercontent.com/3638289/52714664-c3ebf280-2f9a-11e9-8846-59110e853ce0.png) | ![qt-5](https://user-images.githubusercontent.com/3638289/52714727-ea119280-2f9a-11e9-8e0b-bf67ca0486d9.png) |