### PR TITLE
handle device_order for MD RAIDs during installation

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 18 14:54:15 CET 2019 - aschnell@suse.com
+
+- AutoYaST: handle device_order for MD RAIDs during installation
+  (bsc#1083542)
+- 4.1.60
+
+-------------------------------------------------------------------
 Thu Feb 14 17:03:05 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Force mocking arch to x86_64 for unit tests that depend on bcache

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.59
+Version:	4.1.60
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/planned/md.rb
+++ b/src/lib/y2storage/planned/md.rb
@@ -96,9 +96,7 @@ module Y2Storage
             included + missing
           end
 
-        sorted.each do |device|
-          md_device.add_device(device)
-        end
+        md_device.sorted_devices = sorted
       end
 
       # Whether the given name matches the name of the planned MD

--- a/src/lib/y2storage/proposal/autoinst_md_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_md_planner.rb
@@ -119,6 +119,7 @@ module Y2Storage
         md.name = raid_options.raid_name if raid_options.raid_name
         md.chunk_size = chunk_size_from_string(raid_options.chunk_size) if raid_options.chunk_size
         md.md_parity = MdParity.find(raid_options.parity_algorithm) if raid_options.parity_algorithm
+        md.devices_order = raid_options.device_order if !raid_options.device_order.empty?
       end
 
       # Sets 'reusing' attributes for a MD RAID

--- a/test/y2storage/planned/md_test.rb
+++ b/test/y2storage/planned/md_test.rb
@@ -36,16 +36,14 @@ describe Y2Storage::Planned::Md do
     let(:real_md) { double("Y2Storage::Md") }
 
     it "calls Y2Storage::Md#add_device for all the devices" do
-      expect(real_md).to receive(:add_device).exactly(4).times
+      expect(real_md).to receive(:sorted_devices=).once
+
       planned_md.add_devices(real_md, devices)
     end
 
     context "if #devices_order is not set" do
       it "adds the devices in name's alphabetical order" do
-        expect(real_md).to receive(:add_device).with(sda1).ordered
-        expect(real_md).to receive(:add_device).with(sda2).ordered
-        expect(real_md).to receive(:add_device).with(sdb1).ordered
-        expect(real_md).to receive(:add_device).with(sdb2).ordered
+        expect(real_md).to receive(:sorted_devices=).with([sda1, sda2, sdb1, sdb2]).once
 
         planned_md.add_devices(real_md, devices)
       end
@@ -57,10 +55,7 @@ describe Y2Storage::Planned::Md do
       end
 
       it "adds the devices in the specified order" do
-        expect(real_md).to receive(:add_device).with(sdb2).ordered
-        expect(real_md).to receive(:add_device).with(sda1).ordered
-        expect(real_md).to receive(:add_device).with(sda2).ordered
-        expect(real_md).to receive(:add_device).with(sdb1).ordered
+        expect(real_md).to receive(:sorted_devices=).with([sdb2, sda1, sda2, sdb1]).once
 
         planned_md.add_devices(real_md, devices)
       end
@@ -71,16 +66,14 @@ describe Y2Storage::Planned::Md do
         end
 
         it "adds the devices in the specified order" do
-          expect(real_md).to receive(:add_device).with(sdb2).ordered
-          expect(real_md).to receive(:add_device).with(sda1).ordered
-          expect(real_md).to receive(:add_device).with(sda2).ordered
-          expect(real_md).to receive(:add_device).with(sdb1).ordered
+          expect(real_md).to receive(:sorted_devices=).with([sdb2, sda1, sda2, sdb1]).once
 
           planned_md.add_devices(real_md, devices)
         end
 
         it "does not try to add additional devices" do
-          expect(real_md).to receive(:add_device).exactly(4).times
+          expect(real_md).to receive(:sorted_devices=).once
+
           planned_md.add_devices(real_md, devices)
         end
       end
@@ -89,15 +82,13 @@ describe Y2Storage::Planned::Md do
         before { planned_md.devices_order = ["/dev/sdb2", "/dev/sda2"] }
 
         it "adds all the devices" do
-          expect(real_md).to receive(:add_device).exactly(4).times
+          expect(real_md).to receive(:sorted_devices=).once
+
           planned_md.add_devices(real_md, devices)
         end
 
         it "adds first the sorted devices and then the rest (alphabetically)" do
-          expect(real_md).to receive(:add_device).with(sdb2).ordered
-          expect(real_md).to receive(:add_device).with(sda2).ordered
-          expect(real_md).to receive(:add_device).with(sda1).ordered
-          expect(real_md).to receive(:add_device).with(sdb1).ordered
+          expect(real_md).to receive(:sorted_devices=).with([sdb2, sda2, sda1, sdb1]).once
 
           planned_md.add_devices(real_md, devices)
         end


### PR DESCRIPTION
## Problem

The device order for MD RAIDs was not handled by AutoYaST during installation.

https://bugzilla.suse.com/show_bug.cgi?id=1083542

## Solution

Handle the device order during installation.

## Testing

- Extended unit test
- Tested manually
