### PR TITLE
Sort Partition IDs Logically

### DIFF
--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -851,7 +851,7 @@ module Y2Partitioner
       def items
         blk_dev = @controller.blk_device
         if blk_dev.is?(:partition)
-          blk_dev.partition_table.supported_partition_ids.map do |part_id|
+          blk_dev.partition_table.supported_partition_ids.sort.map do |part_id|
             [part_id.to_sym, part_id.to_human_string]
           end
         else

--- a/src/lib/y2storage/partition_id.rb
+++ b/src/lib/y2storage/partition_id.rb
@@ -56,7 +56,32 @@ module Y2Storage
       UNKNOWN.to_i            => N_("Unknown"),
       WINDOWS_BASIC_DATA.to_i => N_("Windows Data")
     }.freeze
-    private_constant :TRANSLATIONS
+
+    SORT_ORDER = [
+      # Linux partition IDs first
+      LINUX,
+      SWAP,
+      LVM,
+      RAID,
+      # Boot-related
+      ESP,
+      BIOS_BOOT,
+      PREP,
+      # Windows-related
+      NTFS,
+      DOS32,
+      DOS16,
+      DOS12,
+      WINDOWS_BASIC_DATA,
+      MICROSOFT_RESERVED,
+      # Other
+      IRST,
+      DIAG,
+      EXTENDED
+      # Eveything not listed here is sorted after this
+    ].freeze
+
+    private_constant :TRANSLATIONS, :SORT_ORDER
 
     def to_human_string
       textdomain "storage"
@@ -169,6 +194,19 @@ module Y2Storage
           name.to_sym == to_sym
         end
       end
+    end
+
+    # Get the sort order of this partition ID.
+    # @return [Integer]
+    def sort_order
+      SORT_ORDER.find_index(self) || SORT_ORDER.size
+    end
+
+    # Comparison operator for sorting.
+    # @return [Integer] -1, 0, 1
+    def <=>(other)
+      return -1 unless other.respond_to?(:sort_order)
+      sort_order <=> other.sort_order
     end
   end
 end

--- a/test/y2storage/partition_id_test.rb
+++ b/test/y2storage/partition_id_test.rb
@@ -128,7 +128,7 @@ describe Y2Storage::PartitionId do
     it "sorts Linux Native before Linux Swap" do
       linux = Y2Storage::PartitionId::LINUX
       swap = Y2Storage::PartitionId::SWAP
-      expect(linux.sort_order < swap.sort_order).to eq true
+      expect(linux.sort_order).to be < swap.sort_order
     end
 
     it "sorts Linux partition IDs naturally" do

--- a/test/y2storage/partition_id_test.rb
+++ b/test/y2storage/partition_id_test.rb
@@ -123,4 +123,68 @@ describe Y2Storage::PartitionId do
       end
     end
   end
+
+  describe "#sort_order" do
+    it "sorts Linux Native before Linux Swap" do
+      linux = Y2Storage::PartitionId::LINUX
+      swap = Y2Storage::PartitionId::SWAP
+      expect(linux.sort_order < swap.sort_order).to eq true
+    end
+
+    it "sorts Linux partition IDs naturally" do
+      unsorted = [
+        Y2Storage::PartitionId::RAID,
+        Y2Storage::PartitionId::SWAP,
+        Y2Storage::PartitionId::LVM,
+        Y2Storage::PartitionId::LINUX
+      ]
+
+      sorted = [
+        Y2Storage::PartitionId::LINUX,
+        Y2Storage::PartitionId::SWAP,
+        Y2Storage::PartitionId::LVM,
+        Y2Storage::PartitionId::RAID
+      ]
+
+      expect(unsorted.sort).to eq sorted
+    end
+
+    it "sorts misc partition IDs naturally" do
+      unsorted = [
+        Y2Storage::PartitionId::NTFS,
+        Y2Storage::PartitionId::BIOS_BOOT,
+        Y2Storage::PartitionId::ESP,
+        Y2Storage::PartitionId::SWAP,
+        Y2Storage::PartitionId::LINUX
+      ]
+
+      sorted = [
+        Y2Storage::PartitionId::LINUX,
+        Y2Storage::PartitionId::SWAP,
+        Y2Storage::PartitionId::ESP,
+        Y2Storage::PartitionId::BIOS_BOOT,
+        Y2Storage::PartitionId::NTFS
+      ]
+
+      expect(unsorted.sort).to eq sorted
+    end
+
+    it "sorts unknown IDs to the end of the list" do
+      unsorted = [
+        Y2Storage::PartitionId::NTFS,
+        4242,
+        Y2Storage::PartitionId::SWAP,
+        Y2Storage::PartitionId::LINUX
+      ]
+
+      sorted = [
+        Y2Storage::PartitionId::LINUX,
+        Y2Storage::PartitionId::SWAP,
+        Y2Storage::PartitionId::NTFS,
+        4242
+      ]
+
+      expect(unsorted.sort).to eq sorted
+    end
+  end
 end


### PR DESCRIPTION
## Trello

https://trello.com/c/uJDzzpFV/

## Bugzilla

_No corresponding bug_

## Problem

Partition IDs (types) were not sorted in any meaningful way in the partitioner.

![](https://trello-attachments.s3.amazonaws.com/5b3095d97ee6207bb8c30e53/5b92784fc4584672239de1fe/3632e4d54d109bdc8336ac1ab1067b69/bar.jpg)


## Fix

Introduced a sort order on the Ruby level of that type (enum which is imported and mapped from libstorage-ng).

We now have a table in the Ruby code for the desired sort order and a spaceship operator (`<=>`) that uses that table so the normal Ruby `sort` function can be used:

https://github.com/yast/yast-storage-ng/pull/872/files#diff-ecc44dd40509958fa302edf2358c7f8fR60

Of course the partitioner still only shows those types that are actually applicable, not just every value of that enum.

Values that are not in that sort order table are sorted at the end.

![part-sort-order](https://user-images.githubusercontent.com/11538225/54364445-38cf4c80-466d-11e9-9556-b3efa0f82bf0.png)

## Notice

This is for SLE-15 SP2. We need to wait until we have a branch for SLE-15 SP1, so for now there is no change log entry and no version bump to avoid complaints of the OBS change log check scripts for entries being out of chronological order.