### PR TITLE
Don't add mount options that are default (ext2/3/4: acl, user_xattr)

### DIFF
--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -78,17 +78,16 @@ module Y2Storage
         },
         ext2:     {
           fstab_options:         COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS,
-          default_fstab_options: ACL_OPTIONS,
           name:                  "Ext2"
         },
         ext3:     {
           fstab_options:         COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],
-          default_fstab_options: JOURNAL_OPTIONS + ACL_OPTIONS,
+          default_fstab_options: JOURNAL_OPTIONS,
           name:                  "Ext3"
         },
         ext4:     {
           fstab_options:         COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],
-          default_fstab_options: JOURNAL_OPTIONS + ACL_OPTIONS,
+          default_fstab_options: JOURNAL_OPTIONS,
           name:                  "Ext4"
         },
         hfs:      {

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -77,8 +77,8 @@ module Y2Storage
           name:          "BtrFS"
         },
         ext2:     {
-          fstab_options:         COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS,
-          name:                  "Ext2"
+          fstab_options: COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS,
+          name:          "Ext2"
         },
         ext3:     {
           fstab_options:         COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],

--- a/test/data/devicegraphs/btrfs_bcache.xml
+++ b/test/data/devicegraphs/btrfs_bcache.xml
@@ -85,7 +85,7 @@
       <sid>257</sid>
       <path>/boot</path>
       <mount-by>uuid</mount-by>
-      <mount-options>data=ordered,acl,user_xattr</mount-options>
+      <mount-options>data=ordered</mount-options>
       <mount-type>ext4</mount-type>
       <active>true</active>
       <in-etc-fstab>true</in-etc-fstab>

--- a/test/data/devicegraphs/dasd1.xml
+++ b/test/data/devicegraphs/dasd1.xml
@@ -83,7 +83,6 @@
       <sid>48</sid>
       <path>/boot/zipl</path>
       <mount-by>path</mount-by>
-      <mount-options>acl,user_xattr</mount-options>
       <in-etc-fstab>true</in-etc-fstab>
       <freq>0</freq>
       <passno>0</passno>
@@ -108,7 +107,6 @@
       <sid>52</sid>
       <path>/</path>
       <mount-by>path</mount-by>
-      <mount-options>acl,user_xattr</mount-options>
       <in-etc-fstab>true</in-etc-fstab>
       <freq>0</freq>
       <passno>0</passno>

--- a/test/data/devicegraphs/md-imsm1-devicegraph.xml
+++ b/test/data/devicegraphs/md-imsm1-devicegraph.xml
@@ -197,7 +197,6 @@
       <sid>57</sid>
       <path>/</path>
       <mount-by>uuid</mount-by>
-      <mount-options>acl,user_xattr</mount-options>
       <in-etc-fstab>true</in-etc-fstab>
       <freq>0</freq>
       <passno>0</passno>

--- a/test/data/devicegraphs/output/empty_dasd_fba_gpt-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_dasd_fba_gpt-sep-home.yml
@@ -12,9 +12,6 @@
         id: linux
         file_system: ext2
         mount_point: /boot/zipl
-        fstab_options:
-          - acl
-          - user_xattr
 
     - partition:
         size: 25685 MiB

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-docker-lvm.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-docker-lvm.yml
@@ -23,9 +23,6 @@
         size: 30708 MiB
         file_system: ext4
         mount_point: "/"
-        fstab_options:
-          - acl
-          - user_xattr
     - lvm_lv:
         lv_name: var_lib_docker
         size: 20 GiB

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-swap.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-root-swap.yml
@@ -14,9 +14,6 @@
         id: linux
         file_system: ext4
         mount_point: "/"
-        fstab_options:
-          - acl
-          - user_xattr
     - partition:
         size: unlimited
         name: "/dev/sda3"

--- a/test/data/devicegraphs/output/ppc_power_nv-lvm.yml
+++ b/test/data/devicegraphs/output/ppc_power_nv-lvm.yml
@@ -13,8 +13,6 @@
         mount_point: "/boot"
         fstab_options:
           - data=ordered
-          - acl
-          - user_xattr
     - partition:
         size: unlimited
         name: "/dev/sda2"

--- a/test/data/devicegraphs/output/s390_dasd_zipl-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl-lvm-sep-home.yml
@@ -12,9 +12,6 @@
         id: linux
         file_system: ext2
         mount_point: /boot/zipl
-        fstab_options:
-          - acl
-          - user_xattr
     - partition:
         size: 23809920 KiB (22.71 GiB)
         name: "/dev/dasda2"

--- a/test/data/devicegraphs/output/s390_dasd_zipl-lvm.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl-lvm.yml
@@ -12,9 +12,6 @@
         id: linux
         file_system: ext2
         mount_point: "/boot/zipl"
-        fstab_options:
-          - acl
-          - user_xattr
     - partition:
         size: 23809920 KiB (22.71 GiB)
         name: "/dev/dasda2"

--- a/test/data/devicegraphs/output/s390_dasd_zipl.yml
+++ b/test/data/devicegraphs/output/s390_dasd_zipl.yml
@@ -12,9 +12,6 @@
         id: linux
         file_system: ext2
         mount_point: "/boot/zipl"
-        fstab_options:
-          - acl
-          - user_xattr
     - partition:
         size: 21712800 KiB (20.71 GiB)
         name: "/dev/dasda2"

--- a/test/data/devicegraphs/output/s390_zfcp_zipl.yml
+++ b/test/data/devicegraphs/output/s390_zfcp_zipl.yml
@@ -10,9 +10,6 @@
         id: linux
         file_system: ext2
         mount_point: "/boot/zipl"
-        fstab_options:
-          - acl
-          - user_xattr
     - partition:
         size: 40 GiB
         name: "/dev/sda2"

--- a/test/data/devicegraphs/output/windows-pc-mbr256-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-mbr256-lvm-sep-home.yml
@@ -22,8 +22,6 @@
         mount_point: "/boot"
         fstab_options:
           - data=ordered
-          - acl
-          - user_xattr
 
     - partition:
         size: 53249 MiB

--- a/test/data/devicegraphs/output/windows-pc-mbr256-lvm.yml
+++ b/test/data/devicegraphs/output/windows-pc-mbr256-lvm.yml
@@ -22,8 +22,6 @@
         mount_point: "/boot"
         fstab_options:
           - data=ordered
-          - acl
-          - user_xattr
 
     - partition:
         size: 43009 MiB

--- a/test/data/devicegraphs/partitioned_btrfs_bcache.xml
+++ b/test/data/devicegraphs/partitioned_btrfs_bcache.xml
@@ -85,7 +85,7 @@
       <sid>257</sid>
       <path>/boot</path>
       <mount-by>uuid</mount-by>
-      <mount-options>data=ordered,acl,user_xattr</mount-options>
+      <mount-options>data=ordered</mount-options>
       <mount-type>ext4</mount-type>
       <active>true</active>
       <in-etc-fstab>true</in-etc-fstab>

--- a/test/y2storage/filesystems/type_test.rb
+++ b/test/y2storage/filesystems/type_test.rb
@@ -142,15 +142,15 @@ describe Y2Storage::Filesystems::Type do
   describe "#default_fstab_options" do
     context "for locale-independent filesystem types" do
       it "ext2 has the correct fstab options" do
-        expect(described_class::EXT2.default_fstab_options).to eq ["acl", "user_xattr"]
+        expect(described_class::EXT2.default_fstab_options).to eq []
       end
 
       it "ext3 has the correct fstab options" do
-        expect(described_class::EXT3.default_fstab_options).to eq ["data=ordered", "acl", "user_xattr"]
+        expect(described_class::EXT3.default_fstab_options).to eq ["data=ordered"]
       end
 
       it "ext4 has the correct fstab options" do
-        expect(described_class::EXT4.default_fstab_options).to eq ["data=ordered", "acl", "user_xattr"]
+        expect(described_class::EXT4.default_fstab_options).to eq ["data=ordered"]
       end
 
       it "xfs has the correct fstab options" do
@@ -186,15 +186,15 @@ describe Y2Storage::Filesystems::Type do
     context "for special paths" do
       context "for root filesystems" do
         it "ext2 has the correct fstab options" do
-          expect(described_class::EXT2.default_fstab_options("/")).to eq ["acl", "user_xattr"]
+          expect(described_class::EXT2.default_fstab_options("/")).to eq []
         end
 
         it "ext3 has the correct fstab options" do
-          expect(described_class::EXT3.default_fstab_options("/")).to eq ["acl", "user_xattr"]
+          expect(described_class::EXT3.default_fstab_options("/")).to eq []
         end
 
         it "ext4 has the correct fstab options" do
-          expect(described_class::EXT4.default_fstab_options("/")).to eq ["acl", "user_xattr"]
+          expect(described_class::EXT4.default_fstab_options("/")).to eq []
         end
       end
 


### PR DESCRIPTION
## Trello

https://trello.com/c/Ys1c4kVI

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1122867

## Problem

Some mount options that we always added are now default:

- ext2/3/4: `acl` and `user_xattr`

## Fix

Remove them from the default options that we write to /etc/fstab.

## Note

No change log entry and no version bump because this will have to wait for merging until SLE-15-SP1 is branched off, and we don't want any unnecessary merge conflicts and problems with the change log check scripts in OBS complaining about change log entries out of chronological sequence.