### PR TITLE
Mock architecture for autoyast test

### DIFF
--- a/test/y2storage/autoinst_proposal_bcache_test.rb
+++ b/test/y2storage/autoinst_proposal_bcache_test.rb
@@ -33,6 +33,7 @@ describe Y2Storage::AutoinstProposal do
   end
 
   let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
+  let(:architecture) { :x86_64 }
 
   before do
     allow(Yast::Mode).to receive(:auto).and_return(true)


### PR DESCRIPTION
## Problem

Architecture mocking was dropped for tests involving Bcache, but we went too far for an autoyast test where mocking is still needed.

* PR dropping architecture mocking: https://github.com/yast/yast-storage-ng/pull/880

## Solution

Bring back architecture mocking for a autoyast test.


## Testing

* All unit tests have been run by simulating a ppc arch and all of them are green now.


NOTE FOR REVIEWERS: version number and changelog are not modified because previous PR and these changes will be manually submitted together (no SR yet). 

