### PR TITLE
Allow to modify Bcache devices

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 19 14:15:16 UTC 2019 - jlopez@suse.com
+
+- Partitioner: allow to edit bcache devices (part of fate#325346).
+- 4.1.62
+
+-------------------------------------------------------------------
 Tue Feb 19 13:39:49 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added help texts for guided setup (bsc#1121801)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -26,8 +26,8 @@ Source:		%{name}-%{version}.tar.bz2
 Requires:	yast2 >= 4.1.11
 # for AbortException and handle direct abort
 Requires:	yast2-ruby-bindings >= 4.0.6
-# Probing Flash-only Bcache devices
-Requires:	libstorage-ng-ruby >= 4.1.81
+# Bcache#remove_bcache_cset
+Requires:	libstorage-ng-ruby >= 4.1.89
 # communicate with udisks
 Requires:	rubygem(ruby-dbus)
 # Y2Packager::Repository
@@ -36,8 +36,8 @@ Requires:	yast2-packager >= 3.3.7
 Requires:	findutils
 
 BuildRequires:	update-desktop-files
-# Probing Flash-only Bcache devices
-BuildRequires:	libstorage-ng-ruby >= 4.1.81
+# Bcache#remove_bcache_cset
+BuildRequires:	libstorage-ng-ruby >= 4.1.89
 BuildRequires:	yast2-ruby-bindings
 BuildRequires:	yast2-devtools
 # yast2-xml dependency is added by yast2 but ignored in the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.61
+Version:	4.1.62
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/actions/add_bcache.rb
+++ b/src/lib/y2partitioner/actions/add_bcache.rb
@@ -23,6 +23,7 @@ require "yast"
 require "y2partitioner/actions/base"
 require "y2partitioner/actions/controllers/bcache"
 require "y2partitioner/dialogs/bcache"
+require "y2partitioner/ui_state"
 
 module Y2Partitioner
   module Actions
@@ -71,6 +72,7 @@ module Y2Partitioner
         return unless dialog.run == :next
 
         controller.create_bcache(dialog.backing_device, dialog.caching_device, dialog.options)
+        UIState.instance.select_row(controller.bcache)
       end
 
       # Whether there is suitable backing devices

--- a/src/lib/y2partitioner/actions/add_bcache.rb
+++ b/src/lib/y2partitioner/actions/add_bcache.rb
@@ -20,150 +20,64 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "yast/i18n"
-require "yast2/popup"
-require "y2storage/bcache"
+require "y2partitioner/actions/base"
+require "y2partitioner/actions/controllers/bcache"
 require "y2partitioner/dialogs/bcache"
-require "y2partitioner/device_graphs"
 
 module Y2Partitioner
   module Actions
-    # Action for adding a bcache device
-    class AddBcache
-      include Yast::I18n
-
+    # Action for adding a bcache device, see {Actions::Base}
+    class AddBcache < Base
       def initialize
+        super
+
         textdomain "storage"
-      end
 
-      # Runs a dialog for adding a bcache and also modifies the device graph if the user
-      # confirms the dialog.
-      #
-      # @return [Symbol] :back, :finish
-      def run
-        return :back unless validate
-
-        dialog = Dialogs::Bcache.new(suitable_backing_devices, suitable_caching_devices)
-
-        create_device(dialog) if dialog.run == :next
-
-        :finish
+        @controller = Controllers::Bcache.new
       end
 
     private
 
-      # Validations before performing the action
-      #
-      # @note The action can be performed is there are no errors (see #errors).
-      #   Only the first error is shown.
-      #
-      # @return [Boolean]
-      def validate
-        current_errors = errors
-        return true if current_errors.empty?
-
-        Yast2::Popup.show(current_errors.first, headline: :error)
-        false
-      end
+      # @return [Controllers::Bcache]
+      attr_reader :controller
 
       # List of errors that avoid to create a Bcache
       #
+      # @see Actions::Base#errors
+      #
       # @return [Array<String>]
       def errors
-        [no_backing_devices_error].compact
+        (super + [no_backing_devices_error]).compact
       end
 
       # Error when there is no suitable backing devices for creating a Bcache
       #
-      # @return [String, nil] nil if there are devices.
+      # @return [String, nil] nil if there are suitable backing devices.
       def no_backing_devices_error
-        return nil if suitable_backing_devices.any?
+        return nil if suitable_backing_devices?
 
         # TRANSLATORS: Error message.
         _("There are not enough suitable unused devices to create a Bcache.")
       end
 
-      # Creates a bcache device according to the user input
+      # Opens a dialog to create a Bcache
       #
-      # @param dialog [Dialogs::Bcache]
-      def create_device(dialog)
-        backing = dialog.backing_device
+      # The Bcache is created only if the dialog is accepted.
+      #
+      # @see Actions::Base#perform_action
+      def perform_action
+        dialog = Dialogs::Bcache.new(controller)
 
-        raise "Invalid result #{dialog.inspect}. Backing not found." unless backing
+        return unless dialog.run == :next
 
-        bcache = backing.create_bcache(Y2Storage::Bcache.find_free_name(device_graph))
-
-        apply_options(bcache, dialog.options)
-
-        attach(bcache, dialog.caching_device) if dialog.caching_device
+        controller.create_bcache(dialog.backing_device, dialog.caching_device, dialog.options)
       end
 
-      # Applies options to the bcache device
+      # Whether there is suitable backing devices
       #
-      # Right now, the dialog only allows to indicate the cache mode.
-      #
-      # @param bcache [Y2Storage::Bcache]
-      # @param options [Hash<Symbol, Object>]
-      def apply_options(bcache, options)
-        options.each_pair do |key, value|
-          bcache.public_send(:"#{key}=", value)
-        end
-      end
-
-      # Attaches the selected caching to the bcache
-      #
-      # @param bcache [Y2Storage::Bcache]
-      # @param caching [Y2Storage::BcacheCset, Y2Storage::BlkDevice, nil]
-      def attach(bcache, caching)
-        return if caching.nil?
-
-        if !caching.is?(:bcache_cset)
-          caching.remove_descendants
-          caching = caching.create_bcache_cset
-        end
-
-        bcache.attach_bcache_cset(caching)
-      end
-
-      # Device graph in which the action operates on
-      #
-      # @return [Y2Storage::Devicegraph]
-      def device_graph
-        DeviceGraphs.instance.current
-      end
-
-      # Suitable devices to be used as backing device
-      #
-      # @return [Array<Y2Storage::BlkDevice>]
-      def suitable_backing_devices
-        usable_blk_devices
-      end
-
-      # Suitable devices to be used for caching
-      #
-      # @return [Array<Y2Storage::BcacheCset, Y2Storage::BlkDevice>]
-      def suitable_caching_devices
-        existing_caches + usable_blk_devices
-      end
-
-      # Block devices that can be used as backing or caching device
-      #
-      # @return [Array<Y2Storage::BlkDevice>]
-      def usable_blk_devices
-        device_graph.blk_devices.select do |dev|
-          dev.component_of.empty? &&
-            (dev.filesystem.nil? || dev.filesystem.mount_point.nil?) &&
-            (!dev.respond_to?(:partitions) || dev.partitions.empty?) &&
-            # do not allow nested bcaches, see doc/bcache.md
-            ([dev] + dev.ancestors).none? { |a| a.is?(:bcache, :bcache_cset) }
-        end
-      end
-
-      # Currently existing caching sets
-      #
-      # @return [Array<Y2Storage::BcacheCset>]
-      def existing_caches
-        device_graph.bcache_csets
+      # @return [Boolean]
+      def suitable_backing_devices?
+        controller.suitable_backing_devices.any?
       end
     end
   end

--- a/src/lib/y2partitioner/actions/base.rb
+++ b/src/lib/y2partitioner/actions/base.rb
@@ -1,0 +1,89 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast/i18n"
+require "yast2/popup"
+
+require "abstract_method"
+
+module Y2Partitioner
+  module Actions
+    # Base class for actions that can be performed by the Expert Partitioner
+    #
+    # This base class is mainly intended to one-step actions. For more complex actions,
+    # see {TransactionWizard}.
+    class Base
+      include Yast::I18n
+
+      def initialize
+        textdomain "storage"
+      end
+
+      # Runs a dialog for adding a bcache and also modifies the device graph if the user
+      # confirms the dialog.
+      #
+      # @return [Symbol] :back, :finish
+      def run
+        return :back unless run?
+
+        perform_action
+
+        :finish
+      end
+
+    private
+
+      # Performs the action, see {#run}
+      #
+      # This method should be defined by derived classes.
+      abstract_method :perform_action
+
+      # Checks whether the action can be performed
+      #
+      # @return [Boolean]
+      def run?
+        validate
+      end
+
+      # Validations before performing the action
+      #
+      # @note The action can be performed if there are no errors (see #errors).
+      #   Only the first error is shown.
+      #
+      # @return [Boolean]
+      def validate
+        current_errors = errors
+        return true if current_errors.empty?
+
+        Yast2::Popup.show(current_errors.first, headline: :error)
+        false
+      end
+
+      # List of errors that avoid to perform the action
+      #
+      # @return [Array<String>] translated error messages
+      def errors
+        []
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/actions/controllers/bcache.rb
+++ b/src/lib/y2partitioner/actions/controllers/bcache.rb
@@ -1,0 +1,303 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage/bcache"
+require "y2partitioner/device_graphs"
+require "y2partitioner/ui_state"
+require "y2partitioner/blk_device_restorer"
+
+module Y2Partitioner
+  module Actions
+    module Controllers
+      # This class is used by different Bcache actions (see, {Actions::AddBcache},
+      # {Actions::EditBcache} and {Actions::DeleteBcache}).
+      class Bcache
+        # @return [Y2Storage::Bcache]
+        attr_reader :bcache
+
+        # Constructor
+        #
+        # @param bcache [Y2Storage::Bcache, nil] nil if a new bcache is being created.
+        def initialize(bcache = nil)
+          @bcache = bcache
+
+          UIState.instance.select_row(bcache) if bcache
+        end
+
+        # Suitable devices to be used as backing device
+        #
+        # When the bcache is being edited, only its own backing device is returned.
+        #
+        # @return [Array<Y2Storage::BlkDevice>]
+        def suitable_backing_devices
+          return [bcache.backing_device] if bcache
+
+          usable_blk_devices
+        end
+
+        # Suitable devices to be used for caching
+        #
+        # @return [Array<Y2Storage::BcacheCset, Y2Storage::BlkDevice>]
+        def suitable_caching_devices
+          bcache_csets + usable_blk_devices
+        end
+
+        # Creates a bcache device
+        #
+        # @param backing_device [Y2Storage::BlkDevice]
+        # @param caching_device [Y2Storage::BlkDevice, Y2Storage::BcacheCset, nil]
+        # @param options [Hash<Symbol, Object>]
+        def create_bcache(backing_device, caching_device, options)
+          raise "A Bcache cannot be created without a Backing device." unless backing_device
+
+          BlkDeviceRestorer.new(backing_device).update_checkpoint
+
+          @bcache = backing_device.create_bcache(Y2Storage::Bcache.find_free_name(current_graph))
+
+          apply_options(options)
+          attach(caching_device) if caching_device
+        end
+
+        # Updates the bcache device
+        #
+        # @param caching_device [Y2Storage::BlkDevice, Y2Storage::BcacheCset, nil]
+        # @param options [Hash<Symbol, Object>]
+        def update_bcache(caching_device, options)
+          apply_options(options)
+
+          return if caching_device == bcache.bcache_cset
+
+          detach if bcache.bcache_cset
+
+          attach(caching_device) if caching_device
+        end
+
+        # Deletes the bcache device
+        def delete_bcache
+          backing_device = bcache.backing_device
+          caching_device = nil
+
+          if bcache.bcache_cset && bcache.bcache_cset.bcaches.size == 1
+            caching_device = bcache.bcache_cset.blk_devices.first
+          end
+
+          current_graph.remove_bcache(bcache)
+
+          # Tries to restore the previous status of the caching and backing devices
+          # (e.g., its filesystem is restored back).
+          BlkDeviceRestorer.new(caching_device).restore_from_checkpoint if caching_device
+          BlkDeviceRestorer.new(backing_device).restore_from_checkpoint
+        end
+
+        # Whether the bcache already exists on disk
+        #
+        # @return [Boolean]
+        def committed_bcache?
+          !committed_bcache.nil?
+        end
+
+        # Whether the bcache on disk already had a caching set
+        #
+        # @return [Boolean]
+        def committed_bcache_cset?
+          !committed_bcache_cset.nil?
+        end
+
+        # Whether the bcache on disk already had a caching set, and this caching set was not
+        # used by another bcache.
+        #
+        # @return [Boolean]
+        def single_committed_bcache_cset?
+          return false unless committed_bcache_cset?
+
+          committed_bcache_cset.bcaches.size == 1
+        end
+
+      private
+
+        # Block devices that can be used as backing or caching device
+        #
+        # @return [Array<Y2Storage::BlkDevice>]
+        def usable_blk_devices
+          current_graph.blk_devices.select { |d| usable_blk_device?(d) }
+        end
+
+        # Whether the device can be used as backing or caching device
+        #
+        # @param device [Y2Storage::BlkDevice]
+        # @return [Boolean]
+        def usable_blk_device?(device)
+          !device_used?(device) &&
+            !device_formatted_and_mounted?(device) &&
+            !device_has_partitions?(device) &&
+            !device_extended_partition?(device) &&
+            !device_belong_to_bcache?(device)
+        end
+
+        # Whether the device is already in use (e.g., as LVM PV or raid disk)
+        #
+        # @param device [Y2Storage::BlkDevice]
+        # @return [Boolean]
+        def device_used?(device)
+          device.component_of.any?
+        end
+
+        # Whether the device is formatted and mounted
+        #
+        # @param device [Y2Storage::BlkDevice]
+        # @return [Boolean]
+        def device_formatted_and_mounted?(device)
+          device.filesystem && device.filesystem.mount_point
+        end
+
+        # Whether the device has partitions
+        #
+        # @param device [Y2Storage::BlkDevice]
+        # @return [Boolean]
+        def device_has_partitions?(device)
+          device.respond_to?(:partitions) && device.partitions.any?
+        end
+
+        # Whether the device is an extended partition
+        #
+        # @param device [Y2Storage::BlkDevice]
+        # @return [Boolean]
+        def device_extended_partition?(device)
+          device.is?(:partition) && device.type.is?(:extended)
+        end
+
+        # Whether the device is part of a bcache device
+        #
+        # @param device [Y2Storage::BlkDevice]
+        # @return [Boolean]
+        def device_belong_to_bcache?(device)
+          # do not allow nested bcaches, see doc/bcache.md
+          ([device] + device.ancestors).any? { |a| a.is?(:bcache, :bcache_cset) }
+        end
+
+        # Currently existing caching sets
+        #
+        # @return [Array<Y2Storage::BcacheCset>]
+        def bcache_csets
+          current_graph.bcache_csets
+        end
+
+        # Applies options to the bcache device
+        #
+        # Right now, only the cache mode can be permanently modified.
+        #
+        # @param options [Hash<Symbol, Object>]
+        def apply_options(options)
+          options.each_pair do |key, value|
+            bcache.public_send(:"#{key}=", value)
+          end
+        end
+
+        # Attaches the selected caching to the bcache
+        #
+        # @param caching_device [Y2Storage::BcacheCset, Y2Storage::BlkDevice]
+        def attach(caching_device)
+          bcache_cset = create_bcache_cset(caching_device)
+
+          bcache.add_bcache_cset(bcache_cset)
+        end
+
+        # Detaches the caching set from the bcache device
+        def detach
+          bcache_cset = bcache.bcache_cset
+
+          bcache.remove_bcache_cset
+
+          remove_bcache_cset(bcache_cset) if remove_bcache_cset?(bcache_cset)
+        end
+
+        # Creates a new caching set if the given caching device is not a caching set yet
+        #
+        # @param caching_device [Y2Storage::BlkDevice, Y2Storage::BcacheCset]
+        def create_bcache_cset(caching_device)
+          return caching_device if caching_device.is?(:bcache_cset)
+
+          # The descendants of the caching device should be restored in case that
+          # this caching set is finally removed and not used at all.
+          BlkDeviceRestorer.new(caching_device).update_checkpoint
+
+          caching_device.remove_descendants
+          caching_device.create_bcache_cset
+        end
+
+        # Whether the caching set can be removed
+        #
+        # @param bcache_cset [Y2Storage::BcacheCset]
+        def remove_bcache_cset?(bcache_cset)
+          bcache_cset.bcaches.none?
+        end
+
+        # Removes the caching set
+        #
+        # Previous state of the caching device is retored.
+        #
+        # @param bcache_cset [Y2Storage::BcacheCset]
+        def remove_bcache_cset(bcache_cset)
+          caching_device = bcache_cset.blk_devices.first
+
+          current_graph.remove_bcache_cset(bcache_cset)
+
+          BlkDeviceRestorer.new(caching_device).restore_from_checkpoint
+        end
+
+        # Bcache existing on disk
+        #
+        # @return [Y2Storage::Bcache, nil] nil if the bcache is being created or
+        #   does not exist on the disk yet.
+        def committed_bcache
+          return nil unless bcache
+
+          system_graph.find_device(bcache.sid)
+        end
+
+        # Caching set of the bcache existing on disk
+        #
+        # @return [Y2Storage::BcacheCset, nil] nil if the bcache does not exist
+        #   on disk or it has no caching set.
+        def committed_bcache_cset
+          return nil unless committed_bcache
+
+          committed_bcache.bcache_cset
+        end
+
+        # Current devicegraph in which the action operates on
+        #
+        # @return [Y2Storage::Devicegraph]
+        def current_graph
+          DeviceGraphs.instance.current
+        end
+
+        # Devicegraph representing the system status
+        #
+        # @return [Y2Storage::Devicegraph]
+        def system_graph
+          DeviceGraphs.instance.system
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/actions/controllers/bcache.rb
+++ b/src/lib/y2partitioner/actions/controllers/bcache.rb
@@ -22,7 +22,6 @@
 require "yast"
 require "y2storage/bcache"
 require "y2partitioner/device_graphs"
-require "y2partitioner/ui_state"
 require "y2partitioner/blk_device_restorer"
 
 module Y2Partitioner
@@ -39,8 +38,6 @@ module Y2Partitioner
         # @param bcache [Y2Storage::Bcache, nil] nil if a new bcache is being created.
         def initialize(bcache = nil)
           @bcache = bcache
-
-          UIState.instance.select_row(bcache) if bcache
         end
 
         # Suitable devices to be used as backing device

--- a/src/lib/y2partitioner/actions/delete_bcache.rb
+++ b/src/lib/y2partitioner/actions/delete_bcache.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "y2partitioner/actions/delete_device"
 require "y2partitioner/actions/controllers/bcache"
+require "y2partitioner/ui_state"
 
 module Y2Partitioner
   module Actions
@@ -36,6 +37,7 @@ module Y2Partitioner
         textdomain "storage"
 
         @bcache_controller = Controllers::Bcache.new(bcache)
+        UIState.instance.select_row(bcache)
       end
 
     private

--- a/src/lib/y2partitioner/actions/delete_bcache.rb
+++ b/src/lib/y2partitioner/actions/delete_bcache.rb
@@ -75,8 +75,8 @@ module Y2Partitioner
         # TRANSLATORS: Error message when detach is not a safe action
         _(
           "The bcache cannot be deleted because it shares its cache set with other devices.\n" \
-          "Detaching is required to avoid possible unreachable space, but detaching action\n" \
-          "could take a very long time in some situations."
+          "Deleting it without detaching the device first can result in unreachable space.\n" \
+          "Unfortunately detaching can take a very long time in some situations."
         )
       end
 

--- a/src/lib/y2partitioner/actions/edit_bcache.rb
+++ b/src/lib/y2partitioner/actions/edit_bcache.rb
@@ -1,0 +1,112 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/actions/base"
+require "y2partitioner/actions/controllers/bcache"
+require "y2partitioner/dialogs/bcache"
+
+module Y2Partitioner
+  module Actions
+    # Action for editing a bcache device, see {Actions::Base}
+    class EditBcache < Base
+      # Constructor
+      #
+      # @param bcache [Y2Storage::Bcache]
+      def initialize(bcache)
+        super()
+
+        textdomain "storage"
+
+        @controller = Controllers::Bcache.new(bcache)
+      end
+
+    private
+
+      # @return [Controllers::Bcache]
+      attr_reader :controller
+
+      # List of errors that avoid to edit a Bcache
+      #
+      # @see Actions::Base#errors
+      #
+      # @return [Array<String>]
+      def errors
+        (super + [flash_only_error, non_editable_error]).compact
+      end
+
+      # Error when the bcache is Flash-only
+      #
+      # @return [String, nil] nil if the bcache is not Flash-only.
+      def flash_only_error
+        return nil unless flash_only_bcache?
+
+        # TRANSLATORS: error message, %{name} is replaced by a bcache name (e.g., /dev/bcache0)
+        format(
+          _("The device %{name} is a Flash-only Bcache and its caching cannot be modified."),
+          name: controller.bcache.name
+        )
+      end
+
+      # Error when the caching device cannot be modified, see {#editable_bcache_cset?}
+      #
+      # @return [String, nil] nil if the caching device can be modified.
+      def non_editable_error
+        return nil if editable_bcache_cset?
+
+        # TRANSLATORS: error message, %{name} is replaced by a bcache name (e.g., /dev/bcache0)
+        format(
+          _("The Bcache %{name} is already created on disk and its caching\n" \
+            "cannot be modified. To modify the caching device, remove the Bcache\n" \
+            "and create it again."),
+          name: controller.bcache.name
+        )
+      end
+
+      # Opens a dialog to edit a Bcache
+      #
+      # The Bcache is updated only if the dialog is accepted.
+      #
+      # @see Actions::Base#perform_action
+      def perform_action
+        dialog = Dialogs::Bcache.new(controller)
+
+        return unless dialog.run == :next
+
+        controller.update_bcache(dialog.caching_device, dialog.options)
+      end
+
+      # Whether the bcache is Flash-only
+      #
+      # @return [Boolean]
+      def flash_only_bcache?
+        controller.bcache.flash_only?
+      end
+
+      # Whether the caching set can be modified
+      #
+      # @return [Boolean]
+      def editable_bcache_cset?
+        !controller.committed_bcache? || !controller.committed_bcache_cset?
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/actions/edit_bcache.rb
+++ b/src/lib/y2partitioner/actions/edit_bcache.rb
@@ -76,9 +76,9 @@ module Y2Partitioner
 
         # TRANSLATORS: error message, %{name} is replaced by a bcache name (e.g., /dev/bcache0)
         format(
-          _("The Bcache %{name} is already created on disk and its caching\n" \
-            "cannot be modified. To modify the caching device, remove the Bcache\n" \
-            "and create it again."),
+          _("The Bcache %{name} is already created on disk. Such device cannot be modified\n" \
+            "because that might imply a detaching operation. Unfortunately detaching can take\n" \
+            "a very long time in some situations."),
           name: controller.bcache.name
         )
       end

--- a/src/lib/y2partitioner/actions/edit_bcache.rb
+++ b/src/lib/y2partitioner/actions/edit_bcache.rb
@@ -23,6 +23,7 @@ require "yast"
 require "y2partitioner/actions/base"
 require "y2partitioner/actions/controllers/bcache"
 require "y2partitioner/dialogs/bcache"
+require "y2partitioner/ui_state"
 
 module Y2Partitioner
   module Actions
@@ -37,6 +38,7 @@ module Y2Partitioner
         textdomain "storage"
 
         @controller = Controllers::Bcache.new(bcache)
+        UIState.instance.select_row(bcache)
       end
 
     private

--- a/src/lib/y2partitioner/dialogs/bcache.rb
+++ b/src/lib/y2partitioner/dialogs/bcache.rb
@@ -34,16 +34,14 @@ module Y2Partitioner
     class Bcache < Base
       # Constructor
       #
-      # @param suitable_backing [Array<Y2Storage::BlkDevice>] devices that can be used for backing.
-      # @param suitable_caching [Array<Y2Storage::BlkDevice, Y2Storage::BcacheCset>]
-      #   devices that can be used for caching.
-      # @param device [Y2Storage::Bcache] existing bcache device or nil if it is a new one.
-      def initialize(suitable_backing, suitable_caching, device = nil)
+      # @param controller [Actions::Controllers::Bcache]
+      def initialize(controller)
         textdomain "storage"
 
-        @caching = CachingDeviceSelector.new(device, suitable_caching)
-        @backing = BackingDeviceSelector.new(device, suitable_backing, @caching)
-        @cache_mode = CacheModeSelector.new(device)
+        @caching = CachingDeviceSelector.new(controller.bcache, controller.suitable_caching_devices)
+        @backing = BackingDeviceSelector.new(controller.bcache,
+          controller.suitable_backing_devices, @caching)
+        @cache_mode = CacheModeSelector.new(controller.bcache)
       end
 
       # @macro seeDialog
@@ -189,6 +187,12 @@ module Y2Partitioner
           @caching = caching
         end
 
+        def init
+          super
+
+          disable if bcache
+        end
+
         # @macro seeAbstractWidget
         def label
           _("Backing Device")
@@ -290,7 +294,7 @@ module Y2Partitioner
         # When the bcache exists, its caching set should be the default device.
         # Otherwise, the first available device is the default one.
         def default_device
-          return bcache.bcache_cset if bcache && bcache.bcache_cset
+          return bcache.bcache_cset if bcache
 
           super
         end

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -55,6 +55,15 @@ module Y2Partitioner
       _("Volume Management")
     end
 
+    # Title of the Bcache section
+    #
+    # @note See note on {.md_raids_label} about why this looks misplaced.
+    #
+    # @return [String]
+    def bcache_label
+      _("Bcache")
+    end
+
     # @return [Integer, nil] if a row must be selected in a table with devices,
     #   this returns the sid of the associated device
     attr_reader :row_sid
@@ -156,6 +165,8 @@ module Y2Partitioner
         [device.sid, device.lvm_vg.sid]
       elsif device.is?(:lvm_vg)
         [device.sid, lvm_label]
+      elsif device.is?(:bcache)
+        [device.sid, bcache_label]
       else
         [device.sid]
       end

--- a/src/lib/y2partitioner/widgets/bcache_device_description.rb
+++ b/src/lib/y2partitioner/widgets/bcache_device_description.rb
@@ -44,15 +44,29 @@ module Y2Partitioner
       # @return [String]
       def bcache_description
         output = Yast::HTML.Heading(_("Bcache Devices:"))
-        output << Yast::HTML.List([
-                                    format(_("Backing Device: %s"), backing_device),
-                                    format(_("Caching UUID: %s"), uuid),
-                                    format(_("Caching Device: %s"), caching_device),
-                                    format(_("Cache mode: %s"), cache_mode)
-                                  ])
+        output << Yast::HTML.List(bcache_attributes)
+      end
+
+      # Fields to show in help
+      #
+      # @return [Array<Symbol>]
+      def help_fields
+        super + bcache_help_fields
       end
 
     private
+
+      # Attributes for describing a bcache device
+      #
+      # @return [Array<String>]
+      def bcache_attributes
+        [
+          format(_("Backing Device: %s"), backing_device),
+          format(_("Caching UUID: %s"), uuid),
+          format(_("Caching Device: %s"), caching_device),
+          format(_("Cache Mode: %s"), cache_mode)
+        ]
+      end
 
       def uuid
         device.bcache_cset ? device.bcache_cset.uuid : ""
@@ -78,6 +92,15 @@ module Y2Partitioner
         return "" if device.flash_only?
 
         device.cache_mode.to_human_string
+      end
+
+      BCACHE_HELP_FIELDS = [:backing_device, :caching_uuid, :caching_device, :cache_mode].freeze
+
+      # Help fields for a bcache device
+      #
+      # @return [Array<Symbol>]
+      def bcache_help_fields
+        BCACHE_HELP_FIELDS.dup
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/bcache_edit_button.rb
+++ b/src/lib/y2partitioner/widgets/bcache_edit_button.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2018-2019] SUSE LLC
+# Copyright (c) [2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,15 +20,15 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "y2partitioner/widgets/device_menu_button"
-require "y2partitioner/actions/edit_blk_device"
+require "y2partitioner/widgets/device_button"
 require "y2partitioner/actions/edit_bcache"
-require "y2partitioner/actions/create_partition_table"
+
+Yast.import "Popup"
 
 module Y2Partitioner
   module Widgets
-    # Menu button for modifying a Bcache device
-    class BcacheModifyButton < DeviceMenuButton
+    # Button for editing a bcache
+    class BcacheEditButton < DeviceButton
       def initialize(*args)
         super
         textdomain "storage"
@@ -36,32 +36,17 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def label
-        _("&Modify")
+        # TRANSLATORS: label for button to edit a bcache
+        _("Change Caching...")
       end
 
     private
 
-      # @see DeviceMenuButton#actions
+      # Returns the proper Actions class to edit the bcache
       #
-      # @return [Array<Hash>]
-      def actions
-        [
-          {
-            id:    :edit,
-            label: _("Edit Bcache..."),
-            class: Actions::EditBlkDevice
-          },
-          {
-            id:    :caching,
-            label: _("Change Caching..."),
-            class: Actions::EditBcache
-          },
-          {
-            id:    :ptable,
-            label: _("Create New Partition Table..."),
-            class: Actions::CreatePartitionTable
-          }
-        ]
+      # @see Actions::EditBcache
+      def actions_class
+        Actions::EditBcache
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/device_buttons_set.rb
+++ b/src/lib/y2partitioner/widgets/device_buttons_set.rb
@@ -130,15 +130,11 @@ module Y2Partitioner
 
       # Buttons to display if {#device} is a bcache device
       def bcache_buttons
-        buttons = [
+        [
           BcacheModifyButton.new(device),
-          PartitionsButton.new(device, pager)
+          PartitionsButton.new(device, pager),
+          DeviceDeleteButton.new(pager: pager, device: device)
         ]
-
-        # TODO: Allow to delete flash-only bcache devices
-        buttons << DeviceDeleteButton.new(pager: pager, device: device) unless device.flash_only?
-
-        buttons
       end
 
       # Buttons to display if {#device} is a disk device

--- a/src/lib/y2partitioner/widgets/disk_device_description.rb
+++ b/src/lib/y2partitioner/widgets/disk_device_description.rb
@@ -70,7 +70,7 @@ module Y2Partitioner
       #
       # @return [Array<Symbol>]
       def help_fields
-        blk_device_help_fields + disk_help_fields
+        blk_device_help_fields + disk_help_fields + filesystem_help_fields
       end
 
       DISK_HELP_FIELDS = [:vendor, :model, :bus, :sectors, :sector_size, :disk_label].freeze

--- a/src/lib/y2partitioner/widgets/help.rb
+++ b/src/lib/y2partitioner/widgets/help.rb
@@ -102,7 +102,19 @@ module Y2Partitioner
         uuid:             N_("<b>UUID</b> shows the Universally Unique\nIdentifier of the file " \
           "system."),
 
-        vendor:           N_("<b>Vendor</b> shows the device vendor.")
+        vendor:           N_("<b>Vendor</b> shows the device vendor."),
+
+        backing_device:   N_("<b>Backing Device</b> shows the device used as backing device " \
+                             "for bcache."),
+
+        caching_uuid:     N_("<b>Caching UUID</b> shows the UUID of the used caching set. This " \
+                             "field is empty if no caching is used."),
+
+        caching_device:   N_("<b>Caching Device</b> shows the device used for caching. This field " \
+                             "is empty if no caching is used."),
+
+        cache_mode:       N_("<b>Cache Mode</b> shows the operating mode for bcache. Currently there " \
+                             "are four supported modes: Writethrough, Writeback, Writearound and None.")
       }.freeze
 
       # help texts that are appended to the common help only in Mode.normal

--- a/src/lib/y2partitioner/widgets/pages.rb
+++ b/src/lib/y2partitioner/widgets/pages.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -44,4 +44,5 @@ require "y2partitioner/widgets/pages/nfs_mounts.rb"
 require "y2partitioner/widgets/pages/device_graph.rb"
 require "y2partitioner/widgets/pages/summary.rb"
 require "y2partitioner/widgets/pages/settings.rb"
+require "y2partitioner/widgets/pages/bcache.rb"
 require "y2partitioner/widgets/pages/bcaches.rb"

--- a/src/lib/y2partitioner/widgets/pages/bcache.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcache.rb
@@ -23,6 +23,7 @@ require "cwm/widget"
 require "y2partitioner/icons"
 require "y2partitioner/widgets/bcache_device_description"
 require "y2partitioner/widgets/blk_device_edit_button"
+require "y2partitioner/widgets/bcache_edit_button"
 require "y2partitioner/widgets/device_delete_button"
 require "y2partitioner/widgets/partition_table_add_button"
 require "y2partitioner/widgets/partitions_tab"
@@ -102,14 +103,12 @@ module Y2Partitioner
 
         # @return [Array<Widgets::DeviceButton>]
         def buttons
-          buttons = [BlkDeviceEditButton.new(device: @bcache)]
-
-          # TODO: Allow to delete flash-only bcache devices
-          buttons << DeviceDeleteButton.new(device: @bcache) unless @bcache.flash_only?
-
-          buttons << PartitionTableAddButton.new(device: @bcache)
-
-          buttons
+          [
+            BlkDeviceEditButton.new(device: @bcache),
+            BcacheEditButton.new(device: @bcache),
+            DeviceDeleteButton.new(device: @bcache),
+            PartitionTableAddButton.new(device: @bcache)
+          ]
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "y2partitioner/icons"
+require "y2partitioner/ui_state"
 require "y2partitioner/widgets/pages/devices_table"
 require "y2partitioner/widgets/bcache_add_button"
 
@@ -43,7 +44,7 @@ module Y2Partitioner
 
         # @macro seeAbstractWidget
         def label
-          _("Bcache")
+          UIState.instance.bcache_label
         end
 
       private

--- a/src/lib/y2storage/bcache.rb
+++ b/src/lib/y2storage/bcache.rb
@@ -63,6 +63,12 @@ module Y2Storage
     #   @param set [BcacheCset] set to attach
     storage_forward :add_bcache_cset
 
+    # @!method remove_bcache_cset
+    #   This method does not make sense for Flash-only Bcache devices.
+    #
+    #   @raise [storage::Exception] if detaching failed
+    #   @raise [storage::LogicException] for a Flash-only Bcache device or when
+    #     the Bcache device has no caching set.
     storage_forward :remove_bcache_cset
 
     # @!attribute cache_mode

--- a/src/lib/y2storage/bcache.rb
+++ b/src/lib/y2storage/bcache.rb
@@ -53,7 +53,7 @@ module Y2Storage
     #   @return [BlkDevice, nil] nil for Flash-only Bcache
     storage_forward :backing_device, as: "BlkDevice"
 
-    # @!method attach_bcache_cset(set)
+    # @!method add_bcache_cset(set)
     #   This method does not make sense for Flash-only Bcache devices.
     #
     #   @raise [storage::Exception] if attaching failed
@@ -61,7 +61,9 @@ module Y2Storage
     #     the Bcache device already has a caching set.
     #
     #   @param set [BcacheCset] set to attach
-    storage_forward :attach_bcache_cset
+    storage_forward :add_bcache_cset
+
+    storage_forward :remove_bcache_cset
 
     # @!attribute cache_mode
     #   Mode in which cache operates.

--- a/src/lib/y2storage/devicegraph.rb
+++ b/src/lib/y2storage/devicegraph.rb
@@ -381,12 +381,16 @@ module Y2Storage
       remove_with_dependants(bcache_cset) if bcache_cset && bcache_cset.bcaches.empty?
     end
 
+    # Removes a caching set
+    #
+    # Bcache devices using this caching set are not removed.
+    #
+    # @raise [ArgumentError] if the caching set does not exist in the devicegraph
     def remove_bcache_cset(bcache_cset)
       if !(bcache_cset && bcache_cset.is?(:bcache_cset))
         raise(ArgumentError, "Incorrect device #{bcache_cset.inspect}")
       end
 
-      # Bcaches using this caching set are not removed
       remove_device(bcache_cset)
     end
 

--- a/src/lib/y2storage/devicegraph.rb
+++ b/src/lib/y2storage/devicegraph.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -379,6 +379,15 @@ module Y2Storage
       remove_with_dependants(bcache)
       # FIXME: Actually we want to automatically remove the cset?
       remove_with_dependants(bcache_cset) if bcache_cset && bcache_cset.bcaches.empty?
+    end
+
+    def remove_bcache_cset(bcache_cset)
+      if !(bcache_cset && bcache_cset.is?(:bcache_cset))
+        raise(ArgumentError, "Incorrect device #{bcache_cset.inspect}")
+      end
+
+      # Bcaches using this caching set are not removed
+      remove_device(bcache_cset)
     end
 
     # Removes a Md raid and all its descendants

--- a/test/data/devicegraphs/bcache2.xml
+++ b/test/data/devicegraphs/bcache2.xml
@@ -283,11 +283,11 @@
         <used>133128257536</used>
       </SpaceInfo>
       <server>192.168.56.1</server>
-      <path>/home/ivan/projects</path>
+      <path>/home/user/projects</path>
     </Nfs>
     <MountPoint>
       <sid>69</sid>
-      <path>/home/ivan/projects</path>
+      <path>/home/user/projects</path>
       <mount-by>device</mount-by>
       <mount-type>nfs</mount-type>
       <active>true</active>

--- a/test/y2partitioner/actions/add_bcache_test.rb
+++ b/test/y2partitioner/actions/add_bcache_test.rb
@@ -165,6 +165,8 @@ describe Y2Partitioner::Actions::AddBcache do
       end
 
       context "when the dialog is discarded" do
+        let(:dialog_result) { :back }
+
         it "does not create a new bcache" do
           subject.run
 

--- a/test/y2partitioner/actions/controllers/bcache_test.rb
+++ b/test/y2partitioner/actions/controllers/bcache_test.rb
@@ -1,0 +1,673 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+
+require "y2partitioner/device_graphs"
+require "y2partitioner/actions/controllers/bcache"
+
+describe Y2Partitioner::Actions::Controllers::Bcache do
+  before do
+    devicegraph_stub(scenario)
+  end
+
+  subject(:controller) { described_class.new(device) }
+
+  let(:device) { nil }
+
+  let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+
+  def dev(name)
+    result = Y2Storage::BlkDevice.find_by_name(current_graph, name)
+    result ||= Y2Storage::LvmVg.all(current_graph).find { |i| i.name == name }
+    result
+  end
+
+  shared_examples "usable devices" do
+    def name_of_devices
+      devices = controller.send(testing_method)
+      devices = devices.select { |d| d.respond_to?(:name) }
+
+      devices.map(&:name)
+    end
+
+    let(:scenario) { "complex-lvm-encrypt.yml" }
+
+    it "returns an array of block devices" do
+      expect(controller.send(testing_method)).to be_an(Array)
+      expect(controller.send(testing_method)).to all be_a(Y2Storage::BlkDevice)
+    end
+
+    it "includes partitions with an unmounted filesystem" do
+      expect(name_of_devices).to include("/dev/sda2", "/dev/sde3")
+    end
+
+    it "excludes partitions with a mount point" do
+      expect(name_of_devices).to include("/dev/sda2", "/dev/sde3")
+
+      sda2 = dev("/dev/sda2")
+      sda2.filesystem.mount_path = "/var"
+      sde3 = dev("/dev/sde3")
+      sde3.filesystem.mount_path = "swap"
+
+      expect(name_of_devices).to_not include("/dev/sda2", "/dev/sde3")
+    end
+
+    it "excludes partitions that are part of an LVM" do
+      expect(name_of_devices).to_not include("/dev/sde1", "/dev/sde2")
+      sda3 = dev("/dev/sda3")
+      expect(controller.send(testing_method)).to include sda3
+
+      vg0 = dev("/dev/vg0")
+      vg0.add_lvm_pv(sda3)
+      expect(controller.send(testing_method)).to_not include sda3
+    end
+
+    it "excludes partitions that are part of a MD Raid" do
+      sda3 = dev("/dev/sda3")
+      expect(controller.send(testing_method)).to include sda3
+
+      new_md = Y2Storage::Md.create(current_graph, "/dev/md0")
+      new_md.add_device(sda3)
+      expect(controller.send(testing_method)).to_not include sda3
+    end
+
+    it "includes disks with no partition tables" do
+      expect(name_of_devices).to include "/dev/sdb"
+    end
+
+    it "includes disks with empty partition tables" do
+      sdb = dev("/dev/sdb")
+      sdb.create_partition_table(Y2Storage::PartitionTables::Type::GPT)
+
+      expect(name_of_devices).to include "/dev/sdb"
+    end
+
+    it "excludes disks with partitions" do
+      expect(name_of_devices).to_not include "/dev/sdf"
+    end
+
+    it "excludes disks with a mount point" do
+      expect(name_of_devices).to include "/dev/sdb"
+
+      sdb = dev("/dev/sdb")
+      sdb.create_filesystem(Y2Storage::Filesystems::Type::EXT3)
+      sdb.filesystem.mount_path = "/var"
+
+      expect(name_of_devices).to_not include "/dev/sdb"
+    end
+
+    it "excludes disks that are part of an LVM" do
+      expect(name_of_devices).to_not include "/dev/sdg"
+    end
+
+    it "excludes disks that are part of a MD Raid" do
+      sdb = dev("/dev/sdb")
+      expect(controller.send(testing_method)).to include sdb
+
+      new_md = Y2Storage::Md.create(current_graph, "/dev/md0")
+      new_md.add_device(sdb)
+      expect(controller.send(testing_method)).to_not include sdb
+    end
+
+    context "when there are extended partitions" do
+      let(:scenario) { "lvm-two-vgs.yml" }
+
+      it "excludes extended partitions" do
+        expect(name_of_devices).to_not include("/dev/sda3")
+      end
+    end
+
+    context "when there are DM RAIDs" do
+      let(:scenario) { "empty-dm_raids.xml" }
+
+      it "excludes disks that are part of a DM RAID" do
+        expect(name_of_devices).to_not include("/dev/sdb", "/dev/sdc")
+      end
+    end
+
+    context "when there are bcaches" do
+      let(:scenario) { "bcache2.xml" }
+
+      it "excludes Bcaches" do
+        expect(name_of_devices).to_not include("/dev/bcache0", "/dev/bcache1", "/dev/bcache2")
+      end
+
+      it "excludes partitions from a Bcache" do
+        expect(name_of_devices).to_not include("/dev/bcache1p1", "/dev/bcache1p2")
+      end
+
+      it "excludes devices used as backing device" do
+        expect(name_of_devices).to_not include("/dev/sdb2")
+      end
+
+      it "excludes devices used as caching device" do
+        expect(name_of_devices).to_not include("/dev/sdb1")
+      end
+    end
+  end
+
+  describe "#suitable_backing_devices" do
+    context "when the bcache device is being created" do
+      let(:device) { nil }
+
+      let(:testing_method) { :suitable_backing_devices }
+
+      include_examples "usable devices"
+
+      context "when there are caching sets" do
+        let(:scenario) { "bcache2.xml" }
+
+        it "excludes all caching set devices" do
+          bcache_csets = Y2Storage::BcacheCset.all(current_graph)
+
+          expect(controller.suitable_backing_devices).to_not include(bcache_csets)
+        end
+      end
+    end
+
+    context "when the bcache device is being edited" do
+      let(:scenario) { "bcache2.xml" }
+
+      let(:device) { current_graph.find_by_name("/dev/bcache0") }
+
+      it "returns an array of block devices" do
+        expect(controller.suitable_backing_devices).to be_an(Array)
+        expect(controller.suitable_backing_devices).to all be_a(Y2Storage::BlkDevice)
+      end
+
+      it "only includes its backing device" do
+        expect(controller.suitable_backing_devices.map(&:name)).to contain_exactly("/dev/sdb2")
+      end
+    end
+  end
+
+  describe "#suitable_caching_devices" do
+    let(:testing_method) { :suitable_caching_devices }
+
+    include_examples "usable devices"
+
+    context "when there are caching sets" do
+      let(:scenario) { "bcache1.xml" }
+
+      before do
+        vda1 = current_graph.find_by_name("/dev/vda1")
+        vda1.create_bcache_cset
+      end
+
+      it "includes all caching set devices" do
+        bcache_csets = Y2Storage::BcacheCset.all(current_graph)
+
+        expect(bcache_csets.size).to eq(2)
+
+        expect(controller.suitable_caching_devices).to include(*bcache_csets)
+      end
+    end
+  end
+
+  describe "#create_bcache" do
+    let(:scenario) { "bcache2.xml" }
+
+    let(:backing_device) { current_graph.find_by_name("/dev/sda1") }
+
+    let(:caching_device) { nil }
+
+    let(:options) { { cache_mode: Y2Storage::CacheMode::WRITEBACK } }
+
+    it "creates a new bcache over the given backing device" do
+      expect(current_graph.find_by_name("/dev/bcache3")).to be_nil
+
+      subject.create_bcache(backing_device, caching_device, options)
+
+      bcache = current_graph.find_by_name("/dev/bcache3")
+
+      expect(bcache).to_not be_nil
+      expect(bcache.backing_device).to eq(backing_device)
+    end
+
+    it "creates a new bcache with the given cache mode" do
+      expect(current_graph.find_by_name("/dev/bcache3")).to be_nil
+
+      subject.create_bcache(backing_device, caching_device, options)
+
+      bcache = current_graph.find_by_name("/dev/bcache3")
+
+      expect(bcache).to_not be_nil
+      expect(bcache.cache_mode).to eq(options[:cache_mode])
+    end
+
+    context "when non caching device is given" do
+      let(:caching_device) { nil }
+
+      it "creates a new bcache without an associated caching set" do
+        expect(current_graph.find_by_name("/dev/bcache3")).to be_nil
+
+        subject.create_bcache(backing_device, caching_device, options)
+
+        bcache = current_graph.find_by_name("/dev/bcache3")
+
+        expect(bcache).to_not be_nil
+        expect(bcache.bcache_cset).to be_nil
+      end
+    end
+
+    context "when a blk device is given for caching" do
+      let(:caching_device) { current_graph.find_by_name("/dev/sda2") }
+
+      it "creates a new bcache with the given device for caching" do
+        expect(current_graph.find_by_name("/dev/bcache3")).to be_nil
+
+        subject.create_bcache(backing_device, caching_device, options)
+
+        bcache = current_graph.find_by_name("/dev/bcache3")
+
+        expect(bcache).to_not be_nil
+        expect(bcache.bcache_cset.blk_devices.first).to eq(caching_device)
+      end
+    end
+
+    context "when a existing caching set is given for caching" do
+      let(:caching_device) { current_graph.bcache_csets.first }
+
+      it "creates a new bcache with the given caching set for caching" do
+        expect(current_graph.find_by_name("/dev/bcache3")).to be_nil
+
+        subject.create_bcache(backing_device, caching_device, options)
+
+        bcache = current_graph.find_by_name("/dev/bcache3")
+
+        expect(bcache).to_not be_nil
+        expect(bcache.bcache_cset).to eq(caching_device)
+      end
+    end
+  end
+
+  shared_examples "update previous caching" do
+    def call_testing_method
+      subject.send(*testing_method)
+    end
+
+    context "and the previous caching set was being used only by this bcache" do
+      let(:previous_caching_device) { current_graph.find_by_name("/dev/sda1") }
+
+      it "removes the previous caching set" do
+        expect(previous_caching_device.in_bcache_cset).to_not be_nil
+
+        call_testing_method
+
+        expect(previous_caching_device.in_bcache_cset).to be_nil
+      end
+
+      it "restores the previous status of the caching device" do
+        expect(previous_caching_device.filesystem).to be_nil
+
+        call_testing_method
+
+        expect(previous_caching_device.filesystem).to_not be_nil
+      end
+    end
+
+    context "and the previous caching set was being used by several bcache devices" do
+      let(:previous_caching_device) { Y2Storage::BcacheCset.all(current_graph).first }
+
+      it "does not remove the previous caching set" do
+        call_testing_method
+
+        expect(previous_caching_device).to_not be_nil
+      end
+    end
+  end
+
+  describe "#update_bcache" do
+    let(:scenario) { "bcache2.xml" }
+
+    before do
+      sda2 = current_graph.find_by_name("/dev/sda2")
+      described_class.new.create_bcache(sda2, previous_caching_device, {})
+    end
+
+    let(:device) { current_graph.find_by_name("/dev/bcache3") }
+
+    let(:previous_caching_device) { nil }
+
+    let(:caching_device) { nil }
+
+    let(:options) { { cache_mode: Y2Storage::CacheMode::WRITEBACK } }
+
+    shared_examples "detach actions" do
+      it "detaches its previous caching set" do
+        previous_sid = device.bcache_cset.sid
+
+        subject.update_bcache(caching_device, options)
+
+        detached = device.bcache_cset.nil? || device.bcache_cset.sid != previous_sid
+
+        expect(detached).to eq(true)
+      end
+
+      let(:testing_method) { [:update_bcache, caching_device, options] }
+
+      include_examples "update previous caching"
+    end
+
+    it "sets the given cache mode" do
+      expect(device.cache_mode).to_not eq(options[:cache_mode])
+
+      subject.update_bcache(caching_device, options)
+
+      expect(device.cache_mode).to eq(options[:cache_mode])
+    end
+
+    context "when a caching device is given" do
+      let(:caching_device) { Y2Storage::BcacheCset.all(current_graph).first }
+
+      context "and the bcache has no previous caching set" do
+        let(:previous_caching_device) { nil }
+
+        it "attaches the given caching device" do
+          expect(device.bcache_cset).to be_nil
+
+          subject.update_bcache(caching_device, options)
+
+          expect(device.bcache_cset).to eq(caching_device)
+        end
+      end
+
+      context "and the bcache is already associated to the given caching set" do
+        let(:previous_caching_device) { caching_device }
+
+        it "does not change the caching set" do
+          expect(device.bcache_cset).to eq(previous_caching_device)
+
+          subject.update_bcache(caching_device, options)
+
+          expect(device.bcache_cset).to eq(previous_caching_device)
+        end
+      end
+
+      context "and the bcache is already associated to another caching set" do
+        let(:previous_caching_device) { current_graph.find_by_name("/dev/sda1") }
+
+        it "attaches the given caching device" do
+          expect(device.bcache_cset).to eq(previous_caching_device.in_bcache_cset)
+
+          subject.update_bcache(caching_device, options)
+
+          expect(device.bcache_cset).to eq(caching_device)
+        end
+
+        include_examples "detach actions"
+      end
+    end
+
+    context "when a caching device is not given" do
+      let(:caching_device) { nil }
+
+      context "and the bcache has already a previous caching set" do
+        let(:previous_caching_device) { Y2Storage::BcacheCset.all(current_graph).first }
+
+        include_examples "detach actions"
+      end
+    end
+  end
+
+  describe "#delete_bcache" do
+    let(:scenario) { "bcache2.xml" }
+
+    before do
+      described_class.new.create_bcache(backing_device, previous_caching_device, {})
+    end
+
+    let(:device) { current_graph.find_by_name("/dev/bcache3") }
+
+    let(:backing_device) { current_graph.find_by_name("/dev/sda3") }
+
+    let(:previous_caching_device) { nil }
+
+    it "deletes the bcache device" do
+      expect(current_graph.find_by_name("/dev/bcache3")).to_not be_nil
+
+      subject.delete_bcache
+
+      expect(current_graph.find_by_name("/dev/bcache3")).to be_nil
+    end
+
+    it "restores the previous status of the backing device" do
+      backing_device = device.backing_device
+
+      expect(backing_device.filesystem).to be_nil
+
+      subject.delete_bcache
+
+      expect(backing_device.filesystem).to_not be_nil
+    end
+
+    context "when the bcache has an associated caching set" do
+      let(:testing_method) { [:delete_bcache] }
+
+      include_examples "update previous caching"
+    end
+  end
+
+  describe "#committed_bcache?" do
+    let(:scenario) { "bcache2.xml" }
+
+    context "when the bcache exists on disk" do
+      let(:device) { current_graph.find_by_name("/dev/bcache0") }
+
+      it "returns true" do
+        expect(subject.committed_bcache?).to eq(true)
+      end
+    end
+
+    context "when the bcache does not exist on disk" do
+      before do
+        sdb1 = current_graph.find_by_name("/dev/sdb1")
+        sdb1.create_bcache("/dev/bcache99")
+      end
+
+      let(:device) { current_graph.find_by_name("/dev/bcache99") }
+
+      it "returns false" do
+        expect(subject.committed_bcache?).to eq(false)
+      end
+    end
+  end
+
+  describe "#committed_bcache_cset?" do
+    let(:scenario) { "bcache1.xml" }
+
+    let(:system_graph) { Y2Partitioner::DeviceGraphs.instance.system }
+
+    let(:system_device) { system_graph.find_by_name(device.name) }
+
+    context "when the bcache exists on disk" do
+      let(:device) { current_graph.find_by_name("/dev/bcache0") }
+
+      context "and currently it has a caching set" do
+        before do
+          expect(device.bcache_cset).to_not be_nil
+        end
+
+        context "but it does not have a caching set on disk" do
+          before do
+            system_device.remove_bcache_cset
+          end
+
+          it "returns false" do
+            expect(subject.committed_bcache_cset?).to eq(false)
+          end
+        end
+
+        context "and it has a caching set on disk" do
+          before do
+            expect(system_device.bcache_cset).to_not be_nil
+          end
+
+          it "returns true" do
+            expect(subject.committed_bcache_cset?).to eq(true)
+          end
+        end
+      end
+
+      context "and currently it does not have a caching set" do
+        before do
+          device.remove_bcache_cset
+        end
+
+        context "and it does not have a caching set on disk" do
+          before do
+            system_device.remove_bcache_cset
+          end
+
+          it "returns false" do
+            expect(subject.committed_bcache_cset?).to eq(false)
+          end
+        end
+
+        context "but it has a caching set on disk" do
+          before do
+            expect(system_device.bcache_cset).to_not be_nil
+          end
+
+          it "returns true" do
+            expect(subject.committed_bcache_cset?).to eq(true)
+          end
+        end
+      end
+    end
+
+    context "when the bcache does not exist on disk" do
+      before do
+        sdb1 = current_graph.find_by_name("/dev/vda1")
+        sdb1.create_bcache("/dev/bcache99")
+      end
+
+      let(:device) { current_graph.find_by_name("/dev/bcache99") }
+
+      it "returns false" do
+        expect(subject.committed_bcache_cset?).to eq(false)
+      end
+    end
+  end
+
+  describe "#single_committed_bcache_cset" do
+    let(:scenario) { "bcache1.xml" }
+
+    let(:system_graph) { Y2Partitioner::DeviceGraphs.instance.system }
+
+    let(:system_device) { system_graph.find_by_name(device.name) }
+
+    def bcache_cset_only_for(bcache)
+      bcache.bcache_cset.bcaches.each do |dev|
+        dev.remove_bcache_cset if dev != bcache
+      end
+    end
+
+    shared_examples "caching set usage" do
+      context "and its caching set is used only by this bcache on disk" do
+        before do
+          bcache_cset_only_for(system_device)
+        end
+
+        it "returns true" do
+          expect(subject.single_committed_bcache_cset?).to eq(true)
+        end
+      end
+
+      context "and its caching set is used by several bcaches on disk" do
+        before do
+          expect(system_device.bcache_cset.bcaches.size).to be > 1
+        end
+
+        it "returns false" do
+          expect(subject.single_committed_bcache_cset?).to eq(false)
+        end
+      end
+    end
+
+    context "when the bcache exists on disk" do
+      let(:device) { current_graph.find_by_name("/dev/bcache0") }
+
+      context "and currently it has a caching set" do
+        before do
+          expect(device.bcache_cset).to_not be_nil
+        end
+
+        context "but it does not have a caching set on disk" do
+          before do
+            system_device.remove_bcache_cset
+          end
+
+          it "returns false" do
+            expect(subject.single_committed_bcache_cset?).to eq(false)
+          end
+        end
+
+        context "and it has a caching set on disk" do
+          before do
+            expect(system_device.bcache_cset).to_not be_nil
+          end
+
+          include_examples "caching set usage"
+        end
+      end
+
+      context "and currently it does not have a caching set" do
+        before do
+          device.remove_bcache_cset
+        end
+
+        context "and it does not have a caching set on disk" do
+          before do
+            system_device.remove_bcache_cset
+          end
+
+          it "returns false" do
+            expect(subject.single_committed_bcache_cset?).to eq(false)
+          end
+        end
+
+        context "but it has a caching set on disk" do
+          before do
+            expect(system_device.bcache_cset).to_not be_nil
+          end
+
+          include_examples "caching set usage"
+        end
+      end
+    end
+
+    context "when the bcache does not exist on disk" do
+      before do
+        sdb1 = current_graph.find_by_name("/dev/vda1")
+        sdb1.create_bcache("/dev/bcache99")
+      end
+
+      let(:device) { current_graph.find_by_name("/dev/bcache99") }
+
+      it "returns false" do
+        expect(subject.single_committed_bcache_cset?).to eq(false)
+      end
+    end
+  end
+end

--- a/test/y2partitioner/actions/delete_bcache_test.rb
+++ b/test/y2partitioner/actions/delete_bcache_test.rb
@@ -148,7 +148,7 @@ describe Y2Partitioner::Actions::DeleteBcache do
           end
 
           it "shows an error message" do
-            expect(Yast2::Popup).to receive(:show).with(/Detaching is required/, headline: :error)
+            expect(Yast2::Popup).to receive(:show).with(/cannot be deleted/, headline: :error)
 
             subject.run
           end

--- a/test/y2partitioner/actions/edit_bcache_test.rb
+++ b/test/y2partitioner/actions/edit_bcache_test.rb
@@ -1,0 +1,253 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/actions/edit_bcache"
+
+describe Y2Partitioner::Actions::EditBcache do
+  subject { described_class.new(device) }
+
+  before do
+    devicegraph_stub(scenario)
+
+    allow_any_instance_of(Y2Partitioner::Dialogs::Bcache).to receive(:run)
+      .and_return(dialog_result)
+
+    allow_any_instance_of(Y2Partitioner::Dialogs::Bcache).to receive(:caching_device)
+      .and_return(selected_caching)
+
+    allow_any_instance_of(Y2Partitioner::Dialogs::Bcache).to receive(:options)
+      .and_return(selected_options)
+  end
+
+  let(:dialog_result) { nil }
+
+  let(:selected_caching) { nil }
+
+  let(:selected_options) { { cache_mode: Y2Storage::CacheMode::WRITEBACK } }
+
+  let(:device) { device_graph.find_by_name(device_name) }
+
+  let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+
+  describe "#run" do
+    before do
+      allow(Yast2::Popup).to receive(:show)
+    end
+
+    shared_examples "not edit device" do
+      it "does not modify the caching device" do
+        bcache_cset = device.bcache_cset
+
+        subject.run
+
+        expect(device.bcache_cset).to eq(bcache_cset)
+      end
+
+      it "does not modify the cache mode" do
+        cache_mode = device.cache_mode
+
+        subject.run
+
+        expect(device.cache_mode).to eq(cache_mode)
+      end
+    end
+
+    shared_examples "not edit action" do
+      it "does not open a dialog to edit a bcache device" do
+        expect(Y2Partitioner::Dialogs::Bcache).to_not receive(:new)
+
+        subject.run
+      end
+
+      include_examples "not edit device"
+
+      it "returns :back" do
+        expect(subject.run).to eq(:back)
+      end
+    end
+
+    shared_examples "edit action" do
+      it "does not show an error popup" do
+        expect(Yast2::Popup).to_not receive(:show)
+
+        subject.run
+      end
+
+      it "opens a dialog to edit the bcache device" do
+        expect(Y2Partitioner::Dialogs::Bcache).to receive(:new).and_call_original
+
+        subject.run
+      end
+
+      context "when the dialog is accepted" do
+        let(:dialog_result) { :next }
+
+        context "and a caching device was selected in the dialog" do
+          before do
+            # Only to ensure the pre-condition is fulfilled
+            expect(selected_caching).to_not be_nil
+          end
+
+          it "attaches the selected caching device" do
+            subject.run
+
+            expect(device.bcache_cset).to_not be_nil
+            expect(device.bcache_cset.blk_devices.first).to eq(selected_caching)
+          end
+
+          it "sets the selected cache mode" do
+            subject.run
+
+            expect(device.cache_mode).to eq(selected_options[:cache_mode])
+          end
+
+          it "returns :finish" do
+            expect(subject.run).to eq :finish
+          end
+        end
+
+        context "when no caching device was selected in the dialog" do
+          let(:selected_caching) { nil }
+
+          it "does not attach a caching device" do
+            subject.run
+
+            expect(device.bcache_cset).to be_nil
+          end
+
+          it "sets the selected cache mode" do
+            subject.run
+
+            expect(device.cache_mode).to eq(selected_options[:cache_mode])
+          end
+
+          it "returns :finish" do
+            expect(subject.run).to eq :finish
+          end
+        end
+      end
+
+      context "when the dialog is discarded" do
+        let(:dialog_result) { :back }
+
+        include_examples "not edit device"
+
+        it "returns :finish" do
+          expect(subject.run).to eq :finish
+        end
+      end
+    end
+
+    context "when the device is a Flash-only bcache" do
+      let(:scenario) { "bcache2.xml" }
+
+      let(:device_name) { "/dev/bcache1" }
+
+      before do
+        # Only to ensure the pre-condition is fulfilled
+        expect(device.flash_only?).to eq(true)
+      end
+
+      it "shows an error message" do
+        expect(Yast2::Popup).to receive(:show).with(/is a Flash-only/, headline: :error)
+
+        subject.run
+      end
+
+      include_examples "not edit action"
+    end
+
+    context "when the bcache already exists on disk" do
+      let(:system_device) { Y2Partitioner::DeviceGraphs.instance.system.find_device(device.sid) }
+
+      let(:scenario) { "bcache1.xml" }
+
+      let(:device_name) { "/dev/bcache1" }
+
+      # Preparing a value for examples that need it (see shared examples "edit bcache")
+      let(:selected_caching) { device_graph.find_by_name("/dev/vda2") }
+
+      before do
+        # Only to ensure the pre-condition is fulfilled
+        expect(system_device).to_not be_nil
+      end
+
+      context "and it had a caching set on disk" do
+        before do
+          # Only to ensure the pre-condition is fulfilled
+          expect(system_device.bcache_cset).to_not be_nil
+        end
+
+        it "shows an error message" do
+          expect(Yast2::Popup).to receive(:show).with(/already created/, headline: :error)
+
+          subject.run
+        end
+
+        include_examples "not edit action"
+      end
+
+      context "and it did not have a caching set on disk" do
+        before do
+          system_device.remove_bcache_cset
+        end
+
+        context "and it currently has no caching set either" do
+          before do
+            device.remove_bcache_cset
+          end
+
+          include_examples "edit action"
+        end
+
+        context "and it currently has a caching set" do
+          before do
+            # Only to ensure the pre-condition is fulfilled
+            expect(device.bcache_cset).to_not be_nil
+          end
+
+          include_examples "edit action"
+        end
+      end
+    end
+
+    context "when the bcache does not exist on disk" do
+      let(:scenario) { "bcache1.xml" }
+
+      before do
+        vda1 = device_graph.find_by_name("/dev/vda1")
+
+        vda1.create_bcache(device_name)
+      end
+
+      let(:device_name) { "/dev/bcache99" }
+
+      # Preparing a value for examples that need it (see shared examples "edit bcache")
+      let(:selected_caching) { device_graph.find_by_name("/dev/vda2") }
+
+      include_examples "edit action"
+    end
+  end
+end

--- a/test/y2partitioner/dialogs/bcache_test.rb
+++ b/test/y2partitioner/dialogs/bcache_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -26,15 +26,28 @@ require "yast"
 require "cwm/rspec"
 require "y2storage"
 require "y2partitioner/dialogs/bcache"
+require "y2partitioner/actions/controllers/bcache"
 
 describe Y2Partitioner::Dialogs::Bcache do
-  before { devicegraph_stub("bcache1.xml") }
+  before do
+    devicegraph_stub("bcache1.xml")
+
+    allow(Y2Partitioner::Actions::Controllers::Bcache).to receive(:new).and_return(controller)
+
+    allow(controller).to receive(:bcache).and_return(bcache)
+    allow(controller).to receive(:suitable_caching_devices).and_return(suitable_caching)
+    allow(controller).to receive(:suitable_backing_devices).and_return(suitable_backing)
+  end
 
   let(:architecture) { :x86_64 } # bcache is only supported on x86_64
+
+  let(:controller) { instance_double(Y2Partitioner::Actions::Controllers::Bcache) }
+
+  let(:bcache) { nil }
   let(:suitable_backing) { fake_devicegraph.blk_devices }
   let(:suitable_caching) { fake_devicegraph.blk_devices + fake_devicegraph.bcache_csets }
 
-  subject { described_class.new(suitable_backing, suitable_caching) }
+  subject { described_class.new(controller) }
 
   include_examples "CWM::Dialog"
 

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -27,7 +27,9 @@ require "y2partitioner/widgets/pages"
 describe Y2Partitioner::UIState do
   subject(:ui_state) { described_class.instance }
 
-  before { devicegraph_stub("complex-lvm-encrypt.yml") }
+  before { devicegraph_stub(scenario) }
+
+  let(:scenario) { "complex-lvm-encrypt.yml" }
 
   let(:device) { Y2Storage::BlkDevice.find_by_name(fake_devicegraph, device_name) }
 
@@ -64,9 +66,10 @@ describe Y2Partitioner::UIState do
     let(:disks_page) { Y2Partitioner::Widgets::Pages::Disks.new(disks, pager) }
     let(:md_raids_page) { Y2Partitioner::Widgets::Pages::MdRaids.new(pager) }
     let(:lvm_page) { Y2Partitioner::Widgets::Pages::Lvm.new(pager) }
+    let(:bcaches_page) { Y2Partitioner::Widgets::Pages::Bcaches.new([], pager) }
     let(:btrfs_page) { Y2Partitioner::Widgets::Pages::Btrfs.new(pager) }
 
-    let(:pages) { [system_page, disks_page, md_raids_page, lvm_page, btrfs_page] }
+    let(:pages) { [system_page, disks_page, md_raids_page, lvm_page, bcaches_page, btrfs_page] }
 
     context "if the user has still not visited any node" do
       before { described_class.create_instance }
@@ -215,6 +218,33 @@ describe Y2Partitioner::UIState do
 
         it "selects the general LVM page" do
           expect(ui_state.find_tree_node(pages)).to eq lvm_page
+        end
+      end
+    end
+
+    context "when the user has opened a Bcache page" do
+      let(:scenario) { "bcache1.xml" }
+      let(:device) { fake_devicegraph.find_by_name("/dev/bcache0") }
+      let(:another_bcache) { fake_devicegraph.find_by_name("/dev/bcache1") }
+
+      let(:page) { Y2Partitioner::Widgets::Pages::Bcache.new(device, pager) }
+      let(:another_bcache_page) { Y2Partitioner::Widgets::Pages::Bcache.new(another_bcache, pager) }
+
+      before { ui_state.go_to_tree_node(page) }
+
+      context "if the Bcache is still there after redrawing" do
+        before { pages.concat [page, another_bcache_page] }
+
+        it "selects the correct Bcache page" do
+          expect(ui_state.find_tree_node(pages)).to eq page
+        end
+      end
+
+      context "if the Bcache is not longer there after redrawing" do
+        before { pages << another_bcache_page }
+
+        it "selects the general Bcache page" do
+          expect(ui_state.find_tree_node(pages)).to eq bcaches_page
         end
       end
     end

--- a/test/y2partitioner/widgets/bcache_edit_button_test.rb
+++ b/test/y2partitioner/widgets/bcache_edit_button_test.rb
@@ -1,0 +1,62 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/bcache_edit_button"
+
+describe Y2Partitioner::Widgets::BcacheEditButton do
+  before do
+    devicegraph_stub(scenario)
+
+    allow(Y2Partitioner::Actions::EditBcache).to receive(:new).and_return(action)
+  end
+
+  let(:action) { instance_double(Y2Partitioner::Actions::EditBcache, run: :finish) }
+
+  subject(:button) { described_class.new(device: device) }
+
+  let(:device) { device_graph.find_by_name(device_name) }
+
+  let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+
+  let(:scenario) { "bcache1.xml" }
+
+  let(:device_name) { "/dev/bcache0" }
+
+  include_examples "CWM::PushButton"
+
+  describe "#handle" do
+    it "returns :redraw if the action was successful" do
+      allow(action).to receive(:run).and_return(:finish)
+
+      expect(button.handle).to eq(:redraw)
+    end
+
+    it "returns nil if the action was not successful" do
+      allow(action).to receive(:run).and_return(:back)
+
+      expect(button.handle).to be_nil
+    end
+  end
+end

--- a/test/y2partitioner/widgets/bcache_modify_button_test.rb
+++ b/test/y2partitioner/widgets/bcache_modify_button_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -63,7 +63,7 @@ describe Y2Partitioner::Widgets::BcacheModifyButton do
       end
     end
 
-    context "when the option for editing the disk is selected" do
+    context "when the option for editing the bcache is selected" do
       let(:selected_option) { :"#{widget_id}_edit" }
 
       before do
@@ -72,6 +72,21 @@ describe Y2Partitioner::Widgets::BcacheModifyButton do
 
       it "opens the workflow for editing the device" do
         expect(Y2Partitioner::Actions::EditBlkDevice).to receive(:new)
+        button.handle(event)
+      end
+
+      include_examples "handle bcache action result"
+    end
+
+    context "when the option for changing the caching is selected" do
+      let(:selected_option) { :"#{widget_id}_caching" }
+
+      before do
+        allow(Y2Partitioner::Actions::EditBcache).to receive(:new).and_return action
+      end
+
+      it "opens the workflow for changing the caching options" do
+        expect(Y2Partitioner::Actions::EditBcache).to receive(:new)
         button.handle(event)
       end
 

--- a/test/y2partitioner/widgets/device_buttons_set_test.rb
+++ b/test/y2partitioner/widgets/device_buttons_set_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -101,63 +101,20 @@ describe Y2Partitioner::Widgets::DeviceButtonsSet do
 
     context "when targeting a Bcache device" do
       let(:scenario) { "bcache2.xml" }
+      let(:device) { device_graph.find_by_name("/dev/bcache0") }
 
-      let(:device) { device_graph.find_by_name(device_name) }
-
-      context "and the device is not a flash-only bcache" do
-        let(:device_name) { "/dev/bcache0" }
-
-        it "replaces the content with buttons to modify and to manage partitions" do
-          expect(widget).to receive(:replace) do |content|
-            widgets = Yast::CWM.widgets_in_contents([content])
-            expect(widgets.map(&:class)).to include(
-              Y2Partitioner::Widgets::DeviceButtonsSet::ButtonsBox,
-              Y2Partitioner::Widgets::BcacheModifyButton,
-              Y2Partitioner::Widgets::PartitionsButton
-            )
-          end
-
-          widget.device = device
+      it "replaces the content with buttons to modify, to delete and to manage partitions" do
+        expect(widget).to receive(:replace) do |content|
+          widgets = Yast::CWM.widgets_in_contents([content])
+          expect(widgets.map(&:class)).to contain_exactly(
+            Y2Partitioner::Widgets::DeviceButtonsSet::ButtonsBox,
+            Y2Partitioner::Widgets::BcacheModifyButton,
+            Y2Partitioner::Widgets::DeviceDeleteButton,
+            Y2Partitioner::Widgets::PartitionsButton
+          )
         end
 
-        it "includes a button to delete the device" do
-          expect(widget).to receive(:replace) do |content|
-            widgets = Yast::CWM.widgets_in_contents([content])
-            expect(widgets.map(&:class)).to include(
-              Y2Partitioner::Widgets::DeviceDeleteButton
-            )
-          end
-
-          widget.device = device
-        end
-      end
-
-      context "and the device is a flash-only bcache" do
-        let(:device_name) { "/dev/bcache1" }
-
-        it "replaces the content with buttons to modify and to manage partitions" do
-          expect(widget).to receive(:replace) do |content|
-            widgets = Yast::CWM.widgets_in_contents([content])
-            expect(widgets.map(&:class)).to contain_exactly(
-              Y2Partitioner::Widgets::DeviceButtonsSet::ButtonsBox,
-              Y2Partitioner::Widgets::BcacheModifyButton,
-              Y2Partitioner::Widgets::PartitionsButton
-            )
-          end
-
-          widget.device = device
-        end
-
-        it "does not include a button to delete the device" do
-          expect(widget).to receive(:replace) do |content|
-            widgets = Yast::CWM.widgets_in_contents([content])
-            expect(widgets.map(&:class)).to_not include(
-              Y2Partitioner::Widgets::DeviceDeleteButton
-            )
-          end
-
-          widget.device = device
-        end
+        widget.device = device
       end
     end
 

--- a/test/y2partitioner/widgets/pages/bcache_test.rb
+++ b/test/y2partitioner/widgets/pages/bcache_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -73,22 +73,24 @@ describe Y2Partitioner::Widgets::Pages::Bcache do
         expect(description).to_not be_nil
       end
 
-      context "when the device is not a flash-only bcache" do
-        let(:device_name) { "/dev/bcache0" }
-
-        it "shows a button for deleting the device" do
-          button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::DeviceDeleteButton) }
-          expect(button).to_not be_nil
-        end
+      it "shows a button for editing the device" do
+        button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDeviceEditButton) }
+        expect(button).to_not be_nil
       end
 
-      context "when the device is a flash-only bcache" do
-        let(:device_name) { "/dev/bcache1" }
+      it "shows a button for changing the caching options" do
+        button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BcacheEditButton) }
+        expect(button).to_not be_nil
+      end
 
-        it "does not show a button for deleting the device" do
-          button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::DeviceDeleteButton) }
-          expect(button).to be_nil
-        end
+      it "shows a button for deleting the device" do
+        button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::DeviceDeleteButton) }
+        expect(button).to_not be_nil
+      end
+
+      it "shows a button for configuring the partition table" do
+        button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::PartitionTableAddButton) }
+        expect(button).to_not be_nil
       end
     end
   end

--- a/test/y2storage/bcache_test.rb
+++ b/test/y2storage/bcache_test.rb
@@ -119,7 +119,7 @@ describe Y2Storage::Bcache do
       end
     end
 
-    describe "#attach_bcache_cset" do
+    describe "#add_bcache_cset" do
       before do
         described_class.create(fake_devicegraph, bcache_name)
       end
@@ -128,19 +128,19 @@ describe Y2Storage::Bcache do
 
       let(:cset) { fake_devicegraph.bcache_csets.first }
 
-      it "attach a caching set to bcache device" do
+      it "adds a caching set to bcache device" do
         expect(subject.bcache_cset).to be_nil
 
-        subject.attach_bcache_cset(cset)
+        subject.add_bcache_cset(cset)
 
         expect(subject.bcache_cset).to eq(cset)
       end
 
       context "when the bcache already has an associated caching set" do
-        let(:bcache_name) { "/dev/bcache1" }
+        let(:bcache_name) { "/dev/bcache0" }
 
         it "raises an exception" do
-          expect { subject.attach_bcache_cset(cset) }.to raise_error(Storage::LogicException)
+          expect { subject.add_bcache_cset(cset) }.to raise_error(Storage::LogicException)
         end
       end
 
@@ -148,7 +148,37 @@ describe Y2Storage::Bcache do
         let(:bcache_name) { "/dev/bcache1" }
 
         it "raises an exception" do
-          expect { subject.attach_bcache_cset(cset) }.to raise_error(Storage::LogicException)
+          expect { subject.add_bcache_cset(cset) }.to raise_error(Storage::LogicException)
+        end
+      end
+    end
+
+    describe "#remove_bcache_cset" do
+      let(:bcache_name) { "/dev/bcache0" }
+
+      it "removes the caching set" do
+        expect(subject.bcache_cset).to_not be_nil
+
+        subject.remove_bcache_cset
+
+        expect(subject.bcache_cset).to be_nil
+      end
+
+      context "when the bcache has no caching set" do
+        before do
+          subject.remove_bcache_cset
+        end
+
+        it "raises an exception" do
+          expect { subject.remove_bcache_cset }.to raise_error(Storage::LogicException)
+        end
+      end
+
+      context "when the bcache is flash-only" do
+        let(:bcache_name) { "/dev/bcache1" }
+
+        it "raises an exception" do
+          expect { subject.remove_bcache_cset }.to raise_error(Storage::LogicException)
         end
       end
     end

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -728,6 +728,25 @@ describe Y2Storage::Devicegraph do
     end
   end
 
+  describe "#remove_bcache_cset" do
+    subject(:devicegraph) { Y2Storage::StorageManager.instance.staging }
+
+    before do
+      fake_scenario("bcache1.xml")
+    end
+
+    it "removes the given caching set device" do
+      bcache_cset = Y2Storage::BcacheCset.all(devicegraph).first
+      expect(bcache_cset).to_not be_nil
+
+      sid = bcache_cset.sid
+
+      devicegraph.remove_bcache_cset(bcache_cset)
+
+      expect(devicegraph.find_device(sid)).to be_nil
+    end
+  end
+
   describe "#remove_md" do
     subject(:devicegraph) { Y2Storage::StorageManager.instance.staging }
 


### PR DESCRIPTION
## Problem

Now, the Expert Partitioner allows to create Bcache devices without a caching set, but there is no way to edit the Bcache later to add a caching set.

- https://jira.suse.de/browse/SLE-4329
- https://trello.com/c/cQo16PQ5/672-editing-an-in-memory-bcache-device-devices-and-cache-mode

## Solution

Add option in the Expert Partitioner for editing a Bcache device. This should allow to change its caching set and its cache mode. Moreover, it should allow to change the caching set of a Bcache only when the Bcache is not using a caching set already (on the real system).

Requires these changes in the library: https://github.com/openSUSE/libstorage-ng/pull/613.

## Testing

- Added unit tests
- Tested manually

## Screenshots

![virtualbox_opensuse tumbleweed_15_02_2019_16_45_35](https://user-images.githubusercontent.com/1112304/52871093-31d21e80-3141-11e9-87ab-7d5bafba2733.png)

![virtualbox_opensuse tumbleweed_15_02_2019_16_45_46](https://user-images.githubusercontent.com/1112304/52871105-35fe3c00-3141-11e9-9556-7fc9ed8c1676.png)

![virtualbox_opensuse tumbleweed_19_02_2019_16_36_48](https://user-images.githubusercontent.com/1112304/53031462-d2d41880-3464-11e9-8de1-39d12e8e7c5f.png)

![virtualbox_opensuse tumbleweed_19_02_2019_16_37_31](https://user-images.githubusercontent.com/1112304/53031474-d7003600-3464-11e9-8048-7f8491520a27.png)

![virtualbox_opensuse tumbleweed_18_02_2019_15_26_18](https://user-images.githubusercontent.com/1112304/52960864-94b9f480-3391-11e9-9e86-ca4462fd9975.png)


