### PR TITLE
do not recreate DASD partition table

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 13 14:52:25 CET 2019 - aschnell@suse.com
+
+- Partitioning proposal: do not recreate DASD partition table
+  (bsc#1112037)
+- 4.1.56
+
+-------------------------------------------------------------------
 Fri Feb  8 11:43:53 UTC 2019 - ancor@suse.com
 
 - AutoYaST: fix broken support for retaining existing MD RAIDs in

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.55
+Version:	4.1.56
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/partitionable.rb
+++ b/src/lib/y2storage/partitionable.rb
@@ -313,6 +313,17 @@ module Y2Storage
       remove_descendants
     end
 
+    # Whether the device contains an DASD partition table
+    #
+    # @see Y2Storage::PartitionTables::Dasd
+    #
+    # @return [Boolean]
+    def dasd_partition_table?
+      return false unless partition_table
+
+      partition_table.type.is?(:dasd)
+    end
+
     # Whether the device contains an implicit partition table
     #
     # @see Y2Storage::PartitionTables::ImplicitPt

--- a/src/lib/y2storage/proposal/partition_killer.rb
+++ b/src/lib/y2storage/proposal/partition_killer.rb
@@ -72,10 +72,11 @@ module Y2Storage
       #
       # @note If the partition was the only remaining logical one, it also deletes the
       #   now empty extended partition. The partition table is also deleted when
-      #   the last partition is deleted. In case of AutoYaST, deletion of the partition
-      #   table is avoided because AutoYaST uses its own logic to reuse partition tables.
-      #   In case of a single implicit partition, the partition is not deleted, but only
-      #   wiped (leaving the partition empty).
+      #   the last partition is deleted unless it is a DASD partition table. In case of
+      #   AutoYaST, deletion of the partition table is avoided because AutoYaST uses
+      #   its own logic to reuse partition tables. In case of a single implicit
+      #   partition, the partition is not deleted, but only wiped (leaving the
+      #   partition empty).
       #
       # @param partition [Partition]
       # @return [Array<Integer>] device sids of all the deleted partitions
@@ -98,7 +99,8 @@ module Y2Storage
         # AutoYaST has its own logic to reuse partition tables.
         return deleted_partitions if Yast::Mode.auto
 
-        device.delete_partition_table if device.partitions.empty?
+        device.delete_partition_table if device.partitions.empty? && !device.dasd_partition_table?
+
         deleted_partitions
       end
 

--- a/test/y2storage/proposal_scenarios_s390_test.rb
+++ b/test/y2storage/proposal_scenarios_s390_test.rb
@@ -147,9 +147,13 @@ describe Y2Storage::GuidedProposal do
             context "and a partition already exists" do
               let(:scenario) { "dasd_50GiB" }
 
-              it "proposes the expected layout" do
+              it "proposes the expected layout without recreating the partition table" do
                 proposal.propose
                 expect(proposal.devices.to_str).to eq expected.to_str
+
+                dasda = Y2Storage::Dasd.find_by_name(proposal.devices, "/dev/dasda")
+                expect(dasda).to_not eq(nil)
+                expect(dasda.partition_table.exists_in_probed?).to eq(true)
               end
             end
           end


### PR DESCRIPTION
## Problem

Recreating a DASD partition table on DASDs using virtio-blk could be dangerous. See https://bugzilla.suse.com/show_bug.cgi?id=1112037.

## Solution

Do not recreate DASD partition tables in the proposal.
