### PR TITLE
save device_order for MD RAIDs in AutoYaST profile

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 14 10:49:47 CET 2019 - aschnell@suse.com
+
+- AutoYaST: save device_order for MD RAIDs (bsc#1083542)
+- 4.1.56
+
+-------------------------------------------------------------------
 Fri Feb  8 11:43:53 UTC 2019 - ancor@suse.com
 
 - AutoYaST: fix broken support for retaining existing MD RAIDs in

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.55
+Version:	4.1.56
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/autoinst_profile/raid_options_section.rb
+++ b/src/lib/y2storage/autoinst_profile/raid_options_section.rb
@@ -92,6 +92,7 @@ module Y2Storage
         # A number will be interpreted as KB, so we explicitly set the unit.
         @chunk_size = "#{md.chunk_size.to_i}B"
         @parity_algorithm = md.md_parity.to_s
+        @device_order = md.sorted_devices.map(&:name)
       end
     end
   end

--- a/test/y2storage/autoinst_profile/raid_options_section_test.rb
+++ b/test/y2storage/autoinst_profile/raid_options_section_test.rb
@@ -103,14 +103,29 @@ describe Y2Storage::AutoinstProfile::RaidOptionsSection do
   describe ".new_from_storage" do
     let(:numeric?) { false }
 
+    let(:sda1) do
+      instance_double(
+        Y2Storage::Partition,
+        name: "/dev/sda1"
+      )
+    end
+
+    let(:sdb1) do
+      instance_double(
+        Y2Storage::Partition,
+        name: "/dev/sdb1"
+      )
+    end
+
     let(:md) do
       instance_double(
         Y2Storage::Md,
-        chunk_size: 1.MB,
-        md_parity:  Y2Storage::MdParity::LEFT_ASYMMETRIC,
-        md_level:   Y2Storage::MdLevel::RAID0,
-        name:       "/dev/md0",
-        numeric?:   numeric?
+        chunk_size:     1.MB,
+        md_parity:      Y2Storage::MdParity::LEFT_ASYMMETRIC,
+        md_level:       Y2Storage::MdLevel::RAID0,
+        name:           "/dev/md0",
+        numeric?:       numeric?,
+        sorted_devices: [sda1, sdb1]
       )
     end
 
@@ -129,7 +144,7 @@ describe Y2Storage::AutoinstProfile::RaidOptionsSection do
     end
 
     it "initializes device_order" do
-      skip ".new_from_storage is not fully implemented yet"
+      expect(raid_options.device_order).to eq(["/dev/sda1", "/dev/sdb1"])
     end
 
     context "when it is a named RAID" do


### PR DESCRIPTION
## Problem

The device_order was so far not saved in the AutoYaST profile during cloning.

- https://bugzilla.suse.com/show_bug.cgi?id=1083542

## Solution

Save the device_order.
