### PR TITLE
Do not export the partition_type attribute when belongs to GPT

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 27 09:57:10 UTC 2019 - David Díaz <dgonzalez@suse.com>
+
+- Do not export the partition_type attribute when it belongs to a
+  GPT partition table (bsc#1115751).
+
+-------------------------------------------------------------------
 Fri Feb 22 15:11:37 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Partitioner: improve "Import Mount Points" feature.

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -124,7 +124,7 @@ module Y2Storage
       #   @return [Integer] the partition number of this partition
 
       # @!attribute partition_type
-      #   @return [String] undocumented attribute that can only contain "primary"
+      #   @return [String, nil] the partition type of this partition (only can be "primary")
 
       # @!attribute subvolumes
       #   @return [Array<SubvolSpecification>,nil] list of subvolumes or nil if not
@@ -297,7 +297,7 @@ module Y2Storage
       def init_partition_fields(partition)
         @create = !NO_CREATE_IDS.include?(partition.id)
         @partition_nr = partition.number
-        @partition_type = "primary" if partition.type.is?(:primary)
+        @partition_type = "primary" if primary_partition?(partition)
         @partition_id = partition_id_from(partition)
         @lvm_group = lvm_group_name(partition)
         @raid_name = partition.md.name if partition.md
@@ -430,6 +430,18 @@ module Y2Storage
       # @return [Boolean]
       def fixed_size?(device)
         device.is?(:disk_device, :software_raid)
+      end
+
+      # Determines whether given partition is primary or not
+      #
+      # Always false when the partition belongs to a GPT partition table.
+      #
+      # @param partition [Y2Storgae::Partition] the partition to check
+      # @return [Boolean] true when is a primary partition; false otherwise
+      def primary_partition?(partition)
+        return false if partition.partition_table.type.is?(:gpt)
+
+        partition.type.is?(:primary)
       end
     end
   end

--- a/test/y2storage/autoinst_profile/partition_section_test.rb
+++ b/test/y2storage/autoinst_profile/partition_section_test.rb
@@ -70,6 +70,14 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
         end
       end
 
+      context "when the partition belongs to a GPT partition table" do
+        let(:dev) { device("sdh") }
+
+        it "does not include the partition_type" do
+          expect(section_for("sdh1").partition_type).to be_nil
+        end
+      end
+
       context "when the partition belongs to an MD RAID" do
         let(:dev) { device("sdb1") }
         let(:md) { instance_double(Y2Storage::Md, name: "/dev/md0") }


### PR DESCRIPTION
## Problem

When cloning a system with GPT, AutoYaST still generating
 
> <partition_type>primary</partition_type>

However, this attribute does not make sense when dealing with GPT partition tables.

- https://bugzilla.suse.com/show_bug.cgi?id=1115751
- https://trello.com/c/9ZIgDgWF

## Solution

Do not export it when the partition belongs to a GPT partition table.


## Testing

- Added a new unit test
- Also tested manually

