### PR TITLE
Fix testsuite

### DIFF
--- a/test/y2storage/fake_device_factory_test.rb
+++ b/test/y2storage/fake_device_factory_test.rb
@@ -24,11 +24,11 @@ require_relative "spec_helper"
 
 describe Y2Storage::FakeDeviceFactory do
   describe ".load_yaml_file" do
-    let(:staging) do
-      environment = Storage::Environment.new(true, Storage::ProbeMode_NONE, Storage::TargetMode_DIRECT)
-      storage = Storage::Storage.new(environment)
-      storage.staging
+    before do
+      Y2Storage::StorageManager.create_test_instance
     end
+
+    let(:staging) { Y2Storage::StorageManager.instance.probed.to_storage_value }
 
     let(:io) { StringIO.new(input) }
 


### PR DESCRIPTION
## Problem

With new ruby 2.6, testsuite has started to fail randomly. Such random failures use to indicate that some tests are using objects that should not be there (e.g., a discarded `devicegraph`). When that happens, the test fails if the ruby Garbage Collector is called before accessing to such objects.

Most likely ruby 2.6 has introduced any change with the GC, or simply the order of tests is now different (we have created new test files). Those could be the reasons why the test failure appears now and not before.  

## Solution

Fix testsuite to use correct objects.


