### PR TITLE
Don't skip the changelog check anymore

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,10 +18,6 @@
 
 require "yast/rake"
 
-# Checking for bug/fate numbers in the changelog does not make sense at this
-# stage of the development
-Rake::Task["package"].prerequisites.delete("check:changelog")
-
 Yast::Tasks.configuration do |conf|
   conf.skip_license_check << /.*/
   conf.documentation_minimal = 87


### PR DESCRIPTION
## Problem

We were ignoring the rake check about valid changelog entries. That was introduced when yast-storage-ng was a prototype, but it makes no sense anymore now that is an official package that must adhere to YaST standards.

## Solution

Just remove the line specifying to skip the changelog checks.