### PR TITLE
Suggest /boot/efi as Mount Point for ESP in Partitioner

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 20 16:39:13 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Suggest /boot/efi as the mount point for EFI System Partitions
+  (bsc#1088120)
+- 4.1.66
+
+-------------------------------------------------------------------
 Wed Feb 20 11:55:30 UTC 2019 - jreidinger@suse.com
 
 - filesystem label is kept when using existing partitioning

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.65
+Version:	4.1.66
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -404,9 +404,17 @@ module Y2Partitioner
         #
         # @return [Array<String>]
         def mount_paths
-          mount_paths = all_mount_paths - mounted_paths
-          mount_paths.unshift("swap") if filesystem && filesystem.type.is?(:swap)
-          mount_paths
+          mount_paths = [suggested_mount_path] + all_mount_paths - mounted_paths
+          mount_paths.compact.uniq
+        end
+
+        # Return a suggested mount path based on the properties of this volume
+        #
+        # @return [String, nil]
+        def suggested_mount_path
+          return "swap" if filesystem_type && filesystem_type.is?(:swap)
+          return "/boot/efi" if partition_id && partition_id.is?(:esp)
+          nil
         end
 
         # All paths used by the preexisting subvolumes (those that will not be
@@ -567,7 +575,7 @@ module Y2Partitioner
         end
 
         # This implements the code that used to live in
-        # Yast::Filesystems::SuggestMPoints (whatever the rationle behind those
+        # Yast::Filesystems::SuggestMPoints (whatever the rationale behind those
         # mount paths was back then) with the only exception mentioned in
         # {#booting_paths}
         #

--- a/src/lib/y2storage/dialogs/guided_setup/select_root_disk.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_root_disk.rb
@@ -167,8 +167,8 @@ module Y2Storage
             "<p>" \
             "Select the disk where to create the root filesystem. " \
             "</p><p>" \
-            "This is also the disk where any boot-related partitions " \
-            "will be created as necessary: /boot, ESP (EFI System " \
+            "This is also the disk where boot-related partitions " \
+            "will typically be created as necessary: /boot, ESP (EFI System " \
             "Partition), BIOS-Grub. " \
             "That means that this disk should be usable by the machine's " \
             "BIOS / firmware." \

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -112,7 +112,7 @@ module Y2Storage
           # TRANSLATORS: Help text for the partitioning scheme (LVM / encryption)
           _(
             "<p>" \
-            "Select the parititioning scheme:" \
+            "Select the partitioning scheme:" \
             "</p><p>" \
             "<ul>" \
             "<li>Plain partitions (no LVM), the simple traditional way</li>" \

--- a/test/y2partitioner/actions/controllers/filesystem_test.rb
+++ b/test/y2partitioner/actions/controllers/filesystem_test.rb
@@ -82,7 +82,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
       end
     end
 
-    context "when the currently editing device has not a filesystem" do
+    context "when the currently editing device does not have a filesystem" do
       before do
         allow(device).to receive(:filesystem).and_return(nil)
         allow(subject).to receive(:blk_device).and_return(device)
@@ -95,7 +95,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
   end
 
   describe "#to_be_formatted?" do
-    context "when the currently editing device has not a filesystem" do
+    context "when the currently editing device does not have a filesystem" do
       before do
         allow(device).to receive(:filesystem).and_return(nil)
         allow(subject).to receive(:blk_device).and_return(device)
@@ -132,7 +132,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
       end
     end
 
-    context "when the currently editing device has not a filesystem that existed previously" do
+    context "when the currently editing device does not have a filesystem that existed previously" do
       before do
         allow(subject).to receive(:encrypt).and_return(encrypt)
         allow(device).to receive(:encrypted?).and_return(encrypted)
@@ -193,7 +193,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
       end
     end
 
-    context "when the currently editing device has not a filesystem" do
+    context "when the currently editing device does not have a filesystem" do
       before do
         allow(device).to receive(:filesystem).and_return(nil)
         allow(subject).to receive(:blk_device).and_return(device)
@@ -224,7 +224,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
       end
     end
 
-    context "when the currently editing device has not a filesystem" do
+    context "when the currently editing device does not have a filesystem" do
       before do
         allow(device).to receive(:filesystem).and_return(nil)
         allow(subject).to receive(:blk_device).and_return(device)
@@ -604,7 +604,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
   end
 
   describe "#dont_format" do
-    context "when the currently editing device has not a filesystem" do
+    context "when the currently editing device does not have a filesystem" do
       before do
         device.remove_descendants
       end
@@ -638,7 +638,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
         end
       end
 
-      context "and there was not a previous filesystem" do
+      context "and there was no previous filesystem" do
         before do
           device.remove_descendants
         end

--- a/test/y2partitioner/actions/controllers/filesystem_test.rb
+++ b/test/y2partitioner/actions/controllers/filesystem_test.rb
@@ -1707,4 +1707,35 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
       end
     end
   end
+
+  describe "#suggested_mount_path" do
+    context "with an unmounted ESP" do
+      let(:scenario) { "efi_not_mounted" }
+      let(:dev_name) { "/dev/sda1" }
+
+      it "suggests /boot/efi as the mount point" do
+        expect(subject.suggested_mount_path).to be == "/boot/efi"
+        expect(subject.mount_paths.first).to be == "/boot/efi"
+      end
+    end
+
+    context "with swap partitions" do
+      let(:scenario) { "swaps" }
+      let(:dev_name) { "/dev/sda2" }
+
+      it "suggests swap as the mount point" do
+        expect(subject.suggested_mount_path).to be == "swap"
+        expect(subject.mount_paths.first).to be == "swap"
+      end
+    end
+
+    context "for other partitions" do
+      let(:scenario) { "mixed_disks" }
+      let(:dev_name) { "/dev/sda2" }
+
+      it "does not suggests a mount point" do
+        expect(subject.suggested_mount_path).to be_nil
+      end
+    end
+  end
 end

--- a/test/y2partitioner/dialogs/btrfs_subvolume_test.rb
+++ b/test/y2partitioner/dialogs/btrfs_subvolume_test.rb
@@ -103,7 +103,7 @@ describe Y2Partitioner::Dialogs::BtrfsSubvolume do
       end
 
       context "when a path is entered" do
-        context "and the filesystem has not a specific subvolumes prefix" do
+        context "and the filesystem does not have a specific subvolumes prefix" do
           let(:dev_name) { "/dev/sdd1" }
 
           context "and the entered path is an absolute path" do

--- a/test/y2partitioner/widgets/overview_test.rb
+++ b/test/y2partitioner/widgets/overview_test.rb
@@ -159,7 +159,7 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
         expect(sde_page).to_not be_nil
       end
 
-      it "disks pager has not a page for disks belonging to a multipath" do
+      it "disks pager does not have a page for disks belonging to a multipath" do
         sda_page = disks_pages.find { |p| p.device.name == "/dev/sda" }
         expect(sda_page).to be_nil
       end
@@ -209,7 +209,7 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
         expect(sda_page).to_not be_nil
       end
 
-      it "disks pager has not a page for disks belonging to a BIOS RAID" do
+      it "disks pager does not have a page for disks belonging to a BIOS RAID" do
         sdb_page = disks_pages.find { |p| p.device.name == "/dev/sdb" }
         expect(sdb_page).to be_nil
 

--- a/test/y2storage/dialogs/guided_setup/select_root_disk_test.rb
+++ b/test/y2storage/dialogs/guided_setup/select_root_disk_test.rb
@@ -72,7 +72,7 @@ describe Y2Storage::Dialogs::GuidedSetup::SelectRootDisk do
       select_widget(:other_delete_mode, :all)
     end
 
-    context "when settings has not a root disk" do
+    context "when settings does not have a root disk" do
       before { settings.root_device = nil }
 
       it "selects 'any' option by default" do

--- a/test/y2storage/disk_test.rb
+++ b/test/y2storage/disk_test.rb
@@ -552,7 +552,7 @@ describe Y2Storage::Disk do
       end
     end
 
-    context "when the device has not a partition table" do
+    context "when the device does not have a partition table" do
       let(:scenario) { "empty_hard_disk_15GiB" }
 
       let(:disk_name) { "/dev/sda" }

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -180,7 +180,7 @@ describe Y2Storage::Filesystems::Btrfs do
       end
     end
 
-    context "when the filesystem has not a subvolume with the indicated path" do
+    context "when the filesystem does not have a subvolume with the indicated path" do
       let(:path) { "@/foo" }
 
       it "does not delete any subvolume" do

--- a/test/y2storage/partition_test.rb
+++ b/test/y2storage/partition_test.rb
@@ -514,7 +514,7 @@ describe Y2Storage::Partition do
 
     subject(:partition) { fake_devicegraph.find_by_name(device_name) }
 
-    context "when has not a swap id" do
+    context "when does not have a swap id" do
       let(:device_name) { "/dev/sda3" }
 
       it "returns false" do


### PR DESCRIPTION
## Problem

This is about bringing back a convenience function in the partitioner:

When adding an ESP (EFI System Partition), the partitioner should automatically suggest `/boot/efi` as the mount point.

- Trello: https://trello.com/c/qatyxSB8/
- Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1088120

## Solution

Refactored the one other similar special case into a new function _suggested_mount_path_ in the controller class of that partitioner dialog.

This now automatically suggests a mount point _swap_ for swap filesystems and _/boot/efi_ for ESPs.

Please notice that this is unconditional whether or not the system currently uses EFI boot (which is consistent with the behaviour of creating a new ESP): The user might be in the process of setting up the system for EFI boot for which he will need the ESP.


## Unrelated Fix: Guided Setup Help Texts

This is aftermath of https://github.com/yast/yast-storage-ng/pull/852 after it was already merged. See the discussion in that PR.
