### PR TITLE
use realistic device name for DASD

### DIFF
--- a/test/data/devicegraphs/dasd_50GiB.yml
+++ b/test/data/devicegraphs/dasd_50GiB.yml
@@ -1,6 +1,6 @@
 ---
 - dasd:
-    name: /dev/sda
+    name: /dev/dasda
     type: eckd
     format: cdl
     size: 23 GiB
@@ -8,6 +8,6 @@
     partitions:
     - partition:
         size: 100 MiB
-        name: "/dev/sda1"
+        name: "/dev/dasda1"
         id: linux
         file_system: ext2

--- a/test/data/devicegraphs/empty_dasd_50GiB.yml
+++ b/test/data/devicegraphs/empty_dasd_50GiB.yml
@@ -1,6 +1,6 @@
 ---
 - dasd:
-    name: /dev/sda
+    name: /dev/dasda
     type: eckd
     format: cdl
     size: 23 GiB

--- a/test/data/devicegraphs/output/s390_dasd_zipl-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl-lvm-sep-home.yml
@@ -1,6 +1,6 @@
 ---
 - dasd:
-    name: "/dev/sda"
+    name: "/dev/dasda"
     type: eckd
     format: cdl
     size: 23 GiB
@@ -8,7 +8,7 @@
     partitions:
     - partition:
         size: 300 MiB
-        name: "/dev/sda1"
+        name: "/dev/dasda1"
         id: linux
         file_system: ext2
         mount_point: /boot/zipl
@@ -17,7 +17,7 @@
           - user_xattr
     - partition:
         size: 23809920 KiB (22.71 GiB)
-        name: "/dev/sda2"
+        name: "/dev/dasda2"
         id: lvm
 - lvm_vg:
     vg_name: system
@@ -39,4 +39,4 @@
         mount_point: swap
     lvm_pvs:
     - lvm_pv:
-        blk_device: "/dev/sda2"
+        blk_device: "/dev/dasda2"

--- a/test/data/devicegraphs/output/s390_dasd_zipl-lvm.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl-lvm.yml
@@ -1,6 +1,6 @@
 ---
 - dasd:
-    name: "/dev/sda"
+    name: "/dev/dasda"
     type: eckd
     format: cdl
     size: 23 GiB
@@ -8,7 +8,7 @@
     partitions:
     - partition:
         size: 300 MiB
-        name: "/dev/sda1"
+        name: "/dev/dasda1"
         id: linux
         file_system: ext2
         mount_point: "/boot/zipl"
@@ -17,7 +17,7 @@
           - user_xattr
     - partition:
         size: 23809920 KiB (22.71 GiB)
-        name: "/dev/sda2"
+        name: "/dev/dasda2"
         id: lvm
 - lvm_vg:
     vg_name: system
@@ -36,4 +36,4 @@
         mount_point: swap
     lvm_pvs:
     - lvm_pv:
-        blk_device: "/dev/sda2"
+        blk_device: "/dev/dasda2"

--- a/test/data/devicegraphs/output/s390_dasd_zipl.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl.yml
@@ -1,6 +1,6 @@
 ---
 - dasd:
-    name: "/dev/sda"
+    name: "/dev/dasda"
     type: eckd
     format: cdl
     size: 23 GiB
@@ -8,7 +8,7 @@
     partitions:
     - partition:
         size: 300 MiB
-        name: "/dev/sda1"
+        name: "/dev/dasda1"
         id: linux
         file_system: ext2
         mount_point: "/boot/zipl"
@@ -17,13 +17,13 @@
           - user_xattr
     - partition:
         size: 21712800 KiB (20.71 GiB)
-        name: "/dev/sda2"
+        name: "/dev/dasda2"
         id: linux
         file_system: btrfs
         mount_point: "/"
     - partition:
         size: 2097120 KiB (2.00 GiB)
-        name: "/dev/sda3"
+        name: "/dev/dasda3"
         id: linux
         file_system: swap
         mount_point: swap

--- a/test/y2partitioner/actions/create_partition_table_test.rb
+++ b/test/y2partitioner/actions/create_partition_table_test.rb
@@ -144,8 +144,8 @@ describe Y2Partitioner::Actions::CreatePartitionTable do
 
     context "With a S/390 DASD with one partition" do
       let(:scenario) { "dasd_50GiB.yml" }
-      let(:disk_name) { "/dev/sda" }
-      let(:original_partitions) { ["/dev/sda1"] }
+      let(:disk_name) { "/dev/dasda" }
+      let(:original_partitions) { ["/dev/dasda1"] }
 
       it "shows a confirmation dialog" do
         expect(action).to receive(:confirm_recursive_delete).with(disk, any_args)

--- a/test/y2partitioner/widgets/blk_device_edit_button_test.rb
+++ b/test/y2partitioner/widgets/blk_device_edit_button_test.rb
@@ -62,7 +62,7 @@ describe Y2Partitioner::Widgets::BlkDeviceEditButton do
 
     context "when the device is a dasd" do
       let(:scenario) { "dasd_50GiB.yml" }
-      let(:device_name) { "/dev/sda" }
+      let(:device_name) { "/dev/dasda" }
       include_examples "run edit action"
     end
 

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -93,8 +93,8 @@ describe Y2Partitioner::Widgets::Pages::System do
 
       it "contains all DASDs and their partitions" do
         expect(items).to contain_exactly(
-          "/dev/sda",
-          "/dev/sda1"
+          "/dev/dasda",
+          "/dev/dasda1"
         )
       end
     end

--- a/test/y2storage/autoinst_profile/skip_list_value_test.rb
+++ b/test/y2storage/autoinst_profile/skip_list_value_test.rb
@@ -104,7 +104,7 @@ describe Y2Storage::AutoinstProfile::SkipListValue do
 
   describe "#dasd_format" do
     let(:scenario) { "dasd_50GiB" }
-    let(:disk) { Y2Storage::Dasd.find_by_name(fake_devicegraph, "/dev/sda") }
+    let(:disk) { Y2Storage::Dasd.find_by_name(fake_devicegraph, "/dev/dasda") }
 
     it "returns format" do
       expect(value.dasd_format).to eq("cdl")
@@ -158,7 +158,7 @@ describe Y2Storage::AutoinstProfile::SkipListValue do
 
   describe "#dasd_type" do
     let(:scenario) { "dasd_50GiB" }
-    let(:disk) { Y2Storage::Dasd.find_by_name(fake_devicegraph, "/dev/sda") }
+    let(:disk) { Y2Storage::Dasd.find_by_name(fake_devicegraph, "/dev/dasda") }
 
     it "returns type" do
       expect(value.dasd_type).to eq("eckd")

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -265,6 +265,10 @@ describe Y2Storage::AutoinstProposal do
           { "mount" => "/", "partition_nr" => 1, "create" => false }
         end
 
+        let(:partitioning) do
+          [{ "device" => "/dev/dasda", "use" => "all", "partitions" => [root, home] }]
+        end
+
         # Regression test for bug#1098594:
         # the partitions are on an Dasd (not a Disk), so when the code did
         #   partition.disk
@@ -275,7 +279,7 @@ describe Y2Storage::AutoinstProposal do
 
         it "reuses the partition with the given partition number" do
           proposal.propose
-          reused_part = proposal.devices.partitions.find { |p| p.name == "/dev/sda1" }
+          reused_part = proposal.devices.partitions.find { |p| p.name == "/dev/dasda1" }
           expect(reused_part).to have_attributes(
             filesystem_type:       Y2Storage::Filesystems::Type::EXT2,
             filesystem_mountpoint: "/"

--- a/test/y2storage/boot_requirements_checker_s390_test.rb
+++ b/test/y2storage/boot_requirements_checker_s390_test.rb
@@ -95,7 +95,7 @@ describe Y2Storage::BootRequirementsChecker do
       include_context "supported device"
     end
 
-    context "trying to install in a zfcp disk (no DASD)" do
+    context "trying to install in a zFCP disk (no DASD)" do
       let(:dasd) { false }
       let(:type) { Y2Storage::DasdType::UNKNOWN }
       let(:format) { Y2Storage::DasdFormat::NONE }

--- a/test/y2storage/boot_requirements_strategies/analyzer_test.rb
+++ b/test/y2storage/boot_requirements_strategies/analyzer_test.rb
@@ -50,7 +50,7 @@ RSpec.shared_examples "boot disk in devicegraph" do
     let(:scenario) { "dasd_50GiB" }
 
     before do
-      partition = Y2Storage::Partition.find_by_name(fake_devicegraph, "/dev/sda1")
+      partition = Y2Storage::Partition.find_by_name(fake_devicegraph, "/dev/dasda1")
       partition.filesystem.mount_path = "/"
     end
 
@@ -59,7 +59,7 @@ RSpec.shared_examples "boot disk in devicegraph" do
     end
 
     it "returns the dasd device containing the '/' partition" do
-      expect(analyzer.boot_disk.name).to eq "/dev/sda"
+      expect(analyzer.boot_disk.name).to eq "/dev/dasda"
     end
   end
 

--- a/test/y2storage/dasd_test.rb
+++ b/test/y2storage/dasd_test.rb
@@ -32,7 +32,7 @@ describe Y2Storage::Dasd do
 
   let(:scenario) { "empty_dasd_50GiB" }
 
-  let(:device_name) { "/dev/sda" }
+  let(:device_name) { "/dev/dasda" }
 
   describe "#usb?" do
     it "returns false" do
@@ -65,7 +65,7 @@ describe Y2Storage::Dasd do
     context "if the device has no partition table" do
       let(:scenario) { "empty_dasd_50GiB" }
 
-      let(:device_name) { "/dev/sda" }
+      let(:device_name) { "/dev/dasda" }
 
       it "returns false" do
         expect(subject.implicit_partition_table?).to eq(false)

--- a/test/y2storage/hwinfo_reader_test.rb
+++ b/test/y2storage/hwinfo_reader_test.rb
@@ -73,7 +73,7 @@ describe Y2Storage::HWInfoReader do
       expect(data).to be_nil
     end
 
-    context "when the system contains some zfcp multipath device" do
+    context "when the system contains some zFCP multipath device" do
       let(:hwinfo_file) { "hwinfo_bug1982536.txt" }
 
       # Regression test for bug#1982536

--- a/test/y2storage/partition_tables/dasd_test.rb
+++ b/test/y2storage/partition_tables/dasd_test.rb
@@ -28,7 +28,7 @@ describe Y2Storage::PartitionTables::Dasd do
     fake_scenario("empty_dasd_50GiB")
   end
 
-  let(:disk) { Y2Storage::Dasd.find_by_name(fake_devicegraph, "/dev/sda") }
+  let(:disk) { Y2Storage::Dasd.find_by_name(fake_devicegraph, "/dev/dasda") }
   let(:partition_table_type) { Y2Storage::PartitionTables::Type.find(:dasd) }
 
   subject { disk.create_partition_table(partition_table_type) }

--- a/test/y2storage/partition_test.rb
+++ b/test/y2storage/partition_test.rb
@@ -141,7 +141,7 @@ describe Y2Storage::Partition do
   describe "#start_aligned?" do
     let(:scenario) { "dasd_50GiB" }
 
-    subject(:partition) { Y2Storage::Partition.find_by_name(fake_devicegraph, "/dev/sda1") }
+    subject(:partition) { Y2Storage::Partition.find_by_name(fake_devicegraph, "/dev/dasda1") }
 
     before do
       partition.region.start = start
@@ -167,7 +167,7 @@ describe Y2Storage::Partition do
   describe "#end_aligned?" do
     let(:scenario) { "dasd_50GiB" }
 
-    subject(:partition) { Y2Storage::Partition.find_by_name(fake_devicegraph, "/dev/sda1") }
+    subject(:partition) { Y2Storage::Partition.find_by_name(fake_devicegraph, "/dev/dasda1") }
 
     before do
       partition.region.length = length

--- a/test/y2storage/proposal_scenarios_s390_test.rb
+++ b/test/y2storage/proposal_scenarios_s390_test.rb
@@ -48,7 +48,7 @@ describe Y2Storage::GuidedProposal do
     let(:type) { Y2Storage::DasdType::UNKNOWN }
     let(:format) { Y2Storage::DasdFormat::NONE }
 
-    context "with a zfcp disk" do
+    context "with a zFCP disk" do
       let(:scenario) { "empty_hard_disk_50GiB" }
       let(:expected_scenario) { "s390_zfcp_zipl" }
 


### PR DESCRIPTION
## Problem

Unrealistic device name in unit tests make unit tests more difficult to understand.

## Solution

Use realistic device names.
