### PR TITLE
Fix missing translations in partitioner

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar  4 16:31:25 UTC 2019 - David Díaz <dgonzalez@suse.com>
+
+- Translates the filesystem roles properly (bsc#1127756).
+- 4.1.69
+
+-------------------------------------------------------------------
 Thu Feb 28 15:33:19 UTC 2019 - David Díaz <dgonzalez@suse.com>
 
 - Do not crash when using an old MD RAID schema and the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.68
+Version:	4.1.69
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/filesystem_role.rb
+++ b/src/lib/y2partitioner/filesystem_role.rb
@@ -30,7 +30,6 @@ module Y2Partitioner
   class FilesystemRole
     include Yast::I18n
     extend Yast::I18n
-    textdomain "storage"
 
     # Constructor, to be used internally by the class
     #
@@ -39,6 +38,8 @@ module Y2Partitioner
     # @param part_id [Symbol] used to initialize {#partition_id}
     # @param fs_type [Symbol, nil] used to initialize {#filesystem_type}
     def initialize(id, name, part_id, fs_type)
+      textdomain "storage"
+
       @id = id
       @name = name
       @partition_id = Y2Storage::PartitionId.find(part_id)


### PR DESCRIPTION
## Problem

The filesystem roles in partitioner were not being translated due a wrongly placed `textdomain`.

- https://bugzilla.suse.com/show_bug.cgi?id=1127756

## Solution

Move the `textdomain` to the `initialize` method.

## Testing

- *Tested manually*

## Screenshots

| Before | After |
|--------|-------|
| ![unfixed_filesytem_role_selection](https://user-images.githubusercontent.com/1691872/53747767-e7b89f00-3e9b-11e9-8d48-7e82bb656735.png) | ![fixed_filesystem_role_selection](https://user-images.githubusercontent.com/1691872/53747778-eedfad00-3e9b-11e9-87a3-90b28e8a18c8.png) |


