### PR TITLE
Fix resetting proposal settings

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  3 07:12:34 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Fix initial proposal resetting settings properly before a new
+  attempt in other candidates (bsc#1130392).
+- 4.1.79
+
+-------------------------------------------------------------------
 Tue Apr  2 15:37:22 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Add support for installing over NFS with AutoYaST (bsc#1130256).

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
 Wed Apr  3 07:12:34 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
-- Fix initial proposal resetting settings properly before a new
-  attempt in other candidates (bsc#1130392).
+- Fix initial proposal to make a clean copy of initial settings
+  before switching to another candidate device (bsc#1130392).
+- Related to bsc#1102026 and bsc#1090383.
 - 4.1.79
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.78
+Version:	4.1.79
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/initial_guided_proposal.rb
+++ b/src/lib/y2storage/initial_guided_proposal.rb
@@ -38,7 +38,7 @@ module Y2Storage
     def initialize(settings: nil, devicegraph: nil, disk_analyzer: nil)
       super
 
-      @initial_settings = self.settings.deep_copy
+      @initial_settings = self.settings
     end
 
   private
@@ -171,7 +171,7 @@ module Y2Storage
     #   devices have changed.
     def reset_settings
       self.space_maker = nil
-      self.settings = initial_settings.deep_copy
+      self.settings = initial_settings
     end
 
     # Creates a generator of settings

--- a/src/lib/y2storage/initial_guided_proposal.rb
+++ b/src/lib/y2storage/initial_guided_proposal.rb
@@ -38,7 +38,7 @@ module Y2Storage
     def initialize(settings: nil, devicegraph: nil, disk_analyzer: nil)
       super
 
-      @initial_settings = self.settings.dup
+      @initial_settings = self.settings.deep_copy
     end
 
   private
@@ -171,7 +171,7 @@ module Y2Storage
     #   devices have changed.
     def reset_settings
       self.space_maker = nil
-      self.settings = initial_settings.dup
+      self.settings = initial_settings.deep_copy
     end
 
     # Creates a generator of settings

--- a/src/lib/y2storage/initial_guided_proposal.rb
+++ b/src/lib/y2storage/initial_guided_proposal.rb
@@ -38,7 +38,7 @@ module Y2Storage
     def initialize(settings: nil, devicegraph: nil, disk_analyzer: nil)
       super
 
-      @initial_settings = Yast.deep_copy(self.settings)
+      @initial_settings = self.settings.dup
     end
 
   private
@@ -171,7 +171,7 @@ module Y2Storage
     #   devices have changed.
     def reset_settings
       self.space_maker = nil
-      self.settings = Yast.deep_copy(initial_settings)
+      self.settings = initial_settings.dup
     end
 
     # Creates a generator of settings

--- a/src/lib/y2storage/proposal/settings_generator/base.rb
+++ b/src/lib/y2storage/proposal/settings_generator/base.rb
@@ -77,7 +77,7 @@ module Y2Storage
         #
         # @param settings [ProposalSettings]
         def initialize_settings(settings)
-          @settings = Yast.deep_copy(settings)
+          @settings = settings.deep_copy
         end
 
         # Sets the initial adjustments
@@ -104,7 +104,7 @@ module Y2Storage
         #
         # @return [ProposalSettings]
         def copy_settings
-          Yast.deep_copy(settings)
+          settings.deep_copy
         end
       end
     end

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -206,7 +206,7 @@ module Y2Storage
     # Produces a deep copy of settings
     #
     # @return [ProposalSettings]
-    def dup
+    def deep_copy
       Marshal.load(Marshal.dump(self))
     end
 

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -203,6 +203,13 @@ module Y2Storage
       load_features
     end
 
+    # Produces a deep copy of settings
+    #
+    # @return [ProposalSettings]
+    def dup
+      Marshal.load(Marshal.dump(self))
+    end
+
     # Whether encryption must be used
     # @return [Boolean]
     def use_encryption

--- a/test/y2storage/initial_guided_proposal_test.rb
+++ b/test/y2storage/initial_guided_proposal_test.rb
@@ -237,7 +237,7 @@ describe Y2Storage::InitialGuidedProposal do
     # Test, at hight level, that settings are reset between candidates
     #
     # Related to bsc#113092, settings must be **correctly** reset after moving to another (group
-    # of) candidate device(s). To check that, the first candidate will be enought small to make not
+    # of) candidate device(s). To check that, the first candidate will be small enough to make not
     # possible the proposal on it even **after adjust the initial settings**, expecting to have a
     # valid proposal **with original settings** in the second candidate.
     context "when a proposal is not possible for a candidate even after adjust the settings" do
@@ -259,7 +259,7 @@ describe Y2Storage::InitialGuidedProposal do
 
         expect(used_devices).to contain_exactly("/dev/sdb")
 
-        # having expeted mount points means that settings were reset properly, since in the
+        # having expected mount points means that settings were reset properly, since in the
         # previous attempts swap and separated home should be deleted
         expect(mount_points).to include("swap", "/home", "/")
       end

--- a/test/y2storage/initial_guided_proposal_test.rb
+++ b/test/y2storage/initial_guided_proposal_test.rb
@@ -234,6 +234,37 @@ describe Y2Storage::InitialGuidedProposal do
       end
     end
 
+    # Test, at hight level, that settings are reset between candidates
+    #
+    # Related to bsc#113092, settings must be **correctly** reset after moving to another (group
+    # of) candidate device(s). To check that, the first candidate will be enought small to make not
+    # possible the proposal on it even **after adjust the initial settings**, expecting to have a
+    # valid proposal **with original settings** in the second candidate.
+    context "when a proposal is not possible for a candidate even after adjust the settings" do
+      include_context "candidate devices"
+
+      let(:candidate_devices) { ["/dev/sda", "/dev/sdb"] }
+
+      let(:control_file_content) { ng_partitioning_section }
+
+      before do
+        sda.size = 2.GiB
+      end
+
+      it "resets the settings before attempting a new proposal with next candidate" do
+        proposal.propose
+
+        partitions = proposal.devices.partitions
+        mount_points = partitions.map(&:filesystem_mountpoint).compact
+
+        expect(used_devices).to contain_exactly("/dev/sdb")
+
+        # having expeted mount points means that settings were reset properly, since in the
+        # previous attempts swap and separated home should be deleted
+        expect(mount_points).to include("swap", "/home", "/")
+      end
+    end
+
     context "when a proposal is not possible" do
       include_context "candidate devices"
 

--- a/test/y2storage/proposal/settings_generator/legacy_test.rb
+++ b/test/y2storage/proposal/settings_generator/legacy_test.rb
@@ -26,6 +26,10 @@ require "y2storage/proposal/settings_generator/legacy"
 describe Y2Storage::Proposal::SettingsGenerator::Legacy do
   subject { described_class.new(settings) }
 
+  def remove_object_ids(input)
+    input.gsub(/:0x\w+ /, "")
+  end
+
   describe "#next_settings" do
     before do
       stub_product_features("partitioning" => partitioning_features)
@@ -47,14 +51,17 @@ describe Y2Storage::Proposal::SettingsGenerator::Legacy do
       next_settings = subject.next_settings
 
       expect(next_settings).to be_a(Y2Storage::ProposalSettings)
-      expect(next_settings.object_id).to_not eq(settings.object_id)
+      expect(next_settings.to_s).to_not eq(settings.to_s)
     end
 
     context "when called for first time" do
       it "returns the same values as the initial settings" do
         next_settings = subject.next_settings
 
-        expect(next_settings.to_s).to eq(settings.to_s)
+        settings_content = remove_object_ids(settings.to_s)
+        next_settings_content = remove_object_ids(next_settings.to_s)
+
+        expect(next_settings_content).to eq(settings_content)
       end
     end
 

--- a/test/y2storage/proposal/settings_generator/legacy_test.rb
+++ b/test/y2storage/proposal/settings_generator/legacy_test.rb
@@ -47,12 +47,15 @@ describe Y2Storage::Proposal::SettingsGenerator::Legacy do
       next_settings = subject.next_settings
 
       expect(next_settings).to be_a(Y2Storage::ProposalSettings)
-      expect(next_settings.object_id).to_not eq(settings.object_id)
+      expect(next_settings).to_not equal(settings)
     end
 
     context "when called for first time" do
       it "returns the same values as the initial settings" do
-        expect(subject.next_settings).to eq(settings)
+        settings_values = Marshal.dump(settings)
+        next_settings_values = Marshal.dump(subject.next_settings)
+
+        expect(next_settings_values).to eq(settings_values)
       end
     end
 

--- a/test/y2storage/proposal/settings_generator/legacy_test.rb
+++ b/test/y2storage/proposal/settings_generator/legacy_test.rb
@@ -26,10 +26,6 @@ require "y2storage/proposal/settings_generator/legacy"
 describe Y2Storage::Proposal::SettingsGenerator::Legacy do
   subject { described_class.new(settings) }
 
-  def remove_object_ids(input)
-    input.gsub(/:0x\w+ /, "")
-  end
-
   describe "#next_settings" do
     before do
       stub_product_features("partitioning" => partitioning_features)
@@ -51,17 +47,12 @@ describe Y2Storage::Proposal::SettingsGenerator::Legacy do
       next_settings = subject.next_settings
 
       expect(next_settings).to be_a(Y2Storage::ProposalSettings)
-      expect(next_settings.to_s).to_not eq(settings.to_s)
+      expect(next_settings.object_id).to_not eq(settings.object_id)
     end
 
     context "when called for first time" do
       it "returns the same values as the initial settings" do
-        next_settings = subject.next_settings
-
-        settings_content = remove_object_ids(settings.to_s)
-        next_settings_content = remove_object_ids(next_settings.to_s)
-
-        expect(next_settings_content).to eq(settings_content)
+        expect(subject.next_settings).to eq(settings)
       end
     end
 

--- a/test/y2storage/proposal/settings_generator/ng_test.rb
+++ b/test/y2storage/proposal/settings_generator/ng_test.rb
@@ -30,6 +30,10 @@ describe Y2Storage::Proposal::SettingsGenerator::Ng do
     settings.volumes.find { |v| v.mount_point == mount_point }
   end
 
+  def remove_object_ids(input)
+    input.gsub(/:0x\w+ /, "")
+  end
+
   describe "#next_settings" do
     before do
       stub_product_features("partitioning" => partitioning_features)
@@ -75,14 +79,17 @@ describe Y2Storage::Proposal::SettingsGenerator::Ng do
       next_settings = subject.next_settings
 
       expect(next_settings).to be_a(Y2Storage::ProposalSettings)
-      expect(next_settings.object_id).to_not eq(settings.object_id)
+      expect(next_settings.to_s).to_not eq(settings.to_s)
     end
 
     context "when called for first time" do
       it "returns the same values as the initial settings" do
         next_settings = subject.next_settings
 
-        expect(next_settings.to_s).to eq(settings.to_s)
+        settings_content = remove_object_ids(settings.to_s)
+        next_settings_content = remove_object_ids(next_settings.to_s)
+
+        expect(next_settings_content).to eq(settings_content)
       end
 
       it "creates an empty SettingsAdjustment object" do

--- a/test/y2storage/proposal/settings_generator/ng_test.rb
+++ b/test/y2storage/proposal/settings_generator/ng_test.rb
@@ -75,12 +75,15 @@ describe Y2Storage::Proposal::SettingsGenerator::Ng do
       next_settings = subject.next_settings
 
       expect(next_settings).to be_a(Y2Storage::ProposalSettings)
-      expect(next_settings.object_id).to_not eq(settings.object_id)
+      expect(next_settings).to_not equal(settings)
     end
 
     context "when called for first time" do
       it "returns the same values as the initial settings" do
-        expect(subject.next_settings).to eq(settings)
+        settings_values = Marshal.dump(settings)
+        next_settings_values = Marshal.dump(subject.next_settings)
+
+        expect(next_settings_values).to eq(settings_values)
       end
 
       it "creates an empty SettingsAdjustment object" do

--- a/test/y2storage/proposal/settings_generator/ng_test.rb
+++ b/test/y2storage/proposal/settings_generator/ng_test.rb
@@ -30,10 +30,6 @@ describe Y2Storage::Proposal::SettingsGenerator::Ng do
     settings.volumes.find { |v| v.mount_point == mount_point }
   end
 
-  def remove_object_ids(input)
-    input.gsub(/:0x\w+ /, "")
-  end
-
   describe "#next_settings" do
     before do
       stub_product_features("partitioning" => partitioning_features)
@@ -79,17 +75,12 @@ describe Y2Storage::Proposal::SettingsGenerator::Ng do
       next_settings = subject.next_settings
 
       expect(next_settings).to be_a(Y2Storage::ProposalSettings)
-      expect(next_settings.to_s).to_not eq(settings.to_s)
+      expect(next_settings.object_id).to_not eq(settings.object_id)
     end
 
     context "when called for first time" do
       it "returns the same values as the initial settings" do
-        next_settings = subject.next_settings
-
-        settings_content = remove_object_ids(settings.to_s)
-        next_settings_content = remove_object_ids(next_settings.to_s)
-
-        expect(next_settings_content).to eq(settings_content)
+        expect(subject.next_settings).to eq(settings)
       end
 
       it "creates an empty SettingsAdjustment object" do

--- a/test/y2storage/proposal_settings_test.rb
+++ b/test/y2storage/proposal_settings_test.rb
@@ -65,8 +65,8 @@ describe Y2Storage::ProposalSettings do
     it "returns a deep copy of settings" do
       dup = settings.dup
 
-      # Let's simply check two nested levels: it's expected to found the same amount of objects with
-      # a different identity. In other words, object must looks equal but being different.
+      # Let's simply check two nested levels: it's expected to find the same amount of objects with
+      # a different identity. In other words, object must look equal but be different.
 
       dup_volumes = dup.volumes
       dup_volumes_ids = dup_volumes.map(&:object_id)
@@ -77,6 +77,10 @@ describe Y2Storage::ProposalSettings do
       settings_volumes_ids = settings_volumes.map(&:object_id)
       settings_volumes_desired_sizes = settings_volumes.map(&:desired_size)
       settings_volumes_desired_sizes_ids = settings_volumes_desired_sizes.map(&:object_id)
+
+      expect(dup_volumes.map(&:mount_point)).to eq(settings_volumes.map(&:mount_point))
+      expect(dup_volumes.map(&:fs_type)).to eq(settings_volumes.map(&:fs_type))
+      expect(dup_volumes_desired_sizes).to eq(settings_volumes_desired_sizes)
 
       expect(dup.object_id).to_not eq(settings.object_id)
       expect(dup_volumes_ids).to_not eq(settings_volumes_ids)

--- a/test/y2storage/proposal_settings_test.rb
+++ b/test/y2storage/proposal_settings_test.rb
@@ -61,29 +61,22 @@ describe Y2Storage::ProposalSettings do
       stub_partitioning_features(partitioning)
     end
 
-    it "returns a deep copy of settings" do
-      copy = settings.deep_copy
+    it "creates a new object" do
+      expect(settings.deep_copy).to_not equal(settings)
+    end
 
-      # Let's simply check two nested levels: it's expected to find the same amount of objects with
-      # a different identity. In other words, the objects must be equal but must be different instances.
+    it "creates an object with the same values" do
+      settings_values = Marshal.dump(settings)
+      settings_deep_copy_values = Marshal.dump(settings.deep_copy)
 
-      copy_volumes = copy.volumes
-      copy_volumes_ids = copy_volumes.map(&:object_id)
-      copy_volumes_desired_sizes = copy_volumes.map(&:desired_size)
-      copy_volumes_desired_sizes_ids = copy_volumes_desired_sizes.map(&:object_id)
+      expect(settings_deep_copy_values).to eq(settings_values)
+    end
 
-      settings_volumes = settings.volumes
-      settings_volumes_ids = settings_volumes.map(&:object_id)
-      settings_volumes_desired_sizes = settings_volumes.map(&:desired_size)
-      settings_volumes_desired_sizes_ids = settings_volumes_desired_sizes.map(&:object_id)
+    it "creates an object with different references" do
+      ids = settings.volumes.map(&:object_id).sort
+      new_ids = settings.deep_copy.volumes.map(&:object_id).sort
 
-      expect(copy_volumes.map(&:mount_point)).to eq(settings_volumes.map(&:mount_point))
-      expect(copy_volumes.map(&:fs_type)).to eq(settings_volumes.map(&:fs_type))
-      expect(copy_volumes_desired_sizes).to eq(settings_volumes_desired_sizes)
-
-      expect(copy.object_id).to_not eq(settings.object_id)
-      expect(copy_volumes_ids).to_not eq(settings_volumes_ids)
-      expect(copy_volumes_desired_sizes_ids).to_not eq(settings_volumes_desired_sizes_ids)
+      expect(new_ids).to_not eq(ids)
     end
   end
 

--- a/test/y2storage/proposal_settings_test.rb
+++ b/test/y2storage/proposal_settings_test.rb
@@ -49,7 +49,6 @@ describe Y2Storage::ProposalSettings do
           "desired_size" => "20GiB", "max_size" => "40GiB"
         },
         { "mount_point" => "/home", "fs_type" => "xfs", "weight" => 40, "desired_size" => "10GiB" },
-        # This should reuse the existing logical swap
         { "mount_point" => "swap", "fs_type" => "swap", "desired_size" => "3GiB" }
       ]
     end
@@ -66,7 +65,7 @@ describe Y2Storage::ProposalSettings do
       copy = settings.deep_copy
 
       # Let's simply check two nested levels: it's expected to find the same amount of objects with
-      # a different identity. In other words, object must look equal but be different.
+      # a different identity. In other words, the objects must be equal but must be different instances.
 
       copy_volumes = copy.volumes
       copy_volumes_ids = copy_volumes.map(&:object_id)

--- a/test/y2storage/proposal_settings_test.rb
+++ b/test/y2storage/proposal_settings_test.rb
@@ -39,7 +39,7 @@ describe Y2Storage::ProposalSettings do
 
   let(:initial_partitioning_features) { {} }
 
-  describe "#dup" do
+  describe "#deep_copy" do
     subject(:settings) { described_class.new_for_current_product }
 
     let(:volumes) do
@@ -63,28 +63,28 @@ describe Y2Storage::ProposalSettings do
     end
 
     it "returns a deep copy of settings" do
-      dup = settings.dup
+      copy = settings.deep_copy
 
       # Let's simply check two nested levels: it's expected to find the same amount of objects with
       # a different identity. In other words, object must look equal but be different.
 
-      dup_volumes = dup.volumes
-      dup_volumes_ids = dup_volumes.map(&:object_id)
-      dup_volumes_desired_sizes = dup_volumes.map(&:desired_size)
-      dup_volumes_desired_sizes_ids = dup_volumes_desired_sizes.map(&:object_id)
+      copy_volumes = copy.volumes
+      copy_volumes_ids = copy_volumes.map(&:object_id)
+      copy_volumes_desired_sizes = copy_volumes.map(&:desired_size)
+      copy_volumes_desired_sizes_ids = copy_volumes_desired_sizes.map(&:object_id)
 
       settings_volumes = settings.volumes
       settings_volumes_ids = settings_volumes.map(&:object_id)
       settings_volumes_desired_sizes = settings_volumes.map(&:desired_size)
       settings_volumes_desired_sizes_ids = settings_volumes_desired_sizes.map(&:object_id)
 
-      expect(dup_volumes.map(&:mount_point)).to eq(settings_volumes.map(&:mount_point))
-      expect(dup_volumes.map(&:fs_type)).to eq(settings_volumes.map(&:fs_type))
-      expect(dup_volumes_desired_sizes).to eq(settings_volumes_desired_sizes)
+      expect(copy_volumes.map(&:mount_point)).to eq(settings_volumes.map(&:mount_point))
+      expect(copy_volumes.map(&:fs_type)).to eq(settings_volumes.map(&:fs_type))
+      expect(copy_volumes_desired_sizes).to eq(settings_volumes_desired_sizes)
 
-      expect(dup.object_id).to_not eq(settings.object_id)
-      expect(dup_volumes_ids).to_not eq(settings_volumes_ids)
-      expect(dup_volumes_desired_sizes_ids).to_not eq(settings_volumes_desired_sizes_ids)
+      expect(copy.object_id).to_not eq(settings.object_id)
+      expect(copy_volumes_ids).to_not eq(settings_volumes_ids)
+      expect(copy_volumes_desired_sizes_ids).to_not eq(settings_volumes_desired_sizes_ids)
     end
   end
 


### PR DESCRIPTION
## Problem

Initial settings are not being restored before each proposal attempt because

> `Yast.deep_copy` is quite a fail that only copies one level, leaving the second level as references instead of copies. — [extracted from Ancor's comment](https://github.com/yast/yast-storage-ng/pull/889#discussion_r271681321)

See also, 

- https://bugzilla.suse.com/show_bug.cgi?id=1130392
- https://trello.com/c/KJpkiH4P/889-1130392-storage-disabled-volumes-stay-disabled-during-proposal-process

## Solution

~~Overwrite the [`ProposalSettings#dup`](https://github.com/yast/yast-storage-ng/compare/SLE-15-SP1...feature/bsc-1130392-fix-reset-proposal-settings?expand=1#diff-30d4c4c7ff63d32d4f2fa075e77d3290R209)~~ Added a [`ProposalSettings#deep_copy`](https://github.com/yast/yast-storage-ng/pull/889/files#diff-30d4c4c7ff63d32d4f2fa075e77d3290R208) method to make a copy based on a `Marshal` serialization  instead of use `Yast.deep_copy` because

>  It did its job with the YCP -> Ruby translation, but it should never be used in new code because it does not do what it promises. We should use Ruby mechanisms for performing deep copies, such as Marshall. —  [extracted from Ancor's comment](https://github.com/yast/yast-storage-ng/pull/889#discussion_r271681321)


## Testing

- Added a new unit tests
- Fixed some existing tests