### PR TITLE
Fix unit tests in ARM architecture (bsc#1130957)

### DIFF
--- a/test/y2storage/existing_filesystem_test.rb
+++ b/test/y2storage/existing_filesystem_test.rb
@@ -105,6 +105,7 @@ describe Y2Storage::ExistingFilesystem do
       let(:device_name) { "/dev/sda1" }
 
       let(:windows_content) { true }
+      let(:architecture) { :x86_64 }
 
       it "returns nil" do
         expect(subject.release_name).to be_nil
@@ -147,6 +148,7 @@ describe Y2Storage::ExistingFilesystem do
       let(:device_name) { "/dev/sda1" }
 
       let(:windows_content) { true }
+      let(:architecture) { :x86_64 }
 
       it "returns nil" do
         expect(subject.fstab).to be_nil


### PR DESCRIPTION
## Problem

The unit tests are failing in architectures other than x86. For example in [aarch64](https://build.opensuse.org/package/live_build_log/openSUSE:Factory:ARM/yast2-storage-ng/standard/aarch64), [armv7](https://build.opensuse.org/package/live_build_log/openSUSE:Factory:ARM/yast2-storage-ng/standard/armv7l) and [armv6](https://build.opensuse.org/package/live_build_log/openSUSE:Factory:ARM/yast2-storage-ng/standard/armv6l).

- See bugzilla: [bsc#1130957](http://bugzilla.suse.com/show_bug.cgi?id=1130957)

## Solution

Mock also the architecture when mocking the Windows presence
