### PR TITLE
Add tab for caching set devices

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 20 09:35:48 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: add new tab in Bcache section to show all caching
+  set devices (part of fate#325346).
+- 4.1.64
+
+-------------------------------------------------------------------
 Tue Feb 19 14:40:11 UTC 2019 - ancor@suse.com
 
 - Partitioner: new option "Provide Crypt Passwords" (bsc#1113515).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.63
+Version:	4.1.64
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -19,18 +19,21 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "cwm/widget"
 require "y2partitioner/icons"
 require "y2partitioner/ui_state"
-require "y2partitioner/widgets/pages/devices_table"
 require "y2partitioner/widgets/bcache_add_button"
+require "y2partitioner/widgets/device_buttons_set"
+require "y2partitioner/widgets/configurable_blk_devices_table"
 
 module Y2Partitioner
   module Widgets
     module Pages
-      # A Page for bcache devices and its partitions. It contains a {ConfigurableBlkDevicesTable}
-      class Bcaches < DevicesTable
-        include Yast::I18n
-
+      # A Page for bcache devices
+      #
+      # It contains two tabs: one tab with a list of bcache devices and another
+      # tab with the list of caching sets.
+      class Bcaches < CWM::Page
         # Constructor
         #
         # @param bcaches [Array<Y2Storage::Bcache>]
@@ -38,8 +41,8 @@ module Y2Partitioner
         def initialize(bcaches, pager)
           textdomain "storage"
 
-          super(pager)
           @bcaches = bcaches
+          @pager = pager
         end
 
         # @macro seeAbstractWidget
@@ -47,14 +50,89 @@ module Y2Partitioner
           UIState.instance.bcache_label
         end
 
+        # @macro seeCustomWidget
+        def contents
+          @contents ||= VBox(
+            Left(
+              HBox(
+                Image(icon, ""),
+                Heading(label)
+              )
+            ),
+            tabs
+          )
+        end
+
+        # @macro seeAbstractWidget
+        def init
+          # Start always in the first tab
+          tabs.switch_page(tabs.initial_page)
+        end
+
       private
 
-        # @return [Array<Y2Storage::BlkDevice>]
+        # Page icon
+        #
+        # @return [String]
+        def icon
+          Icons.small_icon(Icons::BCACHE)
+        end
+
+        # Tabs to show
+        #
+        # @return [Array<CWM::Tab>]
+        def tabs
+          @tabs ||= Tabs.new(
+            BcachesTab.new(@bcaches, @pager),
+            BcacheCsetsTab.new(@pager)
+          )
+        end
+      end
+
+      # A Tab for the list of bcache devices
+      class BcachesTab < CWM::Tab
+        # @return [Array<Y2Storage::Bcache>]
         attr_reader :bcaches
 
-        # @see DevicesTable
-        def icon
-          Icons::BCACHE
+        # @return [CWM::TreePager]
+        attr_reader :pager
+
+        # Constructor
+        #
+        # @param bcaches [Array<Y2Storage::Bcache>]
+        # @param pager [CWM::TreePager]
+        def initialize(bcaches, pager)
+          @bcaches = bcaches
+          @pager = pager
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Bcache Devices")
+        end
+
+        # @macro seeCustomWidget
+        def contents
+          @contents ||=
+            VBox(
+              table,
+              Left(device_buttons),
+              Right(table_buttons)
+            )
+        end
+
+        # Table to list all bcache devices and their partitions
+        #
+        # @return [Widgets::ConfigurableBlkDevicesTable]
+        def table
+          @table ||= ConfigurableBlkDevicesTable.new(devices, pager, device_buttons)
+        end
+
+        # Widget with the dynamic set of buttons for the selected row
+        #
+        # @return [DeviceButtonsSet]
+        def device_buttons
+          @device_buttons ||= DeviceButtonsSet.new(pager)
         end
 
         # @see DevicesTable
@@ -70,6 +148,114 @@ module Y2Partitioner
             devices << bcache
             devices.concat(bcache.partitions)
           end
+        end
+      end
+
+      # A Tab for the list of caching set devices
+      class BcacheCsetsTab < CWM::Tab
+        # @return [CWM::TreePager]
+        attr_reader :pager
+
+        # Constructor
+        #
+        # @param pager [CWM::TreePager]
+        def initialize(pager)
+          @pager = pager
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Caching Set Devices")
+        end
+
+        # @macro seeCustomWidget
+        def contents
+          @contents ||= VBox(table)
+        end
+
+        # Table to list all caching set devices
+        #
+        # @return [BcacheCsetsTable]
+        def table
+          @table ||= BcacheCsetsTable.new(devices, pager)
+        end
+
+        # Returns all caching set devices
+        #
+        # @return [Array<Y2Storage::BcacheCset>]
+        def devices
+          DeviceGraphs.instance.current.bcache_csets
+        end
+      end
+
+      # Table for caching set devices
+      class BcacheCsetsTable < ConfigurableBlkDevicesTable
+        # Constructor
+        #
+        # @param devices [Array<Y2Storage::BcacheCsets>] see {#devices}
+        # @param pager [CWM::Pager] see {#pager}
+        # @param buttons_set [DeviceButtonsSet] see {#buttons_set}
+        def initialize(devices, pager, buttons_set = nil)
+          textdomain "storage"
+
+          super
+          show_columns(:caching_device, :size, :uuid, :used_by)
+        end
+
+        # Column label
+        #
+        # @return [String]
+        def caching_device_title
+          # TRANSLATORS: table column label.
+          _("Caching Device")
+        end
+
+        # Column label
+        #
+        # @return [String]
+        def uuid_title
+          # TRANSLATORS: table column label.
+          _("UUID")
+        end
+
+        # Column label
+        #
+        # @return [String]
+        def used_by_title
+          # TRANSLATORS: table column label.
+          _("Used By")
+        end
+
+        # Column value
+        #
+        # @param device [Y2Storage::BcacheCset]
+        # @return [String] e.g., "/dev/sda1"
+        def caching_device_value(device)
+          device.blk_devices.first.name
+        end
+
+        # Column value
+        #
+        # @param device [Y2Storage::BcacheCset]
+        # @return [String] e.g., "2.00 GiB"
+        def size_value(device)
+          device.blk_devices.first.size.to_human_string
+        end
+
+        # Column value
+        #
+        # @param device [Y2Storage::BcacheCset]
+        # @return [String] e.g., "111222333-444-55"
+        def uuid_value(device)
+          device.uuid
+        end
+
+        # Column value
+        #
+        # @param device [Y2Storage::BcacheCset]
+        # @return [String] e.g., "/dev/bcache0, /dev/bcache1"
+        def used_by_value(device)
+          device.bcaches.map(&:name).join(", ")
         end
       end
     end


### PR DESCRIPTION
## Problem

The Expert Partitioner shows the bcache devices, but  there is no way to see all the caching set devices. 

- https://jira.suse.de/browse/SLE-4329
- https://trello.com/c/NbiTkMzT/689-1-tab-to-display-the-bcache-csets


## Solution

The Bcache section of the Expert Partitioner has now two tabs instead of the list of bcache devices. The first tab (with the label `Bcache Devices`) shows the former list of bcache devices. The second tab (with label `Caching Set Devices`) lists all existing caching sets.

## Testing

- Added unit tests
- Tested manually

## Screenshots

![virtualbox_opensuse tumbleweed_20_02_2019_09_39_21](https://user-images.githubusercontent.com/1112304/53081794-71a75600-34f3-11e9-8bea-4e8f8305ba7a.png)


