### PR TITLE
Preserve old filesystem label (bsc##1087229)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 20 11:55:30 UTC 2019 - jreidinger@suse.com
+
+- filesystem label is kept when using existing partitioning
+  (bsc#108722)
+- 4.1.64
+
+-------------------------------------------------------------------
 Tue Feb 19 14:40:11 UTC 2019 - ancor@suse.com
 
 - Partitioner: new option "Provide Crypt Passwords" (bsc#1113515).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.63
+Version:	4.1.64
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -502,8 +502,7 @@ module Y2Partitioner
           when :mount_point
             filesystem.mount_path
           when :label
-            # Copying the label from the filesystem in the disk looks unexpected
-            new?(filesystem) ? filesystem.label : nil
+            filesystem.label
           end
         end
 

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -502,6 +502,7 @@ module Y2Partitioner
           when :mount_point
             filesystem.mount_path
           when :label
+            # label is kept to be consistent with old partitioner (bsc#1087229)
             filesystem.label
           end
         end

--- a/test/y2partitioner/actions/controllers/filesystem_test.rb
+++ b/test/y2partitioner/actions/controllers/filesystem_test.rb
@@ -595,18 +595,10 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
         expect(subject.partition_id).to eq(type.default_partition_id)
       end
 
-      context "when the previous filesystem does not exist in the disk" do
-        before do
-          subject
-          device.remove_descendants
-          device.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
-          device.filesystem.label = label
-        end
-
-        it "preserves the label" do
-          subject.new_filesystem(type)
-          expect(subject.blk_device.filesystem.label).to eq(label)
-        end
+      # label is kept to be consistent with old partitioner (bsc#1087229)
+      it "preserves the label" do
+        subject.new_filesystem(type)
+        expect(subject.blk_device.filesystem.label).to eq(label)
       end
     end
   end

--- a/test/y2partitioner/actions/controllers/filesystem_test.rb
+++ b/test/y2partitioner/actions/controllers/filesystem_test.rb
@@ -595,13 +595,6 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
         expect(subject.partition_id).to eq(type.default_partition_id)
       end
 
-      context "when the previous filesystem exists in the disk" do
-        it "does not preserve the label" do
-          subject.new_filesystem(type)
-          expect(subject.blk_device.filesystem.label).to be_empty
-        end
-      end
-
       context "when the previous filesystem does not exist in the disk" do
         before do
           subject


### PR DESCRIPTION
## Problem

Insonsistency with old partitioner which keeps old label if just refformating fs.

- https://bugzilla.suse.com/show_bug.cgi?id=1087229


## Solution

lets keep label even when reformat filesystem.


## Testing

- Added a new unit test
- Tested manually