### PR TITLE
Partitioner: button to activate crypt devices

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 19 14:40:11 UTC 2019 - ancor@suse.com
+
+- Partitioner: new option "Provide Crypt Passwords" (bsc#1113515).
+- 4.1.63
+
+-------------------------------------------------------------------
 Tue Feb 19 14:15:16 UTC 2019 - jlopez@suse.com
 
 - Partitioner: allow to edit bcache devices (part of fate#325346).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.62
+Version:	4.1.63
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/widgets/configure.rb
+++ b/src/lib/y2partitioner/widgets/configure.rb
@@ -71,6 +71,20 @@ module Y2Partitioner
         :redraw
       end
 
+      # @macro seeAbstractWidget
+      def help
+        # TRANSLATORS: help text for the Partitioner
+        _(
+          "<p>The <b>Configure</b> button offers several options to activate devices " \
+          "that were not detected by the initial system analysis. After activating the " \
+          "devices of the choosen technology, the system will be rescanned and all the " \
+          "information about storage devices will be refreshed. " \
+          "Thus, the <b>Provide Crypt Passwords</b> option is also useful when no " \
+          "encryption is involved, to activate devices of other technologies like LVM " \
+          "or Multipath.</p>"
+        )
+      end
+
     private
 
       # @return [Array<Yast::WidgetTerm>]

--- a/src/lib/y2partitioner/widgets/configure.rb
+++ b/src/lib/y2partitioner/widgets/configure.rb
@@ -66,8 +66,8 @@ module Y2Partitioner
         return nil unless action
         return nil unless warning_accepted?(action) && availability_ensured?(action)
 
-        Yast::WFM.call(action.client)
-        reprobe
+        Yast::WFM.call(action.client) if action.client
+        reprobe(activate: action.activate)
         :redraw
       end
 
@@ -183,6 +183,8 @@ module Y2Partitioner
 
         # Sorted list of actions
         ALL = [
+          new(:crypt, N_("Provide Crypt &Passwords..."), "yast-encrypted", nil,
+            ["cryptsetup"]),
           new(:iscsi, N_("Configure &iSCSI..."), "yast-iscsi-client", "iscsi-client",
             ["yast2-iscsi-client"]),
           new(:fcoe,  N_("Configure &FCoE..."),  "fcoe",              "fcoe-client",
@@ -202,6 +204,10 @@ module Y2Partitioner
         # are indexed in this constant in order to reuse the existing
         # translations from yast2-storage
         WARNING_TEXTS = {
+          crypt: N_(
+            "Rescanning crypt devices cancels all current changes.\n" \
+            "Really activate crypt devices?"
+          ),
           iscsi: N_(
             "Calling iSCSI configuration cancels all current changes.\n" \
             "Really call iSCSI configuration?"
@@ -274,6 +280,16 @@ module Y2Partitioner
         # @return [Boolean]
         def supported?
           S390_IDS.include?(id) ? Yast::Arch.s390 : true
+        end
+
+        # Value for the 'activate' argument of {Reprobe#reprobe}
+        #
+        # For most cases this returns nil, which implies simply honoring the
+        # default behavior.
+        #
+        # @return [Boolean, nil]
+        def activate
+          id == :crypt ? true : nil
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/rescan_devices_button.rb
+++ b/src/lib/y2partitioner/widgets/rescan_devices_button.rb
@@ -52,6 +52,15 @@ module Y2Partitioner
         :redraw
       end
 
+      # @macro seeAbstractWidget
+      def help
+        # TRANSLATORS: help text for the Partitioner
+        _(
+          "<p>The <b>Rescan Devices</b> button refreshes the information about storage " \
+          "devices.</p>"
+        )
+      end
+
     private
 
       def continue?

--- a/test/support/partitioner_reprobe_examples.rb
+++ b/test/support/partitioner_reprobe_examples.rb
@@ -51,3 +51,15 @@ RSpec.shared_examples "reprobing" do
     end
   end
 end
+
+RSpec.shared_examples "activation" do
+  it "runs activation (again)" do
+    expect(manager).to receive(:activate).and_return true
+    subject.handle(*handle_args)
+  end
+
+  it "raises an exception if activation fails" do
+    allow(manager).to receive(:activate).and_return false
+    expect { subject.handle(*handle_args) }.to raise_error(Y2Partitioner::ForcedAbortError)
+  end
+end

--- a/test/y2partitioner/widgets/configure_test.rb
+++ b/test/y2partitioner/widgets/configure_test.rb
@@ -67,8 +67,9 @@ describe Y2Partitioner::Widgets::Configure do
           it "returns a menu button with buttons for crypt, iSCI, FCoE, DASD, zFCP and XPRAM" do
             term = widget.contents
             expect(term.value).to eq :MenuButton
-            expect(menu_button_item_ids(term))
-              .to contain_exactly(:crypt, :iscsi, :fcoe, :dasd, :zfcp, :xpram)
+            expect(menu_button_item_ids(term)) .to contain_exactly(
+              :CryptAction, :IscsiAction, :FcoeAction, :DasdAction, :ZfcpAction, :XpramAction
+            )
           end
         end
 
@@ -78,8 +79,10 @@ describe Y2Partitioner::Widgets::Configure do
           it "returns a menu button with buttons only for the available clients" do
             term = widget.contents
             expect(term.value).to eq :MenuButton
-            expect(menu_button_item_ids(term)).to contain_exactly(:crypt, :fcoe, :zfcp, :xpram)
-            expect(menu_button_item_ids(term)).to_not include(:iscsi, :dasd)
+            expect(menu_button_item_ids(term)).to contain_exactly(
+              :CryptAction, :FcoeAction, :ZfcpAction, :XpramAction
+            )
+            expect(menu_button_item_ids(term)).to_not include(:IscsiAction, :DasdAction)
           end
         end
 
@@ -89,7 +92,7 @@ describe Y2Partitioner::Widgets::Configure do
           it "returns a menu button with 'Crypt Passwords' as the only option" do
             term = widget.contents
             expect(term.value).to eq :MenuButton
-            expect(menu_button_item_ids(term)).to eq [:crypt]
+            expect(menu_button_item_ids(term)).to eq [:CryptAction]
           end
         end
       end
@@ -103,7 +106,9 @@ describe Y2Partitioner::Widgets::Configure do
           it "returns a menu button with buttons for crypt, iSCI and FCoE" do
             term = widget.contents
             expect(term.value).to eq :MenuButton
-            expect(menu_button_item_ids(term)).to contain_exactly(:crypt, :iscsi, :fcoe)
+            expect(menu_button_item_ids(term)).to contain_exactly(
+              :CryptAction, :IscsiAction, :FcoeAction
+            )
           end
         end
 
@@ -113,8 +118,8 @@ describe Y2Partitioner::Widgets::Configure do
           it "returns a menu button with buttons only for the available clients" do
             term = widget.contents
             expect(term.value).to eq :MenuButton
-            expect(menu_button_item_ids(term)).to eq [:crypt, :fcoe]
-            expect(menu_button_item_ids(term)).to_not include(:iscsi)
+            expect(menu_button_item_ids(term)).to eq [:CryptAction, :FcoeAction]
+            expect(menu_button_item_ids(term)).to_not include(:IscsiAction)
           end
         end
 
@@ -124,7 +129,7 @@ describe Y2Partitioner::Widgets::Configure do
           it "returns a menu button with 'Crypt Passwords' as the only option" do
             term = widget.contents
             expect(term.value).to eq :MenuButton
-            expect(menu_button_item_ids(term)).to eq [:crypt]
+            expect(menu_button_item_ids(term)).to eq [:CryptAction]
           end
         end
       end
@@ -142,8 +147,9 @@ describe Y2Partitioner::Widgets::Configure do
           it "returns a menu button with buttons for all actions" do
             term = widget.contents
             expect(term.value).to eq :MenuButton
-            expect(menu_button_item_ids(term))
-              .to contain_exactly(:crypt, :iscsi, :fcoe, :dasd, :zfcp, :xpram)
+            expect(menu_button_item_ids(term)).to contain_exactly(
+              :CryptAction, :IscsiAction, :FcoeAction, :DasdAction, :ZfcpAction, :XpramAction
+            )
           end
         end
 
@@ -153,8 +159,9 @@ describe Y2Partitioner::Widgets::Configure do
           it "returns a menu button with buttons for all actions" do
             term = widget.contents
             expect(term.value).to eq :MenuButton
-            expect(menu_button_item_ids(term))
-              .to contain_exactly(:crypt, :iscsi, :fcoe, :dasd, :zfcp, :xpram)
+            expect(menu_button_item_ids(term)).to contain_exactly(
+              :CryptAction, :IscsiAction, :FcoeAction, :DasdAction, :ZfcpAction, :XpramAction
+            )
           end
         end
       end
@@ -168,7 +175,9 @@ describe Y2Partitioner::Widgets::Configure do
           it "returns a menu button with buttons for all supported actions (crypt, iSCI and FCoE)" do
             term = widget.contents
             expect(term.value).to eq :MenuButton
-            expect(menu_button_item_ids(term)).to contain_exactly(:crypt, :iscsi, :fcoe)
+            expect(menu_button_item_ids(term)).to contain_exactly(
+              :CryptAction, :IscsiAction, :FcoeAction
+            )
           end
         end
 
@@ -178,7 +187,9 @@ describe Y2Partitioner::Widgets::Configure do
           it "returns a menu button with buttons for all supported actions (crypt, iSCI and FCoE)" do
             term = widget.contents
             expect(term.value).to eq :MenuButton
-            expect(menu_button_item_ids(term)).to contain_exactly(:crypt, :iscsi, :fcoe)
+            expect(menu_button_item_ids(term)).to contain_exactly(
+              :CryptAction, :IscsiAction, :FcoeAction
+            )
           end
         end
       end
@@ -196,9 +207,9 @@ describe Y2Partitioner::Widgets::Configure do
     end
     let(:accepted) { false }
 
-    let(:handle_args) { [event_for(:fcoe)] }
+    let(:handle_args) { [event_for(:FcoeAction)] }
     let(:manager) { Y2Storage::StorageManager.instance }
-    let(:event) { event_for(:iscsi) }
+    let(:event) { event_for(:IscsiAction) }
 
     RSpec.shared_examples "configure nothing" do
       it "returns nil" do
@@ -225,8 +236,8 @@ describe Y2Partitioner::Widgets::Configure do
       it "displays the corresponding warning message" do
         expect(Yast::Popup).to receive(:YesNo).with(/FCoE/).ordered
         expect(Yast::Popup).to receive(:YesNo).with(/iSCSI/).ordered
-        widget.handle(event_for(:fcoe))
-        widget.handle(event_for(:iscsi))
+        widget.handle(event_for(:FcoeAction))
+        widget.handle(event_for(:IscsiAction))
       end
 
       context "if the user rejects the warning" do
@@ -246,7 +257,7 @@ describe Y2Partitioner::Widgets::Configure do
         let(:accepted) { true }
 
         context "for an action performed via a separate client" do
-          let(:event) { event_for(:iscsi) }
+          let(:event) { event_for(:IscsiAction) }
 
           it "calls the corresponding YaST client" do
             expect(Yast::WFM).to receive(:call).with("iscsi-client")
@@ -258,7 +269,7 @@ describe Y2Partitioner::Widgets::Configure do
         end
 
         context "for activation of crypt devices" do
-          let(:event) { event_for(:crypt) }
+          let(:event) { event_for(:CryptAction) }
 
           it "does not call any additional YaST client" do
             expect(Yast::WFM).to_not receive(:call)
@@ -274,6 +285,8 @@ describe Y2Partitioner::Widgets::Configure do
     context "in an already installed system" do
       let(:install) { false }
       let(:handle_args) { [event] }
+      # Ensure all actions are available
+      before { allow(Yast::Arch).to receive(:s390).and_return true }
 
       include_examples "show configure warning"
 
@@ -292,8 +305,8 @@ describe Y2Partitioner::Widgets::Configure do
             .to receive(:CheckAndInstallPackages).with(["yast2-s390"]).ordered
           expect(Yast::PackageSystem)
             .to receive(:CheckAndInstallPackages).with(["yast2-fcoe-client"]).ordered
-          widget.handle(event_for(:dasd))
-          widget.handle(event_for(:fcoe))
+          widget.handle(event_for(:DasdAction))
+          widget.handle(event_for(:FcoeAction))
         end
 
         context "if the packages were not installed" do
@@ -306,7 +319,7 @@ describe Y2Partitioner::Widgets::Configure do
           let(:installed_pkgs) { true }
 
           context "for an action performed via a separate client" do
-            let(:event) { event_for(:iscsi) }
+            let(:event) { event_for(:IscsiAction) }
 
             it "calls the corresponding YaST client" do
               expect(Yast::WFM).to receive(:call).with("iscsi-client")
@@ -322,7 +335,7 @@ describe Y2Partitioner::Widgets::Configure do
           end
 
           context "for activation of crypt devices" do
-            let(:event) { event_for(:crypt) }
+            let(:event) { event_for(:CryptAction) }
             before { allow(manager).to receive(:activate).and_return true }
 
             it "does not call any additional YaST client" do


### PR DESCRIPTION
## Problem

When executed on an already installed system (i.e. not in installation), the Partitioner of storage-ng does not contain any way to activate pre-existing but inactive LUKs device.

The old partitioner (pre-ng) didn't executed an activation by default either, but it offered two ways of activating such device so it could be mounted or used in any other way.

1) The user can click on "Edit" for an encrypted partition and then, in the first screen of the Edit wizard, select to mount the existing file-system. In that case, the next step of the Edit wizard consists on asking the password and activating the existing LUKS.

2) There is also a general option "Provide Crypt Passwords" that is available in  "Configure..." just alongside the similar "Configure Multipath" also used to activate inactive devices (Multipath devices instead of LUKS ones).

See more in the following links 

- [bsc#1113515](https://bugzilla.suse.com/show_bug.cgi?id=1113515)
- [Trello card](https://trello.com/c/HVqpFjMJ)

## Solution

Due to fundamental differences in how activation of devices works in storage-ng, solution 1 cannot be re-implemented.

This pull request re-implements solution 2. But due to the mentioned differences in approach, the "Provide Crypt Passwords" button added in this pull request:

- activates all kind of devices, not only the crypt ones
- refreshes everything (i.e. reprobes the whole devicegraph)

## Testing

- Tested manually
- Unit test added

## Screenshots

![activate-crypt](https://user-images.githubusercontent.com/3638289/52950577-e194cf80-337f-11e9-93dd-6b19eddf9c87.png)

None of the options of "Configure" and "Rescan Devices" buttons has never been explained in the help (not even in the old storage). Let's fix it.

![activate-help](https://user-images.githubusercontent.com/3638289/53074774-e2e30b00-34eb-11e9-9e22-3ff0b2f01521.png)



