### PR TITLE
Avoid to crash when frozen String and fix missing translation

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar  6 11:21:49 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed "can't modify frozen String" crashes (related to
+  bsc#1125006)
+
+-------------------------------------------------------------------
 Mon Mar  4 16:31:25 UTC 2019 - David Díaz <dgonzalez@suse.com>
 
 - Translates the filesystem roles properly (bsc#1127756).

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -3,6 +3,8 @@ Wed Mar  6 11:21:49 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed "can't modify frozen String" crashes (related to
   bsc#1125006)
+- Fixed missing translation (bsc#1127181)
+- 4.1.70
 
 -------------------------------------------------------------------
 Mon Mar  4 16:31:25 UTC 2019 - David Díaz <dgonzalez@suse.com>

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.69
+Version:	4.1.70
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/dialogs/partition_table_type.rb
+++ b/src/lib/y2partitioner/dialogs/partition_table_type.rb
@@ -94,8 +94,8 @@ module Y2Partitioner
 
       # @macro seeDialog
       def title
-        # TRANSLATORS: %s is a device name like /dev/sda
-        format("Create New Partition Table on %s", @disk.name)
+        # TRANSLATORS: %{device_name} is a device name like /dev/sda
+        format(_("Create New Partition Table on %{device_name}"), device_name: @disk.name)
       end
 
       # @macro seeDialog

--- a/src/lib/y2storage/callbacks/libstorage_callback.rb
+++ b/src/lib/y2storage/callbacks/libstorage_callback.rb
@@ -142,17 +142,17 @@ module Y2Storage
         # using AutoYaST), there is nothing else we can advise.
         return result.chomp if forced_multipath? && !Yast::Mode.auto
 
-        result << _(
+        result += _(
           "Maybe there are multipath devices in the system but multipath support\n" \
           "was not enabled.\n\n"
         )
 
         if Yast::Mode.auto
-          result << _(
+          result += _(
             "Use 'start_multipath' in the AutoYaST profile to enable multipath."
           )
         else
-          result << _(
+          result += _(
             "If YaST didn't offer the opportunity to enable multipath in a previous step,\n" \
             "try the 'LIBSTORAGE_MULTIPATH_AUTOSTART=ON' boot parameter.\n" \
             "More information at https://en.opensuse.org/SDB:Linuxrc"

--- a/src/lib/y2storage/devicegraph_sanitizer.rb
+++ b/src/lib/y2storage/devicegraph_sanitizer.rb
@@ -190,8 +190,8 @@ module Y2Storage
     # @return [String]
     def msg_no_bcache_support
       msg = _("Bcache detected, but bcache is not supported on this platform!")
-      msg << "\n\n"
-      msg << _("This may or may not work. Use at your own risk.\n" \
+      msg += "\n\n"
+      msg + _("This may or may not work. Use at your own risk.\n" \
                "The safe way is to remove this bcache manually\n" \
                "with command line tools and then restart YaST.")
     end

--- a/src/lib/y2storage/dialogs/guided_setup/select_root_disk.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_root_disk.rb
@@ -183,7 +183,7 @@ module Y2Storage
           )
 
           # TRANSLATORS: Help text for root disk selection, continued
-          msg << _(
+          msg += _(
             "<ul>" \
             "<li>Resize if needed (Windows partitions only)</li>" \
             "<li>Resize or remove if needed (Windows partitions only)</li>" \


### PR DESCRIPTION
## Problems

There were a missing translation an a "can't modify frozen String" crash.

- https://bugzilla.suse.com/show_bug.cgi?id=1125006
- https://bugzilla.suse.com/show_bug.cgi?id=1127181

## Solution

Simply fix those errors.
