### PR TITLE
Feature/ay warning missing partition nr

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb 28 15:33:19 UTC 2019 - David Díaz <dgonzalez@suse.com>
+
+- Do not crash when using an old MD RAID schema and the
+  partition_nr attribute is missing. Instead, do not allow to
+  continue because a missing value issue (bsc#1126059).
+- 4.1.68
+
+-------------------------------------------------------------------
 Wed Feb 27 09:57:10 UTC 2019 - David Díaz <dgonzalez@suse.com>
 
 - Do not export the partition_type attribute when it belongs to a

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.67
+Version:	4.1.68
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Problem

> AutoYaST installation with MD RAID fails with an internal error popup (unhandled exception) when the `partition_nr` is missing for the MD RAID in the profile

- https://bugzilla.suse.com/show_bug.cgi?id=1126059
- https://trello.com/c/srRTpvWm

## Solution

Do not crash, but add a `MissingValue` issue instead.

## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

**Before**

![screenshot_test_2019-02-28_15 59 50](https://user-images.githubusercontent.com/1691872/53582117-c6dc0b00-3b76-11e9-9137-dff9c74843fd.png) 

**After**

![screenshot_test_2019-02-28_16 32 53](https://user-images.githubusercontent.com/1691872/53582136-cfccdc80-3b76-11e9-8d53-3c8bfded5067.png)

<sub>Screenshots using the AutoYaST profile attached in the bug report.</sub>


