### PR TITLE
Extend ExistingFilesystem class

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 19 15:09:55 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Extend ExistingFilesystem class to read more information related
+  to the filesystem (e.g., ELF arch, complete installation check).
+
+-------------------------------------------------------------------
 Mon Mar 18 09:30:02 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix bcache and AutoYaST related tests (related to fate#325346).

--- a/src/lib/y2storage/disk_analyzer.rb
+++ b/src/lib/y2storage/disk_analyzer.rb
@@ -197,34 +197,18 @@ module Y2Storage
 
     # @see #windows_partitions
     def find_windows_partitions(disk)
-      return nil unless windows_architecture?
-      disk.possible_windows_partitions.select { |p| windows_partition?(p) }
+      disk.partitions.select { |p| windows_partition?(p) }
     end
 
-    # Checks whether the architecture of the system is supported by
-    # MS Windows
+    # Check if the partition contains a MS Windows system that could possibly be resized.
     #
+    # @param partition [Partition] partition to check
     # @return [Boolean]
-    def windows_architecture?
-      # Should we include ARM here?
-      Yast::Arch.x86_64 || Yast::Arch.i386
-    end
-
-    # Check if 'partition' is a MS Windows partition that could possibly be resized.
-    #
-    # @param partition [Partition] partition to check.
-    # @return [Boolean] 'true' if it is a Windows partition, 'false' if not.
     def windows_partition?(partition)
-      log.info("Checking if #{partition.name} is a windows partition")
+      return false unless partition.formatted?
+
       filesystem = partition.filesystem
-      is_win = filesystem && filesystem.detect_content_info.windows?
-
-      log.info("#{partition.name} is a windows partition") if is_win
-      is_win
-
-    rescue Storage::Exception
-      log.warn("#{partition.name} content info cannot be detected")
-      false
+      ExistingFilesystem.new(filesystem).windows?
     end
 
     # Obtain release names of installed systems in a disk.

--- a/src/lib/y2storage/elf_arch.rb
+++ b/src/lib/y2storage/elf_arch.rb
@@ -1,0 +1,77 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast2/execute"
+
+Yast.import "Directory"
+
+module Y2Storage
+  # Class to extract the architecture in which a filesystem was created
+  class ELFArch
+    # Constructor
+    #
+    # @param root_path [String] path where the filesystem is mounted
+    def initialize(root_path = "/")
+      @root_path = root_path
+    end
+
+    # Architecture extracted from the filesystem
+    #
+    # @return [String] e.g., "x86_64", "ppc", "s390", etc. It returns
+    #   "unknown" when the check fails.
+    def value
+      @value ||= command_stdout
+    end
+
+  private
+
+    # @return [String]
+    attr_reader :root_path
+
+    COMMAND_NAME = "elf-arch".freeze
+
+    private_constant :COMMAND_NAME
+
+    # Runs "elf-arch" command over the bash binary and returns its output
+    #
+    # @return [String] architecture or "unknown" in case of error
+    def command_stdout
+      Yast::Execute.locally!(command, bash_path, stdout: :capture).chomp
+    rescue Cheetah::ExecutionFailed
+      "unknown"
+    end
+
+    # Absolute path to "elf-arch" command
+    #
+    # @return [String]
+    def command
+      File.join(Yast::Directory.ybindir, COMMAND_NAME)
+    end
+
+    # Absolute path to bash binary inside the filesystem
+    #
+    # @return [String]
+    def bash_path
+      File.join(root_path, "/bin/bash")
+    end
+  end
+end

--- a/src/lib/y2storage/existing_filesystem.rb
+++ b/src/lib/y2storage/existing_filesystem.rb
@@ -40,11 +40,9 @@ module Y2Storage
     # Constructor
     #
     # @param filesystem [Filesystems::Base]
-    # @param root [String]
     # @param mount_point [String]
-    def initialize(filesystem, root = "/", mount_point = "/mnt")
+    def initialize(filesystem, mount_point = "/mnt")
       @filesystem = filesystem
-      @root = root
       @mount_point = mount_point
 
       @processed = false

--- a/src/lib/y2storage/existing_filesystem.rb
+++ b/src/lib/y2storage/existing_filesystem.rb
@@ -44,7 +44,7 @@ module Y2Storage
       @filesystem = filesystem
       @root = root
       @mount_point = mount_point
-      @rpi_boot = false
+
       @processed = false
     end
 
@@ -71,7 +71,7 @@ module Y2Storage
       @fstab
     end
 
-    # Read the crypttab file from the filesystem
+    # Reads the crypttab file from the filesystem
     #
     # @return [Crypttab, nil] nil if the crypttab file cannot be read
     def crypttab
@@ -85,7 +85,15 @@ module Y2Storage
     # @return [Boolean]
     def rpi_boot?
       set_attributes unless processed?
-      @rpi_boot
+      !!@rpi_boot
+    end
+
+    # Whether the filesystem contains a MS Windows system
+    #
+    # @return [Boolean]
+    def windows?
+      set_attributes unless processed?
+      @windows
     end
 
   protected
@@ -94,7 +102,44 @@ module Y2Storage
     attr_reader :processed
     alias_method :processed?, :processed
 
+    # Sets attributes depending on the kind of system it contains (Windows or Linux)
     def set_attributes
+      @windows = windows_filesystem?
+
+      read_filesystem unless @windows
+
+      @processed = true
+    end
+
+    # Whether the filesystem contains a Windows system
+    #
+    # @return [Boolean]
+    def windows_filesystem?
+      return false if !windows_architecture? || !windows_partition?
+
+      filesystem.detect_content_info.windows?
+    rescue Storage::Exception
+      log.warn("#{device.name} content info cannot be detected")
+      false
+    end
+
+    # Whether the architecture of the system is supported by MS Windows
+    #
+    # @return [Boolean]
+    def windows_architecture?
+      # Should we include ARM here?
+      Yast::Arch.x86_64 || Yast::Arch.i386
+    end
+
+    # Whether the filesystem is created over a Windows-suitable partition
+    #
+    # @return [Boolean]
+    def windows_partition?
+      device.is?(:partition) && device.suitable_for_windows?
+    end
+
+    # Reads needed info from the filesystem
+    def read_filesystem
       mount
       @release_name = read_release_name
       @fstab = read_fstab
@@ -104,8 +149,6 @@ module Y2Storage
     rescue RuntimeError => ex # FIXME: rescue ::Storage::Exception when SWIG bindings are fixed
       log.error("CAUGHT exception: #{ex} for #{device.name}")
       nil
-    ensure
-      @processed = true
     end
 
     # Mounts the device

--- a/src/lib/y2storage/partition.rb
+++ b/src/lib/y2storage/partition.rb
@@ -268,6 +268,13 @@ module Y2Storage
       id.is?(:swap) && formatted_as?(:swap)
     end
 
+    # Whether the partition fulfills conditions to be used for a Windows system
+    #
+    # @return [Boolean]
+    def suitable_for_windows?
+      type.is?(:primary) && id.is?(:windows_system)
+    end
+
   protected
 
     # Values for volume specification matching

--- a/src/lib/y2storage/partitionable.rb
+++ b/src/lib/y2storage/partitionable.rb
@@ -205,7 +205,7 @@ module Y2Storage
     def possible_windows_partitions
       # Sorting is not mandatory, but keeping the output stable looks like a
       # sane practice.
-      partitions.select { |p| p.type.is?(:primary) && p.id.is?(:windows_system) }.sort_by(&:number)
+      partitions.select(&:suitable_for_windows?).sort_by(&:number)
     end
 
     # Size between MBR and first partition.

--- a/test/support/proposal_context.rb
+++ b/test/support/proposal_context.rb
@@ -29,7 +29,7 @@ RSpec.shared_context "proposal" do
 
     allow(Y2Storage::DiskAnalyzer).to receive(:new).and_return disk_analyzer
     allow(disk_analyzer).to receive(:windows_partition?) do |partition|
-      !!(partition.filesystem.label =~ /indows/)
+      partition.filesystem && !!(partition.filesystem.label =~ /indows/)
     end
 
     allow_any_instance_of(Y2Storage::Partition).to receive(:detect_resize_info)

--- a/test/y2storage/elf_arch_test.rb
+++ b/test/y2storage/elf_arch_test.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage/elf_arch"
+
+describe Y2Storage::ELFArch do
+  subject { described_class.new("/") }
+
+  describe "#value" do
+    context "when the 'elf-arch' command successes" do
+      before do
+        allow(Yast::Execute).to receive(:locally!)
+          .with(/elf-arch/, /bash/, anything).and_return("ppc")
+      end
+
+      it "returns the architecture from the ELF of bash binary" do
+        expect(subject.value).to eq("ppc")
+      end
+    end
+
+    context "when the 'elf-arch' command fails" do
+      before do
+        allow(Yast::Execute).to receive(:locally!)
+          .with(/elf-arch/, /bash/, anything).and_raise(cheetah_error)
+      end
+
+      let(:cheetah_error) { Cheetah::ExecutionFailed.new([], "", nil, nil) }
+
+      it "returns 'unknown'" do
+        expect(subject.value).to eq("unknown")
+      end
+    end
+  end
+end

--- a/test/y2storage/existing_filesystem_test.rb
+++ b/test/y2storage/existing_filesystem_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2016-2017] SUSE LLC
+# Copyright (c) [2016-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -65,20 +65,34 @@ RSpec.shared_examples "Mount and umount actions" do
 end
 
 describe Y2Storage::ExistingFilesystem do
+  before do
+    fake_scenario(scenario)
+    allow(filesystem).to receive(:detect_content_info).and_return(content_info)
+  end
+
   subject { described_class.new(filesystem, root, mount_point) }
 
   let(:root) { "" }
+
   let(:mount_point) { "" }
+
   let(:mount_cmd) { ["/usr/bin/mount", "-o", "ro", device.name, mount_point] }
+
   let(:umount_cmd) { ["/usr/bin/umount", "-R", mount_point] }
+
   let(:result_if_mount_fails) { nil }
 
-  let(:filesystem) { instance_double(Storage::BlkFilesystem, blk_devices: [device]) }
-  let(:device) { instance_double(Storage::BlkDevice, name: "/dev/sda") }
+  let(:device) { fake_devicegraph.find_by_name(device_name) }
 
-  before do
-    allow(Yast::Execute).to receive(:locally!)
-  end
+  let(:filesystem) { device.filesystem }
+
+  let(:content_info) { instance_double(Storage::ContentInfo, windows?: windows_content) }
+
+  let(:windows_content) { false }
+
+  let(:scenario) { "windows-linux-free-pc" }
+
+  let(:device_name) { "/dev/sda3" }
 
   describe "#device" do
     it "returns the device of the filesystem" do
@@ -87,121 +101,236 @@ describe Y2Storage::ExistingFilesystem do
   end
 
   describe "#release_name" do
-    let(:tested_method) { :release_name }
+    context "when the filesystem contains a Windows system" do
+      let(:device_name) { "/dev/sda1" }
 
-    before do
-      allow(Yast::OSRelease).to receive(:ReleaseName).and_return release_name
-    end
-
-    let(:release_name) { "Open SUSE" }
-
-    include_examples "Mount and umount actions"
-
-    context "when there is an installed system" do
-      it "returns the release name" do
-        expect(subject.release_name).to eq(release_name)
-      end
-    end
-
-    context "when there is not an installed system" do
-      let(:release_name) { "" }
+      let(:windows_content) { true }
 
       it "returns nil" do
         expect(subject.release_name).to be_nil
       end
     end
+
+    context "when the filesystem does not contain a Windows system" do
+      let(:device_name) { "/dev/sda3" }
+
+      before do
+        allow(Yast::OSRelease).to receive(:ReleaseName).and_return release_name
+      end
+
+      let(:release_name) { "Open SUSE" }
+
+      let(:tested_method) { :release_name }
+
+      include_examples "Mount and umount actions"
+
+      context "when there is an installed system" do
+        let(:release_name) { "Open SUSE" }
+
+        it "returns the release name" do
+          expect(subject.release_name).to eq(release_name)
+        end
+      end
+
+      context "when there is not an installed system" do
+        let(:release_name) { "" }
+
+        it "returns nil" do
+          expect(subject.release_name).to be_nil
+        end
+      end
+    end
   end
 
   describe "#fstab" do
-    let(:tested_method) { :fstab }
+    context "when the filesystem contains a Windows system" do
+      let(:device_name) { "/dev/sda1" }
 
-    before do
-      allow(File).to receive(:exist?).and_return(exists_fstab)
-    end
-
-    let(:exists_fstab) { true }
-
-    include_examples "Mount and umount actions"
-
-    context "when the fstab file does not exist" do
-      let(:exists_fstab) { false }
+      let(:windows_content) { true }
 
       it "returns nil" do
         expect(subject.fstab).to be_nil
       end
     end
 
-    context "when the fstab file exists" do
+    context "when the filesystem does not contain a Windows system" do
+      let(:device_name) { "/dev/sda3" }
+
+      let(:tested_method) { :fstab }
+
+      before do
+        allow(File).to receive(:exist?).and_return(exists_fstab)
+      end
+
       let(:exists_fstab) { true }
 
-      it "returns the fstab" do
-        expect(subject.fstab).to be_a(Y2Storage::Fstab)
+      include_examples "Mount and umount actions"
+
+      context "when the fstab file does not exist" do
+        let(:exists_fstab) { false }
+
+        it "returns nil" do
+          expect(subject.fstab).to be_nil
+        end
+      end
+
+      context "when the fstab file exists" do
+        let(:exists_fstab) { true }
+
+        it "returns the fstab" do
+          expect(subject.fstab).to be_a(Y2Storage::Fstab)
+        end
       end
     end
   end
 
   describe "#crypttab" do
-    let(:tested_method) { :crypttab }
+    context "when the filesystem contains a Windows system" do
+      let(:device_name) { "/dev/sda1" }
 
-    before do
-      allow(File).to receive(:exist?).and_return(exists_crypttab)
-    end
-
-    let(:exists_crypttab) { true }
-
-    include_examples "Mount and umount actions"
-
-    context "when the crypttab file does not exist" do
-      let(:exists_crypttab) { false }
+      let(:windows_content) { true }
 
       it "returns nil" do
         expect(subject.crypttab).to be_nil
       end
     end
 
-    context "when the crypttab file exists" do
+    context "when the filesystem does not contain a Windows system" do
+      let(:device_name) { "/dev/sda3" }
+
+      let(:tested_method) { :crypttab }
+
+      before do
+        allow(File).to receive(:exist?).and_return(exists_crypttab)
+      end
+
       let(:exists_crypttab) { true }
 
-      it "returns the crypttab" do
-        expect(subject.crypttab).to be_a(Y2Storage::Crypttab)
+      include_examples "Mount and umount actions"
+
+      context "when the crypttab file does not exist" do
+        let(:exists_crypttab) { false }
+
+        it "returns nil" do
+          expect(subject.crypttab).to be_nil
+        end
+      end
+
+      context "when the crypttab file exists" do
+        let(:exists_crypttab) { true }
+
+        it "returns the crypttab" do
+          expect(subject.crypttab).to be_a(Y2Storage::Crypttab)
+        end
       end
     end
   end
 
   describe "#rpi_boot?" do
-    let(:tested_method) { :rpi_boot? }
-    let(:existing_files) { [] }
-    let(:result_if_mount_fails) { false }
+    context "when the filesystem contains a Windows system" do
+      let(:device_name) { "/dev/sda1" }
 
-    before do
-      allow(File).to receive(:exist?) do |name|
-        existing_files.include?(name)
-      end
-    end
-
-    include_examples "Mount and umount actions"
-
-    context "when there is no file called bootcode.bin or BOOTCODE.bin" do
-      let(:existing_files) { %w(/foo /bar) }
+      let(:windows_content) { true }
 
       it "returns false" do
-        expect(subject.rpi_boot?).to eq false
+        expect(subject.rpi_boot?).to eq(false)
       end
     end
 
-    context "when there is a file called bootcode.bin" do
-      let(:existing_files) { %w(/foo /bar /bootcode.bin) }
+    context "when the filesystem does not contain a Windows system" do
+      let(:device_name) { "/dev/sda3" }
 
-      it "returns true" do
-        expect(subject.rpi_boot?).to eq true
+      let(:tested_method) { :rpi_boot? }
+      let(:existing_files) { [] }
+      let(:result_if_mount_fails) { false }
+
+      before do
+        allow(File).to receive(:exist?) do |name|
+          existing_files.include?(name)
+        end
+      end
+
+      include_examples "Mount and umount actions"
+
+      context "when there is no file called bootcode.bin or BOOTCODE.bin" do
+        let(:existing_files) { %w(/foo /bar) }
+
+        it "returns false" do
+          expect(subject.rpi_boot?).to eq false
+        end
+      end
+
+      context "when there is a file called bootcode.bin" do
+        let(:existing_files) { %w(/foo /bar /bootcode.bin) }
+
+        it "returns true" do
+          expect(subject.rpi_boot?).to eq true
+        end
+      end
+
+      context "when there is a file called BOOTCODE.BIN" do
+        let(:existing_files) { %w(/BOOTCODE.BIN) }
+
+        it "returns true" do
+          expect(subject.rpi_boot?).to eq true
+        end
+      end
+    end
+  end
+
+  describe "#windows?" do
+    context "when the architecture is not supported for Windows (non-PC system)" do
+      let(:architecture) { :s390 }
+
+      it "returns false" do
+        expect(subject.windows?).to eq(false)
       end
     end
 
-    context "when there is a file called BOOTCODE.BIN" do
-      let(:existing_files) { %w(/BOOTCODE.BIN) }
+    context "when the architecture is supported for Windows (PC system)" do
+      let(:architecture) { :x86_64 }
 
-      it "returns true" do
-        expect(subject.rpi_boot?).to eq true
+      context "and the filesystem is created over a non-suitable Windows partition" do
+        let(:device_name) { "/dev/sda3" }
+
+        it "returns false" do
+          expect(subject.windows?).to eq(false)
+        end
+      end
+
+      context "when the filesystem is created over a suitable Windows partition" do
+        let(:device_name) { "/dev/sda1" }
+
+        context "and the filesystem contains a Windows system" do
+          let(:windows_content) { true }
+
+          it "returns true" do
+            expect(subject.windows?).to eq(true)
+          end
+        end
+
+        context "and the filesystem does not contain a Windows system" do
+          let(:windows_content) { false }
+
+          it "returns false" do
+            expect(subject.windows?).to eq(false)
+          end
+        end
+
+        context "and the filesystem content cannot be inspected" do
+          before do
+            allow(filesystem).to receive(:detect_content_info).and_raise(Storage::Exception)
+          end
+
+          it "returns false" do
+            expect(subject.windows?).to eq(false)
+          end
+        end
+      end
+    end
+  end
+
+
       end
     end
   end

--- a/test/y2storage/existing_filesystem_test.rb
+++ b/test/y2storage/existing_filesystem_test.rb
@@ -75,9 +75,7 @@ describe Y2Storage::ExistingFilesystem do
     allow(filesystem).to receive(:detect_content_info).and_return(content_info)
   end
 
-  subject { described_class.new(filesystem, root, mount_point) }
-
-  let(:root) { "" }
+  subject { described_class.new(filesystem, mount_point) }
 
   let(:mount_point) { "" }
 

--- a/test/y2storage/partition_test.rb
+++ b/test/y2storage/partition_test.rb
@@ -543,4 +543,44 @@ describe Y2Storage::Partition do
       end
     end
   end
+
+  describe "#suitable_for_windows?" do
+    let(:scenario) { "mixed_disks" }
+
+    subject(:partition) { fake_devicegraph.find_by_name(device_name) }
+
+    before do
+      partition.id = id
+    end
+
+    let(:id) { Y2Storage::PartitionId::LINUX }
+
+    context "when it is not a primary partition" do
+      let(:device_name) { "/dev/sdb5" }
+
+      it "returns false" do
+        expect(subject.suitable_for_windows?).to eq(false)
+      end
+    end
+
+    context "when it is a primary partition" do
+      let(:device_name) { "/dev/sda1" }
+
+      context "and it has 'windows_system' id" do
+        let(:id) { Y2Storage::PartitionId::NTFS }
+
+        it "returns true" do
+          expect(subject.suitable_for_windows?).to eq(true)
+        end
+      end
+
+      context "and it has no 'windows_system' id" do
+        let(:id) { Y2Storage::PartitionId::LVM }
+
+        it "returns false" do
+          expect(subject.suitable_for_windows?).to eq(false)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION

**NOTE**: pre-SLE-15-SP2 branch will not be merged into master until SLE-15-SP1 is branched.

## Problem

Class `ExistingFilesystem` needs to be extended to read more information about the filesystem. For example, whether the filesystem installation was complete or the ELF architecture. Such information is used while upgrading the system.

* https://trello.com/c/IcPWJBUW/817-3-missing-icons-in-partitioner-configure
* Needed for https://github.com/yast/yast-update/pull/119

## Solution

Read more information once the filesystem is mounted.

## Testing

- Added unit tests

