### PR TITLE
Fix bcache tests

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 26 11:51:34 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Improve unit tests: mocking architecture for Bcache is not needed
+  anymore (fix regression tests for bsc#1129787).
+- 4.1.77
+
+-------------------------------------------------------------------
 Mon Mar 25 14:20:54 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Fix boot disk detection (bsc#1129787).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.76
+Version:	4.1.77
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -87,6 +87,16 @@ RSpec.configure do |c|
       allow(Yast::Arch).to receive(:s390).and_return(architecture == :s390)
       allow(Yast::Arch).to receive(:aarch64).and_return(architecture == :aarch64)
     end
+
+    # Bcache is only supported for x86_64 architecture. The sanitizer complains when
+    # Bcache is used with another architecture. Bcache errors are mocked here to avoid
+    # to have to indicate x86_84 architecture in every test using Bcache (which has
+    # demonstrated to be quite error prone).
+    #
+    # This should be properly unmocked in the tests where real Bcache checking needs
+    # to be performed (e.g., DevicegraphSanitizer tests).
+    allow_any_instance_of(Y2Storage::DevicegraphSanitizer)
+      .to receive(:errors_for_bcache).and_return([])
   end
 
   # Some tests use ProposalSettings#new_for_current_product to initialize

--- a/test/y2partitioner/actions/add_bcache_test.rb
+++ b/test/y2partitioner/actions/add_bcache_test.rb
@@ -29,8 +29,6 @@ require "y2partitioner/dialogs/bcache"
 describe Y2Partitioner::Actions::AddBcache do
   subject { described_class.new }
 
-  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
-
   before do
     devicegraph_stub(scenario)
 

--- a/test/y2partitioner/actions/controllers/bcache_test.rb
+++ b/test/y2partitioner/actions/controllers/bcache_test.rb
@@ -30,9 +30,6 @@ describe Y2Partitioner::Actions::Controllers::Bcache do
     devicegraph_stub(scenario)
   end
 
-  # Bcache is only supported on x86
-  let(:architecture) { :x86_64 }
-
   subject(:controller) { described_class.new(device) }
 
   let(:device) { nil }

--- a/test/y2partitioner/actions/delete_bcache_test.rb
+++ b/test/y2partitioner/actions/delete_bcache_test.rb
@@ -38,8 +38,6 @@ describe Y2Partitioner::Actions::DeleteBcache do
 
   subject { described_class.new(device) }
 
-  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
-
   let(:device) { Y2Storage::BlkDevice.find_by_name(device_graph, device_name) }
 
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }

--- a/test/y2partitioner/actions/edit_bcache_test.rb
+++ b/test/y2partitioner/actions/edit_bcache_test.rb
@@ -41,9 +41,6 @@ describe Y2Partitioner::Actions::EditBcache do
       .and_return(selected_options)
   end
 
-  # Bcache is only supported on x86
-  let(:architecture) { :x86_64 }
-
   let(:dialog_result) { nil }
 
   let(:selected_caching) { nil }

--- a/test/y2partitioner/actions/edit_blk_device_test.rb
+++ b/test/y2partitioner/actions/edit_blk_device_test.rb
@@ -161,7 +161,6 @@ describe Y2Partitioner::Actions::EditBlkDevice do
       end
 
       context "and the device is a bcache device" do
-        let(:architecture) { :x86_64 } # bcache is only supported on x86_64
         let(:scenario) { "bcache1.xml" }
         let(:dev_name) { "/dev/bcache1" }
 

--- a/test/y2partitioner/dialogs/bcache_test.rb
+++ b/test/y2partitioner/dialogs/bcache_test.rb
@@ -39,8 +39,6 @@ describe Y2Partitioner::Dialogs::Bcache do
     allow(controller).to receive(:suitable_backing_devices).and_return(suitable_backing)
   end
 
-  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
-
   let(:controller) { instance_double(Y2Partitioner::Actions::Controllers::Bcache) }
 
   let(:bcache) { nil }

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -223,9 +223,6 @@ describe Y2Partitioner::UIState do
     end
 
     context "when the user has opened a bcache page" do
-      # Bcache is only supported on x86
-      let(:architecture) { :x86_64 }
-
       let(:scenario) { "bcache1.xml" }
       let(:device) { fake_devicegraph.find_by_name("/dev/bcache0") }
       let(:another_bcache) { fake_devicegraph.find_by_name("/dev/bcache1") }

--- a/test/y2partitioner/widgets/bcache_add_button_test.rb
+++ b/test/y2partitioner/widgets/bcache_add_button_test.rb
@@ -28,8 +28,6 @@ require "y2partitioner/widgets/bcache_add_button"
 describe Y2Partitioner::Widgets::BcacheAddButton do
   subject(:button) { described_class.new }
 
-  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
-
   before do
     devicegraph_stub("bcache1.xml")
 

--- a/test/y2partitioner/widgets/bcache_device_description_test.rb
+++ b/test/y2partitioner/widgets/bcache_device_description_test.rb
@@ -28,8 +28,6 @@ require "y2partitioner/widgets/bcache_device_description"
 describe Y2Partitioner::Widgets::BcacheDeviceDescription do
   before { devicegraph_stub("bcache1.xml") }
 
-  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
-
   let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
 
   let(:bcache) { current_graph.bcaches.first }

--- a/test/y2partitioner/widgets/bcache_edit_button_test.rb
+++ b/test/y2partitioner/widgets/bcache_edit_button_test.rb
@@ -32,9 +32,6 @@ describe Y2Partitioner::Widgets::BcacheEditButton do
     allow(Y2Partitioner::Actions::EditBcache).to receive(:new).and_return(action)
   end
 
-  # Bcache is only supported on x86
-  let(:architecture) { :x86_64 }
-
   let(:action) { instance_double(Y2Partitioner::Actions::EditBcache, run: :finish) }
 
   subject(:button) { described_class.new(device: device) }

--- a/test/y2partitioner/widgets/bcache_modify_button_test.rb
+++ b/test/y2partitioner/widgets/bcache_modify_button_test.rb
@@ -27,7 +27,6 @@ require "y2partitioner/widgets/bcache_modify_button"
 describe Y2Partitioner::Widgets::BcacheModifyButton do
   before { devicegraph_stub("bcache1.xml") }
 
-  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
   let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
   let(:device) { current_graph.bcaches.first }
 

--- a/test/y2partitioner/widgets/device_buttons_set_test.rb
+++ b/test/y2partitioner/widgets/device_buttons_set_test.rb
@@ -29,7 +29,6 @@ require "y2partitioner/widgets/overview"
 describe Y2Partitioner::Widgets::DeviceButtonsSet do
   before { devicegraph_stub(scenario) }
 
-  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
   let(:scenario) { "nested_md_raids" }
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
   let(:pager) { Y2Partitioner::Widgets::OverviewTreePager.new("hostname") }

--- a/test/y2partitioner/widgets/pages/bcache_test.rb
+++ b/test/y2partitioner/widgets/pages/bcache_test.rb
@@ -30,8 +30,6 @@ describe Y2Partitioner::Widgets::Pages::Bcache do
     devicegraph_stub(scenario)
   end
 
-  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
-
   let(:scenario) { "bcache2.xml" }
 
   let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }

--- a/test/y2partitioner/widgets/pages/bcaches_test.rb
+++ b/test/y2partitioner/widgets/pages/bcaches_test.rb
@@ -28,8 +28,6 @@ require "y2partitioner/widgets/pages"
 describe Y2Partitioner::Widgets::Pages::Bcaches do
   before { devicegraph_stub(scenario) }
 
-  let(:architecture) { :x86_64 } # bcache is only supported on x86_64
-
   let(:scenario) { "bcache1.xml" }
 
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -214,7 +214,6 @@ describe Y2Partitioner::Widgets::Pages::System do
     end
 
     context "when there are bcache devices" do
-      let(:architecture) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
 
       it "contains all bcache devices" do

--- a/test/y2storage/autoinst_profile/drive_section_test.rb
+++ b/test/y2storage/autoinst_profile/drive_section_test.rb
@@ -409,8 +409,6 @@ describe Y2Storage::AutoinstProfile::DriveSection do
     end
 
     context "given a bcache" do
-      let(:architecture) { :x86_64 }
-
       before { fake_scenario("btrfs_bcache.xml") }
 
       it "initializes #type to :CT_BCACHE" do

--- a/test/y2storage/autoinst_profile/partition_section_test.rb
+++ b/test/y2storage/autoinst_profile/partition_section_test.rb
@@ -30,7 +30,6 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
   subject(:section) { described_class.new }
 
   let(:scenario) { "autoyast_drive_examples" }
-  let(:architecture) { :x86_64 }
 
   before { fake_scenario(scenario) }
 

--- a/test/y2storage/autoinst_proposal_bcache_test.rb
+++ b/test/y2storage/autoinst_proposal_bcache_test.rb
@@ -33,7 +33,6 @@ describe Y2Storage::AutoinstProposal do
   end
 
   let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
-  let(:architecture) { :x86_64 }
 
   before do
     allow(Yast::Mode).to receive(:auto).and_return(true)

--- a/test/y2storage/bcache_cset_test.rb
+++ b/test/y2storage/bcache_cset_test.rb
@@ -30,7 +30,7 @@ describe Y2Storage::BcacheCset do
 
   let(:scenario) { "bcache1.xml" }
   let(:bcache_name) { "/dev/bcache0" }
-  let(:architecture) { :x86_64 } # need an architecture where bcache is supported
+
   subject(:bcache_cset) { Y2Storage::Bcache.find_by_name(fake_devicegraph, bcache_name).bcache_cset }
 
   describe "#blk_devices" do

--- a/test/y2storage/bcache_test.rb
+++ b/test/y2storage/bcache_test.rb
@@ -65,7 +65,6 @@ describe Y2Storage::Bcache do
 
     let(:scenario) { "bcache2.xml" }
     let(:bcache_name) { "/dev/bcache0" }
-    let(:architecture) { :x86_64 } # need an architecture where bcache is supported
 
     subject(:bcache) { Y2Storage::Bcache.find_by_name(fake_devicegraph, bcache_name) }
 

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -679,7 +679,6 @@ describe Y2Storage::BlkDevice do
   end
 
   describe "#bcache" do
-    let(:architecture) { :x86_64 } # bcache is only supported on x86_64
     let(:scenario) { "bcache2.xml" }
 
     context "when the device is not used as backing device by a bcache" do
@@ -811,7 +810,6 @@ describe Y2Storage::BlkDevice do
     end
 
     context "for a disk that is used as backing device for a bcache" do
-      let(:architecture) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/vdc" }
 
@@ -823,7 +821,6 @@ describe Y2Storage::BlkDevice do
     end
 
     context "for a disk that is used as caching device for a bcache" do
-      let(:architecture) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/vdb" }
 
@@ -835,7 +832,6 @@ describe Y2Storage::BlkDevice do
     end
 
     context "for a bcache device not used in an LVM or in a RAID" do
-      let(:architecture) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/bcache0" }
 
@@ -850,7 +846,6 @@ describe Y2Storage::BlkDevice do
 
   describe "#component_of_names" do
     context "component has name" do
-      let(:architecture) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/vdc" }
 
@@ -861,7 +856,6 @@ describe Y2Storage::BlkDevice do
     end
 
     context "component has display name" do
-      let(:architecture) { :x86_64 } # bcache is only supported on x86_64
       let(:scenario) { "bcache1.xml" }
       let(:device_name) { "/dev/vdb" }
 

--- a/test/y2storage/devicegraph_sanitizer_test.rb
+++ b/test/y2storage/devicegraph_sanitizer_test.rb
@@ -74,6 +74,12 @@ describe Y2Storage::DevicegraphSanitizer do
       let(:devicegraph) { devicegraph_from("bcache2.xml") }
       let(:bcache_name) { "/dev/bcache0" }
 
+      before do
+        # Unmocking errors for Bcache
+        allow_any_instance_of(Y2Storage::DevicegraphSanitizer)
+          .to receive(:errors_for_bcache).and_call_original
+      end
+
       context "on an architecture that supports bcache (x86_64)" do
         let(:architecture) { :x86_64 }
 

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -666,7 +666,6 @@ describe Y2Storage::Devicegraph do
   end
 
   describe "#remove_bcache" do
-    let(:architecture) { :x86_64 } # bcache is only supported on x86_64
     subject(:devicegraph) { Y2Storage::StorageManager.instance.staging }
 
     before do
@@ -734,9 +733,6 @@ describe Y2Storage::Devicegraph do
     before do
       fake_scenario("bcache1.xml")
     end
-
-    # Bcache is only supported on x86
-    let(:architecture) { :x86_64 }
 
     it "removes the given caching set device" do
       bcache_cset = Y2Storage::BcacheCset.all(devicegraph).first
@@ -948,7 +944,6 @@ describe Y2Storage::Devicegraph do
       fake_scenario("bcache1.xml")
     end
 
-    let(:architecture) { :x86_64 } # bcache is only supported on x86_64
     subject(:list) { fake_devicegraph.bcaches }
 
     it "returns an array of bcache devices" do
@@ -972,7 +967,6 @@ describe Y2Storage::Devicegraph do
       fake_scenario("bcache1.xml")
     end
 
-    let(:architecture) { :x86_64 } # bcache is only supported on x86_64
     subject(:list) { fake_devicegraph.bcache_csets }
 
     it "returns an array of bcache csets" do

--- a/test/y2storage/proposal/autoinst_bcache_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_bcache_planner_test.rb
@@ -32,7 +32,6 @@ describe Y2Storage::Proposal::AutoinstBcachePlanner do
   subject(:planner) { described_class.new(fake_devicegraph, issues_list) }
   let(:scenario) { "bcache1.xml" }
   let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
-  let(:architecture) { :x86_64 }
 
   before do
     fake_scenario(scenario)

--- a/test/y2storage/proposal/autoinst_devices_creator_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_creator_test.rb
@@ -49,7 +49,6 @@ describe Y2Storage::Proposal::AutoinstDevicesCreator do
   end
 
   let(:planned_devices) { Y2Storage::Planned::DevicesCollection.new([disk]) }
-  let(:architecture) { :x86_64 }
 
   before { fake_scenario(scenario) }
 

--- a/test/y2storage/proposal/bcache_creator_test.rb
+++ b/test/y2storage/proposal/bcache_creator_test.rb
@@ -49,7 +49,6 @@ describe Y2Storage::Proposal::BcacheCreator do
       mount_point: "/", type: Y2Storage::Filesystems::Type::BTRFS, min_size: 1.GiB, max_size: 1.GiB
     )
   end
-  let(:architecture) { :x86_64 }
 
   describe "#create_bcache" do
     it "creates a new bcache device" do


### PR DESCRIPTION
## Problem

The `DevicegraphSanitizer` complains when Bcache is used with an architecture different to *x86_64*. In unit tests, architecture has to be mocked to avoid test failures when the tests are executed in another architecture. This has demonstrated to be quite error prone. With new tests involving Bcache, OBS will fail when generating the package for other architectures if you forget mocking the architecture.

Errors for Bcache should be mocked in general, and only unmocked when needed.

* Follow-up of https://trello.com/c/WYoMDTMZ/852-bsc1129787-bootrequirementschecker-fails-to-determine-the-boot-disk

* https://bugzilla.suse.com/show_bug.cgi?id=1129787

## Solution

Errors for Bcache are generally mocked. Architecture mocking is also removed from unit tests that don't require it anymore.
