### PR TITLE
Force mocking x86_64 architecture for unit tests that depend on bcache

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 14 17:03:05 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Force mocking arch to x86_64 for unit tests that depend on bcache
+  (part of jsc#SLE-4329)
+- 4.1.59
+
+-------------------------------------------------------------------
 Thu Feb 14 12:49:25 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Limit bcache support to x86_64 arch (jsc#SLE-4329)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.58
+Version:	4.1.59
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/test/y2partitioner/actions/add_bcache_test.rb
+++ b/test/y2partitioner/actions/add_bcache_test.rb
@@ -29,6 +29,8 @@ require "y2partitioner/dialogs/bcache"
 describe Y2Partitioner::Actions::AddBcache do
   subject { described_class.new }
 
+  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+
   before do
     devicegraph_stub(scenario)
 

--- a/test/y2partitioner/actions/add_bcache_test.rb
+++ b/test/y2partitioner/actions/add_bcache_test.rb
@@ -29,7 +29,7 @@ require "y2partitioner/dialogs/bcache"
 describe Y2Partitioner::Actions::AddBcache do
   subject { described_class.new }
 
-  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
 
   before do
     devicegraph_stub(scenario)

--- a/test/y2partitioner/actions/delete_bcache_test.rb
+++ b/test/y2partitioner/actions/delete_bcache_test.rb
@@ -32,6 +32,8 @@ describe Y2Partitioner::Actions::DeleteBcache do
 
   subject { described_class.new(device) }
 
+  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+
   let(:scenario) { "bcache1.xml" }
 
   let(:device) { Y2Storage::BlkDevice.find_by_name(device_graph, device_name) }

--- a/test/y2partitioner/actions/delete_bcache_test.rb
+++ b/test/y2partitioner/actions/delete_bcache_test.rb
@@ -32,7 +32,7 @@ describe Y2Partitioner::Actions::DeleteBcache do
 
   subject { described_class.new(device) }
 
-  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
 
   let(:scenario) { "bcache1.xml" }
 

--- a/test/y2partitioner/actions/edit_blk_device_test.rb
+++ b/test/y2partitioner/actions/edit_blk_device_test.rb
@@ -161,6 +161,7 @@ describe Y2Partitioner::Actions::EditBlkDevice do
       end
 
       context "and the device is a bcache device" do
+        let(:architecture) { :x86_64 } # bcache is only supported on x86_64
         let(:scenario) { "bcache1.xml" }
         let(:dev_name) { "/dev/bcache1" }
 

--- a/test/y2partitioner/dialogs/bcache_test.rb
+++ b/test/y2partitioner/dialogs/bcache_test.rb
@@ -30,7 +30,7 @@ require "y2partitioner/dialogs/bcache"
 describe Y2Partitioner::Dialogs::Bcache do
   before { devicegraph_stub("bcache1.xml") }
 
-  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
   let(:suitable_backing) { fake_devicegraph.blk_devices }
   let(:suitable_caching) { fake_devicegraph.blk_devices + fake_devicegraph.bcache_csets }
 

--- a/test/y2partitioner/dialogs/bcache_test.rb
+++ b/test/y2partitioner/dialogs/bcache_test.rb
@@ -30,6 +30,7 @@ require "y2partitioner/dialogs/bcache"
 describe Y2Partitioner::Dialogs::Bcache do
   before { devicegraph_stub("bcache1.xml") }
 
+  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
   let(:suitable_backing) { fake_devicegraph.blk_devices }
   let(:suitable_caching) { fake_devicegraph.blk_devices + fake_devicegraph.bcache_csets }
 

--- a/test/y2partitioner/widgets/bcache_add_button_test.rb
+++ b/test/y2partitioner/widgets/bcache_add_button_test.rb
@@ -28,6 +28,8 @@ require "y2partitioner/widgets/bcache_add_button"
 describe Y2Partitioner::Widgets::BcacheAddButton do
   subject(:button) { described_class.new }
 
+  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+
   before do
     devicegraph_stub("bcache1.xml")
 

--- a/test/y2partitioner/widgets/bcache_add_button_test.rb
+++ b/test/y2partitioner/widgets/bcache_add_button_test.rb
@@ -28,7 +28,7 @@ require "y2partitioner/widgets/bcache_add_button"
 describe Y2Partitioner::Widgets::BcacheAddButton do
   subject(:button) { described_class.new }
 
-  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
 
   before do
     devicegraph_stub("bcache1.xml")

--- a/test/y2partitioner/widgets/bcache_device_description_test.rb
+++ b/test/y2partitioner/widgets/bcache_device_description_test.rb
@@ -28,7 +28,7 @@ require "y2partitioner/widgets/bcache_device_description"
 describe Y2Partitioner::Widgets::BcacheDeviceDescription do
   before { devicegraph_stub("bcache1.xml") }
 
-  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
 
   let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
 

--- a/test/y2partitioner/widgets/bcache_device_description_test.rb
+++ b/test/y2partitioner/widgets/bcache_device_description_test.rb
@@ -28,6 +28,8 @@ require "y2partitioner/widgets/bcache_device_description"
 describe Y2Partitioner::Widgets::BcacheDeviceDescription do
   before { devicegraph_stub("bcache1.xml") }
 
+  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+
   let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
 
   let(:bcache) { current_graph.bcaches.first }

--- a/test/y2partitioner/widgets/bcache_modify_button_test.rb
+++ b/test/y2partitioner/widgets/bcache_modify_button_test.rb
@@ -27,7 +27,7 @@ require "y2partitioner/widgets/bcache_modify_button"
 describe Y2Partitioner::Widgets::BcacheModifyButton do
   before { devicegraph_stub("bcache1.xml") }
 
-  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
   let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
   let(:device) { current_graph.bcaches.first }
 

--- a/test/y2partitioner/widgets/bcache_modify_button_test.rb
+++ b/test/y2partitioner/widgets/bcache_modify_button_test.rb
@@ -27,6 +27,7 @@ require "y2partitioner/widgets/bcache_modify_button"
 describe Y2Partitioner::Widgets::BcacheModifyButton do
   before { devicegraph_stub("bcache1.xml") }
 
+  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
   let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
   let(:device) { current_graph.bcaches.first }
 

--- a/test/y2partitioner/widgets/device_buttons_set_test.rb
+++ b/test/y2partitioner/widgets/device_buttons_set_test.rb
@@ -29,6 +29,7 @@ require "y2partitioner/widgets/overview"
 describe Y2Partitioner::Widgets::DeviceButtonsSet do
   before { devicegraph_stub(scenario) }
 
+  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
   let(:scenario) { "nested_md_raids" }
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
   let(:pager) { Y2Partitioner::Widgets::OverviewTreePager.new("hostname") }

--- a/test/y2partitioner/widgets/device_buttons_set_test.rb
+++ b/test/y2partitioner/widgets/device_buttons_set_test.rb
@@ -29,7 +29,7 @@ require "y2partitioner/widgets/overview"
 describe Y2Partitioner::Widgets::DeviceButtonsSet do
   before { devicegraph_stub(scenario) }
 
-  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
   let(:scenario) { "nested_md_raids" }
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
   let(:pager) { Y2Partitioner::Widgets::OverviewTreePager.new("hostname") }

--- a/test/y2partitioner/widgets/pages/bcache_test.rb
+++ b/test/y2partitioner/widgets/pages/bcache_test.rb
@@ -30,6 +30,8 @@ describe Y2Partitioner::Widgets::Pages::Bcache do
     devicegraph_stub(scenario)
   end
 
+  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+
   let(:scenario) { "bcache2.xml" }
 
   let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }

--- a/test/y2partitioner/widgets/pages/bcache_test.rb
+++ b/test/y2partitioner/widgets/pages/bcache_test.rb
@@ -30,7 +30,7 @@ describe Y2Partitioner::Widgets::Pages::Bcache do
     devicegraph_stub(scenario)
   end
 
-  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
 
   let(:scenario) { "bcache2.xml" }
 

--- a/test/y2partitioner/widgets/pages/bcaches_test.rb
+++ b/test/y2partitioner/widgets/pages/bcaches_test.rb
@@ -27,6 +27,9 @@ require "y2partitioner/widgets/pages"
 
 describe Y2Partitioner::Widgets::Pages::Bcaches do
   before { devicegraph_stub(scenario) }
+
+  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+
   let(:scenario) { "bcache1.xml" }
 
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }

--- a/test/y2partitioner/widgets/pages/bcaches_test.rb
+++ b/test/y2partitioner/widgets/pages/bcaches_test.rb
@@ -28,7 +28,7 @@ require "y2partitioner/widgets/pages"
 describe Y2Partitioner::Widgets::Pages::Bcaches do
   before { devicegraph_stub(scenario) }
 
-  let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
 
   let(:scenario) { "bcache1.xml" }
 

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -214,6 +214,7 @@ describe Y2Partitioner::Widgets::Pages::System do
     end
 
     context "when there are bcache devices" do
+      let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
 
       it "contains all bcache devices" do

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -214,7 +214,7 @@ describe Y2Partitioner::Widgets::Pages::System do
     end
 
     context "when there are bcache devices" do
-      let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+      let(:architecture) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
 
       it "contains all bcache devices" do

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -679,6 +679,7 @@ describe Y2Storage::BlkDevice do
   end
 
   describe "#bcache" do
+    let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
     let(:scenario) { "bcache2.xml" }
 
     context "when the device is not used as backing device by a bcache" do
@@ -810,6 +811,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "for a disk that is used as backing device for a bcache" do
+      let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/vdc" }
 
@@ -821,6 +823,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "for a disk that is used as caching device for a bcache" do
+      let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/vdb" }
 
@@ -832,6 +835,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "for a bcache device not used in an LVM or in a RAID" do
+      let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/bcache0" }
 
@@ -846,6 +850,7 @@ describe Y2Storage::BlkDevice do
 
   describe "#component_of_names" do
     context "component has name" do
+      let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/vdc" }
 
@@ -856,6 +861,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "component has display name" do
+      let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/vdb" }
 

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -679,7 +679,7 @@ describe Y2Storage::BlkDevice do
   end
 
   describe "#bcache" do
-    let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+    let(:architecture) { :x86_64 } # bcache is only supported on x86_64
     let(:scenario) { "bcache2.xml" }
 
     context "when the device is not used as backing device by a bcache" do
@@ -811,7 +811,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "for a disk that is used as backing device for a bcache" do
-      let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+      let(:architecture) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/vdc" }
 
@@ -823,7 +823,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "for a disk that is used as caching device for a bcache" do
-      let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+      let(:architecture) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/vdb" }
 
@@ -835,7 +835,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "for a bcache device not used in an LVM or in a RAID" do
-      let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+      let(:architecture) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/bcache0" }
 
@@ -850,7 +850,7 @@ describe Y2Storage::BlkDevice do
 
   describe "#component_of_names" do
     context "component has name" do
-      let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+      let(:architecture) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/vdc" }
 
@@ -861,7 +861,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "component has display name" do
-      let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+      let(:architecture) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/vdb" }
 

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -666,7 +666,7 @@ describe Y2Storage::Devicegraph do
   end
 
   describe "#remove_bcache" do
-    let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+    let(:architecture) { :x86_64 } # bcache is only supported on x86_64
     subject(:devicegraph) { Y2Storage::StorageManager.instance.staging }
 
     before do
@@ -926,7 +926,7 @@ describe Y2Storage::Devicegraph do
       fake_scenario("bcache1.xml")
     end
 
-    let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+    let(:architecture) { :x86_64 } # bcache is only supported on x86_64
     subject(:list) { fake_devicegraph.bcaches }
 
     it "returns an array of bcache devices" do
@@ -950,7 +950,7 @@ describe Y2Storage::Devicegraph do
       fake_scenario("bcache1.xml")
     end
 
-    let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
+    let(:architecture) { :x86_64 } # bcache is only supported on x86_64
     subject(:list) { fake_devicegraph.bcache_csets }
 
     it "returns an array of bcache csets" do

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -666,6 +666,7 @@ describe Y2Storage::Devicegraph do
   end
 
   describe "#remove_bcache" do
+    let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
     subject(:devicegraph) { Y2Storage::StorageManager.instance.staging }
 
     before do
@@ -925,6 +926,7 @@ describe Y2Storage::Devicegraph do
       fake_scenario("bcache1.xml")
     end
 
+    let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
     subject(:list) { fake_devicegraph.bcaches }
 
     it "returns an array of bcache devices" do
@@ -948,6 +950,7 @@ describe Y2Storage::Devicegraph do
       fake_scenario("bcache1.xml")
     end
 
+    let(:architecture ) { :x86_64 } # bcache is only supported on x86_64
     subject(:list) { fake_devicegraph.bcache_csets }
 
     it "returns an array of bcache csets" do


### PR DESCRIPTION
Unit tests fail on arch other than x86_64 because there is no more bcache support there.

Now forcing mocking arch to x86_64 for those unit tests that depend on bcache things; otherwise `fake_scenario` will get an exception _probed devicegraph not sanitized_.