### PR TITLE
Add support for NFS in AutoYaST

### DIFF
--- a/doc/autoyast.md
+++ b/doc/autoyast.md
@@ -121,8 +121,8 @@ create {Y2Storage::Planned::Device} objects. Those objects are meant to contain
 information about the devices that will be created or reused. There are
 especialized classes for each device: {Y2Storage::Planned::Partition},
 {Y2Storage::Planned::LvmLv}, {Y2Storage::Planned::LvmVg},
-{Y2Storage::Planned::Md}, {Y2Storage::Planned::Bcache} and
-{Y2Storage::Planned::StrayBlkDevice}.
+{Y2Storage::Planned::Md}, {Y2Storage::Planned::Bcache},
+{Y2Storage::Planned::StrayBlkDevice} and {Y2Storage::Planned::Nfs}.
 
 The class responsible for driving this phase is
 {Y2Storage::Proposal::AutoinstDevicesPlanner}. Basically, it goes through the
@@ -135,6 +135,7 @@ However, each type of drive is processed by a different planner class:
 * {Y2Storage::Proposal::AutoinstVgPlanner} for `:CT_LVM`.
 * {Y2Storage::Proposal::AutoinstMdPlanner} for `:CT_MD`.
 * {Y2Storage::Proposal::AutoinstBcachePlanner} for `:CT_BCACHE`.
+* {Y2Storage::Proposal::AutoinstNfsPlanner} for `:CT_NFS`.
 
 ### Phase four: deleting old stuff
 
@@ -159,6 +160,7 @@ The logic to create each plan device, however, is splitted into several classes:
 * {Y2Storage::Proposal::LvmCreator} for {Y2Storage::Planned::LvmVg}.
 * {Y2Storage::Proposal::MdCreator} for {Y2Storage::Planned::Md}.
 * {Y2Storage::Proposal::BcacheCreator} for {Y2Storage::Planned::Bcache}.
+* {Y2Storage::Proposal::NfsCreator} for {Y2Storage::Planned::Nfs}.
 
 Note that there are no separate classes for {Y2Storage::Planned::Disk} and
 {Y2Storage::Planned::StrayBlkDevice}. The logic for that kind of devices lives

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr  2 15:37:22 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Add support for installing over NFS with AutoYaST (bsc#1130256).
+- 4.2.1
+
+-------------------------------------------------------------------
 Tue Apr  2 13:55:19 UTC 2019 - ancor@suse.com
 
 - Fixed unit tests to also work in ARM architecture (bsc#1130957).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.2.0
+Version:	4.2.1
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/autoinst_issues/list.rb
+++ b/src/lib/y2storage/autoinst_issues/list.rb
@@ -47,7 +47,7 @@ module Y2Storage
       # Add a problem to the list
       #
       # The type of the problem is identified as a symbol which name is the
-      # underscore version of the class which implements it.  For instance,
+      # underscore version of the class which implements it. For instance,
       # `MissingRoot` would be referred as `:missing_root`.
       #
       # If a given type of problem requires some additional arguments, they

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -139,9 +139,17 @@ module Y2Storage
       end
 
       def default_type_for(hash)
-        return :CT_MD if hash["device"].to_s.start_with?("/dev/md")
-        return :CT_BCACHE if hash["device"].to_s.start_with?("/dev/bcache")
-        :CT_DISK
+        device_name = hash["device"].to_s
+
+        if md_name?(device_name)
+          :CT_MD
+        elsif bcache_name?(device_name)
+          :CT_BCACHE
+        elsif nfs_name?(device_name)
+          :CT_NFS
+        else
+          :CT_DISK
+        end
       end
 
       # Clones a drive into an AutoYaST profile section by creating an instance
@@ -248,6 +256,31 @@ module Y2Storage
       end
 
     protected
+
+      # Whether the given name is a Md name
+      #
+      # @param device_name [String]
+      # @return [Boolean]
+      def md_name?(device_name)
+        device_name.start_with?("/dev/md")
+      end
+
+      # Whether the given name is a Bcache name
+      #
+      # @param device_name [String]
+      # @return [Boolean]
+      def bcache_name?(device_name)
+        device_name.start_with?("/dev/bcache")
+      end
+
+      # Whether the given name is a NFS name
+      #
+      # @param device_name [String]
+      # @return [Boolean]
+      def nfs_name?(device_name)
+        # TODO: with the new format, device_name would be "server:path"
+        device_name == "/dev/nfs"
+      end
 
       # Method used by {.new_from_storage} to populate the attributes when
       # cloning a disk or DASD device.

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -78,7 +78,8 @@ module Y2Storage
         { name: :stripes },
         { name: :stripe_size, xml_name: :stripesize },
         { name: :bcache_backing_for },
-        { name: :bcache_caching_for }
+        { name: :bcache_caching_for },
+        { name: :device }
       ].freeze
       private_constant :ATTRIBUTES
 
@@ -156,6 +157,10 @@ module Y2Storage
 
       # @!attribute subvolumes_prefix
       #   @return [String] Name of the default Btrfs subvolume
+
+      # @!attribute device
+      #   @return [String, nil] undocumented attribute, but used to indicate a NFS
+      #     share when installing over NFS
 
       def init_from_hashes(hash)
         super

--- a/src/lib/y2storage/autoinst_profile/partitioning_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partitioning_section.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -69,7 +69,7 @@ module Y2Storage
       end
 
       # Clones a system into an AutoYaST profile section, creating an instance
-      # if this class from the information in a devicegraph.
+      # of this class from the information in a devicegraph.
       #
       # This implements the same behavior followed by the old AutoYaST
       # cloning/export, which includes some custom logic beyond the direct
@@ -126,6 +126,13 @@ module Y2Storage
       # @return [Array<DriveSection>]
       def bcache_drives
         drives.select { |d| d.type == :CT_BCACHE }
+      end
+
+      # Drive sections with type :CT_NFS
+      #
+      # @return [Array<DriveSection>]
+      def nfs_drives
+        drives.select { |d| d.type == :CT_NFS }
       end
 
       # Return section name

--- a/src/lib/y2storage/planned.rb
+++ b/src/lib/y2storage/planned.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -26,6 +26,7 @@ require "y2storage/planned/lvm_lv"
 require "y2storage/planned/lvm_vg"
 require "y2storage/planned/md"
 require "y2storage/planned/bcache"
+require "y2storage/planned/nfs"
 require "y2storage/planned/assigned_space"
 require "y2storage/planned/partitions_distribution"
 require "y2storage/planned/devices_collection"

--- a/src/lib/y2storage/planned/devices_collection.rb
+++ b/src/lib/y2storage/planned/devices_collection.rb
@@ -163,14 +163,8 @@ module Y2Storage
       #
       # @return [Array<Planned::Device>]
       def all
-        @all ||= partitions +
-          disks +
-          stray_blk_devices +
-          vgs +
-          lvs +
-          mds +
-          bcaches +
-          nfs_filesystems
+        @all ||= [].concat(partitions, disks, stray_blk_devices, vgs, lvs, mds,
+          bcaches, nfs_filesystems)
       end
 
       # Returns the list of devices that can be mounted

--- a/src/lib/y2storage/planned/devices_collection.rb
+++ b/src/lib/y2storage/planned/devices_collection.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -138,6 +138,13 @@ module Y2Storage
         @bcaches ||= devices.select { |d| d.is_a?(Planned::Bcache) }
       end
 
+      # Returns the list of planned NFS filesystems
+      #
+      # @return [Array<Planned::Nfs>]
+      def nfs_filesystems
+        @nfs_filesystems ||= devices.select { |d| d.is_a?(Planned::Nfs) }
+      end
+
       # Returns the list of planned LVM logical volumes
       #
       # @return [Array<Planned::LvmLv>]
@@ -156,7 +163,14 @@ module Y2Storage
       #
       # @return [Array<Planned::Device>]
       def all
-        @all ||= partitions + disks + stray_blk_devices + vgs + lvs + mds + bcaches
+        @all ||= partitions +
+          disks +
+          stray_blk_devices +
+          vgs +
+          lvs +
+          mds +
+          bcaches +
+          nfs_filesystems
       end
 
       # Returns the list of devices that can be mounted

--- a/src/lib/y2storage/planned/md.rb
+++ b/src/lib/y2storage/planned/md.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-#
 # encoding: utf-8
 
 # Copyright (c) [2017] SUSE LLC

--- a/src/lib/y2storage/planned/nfs.rb
+++ b/src/lib/y2storage/planned/nfs.rb
@@ -1,0 +1,72 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage/planned/device"
+require "y2storage/planned/mixins"
+require "y2storage/match_volume_spec"
+require "y2storage/filesystems/type"
+
+module Y2Storage
+  module Planned
+    # Specification for a Y2Storage::Filesystems::Nfs object to be created during the
+    # AutoYaST proposal
+    #
+    # @see Device
+    class Nfs < Device
+      include Planned::CanBeMounted
+      include MatchVolumeSpec
+
+      # @return [String] server name
+      attr_accessor :server
+
+      # @return [String] path to shared directory
+      attr_accessor :path
+
+      # Constructor
+      #
+      # @param server [String]
+      # @param path [String]
+      def initialize(server = "", path = "")
+        super()
+
+        initialize_can_be_mounted
+
+        @server = server
+        @path = path
+      end
+
+    protected
+
+      # Values for volume specification matching
+      #
+      # @see MatchVolumeSpec
+      def volume_match_values
+        {
+          mount_point:  mount_point,
+          size:         nil,
+          fs_type:      Filesystems::Type::Nfs,
+          partition_id: nil
+        }
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/autoinst_devices_creator.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_creator.rb
@@ -351,9 +351,9 @@ module Y2Storage
       # @return [Proposal::CreatorResult] Result containing the specified volume groups
       def set_up_lvm(vgs, devs_to_reuse)
         # log separately to be more readable
-        log.info "BEGIN: set_up_lvm: vgs=#{vgs.inspect}"
-        log.info "BEGIN: set_up_lvm: previous_result=#{creator_result.inspect}"
-        log.info "BEGIN: set_up_lvm: devs_to_reuse=#{devs_to_reuse.inspect}"
+        log.info "set_up_lvm: vgs=#{vgs.inspect}"
+        log.info "set_up_lvm: previous_result=#{creator_result.inspect}"
+        log.info "set_up_lvm: devs_to_reuse=#{devs_to_reuse.inspect}"
 
         vgs.reduce(creator_result) do |result, vg|
           pvs = creator_result.created_names { |d| d.pv_for?(vg.volume_group_name) }
@@ -417,7 +417,8 @@ module Y2Storage
       def create_logical_volumes(devicegraph, vg, pvs)
         lvm_creator = Proposal::LvmCreator.new(devicegraph)
         lvm_creator.create_volumes(vg, pvs)
-      rescue RuntimeError
+      rescue RuntimeError => error
+        log.error error.message
         lvm_creator = Proposal::LvmCreator.new(devicegraph)
         new_vg = vg.clone
         new_vg.lvs = flexible_devices(vg.lvs)

--- a/src/lib/y2storage/proposal/autoinst_devices_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_planner.rb
@@ -1,8 +1,6 @@
-#!/usr/bin/env ruby
-#
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -28,6 +26,7 @@ require "y2storage/proposal/autoinst_disk_device_planner"
 require "y2storage/proposal/autoinst_vg_planner"
 require "y2storage/proposal/autoinst_md_planner"
 require "y2storage/proposal/autoinst_bcache_planner"
+require "y2storage/proposal/autoinst_nfs_planner"
 require "y2storage/planned"
 
 module Y2Storage
@@ -52,23 +51,13 @@ module Y2Storage
         @issues_list = issues_list
       end
 
-      # Returns an array of planned devices according to the drives map
+      # Returns a collection of planned devices according to the drives map
       #
       # @param drives_map [Proposal::AutoinstDrivesMap] Drives map from AutoYaST
-      # @return [Planned::DevicesCollection] Collection of planned devices
+      # @return [Planned::DevicesCollection]
       def planned_devices(drives_map)
         devices = drives_map.each_pair.each_with_object([]) do |(disk_name, drive), memo|
-          planned_devs =
-            case drive.type
-            when :CT_DISK
-              planned_for_disk_device(drive, disk_name)
-            when :CT_LVM
-              planned_for_vg(drive)
-            when :CT_MD
-              planned_for_md(drive)
-            when :CT_BCACHE
-              planned_for_bcache(drive)
-            end
+          planned_devs = planned_for_drive(drive, disk_name)
           memo.concat(planned_devs) if planned_devs
         end
 
@@ -85,44 +74,85 @@ module Y2Storage
       # @return [AutoinstIssues::List] List of AutoYaST issues to register them
       attr_reader :issues_list
 
+      # Returns a list of planned devices according to an AutoYaST specification
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the device
+      # @param disk_name [String]
+      #
+      # @return [Array<Planned::Device>, nil] nil if the device cannot be planned
+      def planned_for_drive(drive, disk_name)
+        case drive.type
+        when :CT_DISK
+          planned_for_disk_device(drive, disk_name)
+        when :CT_LVM
+          planned_for_vg(drive)
+        when :CT_MD
+          planned_for_md(drive)
+        when :CT_BCACHE
+          planned_for_bcache(drive)
+        when :CT_NFS
+          planned_for_nfs(drive)
+        end
+      end
+
+      # Returns a list of planned partitions (or disks) according to an AutoYaST specification
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the partitions
+      # @param disk_name [String]
+      #
+      # @return [Array<Planned::Partition, Planned::StrayBlkDevice>]
       def planned_for_disk_device(drive, disk_name)
         planner = Y2Storage::Proposal::AutoinstDiskDevicePlanner.new(devicegraph, issues_list)
         drive.device = disk_name
         planner.planned_devices(drive)
       end
 
-      # Returns a planned volume group according to an AutoYaST specification
+      # Returns a list with the planned volume group according to an AutoYaST specification
       #
-      # @param drive [AutoinstProfile::DriveSection] drive section describing
-      #   the volume group
-      # @return [Planned::LvmVg] Planned volume group
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the volume group
+      # @return [Array<Planned::LvmVg>]
       def planned_for_vg(drive)
         planner = Y2Storage::Proposal::AutoinstVgPlanner.new(devicegraph, issues_list)
         planner.planned_devices(drive)
       end
 
-      # Returns a MD array according to an AutoYaST specification
+      # Returns a list of planned MDs according to an AutoYaST specification
       #
-      # @param drive [AutoinstProfile::DriveSection] drive section describing
-      #   the MD RAID
-      # @return [Planned::Md] Planned MD RAID
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the MD RAID
+      # @return [Array<Planned::Md>]
       def planned_for_md(drive)
         planner = Y2Storage::Proposal::AutoinstMdPlanner.new(devicegraph, issues_list)
         planner.planned_devices(drive)
       end
 
-      # Returns a list of bcache devices according to an AutoYaST specification
+      # Returns a list of planned bcache devices according to an AutoYaST specification
       #
-      # @param drive [AutoinstProfile::DriveSection] drive section describing
-      #   the bcache device
-      # @return [Planned::Bcache] List containing a planned bcache device
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the bcache device
+      # @return [Array<Planned::Bcache>]
       def planned_for_bcache(drive)
         planner = Y2Storage::Proposal::AutoinstBcachePlanner.new(devicegraph, issues_list)
         planner.planned_devices(drive)
       end
 
+      # Returns a list of planned NFS filesystems according to an AutoYaST specification
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the NFS share
+      # @return [Array<Planned::Nfs>]
+      def planned_for_nfs(drive)
+        planner = Y2Storage::Proposal::AutoinstNfsPlanner.new(devicegraph, issues_list)
+        planner.planned_devices(drive)
+      end
+
+      # Removes shadowed subvolumes from each planned device that can be mounted
+      #
+      # @param planned_devices [Array<Planned::Device>]
       def remove_shadowed_subvols(planned_devices)
         planned_devices.each do |device|
+          # Some planned devices could be mountable but not formattable (e.g., {Planned::Nfs}).
+          # Those devices might shadow some subvolumes but they do no have any subvolume to
+          # be shadowed.
+          next unless device.respond_to?(:shadowed_subvolumes)
+
           device.shadowed_subvolumes(planned_devices).each do |subvol|
             # TODO: this should be reported to the user when the shadowed
             # subvolumes was specified in the profile.

--- a/src/lib/y2storage/proposal/autoinst_drives_map.rb
+++ b/src/lib/y2storage/proposal/autoinst_drives_map.rb
@@ -1,8 +1,6 @@
-#!/usr/bin/env ruby
-#
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -34,7 +32,7 @@ module Y2Storage
       extend Forwardable
 
       # @!method each_pair
-      #   Calls block once por each disk that contains the AutoYaST specification
+      #   Calls block once per each disk that contains the AutoYaST specification
       #   passing as arguments the disk name and the corresponding
       #   AutoinstProfile::DriveSection object.
       #
@@ -64,6 +62,7 @@ module Y2Storage
         add_vgs(partitioning.lvm_drives)
         add_mds(partitioning.md_drives)
         add_bcaches(partitioning.bcache_drives)
+        add_nfs_filesystems(partitioning.nfs_drives)
       end
 
       # Returns the list of disk names
@@ -197,10 +196,24 @@ module Y2Storage
         bcaches.each { |b| @drives[b.device] = b }
       end
 
-      # Find a disk using any possible name
+      # Adds NFS filesystems to the device map
       #
-      # @return [Disk,nil] Usable disk or nil if none is found
-      # @see [Y2Storage::Devicegraph#find_by_any_name]
+      # All NFS filesystems should have a "device" property.
+      #
+      # @param nfs_drives [Array<AutoinstProfile::DriveSection>] List of NFS specifications from
+      #   AutoYaST
+      def add_nfs_filesystems(nfs_drives)
+        nfs_drives.each { |d| @drives[d.device] = d }
+      end
+
+      # Finds a disk using any possible name
+      #
+      # @see Y2Storage::Devicegraph#find_by_any_name
+      #
+      # @param devicegraph [Devicegraph]
+      # @param device_name [String, nil] e.g., "/dev/sda"
+      #
+      # @return [Disk, nil] Usable disk or nil if none is found
       def find_disk(devicegraph, device_name)
         device = devicegraph.find_by_any_name(device_name)
         return nil unless device

--- a/src/lib/y2storage/proposal/autoinst_nfs_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_nfs_planner.rb
@@ -38,11 +38,29 @@ module Y2Storage
 
     private
 
-      NEW_FORMAT_MANDATORY_VALUES = { drive: [:device], partition: [:mount] }.freeze
-
+      # This hash defines mandatory profile values for a NFS share using the old AutoYaST style.
+      #
+      # Keys are the name of the section, and values are the mandatory values for such section.
+      #
+      # With old format, the partition section must contain a device and a mount value, e.g.:
+      #
+      # <drive>
+      #   <device>/dev/nfs</device>
+      #   <partitions>
+      #     <partition>
+      #       <device>192.168.56.1:/root_fs</device>
+      #       <mount>/</mount>
+      #     </partition>
+      #   </partitions>
+      # </drive>
       OLD_FORMAT_MANDATORY_VALUES = { drive: [], partition: [:device, :mount] }.freeze
 
-      private_constant :NEW_FORMAT_MANDATORY_VALUES, :OLD_FORMAT_MANDATORY_VALUES
+      # Similar to {OLD_FORMAT_MANDATORY_VALUES}, but for the new AutoYaST style.
+      #
+      # TODO
+      NEW_FORMAT_MANDATORY_VALUES = {}.freeze
+
+      private_constant :OLD_FORMAT_MANDATORY_VALUES, :NEW_FORMAT_MANDATORY_VALUES
 
       # Returns a list of planned NFS filesystems from the old-style AutoYaST profile
       #
@@ -175,7 +193,8 @@ module Y2Storage
       # Mandatory values depending on the AutoYaST style
       #
       # @param format [:new, :old] new or old AutoYaST style
-      # @return [Hash<Symbol, Array<Symbol>>]
+      # @return [Hash<Symbol, Array<Symbol>>] see {OLD_FORMAT_MANDATORY_VALUES} and
+      #   {NEW_FORMAT_MANDATORY_VALUES}
       def mandatory_values(format)
         if format == :new
           NEW_FORMAT_MANDATORY_VALUES
@@ -187,7 +206,7 @@ module Y2Storage
       # Name of the server from a NFS share
       #
       # @param share [String] e.g., "192.168.56.1:/root_fs"
-      # @return [String]
+      # @return [String] e.g., "192.168.56.1"
       def server(share)
         server_and_path(share).first || ""
       end
@@ -195,17 +214,21 @@ module Y2Storage
       # Name of the shared directory from a NFS share
       #
       # @param share [String] e.g., "192.168.56.1:/root_fs"
-      # @return [String]
+      # @return [String] e.g., "/root_fs"
       def path(share)
         server_and_path(share).last || ""
       end
 
       # Name of the server and the shared directory from a NFS share
       #
+      # Note that the directory can be omitted (e.g., "192.168.56.1"). For more details,
+      # see {https://tools.ietf.org/html/rfc2224}.
+      #
       # @param share [String] e.g., "192.168.56.1:/root_fs"
-      # @return [Array<String>]
+      # @return [Array<String, nil>]
       def server_and_path(share)
-        share.split(":")
+        server, path = share.split(":")
+        [server, path]
       end
     end
   end

--- a/src/lib/y2storage/proposal/autoinst_nfs_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_nfs_planner.rb
@@ -1,0 +1,212 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/proposal/autoinst_drive_planner"
+
+module Y2Storage
+  module Proposal
+    # This class converts an AutoYaST specification into a Planned::Nfs in order
+    # to set up a NFS filesystem.
+    class AutoinstNfsPlanner < AutoinstDrivePlanner
+      # Returns an array of planned NFS filesystems according to an AutoYaST specification
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing NFS filesystems
+      # @return [Array<Planned::Nfs>] Planned NFS filesystems
+      def planned_devices(drive)
+        # TODO: planned device with new format
+
+        planned_devices_old_format(drive)
+      end
+
+    private
+
+      NEW_FORMAT_MANDATORY_VALUES = { drive: [:device], partition: [:mount] }.freeze
+
+      OLD_FORMAT_MANDATORY_VALUES = { drive: [], partition: [:device, :mount] }.freeze
+
+      private_constant :NEW_FORMAT_MANDATORY_VALUES, :OLD_FORMAT_MANDATORY_VALUES
+
+      # Returns a list of planned NFS filesystems from the old-style AutoYaST profile
+      #
+      # Using `/dev/nfs` as device name means that the whole drive section should be treated as an
+      # old-style AutoYaST NFS description. Each partition represents an NFS filesystem and the `device`
+      # is used to indicate the NFS share (e.g., `192.168.56.1:/root_fs`).
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the list of NFS
+      #   filesystems (old-style AutoYaST)
+      # @return [Array<Planned::Nfs>] List of planned NFS filesystems
+      def planned_devices_old_format(drive)
+        drive.partitions.map { |p| planned_device_old_format(drive, p) }.compact
+      end
+
+      # Creates a planned NFS filesystem from the old-style AutoYaST profile
+      #
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the list of NFS
+      #   filesystems
+      # @param partition_section [AutoinstProfile::PartitionSection] partition section describing
+      #   a NFS filesystem
+      #
+      # @return [Planned::Nfs]
+      def planned_device_old_format(drive, partition_section)
+        return nil unless valid_drive?(drive, partition: partition_section, format: :old)
+
+        share = partition_section.device
+
+        planned_nfs = Planned::Nfs.new(server(share), path(share))
+        add_options(planned_nfs, partition_section)
+
+        planned_nfs
+      end
+
+      # Adds options to the planned NFS filesystem
+      #
+      # @param planned_nfs [Planned::Nfs]
+      # @param partition_section [AutoinstProfile::PartitionSection] partition section describing
+      #   a NFS filesystem
+      def add_options(planned_nfs, partition_section)
+        planned_nfs.mount_point = partition_section.mount
+        planned_nfs.fstab_options = partition_section.fstab_options || []
+      end
+
+      # Whether the drive section is valid
+      #
+      # Errors are registered when the section is not valid.
+      #
+      # @param drive [AutoinstProfile::DriveSection]
+      # @param partition [AutoinstProfile::PartitionSection]
+      # @param format [:new, :old] whether the section is using the new or old AutoYaST style
+      #
+      # @return [Boolean]
+      def valid_drive?(drive, partition: nil, format: :new)
+        partition_section = partition || drive.partitions.first
+
+        !missing_drive_values?(drive, format) &&
+          !missing_partition_values?(partition_section, format)
+      end
+
+      # Whether any value is missing for the drive section
+      #
+      # Errors are registered when values are missing.
+      #
+      # @param drive [AutoinstProfile::DriveSection]
+      # @param format [:new, :old] whether the section is using the new or old AutoYaST style
+      #
+      # @return [Boolean]
+      def missing_drive_values?(drive, format)
+        missing_any_value?(drive, mandatory_drive_values(format))
+      end
+
+      # Whether any value is missing for the partition section
+      #
+      # Errors are registered when values are missing.
+      #
+      # @param partition_section [AutoinstProfile::PartitionSection]
+      # @param format [:new, :old] whether the section is using the new or old AutoYaST style
+      #
+      # @return [Boolean]
+      def missing_partition_values?(partition_section, format)
+        missing_any_value?(partition_section, mandatory_partition_values(format))
+      end
+
+      # Whether any of the given values is missing in the given section
+      #
+      # Note: finding the first missing value is faster, but all values are checked to
+      # register all possible issues.
+      #
+      # @param section [AutoinstProfile::SectionWithAttributes]
+      # @param values [Array<Symbol>]
+      #
+      # @return [Boolean]
+      def missing_any_value?(section, values)
+        values.map { |v| missing_value?(section, v) }.any?
+      end
+
+      # Whether the given value is missing in the given section
+      #
+      # An error is registered when the value is missing.
+      #
+      # @param section [AutoinstProfile::SectionWithAttributes]
+      # @param value [Symbol]
+      #
+      # @return [Boolean]
+      def missing_value?(section, value)
+        return false if section.send(value)
+
+        issues_list.add(:missing_value, section, value)
+
+        true
+      end
+
+      # Mandatory values for the drive section
+      #
+      # @param format [:new, :old] whether the section is using the new or old AutoYaST style
+      # @return [Array<Symbol>]
+      def mandatory_drive_values(format)
+        mandatory_values(format)[:drive]
+      end
+
+      # Mandatory values for the partition section
+      #
+      # @param format [:new, :old] whether the section is using the new or old AutoYaST style
+      # @return [Array<Symbol>]
+      def mandatory_partition_values(format)
+        mandatory_values(format)[:partition]
+      end
+
+      # Mandatory values depending on the AutoYaST style
+      #
+      # @param format [:new, :old] new or old AutoYaST style
+      # @return [Hash<Symbol, Array<Symbol>>]
+      def mandatory_values(format)
+        if format == :new
+          NEW_FORMAT_MANDATORY_VALUES
+        else
+          OLD_FORMAT_MANDATORY_VALUES
+        end
+      end
+
+      # Name of the server from a NFS share
+      #
+      # @param share [String] e.g., "192.168.56.1:/root_fs"
+      # @return [String]
+      def server(share)
+        server_and_path(share).first || ""
+      end
+
+      # Name of the shared directory from a NFS share
+      #
+      # @param share [String] e.g., "192.168.56.1:/root_fs"
+      # @return [String]
+      def path(share)
+        server_and_path(share).last || ""
+      end
+
+      # Name of the server and the shared directory from a NFS share
+      #
+      # @param share [String] e.g., "192.168.56.1:/root_fs"
+      # @return [Array<String>]
+      def server_and_path(share)
+        share.split(":")
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/nfs_creator.rb
+++ b/src/lib/y2storage/proposal/nfs_creator.rb
@@ -1,0 +1,53 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/planned"
+require "y2storage/proposal/creator_result"
+
+module Y2Storage
+  module Proposal
+    # Class to create a NFS filesystem according to a Planned::Nfs object
+    class NfsCreator
+      attr_reader :original_devicegraph
+
+      # Constructor
+      #
+      # @param original_devicegraph [Devicegraph] Initial devicegraph
+      def initialize(original_devicegraph)
+        @original_devicegraph = original_devicegraph
+      end
+
+      # Creates the NFS filesystem
+      #
+      # @param planned_nfs  [Planned::Nfs] planned NFS filesystem
+      # @return [CreatorResult] result containing the new NFS filesystem
+      def create_nfs(planned_nfs)
+        new_graph = original_devicegraph.duplicate
+
+        nfs = Filesystems::Nfs.create(new_graph, planned_nfs.server, planned_nfs.path)
+        nfs.mount_path = planned_nfs.mount_point
+        nfs.mount_point.mount_options = planned_nfs.fstab_options
+
+        CreatorResult.new(new_graph, nfs.share => planned_nfs)
+      end
+    end
+  end
+end

--- a/test/support/storage_helpers.rb
+++ b/test/support/storage_helpers.rb
@@ -145,6 +145,11 @@ module Yast
         add_planned_attributes(bcache, attrs)
       end
 
+      def planned_nfs(attrs = {})
+        nfs = Y2Storage::Planned::Nfs.new
+        add_planned_attributes(nfs, attrs)
+      end
+
       def add_planned_attributes(device, attrs)
         attrs = attrs.dup
 

--- a/test/y2storage/autoinst_profile/drive_section_test.rb
+++ b/test/y2storage/autoinst_profile/drive_section_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -40,11 +40,17 @@ describe Y2Storage::AutoinstProfile::DriveSection do
   end
 
   describe ".new_from_hashes" do
-    context "when type is not specified" do
-      let(:root) { { "mount" => "/" } }
-      let(:hash) { { "partitions" => [root], "raid_options" => raid_options } }
-      let(:raid_options) { { "raid_type" => "raid0" } }
+    let(:hash) { { "partitions" => [root] } }
 
+    let(:root) { { "mount" => "/" } }
+
+    it "initializes partitions" do
+      expect(Y2Storage::AutoinstProfile::PartitionSection).to receive(:new_from_hashes)
+        .with(root, Y2Storage::AutoinstProfile::DriveSection)
+      described_class.new_from_hashes(hash)
+    end
+
+    context "when type is not specified" do
       it "initializes it to :CT_DISK" do
         expect(described_class.new_from_hashes(hash).type).to eq(:CT_DISK)
       end
@@ -57,7 +63,7 @@ describe Y2Storage::AutoinstProfile::DriveSection do
         end
       end
 
-      context "and device name starts by /dev/md" do
+      context "and device name starts by /dev/bcache" do
         let(:hash) { { "device" => "/dev/bcache0" } }
 
         it "initializes it to :CT_BCACHE" do
@@ -65,11 +71,28 @@ describe Y2Storage::AutoinstProfile::DriveSection do
         end
       end
 
-      it "initializes partitions" do
-        expect(Y2Storage::AutoinstProfile::PartitionSection).to receive(:new_from_hashes)
-          .with(root, Y2Storage::AutoinstProfile::DriveSection)
-        described_class.new_from_hashes(hash)
+      context "and device name is /dev/nfs" do
+        let(:hash) { { "device" => "/dev/nfs" } }
+
+        it "initializes it to :CT_NFS" do
+          expect(described_class.new_from_hashes(hash).type).to eq(:CT_NFS)
+        end
       end
+    end
+
+    context "when bcache options are given" do
+      let(:hash) { { "partitions" => [root], "bcache_options" => bcache_options } }
+      let(:bcache_options) { { "cache_mode" => "writethrough" } }
+
+      it "initializes bcache options" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.bcache_options.cache_mode).to eq("writethrough")
+      end
+    end
+
+    context "when the raid options are given" do
+      let(:hash) { { "partitions" => [root], "raid_options" => raid_options } }
+      let(:raid_options) { { "raid_type" => "raid0" } }
 
       it "initializes raid options" do
         expect(Y2Storage::AutoinstProfile::RaidOptionsSection).to receive(:new_from_hashes)
@@ -79,17 +102,7 @@ describe Y2Storage::AutoinstProfile::DriveSection do
         expect(section.raid_options.raid_type).to eq("raid0")
       end
 
-      context "when bcache options are given" do
-        let(:hash) { { "partitions" => [root], "bcache_options" => bcache_options } }
-        let(:bcache_options) { { "cache_mode" => "writethrough" } }
-
-        it "initializes bcache options" do
-          section = described_class.new_from_hashes(hash)
-          expect(section.bcache_options.cache_mode).to eq("writethrough")
-        end
-      end
-
-      context "when the raid_name is specified in the raid_options" do
+      context "and the raid_type is specified" do
         let(:raid_options) { { "raid_type" => "raid0" } }
 
         it "ignores the raid_name element" do

--- a/test/y2storage/autoinst_profile/partition_section_test.rb
+++ b/test/y2storage/autoinst_profile/partition_section_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -582,6 +582,26 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
       it "initializes bcache caching devices list to an empty array" do
         section = described_class.new_from_hashes(hash)
         expect(section.bcache_caching_for).to eq([])
+      end
+    end
+
+    context "when device is present" do
+      let(:hash) { { device: nfs_share } }
+
+      let(:nfs_share) { "192.168.56.1:/root" }
+
+      it "initializes device" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.device).to eq(nfs_share)
+      end
+    end
+
+    context "when device is not present" do
+      let(:hash) { {} }
+
+      it "initializes device to nil" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.device).to be_nil
       end
     end
   end

--- a/test/y2storage/autoinst_profile/partitioning_section_test.rb
+++ b/test/y2storage/autoinst_profile/partitioning_section_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -157,6 +157,7 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
     let(:drive6) { double("DriveSection", device: "/dev/md", type: :CT_MD) }
     let(:drive7) { double("DriveSection", type: :CT_DISK) }
     let(:drive8) { double("DriveSection", type: :CT_BCACHE) }
+    let(:drive9) { double("DriveSection", type: :CT_NFS) }
     let(:wrongdrv1) { double("DriveSection", device: "/dev/md", type: :CT_DISK) }
     let(:wrongdrv2) { double("DriveSection", device: "/dev/sdc", type: :CT_MD) }
     let(:wrongdrv3) { double("DriveSection", device: "/dev/sdd", type: :CT_WRONG) }
@@ -165,7 +166,7 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
 
     before do
       section.drives = [
-        drive1, drive2, drive3, drive4, drive5, drive6, drive7, drive8,
+        drive1, drive2, drive3, drive4, drive5, drive6, drive7, drive8, drive9,
         wrongdrv1, wrongdrv2, wrongdrv3, wrongdrv4, wrongdrv5
       ]
     end
@@ -195,6 +196,12 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
     describe "#bcache_drives" do
       it "returns drives which type is :CT_BCACHE, even if they look invalid" do
         expect(section.bcache_drives).to contain_exactly(drive8)
+      end
+    end
+
+    describe "#nfs_drives" do
+      it "returns drives which type is :CT_NFS, even if they look invalid" do
+        expect(section.nfs_drives).to contain_exactly(drive9)
       end
     end
   end

--- a/test/y2storage/autoinst_proposal_nfs_test.rb
+++ b/test/y2storage/autoinst_proposal_nfs_test.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+#
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+describe Y2Storage::AutoinstProposal do
+  using Y2Storage::Refinements::SizeCasts
+
+  before do
+    fake_scenario(scenario)
+
+    allow(Yast::Mode).to receive(:auto).and_return(true)
+  end
+
+  let(:scenario) { "empty_hard_disk_15GiB" }
+
+  subject(:proposal) do
+    described_class.new(
+      partitioning: partitioning, devicegraph: fake_devicegraph, issues_list: issues_list
+    )
+  end
+
+  let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
+
+  describe "#propose" do
+    context "when installing over NFS" do
+      let(:nfs_drive) do
+        {
+          "device"     => "/dev/nfs",
+          "partitions" => [
+            {
+              "device" => "192.168.56.1:/root_fs",
+              "mount"  => "/"
+            }
+          ]
+        }
+      end
+
+      let(:disk_drive) do
+        {
+          "device" => "/dev/sda",
+          "type" => :CT_DISK, "use" => "all", "initialize" => true, "disklabel" => "msdos",
+          "partitions" => [
+            {
+              "create" => true, "filesystem" => :swap, "format" => true, "mount" => "swap",
+              "size" => 2.GiB
+            }
+          ]
+        }
+      end
+
+      let(:partitioning) { [nfs_drive, disk_drive] }
+
+      it "creates a NFS filesystem for installing over it" do
+        proposal.propose
+        nfs = proposal.devices.nfs_mounts.first
+
+        expect(nfs).to_not be_nil
+        expect(nfs.mount_path).to eq("/")
+      end
+
+      it "creates local partitions when required" do
+        proposal.propose
+        sda1 = proposal.devices.find_by_name("/dev/sda1")
+
+        expect(sda1.swap?).to eq(true)
+        expect(sda1.size).to eq(2.GiB)
+      end
+
+      it "does not register any issue" do
+        proposal.propose
+        expect(issues_list).to be_empty
+      end
+    end
+  end
+end

--- a/test/y2storage/planned/devices_collection_test.rb
+++ b/test/y2storage/planned/devices_collection_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -37,7 +37,8 @@ describe Y2Storage::Planned::DevicesCollection do
   let(:lv1) { planned_lv }
   let(:vg) { planned_vg(lvs: [lv0, lv1]) }
   let(:bcache) { planned_bcache(partitions: [bcache_partition]) }
-  let(:devices) { [partition, disk, stray_blk_device, md, bcache, vg] }
+  let(:nfs) { planned_nfs }
+  let(:devices) { [partition, disk, stray_blk_device, md, bcache, vg, nfs] }
 
   describe "#devices" do
     context "when there are no planned devices" do
@@ -72,7 +73,7 @@ describe Y2Storage::Planned::DevicesCollection do
     it "returns all planned devices" do
       expect(collection.all).to contain_exactly(
         partition, disk_partition, disk, stray_blk_device, md, md_partition, lv0, lv1, vg, bcache,
-        bcache_partition
+        bcache_partition, nfs
       )
     end
   end
@@ -125,11 +126,17 @@ describe Y2Storage::Planned::DevicesCollection do
     end
   end
 
+  describe "#nfs_filesystems" do
+    it "returns NFS filesystems" do
+      expect(collection.nfs_filesystems).to eq([nfs])
+    end
+  end
+
   describe "#mountable_devices" do
     it "returns all devices that can be mounted" do
       expect(collection.mountable_devices).to contain_exactly(
         partition, disk, disk_partition, stray_blk_device, lv0, lv1, md, md_partition,
-        bcache, bcache_partition
+        bcache, bcache_partition, nfs
       )
     end
   end

--- a/test/y2storage/proposal/autoinst_devices_creator_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_creator_test.rb
@@ -2,7 +2,7 @@
 #
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -365,6 +365,28 @@ describe Y2Storage::Proposal::AutoinstDevicesCreator do
           result = creator.populated_devicegraph(planned_devices, ["/dev/sda", "/dev/sdb"])
           expect(result.shrinked_partitions.map(&:planned)).to eq([root])
         end
+      end
+    end
+
+    describe "using NFS" do
+      let(:nfs0) do
+        planned_nfs(
+          server:        "192.168.56.1",
+          path:          "/root_fs",
+          mount_point:   "/",
+          fstab_options: ["rw"]
+        )
+      end
+
+      let(:planned_devices) { Y2Storage::Planned::DevicesCollection.new([nfs0]) }
+
+      it "adds the NFS filesystem" do
+        result = creator.populated_devicegraph(planned_devices, [])
+        devicegraph = result.devicegraph
+        nfs = devicegraph.nfs_mounts.first
+
+        expect(nfs).to be_a(Y2Storage::Filesystems::Nfs)
+        expect(nfs.mount_path).to eq("/")
       end
     end
 

--- a/test/y2storage/proposal/autoinst_devices_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_planner_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -55,6 +55,21 @@ describe Y2Storage::Proposal::AutoinstDevicesPlanner do
   end
 
   describe "#planned_devices" do
+    context "using NFS" do
+      let(:partitioning_array) do
+        [{
+          "device" => "/dev/nfs", "partitions" => [{ "mount" => "/", "device" => "server:path" }]
+        }]
+      end
+
+      it "plans NFS filesystems" do
+        devices = planner.planned_devices(drives_map)
+
+        expect(devices.nfs_filesystems).to_not be_empty
+        expect(devices.nfs_filesystems.first.root?).to eq(true)
+      end
+    end
+
     context "using Btrfs" do
       let(:partitioning_array) do
         [{

--- a/test/y2storage/proposal/autoinst_drives_map_test.rb
+++ b/test/y2storage/proposal/autoinst_drives_map_test.rb
@@ -127,6 +127,23 @@ describe Y2Storage::Proposal::AutoinstDrivesMap do
         end
       end
     end
+
+    context "when NFS is used" do
+      let(:partitioning_array) do
+        [
+          {
+            "device"     => "/dev/nfs",
+            "partitions" => [{ "device" => "srv:/home/a" }]
+          }
+        ]
+      end
+
+      it "uses the device name" do
+        described_class.new(fake_devicegraph, partitioning, issues_list)
+
+        expect(drives_map.disk_names).to include("/dev/nfs")
+      end
+    end
   end
 
   describe "#each" do

--- a/test/y2storage/proposal/autoinst_nfs_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_nfs_planner_test.rb
@@ -1,0 +1,136 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage/proposal/autoinst_nfs_planner"
+require "y2storage/autoinst_issues/list"
+require "y2storage/autoinst_profile/drive_section"
+
+describe Y2Storage::Proposal::AutoinstNfsPlanner do
+  before do
+    fake_scenario(scenario)
+  end
+
+  let(:scenario) { "empty_hard_disk_15GiB" }
+
+  subject(:planner) { described_class.new(fake_devicegraph, issues_list) }
+
+  let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
+
+  describe "#planned_devices" do
+    let(:drive) { Y2Storage::AutoinstProfile::DriveSection.new_from_hashes(drive_section) }
+
+    let(:drive_section) { { "device" => "/dev/nfs", "partitions" => [partition_section] } }
+
+    context "when the partition section does not contain a device value" do
+      let(:partition_section) do
+        { "mount" => "/", "fstopt" => "rw,wsize=8192" }
+      end
+
+      it "does not plan a NFS filesystem" do
+        expect(planner.planned_devices(drive)).to be_empty
+      end
+
+      it "registers an issue" do
+        planner.planned_devices(drive)
+        issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::MissingValue) }
+
+        expect(issue).to_not be_nil
+        expect(issue.attr).to eq(:device)
+      end
+    end
+
+    context "when the partition section does not contain a mount value" do
+      let(:partition_section) do
+        { "device" => "192.168.56.1:/root_fs", "fstopt" => "rw,wsize=8192" }
+      end
+
+      it "does not plan a NFS filesystem" do
+        expect(planner.planned_devices(drive)).to be_empty
+      end
+
+      it "registers an issue" do
+        planner.planned_devices(drive)
+        issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::MissingValue) }
+
+        expect(issue).to_not be_nil
+        expect(issue.attr).to eq(:mount)
+      end
+    end
+
+    context "when the partition section contains a device and a mount value" do
+      let(:partition_section) do
+        { "mount" => "/", "device" => "192.168.56.1:/root_fs", "fstopt" => fstopt }
+      end
+
+      let(:fstopt) { nil }
+
+      it "plans a NFS filesystem" do
+        expect(planner.planned_devices(drive)).to_not be_empty
+      end
+
+      it "sets the server" do
+        planned_nfs = planner.planned_devices(drive).first
+
+        expect(planned_nfs.server).to eq("192.168.56.1")
+      end
+
+      it "sets the shared path" do
+        planned_nfs = planner.planned_devices(drive).first
+
+        expect(planned_nfs.path).to eq("/root_fs")
+      end
+
+      it "sets the mount point" do
+        planned_nfs = planner.planned_devices(drive).first
+
+        expect(planned_nfs.mount_point).to eq("/")
+      end
+
+      it "does not register an issue" do
+        planner.planned_devices(drive)
+
+        expect(issues_list).to be_empty
+      end
+
+      context "and the fstab options are not given" do
+        let(:fstopt) { nil }
+
+        it "does not set the fstab options" do
+          planned_nfs = planner.planned_devices(drive).first
+
+          expect(planned_nfs.fstab_options).to be_empty
+        end
+      end
+
+      context "and the fstab options are given" do
+        let(:fstopt) { "rw,wsize=8192" }
+
+        it "sets the fstab options" do
+          planned_nfs = planner.planned_devices(drive).first
+
+          expect(planned_nfs.fstab_options).to contain_exactly("rw", "wsize=8192")
+        end
+      end
+    end
+  end
+end

--- a/test/y2storage/proposal/nfs_creator_test.rb
+++ b/test/y2storage/proposal/nfs_creator_test.rb
@@ -1,0 +1,90 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::Proposal::NfsCreator do
+  before do
+    fake_scenario(scenario)
+  end
+
+  let(:scenario) { "windows-linux-free-pc" }
+
+  subject(:creator) { described_class.new(fake_devicegraph) }
+
+  let(:planned_nfs0) do
+    planned_nfs(
+      server: server, path: path, mount_point: mount_point, fstab_options: fstab_options
+    )
+  end
+
+  let(:server) { "192.168.56.1" }
+
+  let(:path) { "/root_fs" }
+
+  let(:mount_point) { "/" }
+
+  let(:fstab_options) { ["rw", "wsize=8192", "acdirmax=120"] }
+
+  describe "#create_nfs" do
+    def nfs(devicegraph)
+      Y2Storage::Filesystems::Nfs.find_by_server_and_path(devicegraph, server, path)
+    end
+
+    it "creates a new NFS filesystem" do
+      expect(fake_devicegraph.nfs_mounts).to be_empty
+
+      result = creator.create_nfs(planned_nfs0)
+
+      expect(result.devicegraph.nfs_mounts.size).to eq(1)
+    end
+
+    it "sets the server name" do
+      result = creator.create_nfs(planned_nfs0)
+      nfs = nfs(result.devicegraph)
+
+      expect(nfs.server).to eq(server)
+    end
+
+    it "sets the path" do
+      result = creator.create_nfs(planned_nfs0)
+      nfs = nfs(result.devicegraph)
+
+      expect(nfs.path).to eq(path)
+    end
+
+    it "sets the mount path" do
+      result = creator.create_nfs(planned_nfs0)
+      nfs = nfs(result.devicegraph)
+
+      expect(nfs.mount_point.path).to eq(mount_point)
+    end
+
+    it "sets the mount options" do
+      result = creator.create_nfs(planned_nfs0)
+      nfs = nfs(result.devicegraph)
+
+      expect(nfs.mount_point.mount_options).to eq(fstab_options)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

In SLE-12, AutoYaST supported installation over NFS. The way to indicate NFS drives in the AutoYaST profile is not documented at all, but it can be achieved by giving a *\<device\>* inside the *\<partition\>* section. This invalidates the profile because *\<partition\>* cannot contain a *\<device\>*, but it works in SLE-12.

Storage-ng has no support for installing over NFS with AutoYaST, so the *\<device\>* hack should be brought back again.

* https://bugzilla.suse.com/show_bug.cgi?id=1130256
* https://trello.com/c/x4LYDnwe/865-3-l3-important-bug-1130256-autoyast-for-a-nfs-root-fails-at-partitioning


## Solution

Add support for installing over NFS as before, that is, by specifying a device inside the partition section. Such device contains the NFS share in which to install.

NOTE: exporting NFS is not implemented in this PR. The idea is to create a follow-up PBI to implement both, import and export, but using a new style for defining NFS drives (current style invalidates the profile).

## Testing

- Added unit tests
- Tested manually
