### PR TITLE
Help Texts for Guided Setup

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 19 13:39:49 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added help texts for guided setup (bsc#1121801)
+- 4.1.61
+
+-------------------------------------------------------------------
 Mon Feb 18 14:54:15 CET 2019 - aschnell@suse.com
 
 - AutoYaST: handle device_order for MD RAIDs during installation

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.60
+Version:	4.1.61
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/dialogs/guided_setup/select_disks.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_disks.rb
@@ -75,6 +75,26 @@ module Y2Storage
           settings.candidate_devices = selected_disks.map(&:name)
         end
 
+        def help_text
+          # TRANSLATORS: Help text for guided storage setup
+          _(
+            "<p>" \
+            "Select the disks to install on." \
+            "</p><p>" \
+            "In later dialogs, you can select which of those disks " \
+            "will be used for the root filesystem and what to do with " \
+            "any existing Linux, Windows or other partitions (keep, " \
+            "remove, sometimes resize)." \
+            "</p><p>" \
+            "How many of the disks you select here will actually be used " \
+            "depends on the exact scenario you choose (LVM, with or " \
+            "without separate home partition etc.)." \
+            "</p><p>" \
+            "Disks that are not selected here remain completely untouched." \
+            "</p>"
+          )
+        end
+
       private
 
         def valid?

--- a/src/lib/y2storage/dialogs/guided_setup/select_filesystem/base.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_filesystem/base.rb
@@ -38,6 +38,18 @@ module Y2Storage
           def dialog_title
             _("Filesystem Options")
           end
+
+          def help_text
+            settings.lvm ? help_text_for_volumes : help_text_for_partitions
+          end
+
+          def help_text_for_volumes
+            _("Select the filesystem type for each of the volumes.")
+          end
+
+          def help_text_for_partitions
+            _("Select the filesystem type for each of the partitions.")
+          end
         end
       end
     end

--- a/src/lib/y2storage/dialogs/guided_setup/select_root_disk.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_root_disk.rb
@@ -161,6 +161,43 @@ module Y2Storage
           update_windows_settings if activate_windows_actions?
         end
 
+        def help_text
+          # TRANSLATORS: Help text for root disk selection
+          msg = _(
+            "<p>" \
+            "Select the disk where to create the root filesystem. " \
+            "</p><p>" \
+            "This is also the disk where any boot-related partitions " \
+            "will be created as necessary: /boot, ESP (EFI System " \
+            "Partition), BIOS-Grub. " \
+            "That means that this disk should be usable by the machine's " \
+            "BIOS / firmware." \
+            "</p><p>" \
+            "In this dialog you can also choose what to do with existing partitions:" \
+            "</p><p>" \
+            "<ul>" \
+            "<li>Do not modify (keep them as they are)</li>" \
+            "<li>Remove if needed</li>" \
+            "<li>Remove even if not needed (always remove)</li>" \
+            "</ul>"
+          )
+
+          # TRANSLATORS: Help text for root disk selection, continued
+          msg << _(
+            "<ul>" \
+            "<li>Resize if needed (Windows partitions only)</li>" \
+            "<li>Resize or remove if needed (Windows partitions only)</li>" \
+            "</ul>" \
+            "<p>" \
+            "That last option means to try to resize the Windows partition(s) to " \
+            "make enough disk space available for Linux, but if that is not " \
+            "enough, completely delete the Windows partition." \
+            "</p>"
+          ) if activate_windows_actions?
+
+          msg
+        end
+
       private
 
         def update_windows_settings

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -107,6 +107,44 @@ module Y2Storage
           settings.encryption_password = password
         end
 
+        # rubocop:disable Metrics/MethodLength
+        def help_text
+          # TRANSLATORS: Help text for the partitioning scheme (LVM / encryption)
+          _(
+            "<p>" \
+            "Select the parititioning scheme:" \
+            "</p><p>" \
+            "<ul>" \
+            "<li>Plain partitions (no LVM), the simple traditional way</li>" \
+            "<li>LVM (Logical Volume Management): " \
+            "<p>" \
+            "This is a more flexible way of managing disk space. " \
+            "</p><p>" \
+            "You can spread single filesystems over multiple disks and add " \
+            "(or, to some extent, remove) disks later as necessary. " \
+            "</p><p>" \
+            "You define PVs (Physical Volumes) from partitions or whole disks " \
+            "and combine them into VGs (Volume Groups) that serve as storage " \
+            "pools. You can create LVs (logical volumes) to create filesystems " \
+            "(Btrfs, Ext2/3/4, XFS) on." \
+            "</p><p>" \
+            "In this <i>Guided Setup</i>, all this is done for you for the " \
+            "standard filesystem layout if you check <b>Enable LVM</b>." \
+            "</li>" \
+            "</ul>" \
+            "</p><p>" \
+            "<b>Enable Disk Encryption</b> (with or without LVM) adds a LUKS " \
+            " disk encryption layer to the partitioning setup. " \
+            "Notice that you will have to enter the correct password each time " \
+            "you boot the system. " \
+            "</p><p>" \
+            "<i>If you lose the password, there is no way to recover it, " \
+            "so make sure not to lose it!</i>" \
+            "</p>"
+          )
+          # rubocop:enable Metrics/MethodLength
+        end
+
       private
 
         def valid?


### PR DESCRIPTION
## Problem

There were no help texts yet in the _guided setup_.

- Trello: https://trello.com/c/iCjvewN0/

- Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1121801


## Testing

Manually tested with the proposal test client:

```
/sbin/yast2 ./proposal_testing.rb ../../test/data/devicegraphs/windows-pc.yml
```

(or any other suitable YAML or XML devicegraph)


## Screenshots

![help-text-01](https://user-images.githubusercontent.com/11538225/53019702-9d73fe80-3455-11e9-9d03-f6f7a0d2678d.png)

If there are Windows partitions that can be resized, this can contain two more lines that refer to the resize options.

![help-text-02](https://user-images.githubusercontent.com/11538225/53019705-a06eef00-3455-11e9-8f44-28a270f205a3.png)



![help-text-03](https://user-images.githubusercontent.com/11538225/53019711-a4027600-3455-11e9-8970-a62e3e72766d.png)

This is a bit lame; in particular, it does not explain the pros and cons of the different filesystem types. It also does not explain why and when a user would want a separate /home partition and the pros and cons of Btrfs snapshots.

The problem with that is that those widges are created quite dynamically, depending on the settings on control.xml. It would be pretty awkward to explain things that are not available to the user if they are not configured for the product; and we'd have to do it for both _legacy_ and _ng_ settings.

But at least this is conistent with the help text for the initial proposal dialog:

![help-text-proposal](https://user-images.githubusercontent.com/11538225/53019715-a795fd00-3455-11e9-8d6b-0066f70e0e86.png)

## Unit Tests

`rake test:unit` runs without problems locally; it's only in Travis where some recent changes to libstorage-ng about Bcache have not arrived yet.