### PR TITLE
Display pathnames correctly in a Right-to-Left context (bsc#1128091)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,11 @@
 require "yast/rake"
 
 Yast::Tasks.configuration do |conf|
-  conf.skip_license_check << /.*/
+  conf.skip_license_check << /\.pdf$/ # binary
+  conf.skip_license_check << /\.desktop$/
+  conf.skip_license_check << /\.scr$/
+  # conf file template, you don't want licenses in your config files
+  conf.skip_license_check << /\/fillup\//
+
   conf.documentation_minimal = 91
 end

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  6 08:00:23 UTC 2021 - Martin Vidner <mvidner@suse.com>
+
+- Display pathnames correctly in a Right-to-Left context
+  (bsc#1128091).
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0 (bsc#1185510)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/bin/mask-systemd-units
+++ b/src/bin/mask-systemd-units
@@ -1,5 +1,22 @@
 #!/bin/bash
-
+# Copyright (c) [2018-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 # This script can mask or unmask systemd mount and swap units since systemd
 # and YaST mounting the same file system leads to race conditions (see bsc

--- a/src/lib/bidi_markup.rb
+++ b/src/lib/bidi_markup.rb
@@ -1,7 +1,7 @@
 # Bidirectional Text: Left-to-right (Latin) and right-to-left (Arabic).
 #
 # See https://en.wikipedia.org/wiki/Bidirectional_text
-module Bidi
+module BidiMarkup
   LRE = "\u{202A}".freeze
   RLE = "\u{202B}".freeze
   PDF = "\u{202C}".freeze

--- a/src/lib/bidi_markup.rb
+++ b/src/lib/bidi_markup.rb
@@ -1,6 +1,46 @@
+# Copyright (c) [2020-2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 # Bidirectional Text: Left-to-right (Latin) and right-to-left (Arabic).
 #
 # See https://en.wikipedia.org/wiki/Bidirectional_text
+#
+# If you feel lost, try wrapping a piece of text that belongs together with
+# {.first_strong_isolate First Strong Isolate}.
+#
+# Quoting from the standard, Unicode TR 9, Section 6.3 Formatting,
+# where UPPER CASE simulates a RTL script:
+#
+# > The most common problematic case is that of neutrals on the
+# > boundary of an embedded language. This can be addressed by
+# > setting the level of the embedded text correctly. For example,
+# > with all the text at level 0 the following occurs:
+# >
+# >     Memory:  he said "I NEED WATER!", and expired.
+# >     Display: he said "RETAW DEEN I!", and expired.
+# >
+# > If the exclamation mark is to be part of the Arabic quotation,
+# > then the user can select the text I NEED WATER! and explicitly
+# > mark it as embedded Arabic, which produces the following result:
+# >
+# >     Memory:  he said "(RLI)I NEED WATER!(PDI)", and expired.
+# >     Display: he said "!RETAW DEEN I", and expired.
 module BidiMarkup
   LRE = "\u{202A}".freeze
   RLE = "\u{202B}".freeze
@@ -24,37 +64,59 @@ module BidiMarkup
 
   module_function
 
-  # Wrap *str* in a pair of characters: Left-to-Right Embedding
+  # Wrap *str* in a pair of characters: Left-to-Right Embedding.
+  #
+  # @deprecated Use {.ltr_isolate}.
+  #   Embedding is an older method that may have side effect on
+  #   the *surrounding* text so since Unicode 6.3 (2013) it is discouraged
+  #   in favor of Isolates.
   def ltr_embed(str)
     LRE + str + PDF
   end
 
-  # Wrap *str* in a pair of characters: Right-to-Left Embedding
+  # Wrap *str* in a pair of characters: Right-to-Left Embedding.
+  #
+  # @deprecated Use {.rtl_isolate}.
+  #   Embedding is an older method that may have side effect on
+  #   the *surrounding* text so since Unicode 6.3 (2013) it is discouraged
+  #   in favor of Isolates.
   def rtl_embed(str)
     RLE + str + PDF
   end
 
-  # Wrap *str* in a pair of characters: Left-to-Right Override
+  # Wrap *str* in a pair of characters: Left-to-Right Override.
+  #
+  # Force text direction regardless of the characters it contains.
+  # "Can be used to force a part number made of mixed English, digits
+  # and Hebrew letters to be written from right to left."
   def ltr_override(str)
     LRO + str + PDF
   end
 
-  # Wrap *str* in a pair of characters: Right-to-Left Override
+  # Wrap *str* in a pair of characters: Right-to-Left Override.
+  #
+  # Force text direction regardless of the characters it contains.
+  # "Can be used to force a part number made of mixed English, digits
+  # and Hebrew letters to be written from right to left."
   def rtl_override(str)
     RLO + str + PDF
   end
 
-  # Wrap *str* in a pair of characters: Left-to-Right Isolate
+  # Wrap *str* in a pair of characters: Left-to-Right Isolate.
   def ltr_isolate(str)
     LRI + str + PDI
   end
 
-  # Wrap *str* in a pair of characters: Right-to-Left Isolate
+  # Wrap *str* in a pair of characters: Right-to-Left Isolate.
   def rtl_isolate(str)
     RLI + str + PDI
   end
 
-  # Wrap *str* in a pair of characters: First Strong Isolate
+  # Wrap *str* in a pair of characters: First Strong Isolate.
+  #
+  # This is like LTR Isolate or RTL Isolate but the direction is decided by
+  # the first character that is directionally strong (usually a letter, not
+  # punctuation).
   def first_strong_isolate(str)
     FSI + str + PDI
   end
@@ -83,7 +145,10 @@ module BidiMarkup
     ltr_isolate(joined)
   end
 
-  # Return a copy of *str* where bidirectional formatting characters are removed
+  # Return a copy of *str* where bidirectional formatting chars are removed.
+  #
+  # LRM, RLM, ALM are kept because they are not added by the methods
+  # of this module, a human has probably added them instead.
   # @param str [String]
   # @return [String]
   def bidi_strip(str)

--- a/src/lib/y2partitioner/bidi.rb
+++ b/src/lib/y2partitioner/bidi.rb
@@ -1,0 +1,55 @@
+# Bidirectional Text: Left-to-right (Latin) and right-to-left (Arabic).
+module Bidi
+  LRE = "\u{202A}".freeze
+  RLE = "\u{202B}".freeze
+  PDF = "\u{202C}".freeze
+  LRO = "\u{202D}".freeze
+  RLO = "\u{202E}".freeze
+  LRI = "\u{2066}".freeze
+  RLI = "\u{2067}".freeze
+  FSI = "\u{2068}".freeze
+  PDI = "\u{2069}".freeze
+
+  LEFT_TO_RIGHT_EMBEDDING = LRE
+  RIGHT_TO_LEFT_EMBEDDING = RLE
+  POP_DIRECTIONAL_FORMATTING = PDF
+  LEFT_TO_RIGHT_OVERRIDE = LRO
+  RIGHT_TO_LEFT_OVERRIDE = RLO
+  LEFT_TO_RIGHT_ISOLATE = LRI
+  RIGHT_TO_LEFT_ISOLATE = RLI
+  FIRST_STRONG_ISOLATE = FSI
+  POP_DIRECTIONAL_ISOLATE = PDI
+
+  BIDI_CONTROLS = LRE + RLE + PDF + LRO + RLO + LRI + RLI + FSI + PDI
+
+  LRM = "\u{200E}".freeze
+  RLM = "\u{200F}".freeze
+  ALM = "\u{061C}".freeze
+
+  LEFT_TO_RIGHT_MARK = LRM
+  RIGHT_TO_LEFT_MARK = RLM
+  ARABIC_LETTER_MARK = ALM
+
+  # Add bidi formatting characters to *pn*
+  # otherwise /dev/sda will be presented as dev/sda/ in RTL context
+  # @param pn [Pathname]
+  def pathname_bidi_to_s(pn)
+    isolated_components = pn.each_filename.map do |fn|
+      Bidi::FIRST_STRONG_ISOLATE + fn + Bidi::POP_DIRECTIONAL_ISOLATE
+    end
+
+    isolated_components.unshift("") if pn.absolute?
+    joined = isolated_components.join(File::SEPARATOR) # "/" pedantry
+
+    Bidi::LEFT_TO_RIGHT_ISOLATE + joined + POP_DIRECTIONAL_ISOLATE
+  end
+  module_function :pathname_bidi_to_s
+
+  # Return a copy of *str* where bidirectional formatting characters are removed
+  # @param str [String]
+  # @return [String]
+  def bidi_strip(str)
+    str.tr(BIDI_CONTROLS, "")
+  end
+  module_function :bidi_strip
+end

--- a/src/lib/y2partitioner/bidi.rb
+++ b/src/lib/y2partitioner/bidi.rb
@@ -73,6 +73,8 @@ module Bidi
   # otherwise /dev/sda will be presented as dev/sda/ in RTL context
   # @param pname [Pathname]
   def pathname_bidi_to_s(pname)
+    return ltr_isolate(File::SEPARATOR) if pname.root?
+
     isolated_components = pname.each_filename.map { |fn| first_strong_isolate(fn) }
 
     isolated_components.unshift("") if pname.absolute?

--- a/src/lib/y2partitioner/widgets/columns/base.rb
+++ b/src/lib/y2partitioner/widgets/columns/base.rb
@@ -20,6 +20,7 @@
 require "yast"
 require "abstract_method"
 require "y2partitioner/device_graphs"
+require "y2partitioner/bidi"
 
 module Y2Partitioner
   module Widgets
@@ -110,6 +111,11 @@ module Y2Partitioner
         end
 
         private
+
+        def left_to_right(path_string)
+          pn = Pathname.new(path_string)
+          Bidi.pathname_bidi_to_s(pn)
+        end
 
         # Helper method to create a `cell` term
         #

--- a/src/lib/y2partitioner/widgets/columns/base.rb
+++ b/src/lib/y2partitioner/widgets/columns/base.rb
@@ -113,8 +113,20 @@ module Y2Partitioner
         private
 
         def left_to_right(path_string)
+          return path_string unless bidi_supported?
+
           pn = Pathname.new(path_string)
           Bidi.pathname_bidi_to_s(pn)
+        end
+
+        # In ncurses the bidi characters would mess up columns,
+        # making things worse; return false there.
+        def bidi_supported?
+          return @bidi_supported unless @bidi_supported.nil?
+
+          di = Yast::UI.GetDisplayInfo() || {}
+          text_mode = di.fetch("TextMode", true)
+          @bidi_supported = !text_mode
         end
 
         # Helper method to create a `cell` term

--- a/src/lib/y2partitioner/widgets/columns/base.rb
+++ b/src/lib/y2partitioner/widgets/columns/base.rb
@@ -19,8 +19,8 @@
 
 require "yast"
 require "abstract_method"
+require "bidi_markup"
 require "y2partitioner/device_graphs"
-require "y2partitioner/bidi"
 
 module Y2Partitioner
   module Widgets
@@ -116,7 +116,7 @@ module Y2Partitioner
           return path_string unless bidi_supported?
 
           pn = Pathname.new(path_string)
-          Bidi.pathname_bidi_to_s(pn)
+          BidiMarkup.pathname_bidi_to_s(pn)
         end
 
         # In ncurses the bidi characters would mess up columns,

--- a/src/lib/y2partitioner/widgets/columns/device.rb
+++ b/src/lib/y2partitioner/widgets/columns/device.rb
@@ -53,11 +53,12 @@ module Y2Partitioner
 
         # The device name
         #
+        # @param entry [DeviceTableEntry]
         # @return [String]
         def device_name(device, entry)
-          return fstab_device_name(device, entry) if fstab_entry?(device)
-          return device.path if device.is?(:btrfs_subvolume)
-          return blk_device_name(device, entry) unless device.is?(:blk_filesystem)
+          return left_to_right(fstab_device_name(device, entry)) if fstab_entry?(device)
+          return left_to_right(device.path) if device.is?(:btrfs_subvolume)
+          return left_to_right(blk_device_name(device, entry)) unless device.is?(:blk_filesystem)
 
           device.name
         end

--- a/src/lib/y2partitioner/widgets/columns/mount_point.rb
+++ b/src/lib/y2partitioner/widgets/columns/mount_point.rb
@@ -38,13 +38,13 @@ module Y2Partitioner
 
         # @see Columns::Base#value_for
         def value_for(device)
-          return device.mount_point if fstab_entry?(device)
+          return left_to_right(device.mount_point) if fstab_entry?(device)
 
           mount_point = mount_point_for(device)
 
           return "" unless mount_point
 
-          path = mount_point.path
+          path = left_to_right(mount_point.path)
           path += " *" unless mount_point.active?
 
           path

--- a/src/lib/y2partitioner/widgets/tabs.rb
+++ b/src/lib/y2partitioner/widgets/tabs.rb
@@ -1,3 +1,22 @@
+# Copyright (c) [2017-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require "yast"
 require "cwm/tabs"
 require "y2partitioner/ui_state"

--- a/src/lib/y2partitioner/yard_links.rb
+++ b/src/lib/y2partitioner/yard_links.rb
@@ -1,3 +1,22 @@
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 # The documentatin tool YARD has no mechanism
 # for linking to separately generated YARD documentation.
 # So we use this file to help YARD.

--- a/test/data/devicegraphs/bidi.yml
+++ b/test/data/devicegraphs/bidi.yml
@@ -1,0 +1,29 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    file_system:  ext4
+    label:        root
+    mount_point:  "/"
+
+- disk:
+    name: /dev/sdb
+    size: 1 GiB
+    partition_table:  msdos
+    partitions:
+
+    - partition:
+        size:         500 MiB
+        name:         /dev/sdb1
+        file_system:  ext4
+        # /fidiu/qdima (/video/old)
+        mount_point:  "/\u0641\u064A\u062F\u064A\u0648/\u0642\u062F\u064A\u0645\u0629"
+
+    - partition:
+        size:         500 MiB
+        name:         /dev/sdb2
+        file_system:  ext4
+        # /fidiu/jdida (/video/new)
+        mount_point:  "/\u0641\u064A\u062F\u064A\u0648/\u062C\u062F\u064A\u062F\u0629"
+
+

--- a/test/y2partitioner/test_helper.rb
+++ b/test/y2partitioner/test_helper.rb
@@ -19,6 +19,7 @@
 # find current contact information at www.suse.com
 
 require_relative "../spec_helper"
+require "y2partitioner/bidi"
 
 # Removes the :sortKey term from a :cell term, possibly returning only
 # the single param of the term.
@@ -31,7 +32,7 @@ def remove_sort_key(term)
   term.params.delete_if { |param| param.is_a?(Yast::Term) && param.value == :sortKey }
   return term if term.params.size > 1
 
-  term.params[0]
+  Bidi.bidi_strip(term.params[0])
 end
 
 # Removes the :sortKey term from :cell terms somewhere inside (to the

--- a/test/y2partitioner/test_helper.rb
+++ b/test/y2partitioner/test_helper.rb
@@ -19,7 +19,7 @@
 # find current contact information at www.suse.com
 
 require_relative "../spec_helper"
-require "y2partitioner/bidi"
+require "bidi_markup"
 
 # Removes the :sortKey term from a :cell term, possibly returning only
 # the single param of the term.
@@ -32,7 +32,7 @@ def remove_sort_key(term)
   term.params.delete_if { |param| param.is_a?(Yast::Term) && param.value == :sortKey }
   return term if term.params.size > 1
 
-  Bidi.bidi_strip(term.params[0])
+  BidiMarkup.bidi_strip(term.params[0])
 end
 
 # Removes the :sortKey term from :cell terms somewhere inside (to the

--- a/test/y2partitioner/widgets/columns/device_test.rb
+++ b/test/y2partitioner/widgets/columns/device_test.rb
@@ -56,6 +56,13 @@ describe Y2Partitioner::Widgets::Columns::Device do
       it "uses the sort key provided by libstorage-ng" do
         expect(sort_key).to eq(device.name_sort_key)
       end
+
+      it "wraps the value with bidi control characters" do
+        expect(subject.value_for(device)).to satisfy do |term|
+          term.value == :cell &&
+            term.params[0] == "\u2066/\u2068dev\u2069/\u2068sdb1\u2069\u2069"
+        end
+      end
     end
 
     shared_examples "filesystem" do

--- a/test/y2partitioner/widgets/columns/device_test.rb
+++ b/test/y2partitioner/widgets/columns/device_test.rb
@@ -58,6 +58,8 @@ describe Y2Partitioner::Widgets::Columns::Device do
       end
 
       it "wraps the value with bidi control characters" do
+        allow(subject).to receive(:bidi_supported?).and_return(true)
+
         expect(subject.value_for(device)).to satisfy do |term|
           term.value == :cell &&
             term.params[0] == "\u2066/\u2068dev\u2069/\u2068sdb1\u2069\u2069"

--- a/test/y2partitioner/widgets/columns/mount_point_test.rb
+++ b/test/y2partitioner/widgets/columns/mount_point_test.rb
@@ -37,13 +37,13 @@ describe Y2Partitioner::Widgets::Columns::MountPoint do
     devicegraph_stub(scenario)
   end
 
-  describe "#values_for" do
+  describe "#value_for" do
     context "when given device is a fstab entry" do
       let(:btrfs) { Y2Storage::Filesystems::Type::BTRFS }
       let(:home_fstab_entry) { fstab_entry("/dev/sda2", "/home", btrfs, ["subvol=@/home"], 0, 0) }
 
       it "returns its mount point" do
-        expect(subject.value_for(home_fstab_entry)).to eq("/home")
+        expect(Bidi.bidi_strip(subject.value_for(home_fstab_entry))).to eq("/home")
       end
     end
 
@@ -95,7 +95,7 @@ describe Y2Partitioner::Widgets::Columns::MountPoint do
       end
 
       it "returns the mount path without an asterisk sign" do
-        expect(subject.value_for(device)).to eq("/test2")
+        expect(Bidi.bidi_strip(subject.value_for(device))).to eq("/test2")
       end
     end
 
@@ -105,8 +105,8 @@ describe Y2Partitioner::Widgets::Columns::MountPoint do
         Y2Storage::Filesystems::Nfs.find_by_server_and_path(devicegraph, "srv", "/home/a")
       end
 
-      it "returns the mount path including an asterkisk sign" do
-        expect(subject.value_for(device)).to eq("/test1 *")
+      it "returns the mount path including an asterisk sign" do
+        expect(Bidi.bidi_strip(subject.value_for(device))).to eq("/test1 *")
       end
     end
   end

--- a/test/y2partitioner/widgets/columns/mount_point_test.rb
+++ b/test/y2partitioner/widgets/columns/mount_point_test.rb
@@ -115,6 +115,8 @@ describe Y2Partitioner::Widgets::Columns::MountPoint do
       let(:device_name) { "/dev/sdb1" }
 
       it "returns the mount path with appropriate bidi control characters" do
+        allow(subject).to receive(:bidi_supported?).and_return(true)
+
         # \u20xx are the control characters
         # \u06xx are Arabic letters
         expect(subject.value_for(device)).to eq("\u2066" \

--- a/test/y2partitioner/widgets/columns/mount_point_test.rb
+++ b/test/y2partitioner/widgets/columns/mount_point_test.rb
@@ -43,7 +43,7 @@ describe Y2Partitioner::Widgets::Columns::MountPoint do
       let(:home_fstab_entry) { fstab_entry("/dev/sda2", "/home", btrfs, ["subvol=@/home"], 0, 0) }
 
       it "returns its mount point" do
-        expect(Bidi.bidi_strip(subject.value_for(home_fstab_entry))).to eq("/home")
+        expect(BidiMarkup.bidi_strip(subject.value_for(home_fstab_entry))).to eq("/home")
       end
     end
 
@@ -95,7 +95,7 @@ describe Y2Partitioner::Widgets::Columns::MountPoint do
       end
 
       it "returns the mount path without an asterisk sign" do
-        expect(Bidi.bidi_strip(subject.value_for(device))).to eq("/test2")
+        expect(BidiMarkup.bidi_strip(subject.value_for(device))).to eq("/test2")
       end
     end
 
@@ -106,7 +106,7 @@ describe Y2Partitioner::Widgets::Columns::MountPoint do
       end
 
       it "returns the mount path including an asterisk sign" do
-        expect(Bidi.bidi_strip(subject.value_for(device))).to eq("/test1 *")
+        expect(BidiMarkup.bidi_strip(subject.value_for(device))).to eq("/test1 *")
       end
     end
 

--- a/test/y2partitioner/widgets/columns/mount_point_test.rb
+++ b/test/y2partitioner/widgets/columns/mount_point_test.rb
@@ -109,5 +109,19 @@ describe Y2Partitioner::Widgets::Columns::MountPoint do
         expect(Bidi.bidi_strip(subject.value_for(device))).to eq("/test1 *")
       end
     end
+
+    context "(not only) when the mount path contains right to left (RTL) characters" do
+      let(:scenario) { "bidi.yml" }
+      let(:device_name) { "/dev/sdb1" }
+
+      it "returns the mount path with appropriate bidi control characters" do
+        # \u20xx are the control characters
+        # \u06xx are Arabic letters
+        expect(subject.value_for(device)).to eq("\u2066" \
+                                                "/\u2068\u0641\u064A\u062F\u064A\u0648\u2069" \
+                                                "/\u2068\u0642\u062F\u064A\u0645\u0629\u2069" \
+                                                "\u2069")
+      end
+    end
   end
 end

--- a/test/y2partitioner/widgets/columns/mount_point_test.rb
+++ b/test/y2partitioner/widgets/columns/mount_point_test.rb
@@ -110,8 +110,11 @@ describe Y2Partitioner::Widgets::Columns::MountPoint do
       end
     end
 
-    context "(not only) when the mount path contains right to left (RTL) characters" do
+    describe "bidi right to left (RTL) handling" do
       let(:scenario) { "bidi.yml" }
+      before do
+        allow(subject).to receive(:bidi_supported?).and_return(true)
+      end
       let(:device_name) { "/dev/sdb1" }
 
       it "returns the mount path with appropriate bidi control characters" do
@@ -123,6 +126,14 @@ describe Y2Partitioner::Widgets::Columns::MountPoint do
                                                 "/\u2068\u0641\u064A\u062F\u064A\u0648\u2069" \
                                                 "/\u2068\u0642\u062F\u064A\u0645\u0629\u2069" \
                                                 "\u2069")
+      end
+
+      context "when the path is root /" do
+        let(:device_name) { "/dev/sda" }
+
+        it "returns the mount path wrapped with LTR Isolate" do
+          expect(subject.value_for(device)).to eq("\u2066/\u2069")
+        end
       end
     end
   end


### PR DESCRIPTION
## Problem

In Arabic, the device table displays `/dev/sda1` as `dev/sda1/`

- https://bugzilla.suse.com/show_bug.cgi?id=1128091

## Solution

Use [Unicode BiDi formatting characters](https://www.unicode.org/reports/tr9/#Directional_Formatting_Codes) in the source (creating a machine "translation" of the string).

Disabled for TUI: libyui-ncurses does not handle the BiDi characters well, truncating the strings. TUI does not have the general RTL direction anyway.

If you start off with a JEOS and only install the bare minimum of packages needed to test this, you may end up seeing dotted box characters in place of the BiDi controls. Installing *noto-sans-fonts.rpm* helps.

## Testing

- [x] Added a new unit test
- [x] Tested manually
- [x] Fix and test handling `/`


## Screenshots

<table>
<tr><td>before</td><td>after</td></tr>
<tr><td>
<img title="yast-disk-rtl-pathnames-bad" src="https://user-images.githubusercontent.com/102056/99941060-a9e56380-2d6d-11eb-9217-85f103b3aa60.png">
</td><td>
<img title="yast-disk-rtl-pathnames-good2" src="https://user-images.githubusercontent.com/102056/99941075-aeaa1780-2d6d-11eb-8a1a-ed435b55d75d.png">
</td>
</tr></table>
