### PR TITLE
Improve the logic to decide when exports partition_type attribute

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 11 22:19:33 UTC 2019 - David Díaz <dgonzalez@suse.com>
+
+- Only exports the partition_type attribute when it belongs to a
+  partition table with support for extended partitions
+  (bsc#1115751).
+
+-------------------------------------------------------------------
 Wed Mar  6 16:28:26 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Prevent crash if resizing a newly formatted filesystem (bsc#1124146)

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -434,12 +434,12 @@ module Y2Storage
 
       # Determines whether given partition is primary or not
       #
-      # Always false when the partition belongs to a GPT partition table.
+      # Always false when the partition table does not allow extended partitions
       #
       # @param partition [Y2Storgae::Partition] the partition to check
       # @return [Boolean] true when is a primary partition; false otherwise
       def primary_partition?(partition)
-        return false if partition.partition_table.type.is?(:gpt)
+        return false unless partition.partition_table.extended_possible?
 
         partition.type.is?(:primary)
       end

--- a/test/y2storage/autoinst_profile/partition_section_test.rb
+++ b/test/y2storage/autoinst_profile/partition_section_test.rb
@@ -70,14 +70,6 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
         end
       end
 
-      context "when the partition belongs to a GPT partition table" do
-        let(:dev) { device("sdh") }
-
-        it "does not include the partition_type" do
-          expect(section_for("sdh1").partition_type).to be_nil
-        end
-      end
-
       context "when the partition belongs to an MD RAID" do
         let(:dev) { device("sdb1") }
         let(:md) { instance_double(Y2Storage::Md, name: "/dev/md0") }
@@ -89,6 +81,14 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
         it "initializes #raid_name" do
           section = described_class.new_from_storage(dev)
           expect(section.raid_name).to eq(md.name)
+        end
+      end
+
+      context "when the partition table does not have support for extended partitions" do
+        let(:dev) { device("sdh") }
+
+        it "does not include the partition_type" do
+          expect(section_for("sdh1").partition_type).to be_nil
         end
       end
     end


### PR DESCRIPTION
## Problem

In #860 was introduced a too much specific checking to decide if the `partition_type` attribute should be exported when cloning.

See the @ancorgs' [comment](https://github.com/yast/yast-storage-ng/pull/860#discussion_r264133770)

## Solution
Use the PartitionTable API.
