### PR TITLE
Add missing icons

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 13 17:18:19 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Show new icons for the options of the Configure menu button
+  (related to bsc#1122174).
+- 4.1.74
+
+-------------------------------------------------------------------
 Wed Mar 13 16:45:16 CET 2019 - schubi@suse.de
 
 - Unifying name Bcache/bcache to bcache (fate#325346).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.73
+Version:	4.1.74
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/icons.rb
+++ b/src/lib/y2partitioner/icons.rb
@@ -60,11 +60,5 @@ module Y2Partitioner
 
     # icon
     BCACHE = HD
-
-    # helper to get full path to small version of icon
-    # @param icon [String] icon filename including suffix
-    def self.small_icon(icon)
-      icon
-    end
   end
 end

--- a/src/lib/y2partitioner/icons.rb
+++ b/src/lib/y2partitioner/icons.rb
@@ -60,5 +60,17 @@ module Y2Partitioner
 
     # icon
     BCACHE = HD
+
+    LOCK = "lock".freeze
+
+    ISCSI = "drive-iscsi".freeze
+
+    FCOE = "drive-fcoe".freeze
+
+    DASD = "drive-dasd".freeze
+
+    ZFCP = "drive-zfcp".freeze
+
+    XPRAM = "drive-xpram".freeze
   end
 end

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -171,7 +171,7 @@ module Y2Partitioner
         return "" unless device.encrypted?
 
         if Yast::UI.GetDisplayInfo["HasIconSupport"]
-          cell(small_icon(Icons::ENCRYPTED))
+          cell(icon(Icons::ENCRYPTED))
         else
           "E"
         end
@@ -242,9 +242,9 @@ module Y2Partitioner
         return type_icon(device.plain_blk_device) if device.is?(:lvm_pv)
 
         type = DEVICE_ICONS.keys.find { |k| device.is?(k) }
-        icon = type.nil? ? Icons::DEFAULT_DEVICE : DEVICE_ICONS[type]
+        icon_name = type.nil? ? Icons::DEFAULT_DEVICE : DEVICE_ICONS[type]
 
-        small_icon(icon)
+        icon(icon_name)
       end
 
       DEVICE_LABELS = {
@@ -323,15 +323,6 @@ module Y2Partitioner
         # bcache has as vendor Disk, but we want to write bcache as type here
         data = "" if device.is?(:bcache)
         data.empty? ? default_type_label(device) : data.join("-")
-      end
-
-      # Small icon to show in tables
-      #
-      # @param icon [String] relative path
-      # @return [Yast::Term] icon
-      def small_icon(icon)
-        icon_path = Icons.small_icon(icon)
-        icon(icon_path)
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/configure.rb
+++ b/src/lib/y2partitioner/widgets/configure.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "cwm"
 require "y2partitioner/widgets/reprobe"
+require "y2partitioner/icons"
 
 Yast.import "Stage"
 Yast.import "Popup"
@@ -173,12 +174,12 @@ module Y2Partitioner
       # Sorted list of actions
       def supported_actions
         @supported_actions ||= [
-          CryptAction.new(_("Provide Crypt &Passwords..."), "yast-encrypted"),
-          IscsiAction.new(_("Configure &iSCSI..."),         "yast-iscsi-client"),
-          FcoeAction.new(_("Configure &FCoE..."),           "fcoe"),
-          DasdAction.new(_("Configure &DASD..."),           "yast-dasd"),
-          ZfcpAction.new(_("Configure &zFCP..."),           "yast-zfcp"),
-          XpramAction.new(_("Configure &XPRAM..."),         "yast-xpram")
+          CryptAction.new(_("Provide Crypt &Passwords..."), Icons::LOCK),
+          IscsiAction.new(_("Configure &iSCSI..."),         Icons::ISCSI),
+          FcoeAction.new(_("Configure &FCoE..."),           Icons::FCOE),
+          DasdAction.new(_("Configure &DASD..."),           Icons::DASD),
+          ZfcpAction.new(_("Configure &zFCP..."),           Icons::ZFCP),
+          XpramAction.new(_("Configure &XPRAM..."),         Icons::XPRAM)
         ].select(&:supported?)
       end
 

--- a/src/lib/y2partitioner/widgets/pages/bcache.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcache.rb
@@ -56,11 +56,10 @@ module Y2Partitioner
 
         # @macro seeCustomWidget
         def contents
-          icon = Icons.small_icon(Icons::BCACHE)
           VBox(
             Left(
               HBox(
-                Image(icon, ""),
+                Image(Icons::BCACHE, ""),
                 # TRANSLATORS: Heading. String followed a device name like /dev/bcache0
                 Heading(format(_("Bcache: %s"), device.name))
               )

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -75,7 +75,7 @@ module Y2Partitioner
         #
         # @return [String]
         def icon
-          Icons.small_icon(Icons::BCACHE)
+          Icons::BCACHE
         end
 
         # Tabs to show

--- a/src/lib/y2partitioner/widgets/pages/btrfs.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs.rb
@@ -24,11 +24,10 @@ module Y2Partitioner
         def contents
           return @contents if @contents
 
-          icon = Icons.small_icon(Icons::BTRFS)
           @contents = VBox(
             Left(
               HBox(
-                Image(icon, ""),
+                Image(Icons::BTRFS, ""),
                 # TRANSLATORS: Heading
                 Heading(_("Btrfs Volumes"))
               )

--- a/src/lib/y2partitioner/widgets/pages/device_graph.rb
+++ b/src/lib/y2partitioner/widgets/pages/device_graph.rb
@@ -54,12 +54,11 @@ module Y2Partitioner
         def contents
           return @contents if @contents
 
-          icon = Icons.small_icon(Icons::GRAPH)
           @tabs = Tabs.new(current_tab, system_tab)
           @contents = VBox(
             Left(
               HBox(
-                Image(icon, ""),
+                Image(Icons::GRAPH, ""),
                 # TRANSLATORS: Heading for the expert partitioner page
                 Heading(_("Device Graphs"))
               )

--- a/src/lib/y2partitioner/widgets/pages/devices_table.rb
+++ b/src/lib/y2partitioner/widgets/pages/devices_table.rb
@@ -47,11 +47,10 @@ module Y2Partitioner
         def contents
           return @contents if @contents
 
-          icon_img = Icons.small_icon(icon)
           @contents = VBox(
             Left(
               HBox(
-                Image(icon_img, ""),
+                Image(icon, ""),
                 Heading(heading)
               )
             ),

--- a/src/lib/y2partitioner/widgets/pages/disk.rb
+++ b/src/lib/y2partitioner/widgets/pages/disk.rb
@@ -59,11 +59,10 @@ module Y2Partitioner
 
         # @macro seeCustomWidget
         def contents
-          icon = Icons.small_icon(Icons::HD)
           VBox(
             Left(
               HBox(
-                Image(icon, ""),
+                Image(Icons::HD, ""),
                 # TRANSLATORS: Heading. String followed by device name of hard disk
                 Heading(format(_("Hard Disk: %s"), disk.name))
               )

--- a/src/lib/y2partitioner/widgets/pages/lvm_lv.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm_lv.rb
@@ -54,11 +54,10 @@ module Y2Partitioner
         def contents
           return @contents if @contents
 
-          icon = Icons.small_icon(Icons::LVM_LV)
           @contents = VBox(
             Left(
               HBox(
-                Image(icon, ""),
+                Image(Icons::LVM_LV, ""),
                 # TRANSLATORS: Heading. String followed by name of partition
                 Heading(format(_("Logical Volume: %s"), @lvm_lv.name))
               )

--- a/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
@@ -62,11 +62,10 @@ module Y2Partitioner
 
         # @macro seeCustomWidget
         def contents
-          icon = Icons.small_icon(Icons::LVM)
           VBox(
             Left(
               HBox(
-                Image(icon, ""),
+                Image(Icons::LVM, ""),
                 Heading(format(_("Volume Group: %s"), "/dev/" + @lvm_vg.vg_name))
               )
             ),

--- a/src/lib/y2partitioner/widgets/pages/md_raid.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raid.rb
@@ -61,11 +61,10 @@ module Y2Partitioner
 
         # @macro seeCustomWidget
         def contents
-          icon = Icons.small_icon(Icons::RAID)
           VBox(
             Left(
               HBox(
-                Image(icon, ""),
+                Image(Icons::RAID, ""),
                 Heading(format(_("RAID: %s"), @md.name))
               )
             ),

--- a/src/lib/y2partitioner/widgets/pages/nfs_mounts.rb
+++ b/src/lib/y2partitioner/widgets/pages/nfs_mounts.rb
@@ -53,11 +53,10 @@ module Y2Partitioner
           # so some caching is required
           return @contents if @contents
 
-          icon = Icons.small_icon(Icons::NFS)
           @contents = VBox(
             Left(
               HBox(
-                Image(icon, ""),
+                Image(Icons::NFS, ""),
                 # TRANSLATORS: Heading for the expert partitioner page
                 Heading(_("Network File System (NFS)"))
               )

--- a/src/lib/y2partitioner/widgets/pages/partition.rb
+++ b/src/lib/y2partitioner/widgets/pages/partition.rb
@@ -58,11 +58,10 @@ module Y2Partitioner
           # FIXME: this is called dozens of times per single click!!
           return @contents if @contents
 
-          icon = Icons.small_icon(Icons::HD_PART)
           @contents = VBox(
             Left(
               HBox(
-                Image(icon, ""),
+                Image(Icons::HD_PART, ""),
                 # TRANSLATORS: Heading. String followed by name of partition
                 Heading(format(_("Partition: %s"), @partition.name))
               )

--- a/src/lib/y2partitioner/widgets/pages/settings.rb
+++ b/src/lib/y2partitioner/widgets/pages/settings.rb
@@ -46,11 +46,10 @@ module Y2Partitioner
         def contents
           return @contents if @contents
 
-          icon = Icons.small_icon(Icons::SETTINGS)
           @contents = VBox(
             Left(
               HBox(
-                Image(icon, ""),
+                Image(Icons::SETTINGS, ""),
                 # TRANSLATORS: Heading for the expert partitioner page
                 Heading(_("Settings"))
               )

--- a/src/lib/y2partitioner/widgets/pages/stray_blk_device.rb
+++ b/src/lib/y2partitioner/widgets/pages/stray_blk_device.rb
@@ -52,11 +52,10 @@ module Y2Partitioner
         def contents
           return @contents if @contents
 
-          icon = Icons.small_icon(Icons::DEFAULT_DEVICE)
           @contents = VBox(
             Left(
               HBox(
-                Image(icon, ""),
+                Image(Icons::DEFAULT_DEVICE, ""),
                 # TRANSLATORS: Heading for a generic storage device
                 # TRANSLATORS: String followed by name of the storage device
                 Heading(format(_("Device: %s"), device.name))

--- a/src/lib/y2partitioner/widgets/pages/summary.rb
+++ b/src/lib/y2partitioner/widgets/pages/summary.rb
@@ -46,11 +46,10 @@ module Y2Partitioner
         def contents
           return @contents if @contents
 
-          icon = Icons.small_icon(Icons::SUMMARY)
           @contents = VBox(
             Left(
               HBox(
-                Image(icon, ""),
+                Image(Icons::SUMMARY, ""),
                 # TRANSLATORS: Heading for the expert partitioner page
                 Heading(_("Installation Summary"))
               )

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -85,10 +85,8 @@ module Y2Partitioner
         #
         # @return [Yast::UI::Term]
         def header
-          icon = Icons.small_icon(Icons::ALL)
-
           HBox(
-            Image(icon, ""),
+            Image(Icons::ALL, ""),
             # TRANSLATORS: Heading. String followed by the hostname
             Heading(format(_("Available Storage on %s"), hostname))
           )


### PR DESCRIPTION
## Problem

Some icons used by the Expert Partitioner are not provided (neither by [yast-theme](https://github.com/yast/yast-theme/tree/master/icons/hicolor/scalable/apps) nor by [libyui-qt](https://github.com/libyui/libyui-qt/tree/master/src/icons)): *fcoe*, *xpram*, *dasd* and *zfcp* icons are missing. As consequence, the *Configure* menu button does not show the icon for some of its options, see the following screenshot:

![97095243](https://user-images.githubusercontent.com/1112304/54217066-d77b7200-44e2-11e9-84a5-1d7ca66a6d79.png)

* Related to https://bugzilla.suse.com/show_bug.cgi?id=1122174
* https://trello.com/c/IcPWJBUW/817-3-missing-icons-in-partitioner-configure
* [old_icons.tar.gz](https://github.com/yast/yast-storage-ng/files/2960648/old_icons.tar.gz)
* https://github.com/libyui/libyui-qt/pull/101

## Solution

@hellcp has provided [svg version](https://github.com/libyui/libyui-qt/pull/101) for the missing icons.

After some discussion in IRC, it seems that [these icons in the old partitioner](https://github.com/yast/yast-storage-ng/files/2960648/old_icons.tar.gz) are quite pointless because they are quite similar between them. But we have now new versions, so let's use them. 

## Testing

* Tested manually

## Screenshots

![VirtualBox_openSUSE Tumbleweed_13_03_2019_16_27_15](https://user-images.githubusercontent.com/1112304/54296520-03fbc080-45ad-11e9-8cc2-07f4aba8aba7.png)

