### PR TITLE
Fix translation using flag instead named parameter

### DIFF
--- a/src/lib/y2partitioner/dialogs/partition_table_type.rb
+++ b/src/lib/y2partitioner/dialogs/partition_table_type.rb
@@ -94,8 +94,8 @@ module Y2Partitioner
 
       # @macro seeDialog
       def title
-        # TRANSLATORS: %{device_name} is a device name like /dev/sda
-        format(_("Create New Partition Table on %{device_name}"), device_name: @disk.name)
+        # TRANSLATORS: %s is a device name like /dev/sda
+        format(_("Create New Partition Table on %s"), @disk.name)
       end
 
       # @macro seeDialog


### PR DESCRIPTION
Fix translation, using a `%s` flag instead a `%{device_name}`

Discussed in IRC

> \<dgdavid> ancorgs: I regret to check that you were right :( --> https://github.com/yast/yast-translations/commit/a764fd40804ed07bd56de51359309791749c2c3e#diff-f567bd0448f631420a03b5f26ea184baR1542
> \<ancorgs> dgdavid: yes, that was another argument I forgot to use: keeping the old string that was already translated in yast-storage
> \<ancorgs> it all summarize to the same. In I18n stuff, be conservative
> \<ancorgs> if we keep the old string, it will be translated already in all languages
> \<dgdavid> ancorgs: do you think I should do a new PR changing the %{device_name} by %s ?
> \<ancorgs> dgdavid: yes. It's two minutes for us. And will safe 5 minutes for each translator


Using a @lslezak words from other PR, 

> No version update, it's enough to release it with the next change (the translations are extracted directly from GitHub so it does not matter)

---

<sub>Related to #864 </sub> 
