### PR TITLE
Add missing arch mocking for bcache tests

### DIFF
--- a/test/y2partitioner/actions/controllers/bcache_test.rb
+++ b/test/y2partitioner/actions/controllers/bcache_test.rb
@@ -30,6 +30,9 @@ describe Y2Partitioner::Actions::Controllers::Bcache do
     devicegraph_stub(scenario)
   end
 
+  # Bcache is only supported on x86
+  let(:architecture) { :x86_64 }
+
   subject(:controller) { described_class.new(device) }
 
   let(:device) { nil }

--- a/test/y2partitioner/actions/edit_bcache_test.rb
+++ b/test/y2partitioner/actions/edit_bcache_test.rb
@@ -41,6 +41,9 @@ describe Y2Partitioner::Actions::EditBcache do
       .and_return(selected_options)
   end
 
+  # Bcache is only supported on x86
+  let(:architecture) { :x86_64 }
+
   let(:dialog_result) { nil }
 
   let(:selected_caching) { nil }

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -223,6 +223,9 @@ describe Y2Partitioner::UIState do
     end
 
     context "when the user has opened a Bcache page" do
+      # Bcache is only supported on x86
+      let(:architecture) { :x86_64 }
+
       let(:scenario) { "bcache1.xml" }
       let(:device) { fake_devicegraph.find_by_name("/dev/bcache0") }
       let(:another_bcache) { fake_devicegraph.find_by_name("/dev/bcache1") }

--- a/test/y2partitioner/widgets/bcache_edit_button_test.rb
+++ b/test/y2partitioner/widgets/bcache_edit_button_test.rb
@@ -32,6 +32,9 @@ describe Y2Partitioner::Widgets::BcacheEditButton do
     allow(Y2Partitioner::Actions::EditBcache).to receive(:new).and_return(action)
   end
 
+  # Bcache is only supported on x86
+  let(:architecture) { :x86_64 }
+
   let(:action) { instance_double(Y2Partitioner::Actions::EditBcache, run: :finish) }
 
   subject(:button) { described_class.new(device: device) }

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -735,6 +735,9 @@ describe Y2Storage::Devicegraph do
       fake_scenario("bcache1.xml")
     end
 
+    # Bcache is only supported on x86
+    let(:architecture) { :x86_64 }
+
     it "removes the given caching set device" do
       bcache_cset = Y2Storage::BcacheCset.all(devicegraph).first
       expect(bcache_cset).to_not be_nil


### PR DESCRIPTION
## Problem

Bcache tests require arch to be mocked as x86.

* Related to https://trello.com/c/cQo16PQ5/672-editing-an-in-memory-bcache-device-devices-and-cache-mode
* https://jira.suse.de/browse/SLE-4329


## Solution

Mock arch where it is needed.

## Testing

- Unit tests


