### PR TITLE
Backport (GA): Add support for NFS in AutoYaST

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr  2 15:37:22 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Add support for installing over NFS with AutoYaST (bsc#1130256).
+- 4.0.219
+
+-------------------------------------------------------------------
 Fri Feb  8 11:43:53 UTC 2019 - ancor@suse.com
 
 - AutoYaST: fix broken support for retaining existing MD RAIDs in
@@ -509,7 +515,7 @@ Wed Apr 18 10:37:17 UTC 2018 - ancor@suse.com
 -------------------------------------------------------------------
 Tue Apr 17 12:01:08 UTC 2018 - shundhammer@suse.com
 
-- Added missing help texts in the partitioner (bsc#1079591) 
+- Added missing help texts in the partitioner (bsc#1079591)
 - 4.0.157
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.218
+Version:        4.0.219
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/autoinst_issues/list.rb
+++ b/src/lib/y2storage/autoinst_issues/list.rb
@@ -47,7 +47,7 @@ module Y2Storage
       # Add a problem to the list
       #
       # The type of the problem is identified as a symbol which name is the
-      # underscore version of the class which implements it.  For instance,
+      # underscore version of the class which implements it. For instance,
       # `MissingRoot` would be referred as `:missing_root`.
       #
       # If a given type of problem requires some additional arguments, they

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -131,8 +131,15 @@ module Y2Storage
       end
 
       def default_type_for(hash)
-        return :CT_MD if hash["device"].to_s.start_with?("/dev/md")
-        :CT_DISK
+        device_name = hash["device"].to_s
+
+        if md_name?(device_name)
+          :CT_MD
+        elsif nfs_name?(device_name)
+          :CT_NFS
+        else
+          :CT_DISK
+        end
       end
 
       # Clones a drive into an AutoYaST profile section by creating an instance
@@ -237,6 +244,23 @@ module Y2Storage
       end
 
     protected
+
+      # Whether the given name is a Md name
+      #
+      # @param device_name [String]
+      # @return [Boolean]
+      def md_name?(device_name)
+        device_name.start_with?("/dev/md")
+      end
+
+      # Whether the given name is a NFS name
+      #
+      # @param device_name [String]
+      # @return [Boolean]
+      def nfs_name?(device_name)
+        # TODO: with the new format, device_name would be "server:path"
+        device_name == "/dev/nfs"
+      end
 
       # Method used by {.new_from_storage} to populate the attributes when
       # cloning a disk or DASD device.

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -48,37 +48,41 @@ module Y2Storage
       NO_CREATE_IDS = []
       private_constant :NO_CREATE_IDS
 
+      ATTRIBUTES = [
+        { name: :create },
+        { name: :filesystem },
+        { name: :format },
+        { name: :label },
+        { name: :uuid },
+        { name: :lv_name },
+        { name: :lvm_group },
+        { name: :mount },
+        { name: :mountby },
+        { name: :partition_id },
+        { name: :partition_nr },
+        { name: :partition_type },
+        { name: :subvolumes },
+        { name: :size },
+        { name: :crypt_fs },
+        { name: :loop_fs },
+        { name: :crypt_key },
+        { name: :raid_name },
+        { name: :raid_options },
+        { name: :mkfs_options },
+        { name: :fstab_options, xml_name: :fstopt },
+        { name: :subvolumes_prefix },
+        { name: :create_subvolumes },
+        { name: :resize },
+        { name: :pool },
+        { name: :used_pool },
+        { name: :stripes },
+        { name: :stripe_size, xml_name: :stripesize },
+        { name: :device }
+      ].freeze
+      private_constant :ATTRIBUTES
+
       def self.attributes
-        [
-          { name: :create },
-          { name: :filesystem },
-          { name: :format },
-          { name: :label },
-          { name: :uuid },
-          { name: :lv_name },
-          { name: :lvm_group },
-          { name: :mount },
-          { name: :mountby },
-          { name: :partition_id },
-          { name: :partition_nr },
-          { name: :partition_type },
-          { name: :subvolumes },
-          { name: :size },
-          { name: :crypt_fs },
-          { name: :loop_fs },
-          { name: :crypt_key },
-          { name: :raid_name },
-          { name: :raid_options },
-          { name: :mkfs_options },
-          { name: :fstab_options, xml_name: :fstopt },
-          { name: :subvolumes_prefix },
-          { name: :create_subvolumes },
-          { name: :resize },
-          { name: :pool },
-          { name: :used_pool },
-          { name: :stripes },
-          { name: :stripe_size, xml_name: :stripesize }
-        ]
+        ATTRIBUTES
       end
 
       define_attr_accessors
@@ -151,6 +155,10 @@ module Y2Storage
 
       # @!attribute subvolumes_prefix
       #   @return [String] Name of the default Btrfs subvolume
+
+      # @!attribute device
+      #   @return [String, nil] undocumented attribute, but used to indicate a NFS
+      #     share when installing over NFS
 
       def init_from_hashes(hash)
         super

--- a/src/lib/y2storage/autoinst_profile/partitioning_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partitioning_section.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -69,7 +69,7 @@ module Y2Storage
       end
 
       # Clones a system into an AutoYaST profile section, creating an instance
-      # if this class from the information in a devicegraph.
+      # of this class from the information in a devicegraph.
       #
       # This implements the same behavior followed by the old AutoYaST
       # cloning/export, which includes some custom logic beyond the direct
@@ -119,6 +119,13 @@ module Y2Storage
       # @return [Array<DriveSection>]
       def md_drives
         drives.select { |d| d.type == :CT_MD }
+      end
+
+      # Drive sections with type :CT_NFS
+      #
+      # @return [Array<DriveSection>]
+      def nfs_drives
+        drives.select { |d| d.type == :CT_NFS }
       end
 
       # Return section name

--- a/src/lib/y2storage/boot_requirements_checker.rb
+++ b/src/lib/y2storage/boot_requirements_checker.rb
@@ -131,6 +131,20 @@ module Y2Storage
     #
     # @return [Boolean]
     def nfs_root?
+      planned_nfs_root? || exist_nfs_root?
+    end
+
+    # Whether there is a planned NFS root
+    #
+    # @return [Boolean]
+    def planned_nfs_root?
+      planned_devices.find { |d| d.is_a?(Planned::Nfs) && d.mount_point == "/" }
+    end
+
+    # Whether a NFS root already exists
+    #
+    # @return [Boolean]
+    def exist_nfs_root?
       devicegraph.nfs_mounts.any? { |i| i.mount_point && i.mount_point.root? }
     end
   end

--- a/src/lib/y2storage/planned.rb
+++ b/src/lib/y2storage/planned.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -25,6 +25,7 @@ require "y2storage/planned/stray_blk_device"
 require "y2storage/planned/lvm_lv"
 require "y2storage/planned/lvm_vg"
 require "y2storage/planned/md"
+require "y2storage/planned/nfs"
 require "y2storage/planned/assigned_space"
 require "y2storage/planned/partitions_distribution"
 require "y2storage/planned/devices_collection"

--- a/src/lib/y2storage/planned/devices_collection.rb
+++ b/src/lib/y2storage/planned/devices_collection.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -124,6 +124,13 @@ module Y2Storage
         @mds ||= devices.select { |d| d.is_a?(Planned::Md) }
       end
 
+      # Returns the list of planned NFS filesystems
+      #
+      # @return [Array<Planned::Nfs>]
+      def nfs_filesystems
+        @nfs_filesystems ||= devices.select { |d| d.is_a?(Planned::Nfs) }
+      end
+
       # Returns the list of planned LVM logical volumes
       #
       # @return [Array<Planned::LvmLv>]
@@ -142,7 +149,7 @@ module Y2Storage
       #
       # @return [Array<Planned::Device>]
       def all
-        @all ||= partitions + disks + stray_blk_devices + vgs + lvs + mds
+        @all ||= [].concat(partitions, disks, stray_blk_devices, vgs, lvs, mds, nfs_filesystems)
       end
 
       # Returns the list of devices that can be mounted

--- a/src/lib/y2storage/planned/md.rb
+++ b/src/lib/y2storage/planned/md.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-#
 # encoding: utf-8
 
 # Copyright (c) [2017] SUSE LLC

--- a/src/lib/y2storage/planned/nfs.rb
+++ b/src/lib/y2storage/planned/nfs.rb
@@ -1,0 +1,72 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage/planned/device"
+require "y2storage/planned/mixins"
+require "y2storage/match_volume_spec"
+require "y2storage/filesystems/type"
+
+module Y2Storage
+  module Planned
+    # Specification for a Y2Storage::Filesystems::Nfs object to be created during the
+    # AutoYaST proposal
+    #
+    # @see Device
+    class Nfs < Device
+      include Planned::CanBeMounted
+      include MatchVolumeSpec
+
+      # @return [String] server name
+      attr_accessor :server
+
+      # @return [String] path to shared directory
+      attr_accessor :path
+
+      # Constructor
+      #
+      # @param server [String]
+      # @param path [String]
+      def initialize(server = "", path = "")
+        super()
+
+        initialize_can_be_mounted
+
+        @server = server
+        @path = path
+      end
+
+    protected
+
+      # Values for volume specification matching
+      #
+      # @see MatchVolumeSpec
+      def volume_match_values
+        {
+          mount_point:  mount_point,
+          size:         nil,
+          fs_type:      Filesystems::Type::Nfs,
+          partition_id: nil
+        }
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/autoinst_devices_creator.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_creator.rb
@@ -1,8 +1,6 @@
-#!/usr/bin/env ruby
-#
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -24,6 +22,7 @@
 require "y2storage/proposal/partitions_distribution_calculator"
 require "y2storage/proposal/partition_creator"
 require "y2storage/proposal/md_creator"
+require "y2storage/proposal/nfs_creator"
 require "y2storage/proposal/autoinst_creator_result"
 require "y2storage/exceptions"
 
@@ -82,28 +81,12 @@ module Y2Storage
         log.info "planned devices = #{planned_devices.to_a.inspect}"
         log.info "disk names = #{disk_names.inspect}"
 
-        # Process planned partitions
-        parts_to_create, parts_to_reuse, creator_result =
-          process_partitions(planned_devices, disk_names, original_graph.duplicate)
+        reset
 
-        # Process planned disk like devices (Xen virtual partitions and full disks)
-        planned_disk_like_devs = process_disk_like_devs(planned_devices, creator_result.devicegraph)
+        @planned_devices = planned_devices
+        @disk_names = disk_names
 
-        # Add planned disk like devices to reuse list so they can be considered for lvm and raids
-        # later on.
-        devs_to_reuse = parts_to_reuse + planned_disk_like_devs
-
-        # Process planned Mds
-        mds_to_create, _mds_to_reuse, creator_result =
-          process_mds(planned_devices, devs_to_reuse, creator_result)
-
-        # Process planned Vgs
-        planned_vgs, creator_result =
-          process_vgs(planned_devices, devs_to_reuse, creator_result)
-
-        Y2Storage::Proposal::AutoinstCreatorResult.new(
-          creator_result, parts_to_create + mds_to_create + planned_vgs
-        )
+        process_devices
       end
 
     protected
@@ -111,14 +94,31 @@ module Y2Storage
       # @return [Devicegraph] Original devicegraph
       attr_reader :original_graph
 
+      # @return [Planned::DevicesCollection] Devices to create/reuse
+      attr_reader :planned_devices
+
+      # @return [Array<String>] Disks to consider
+      attr_reader :disk_names
+
+      # @return [Array<Planned::Device>] Devices to create
+      attr_reader :devices_to_create
+
+      # @return [Array<Planned::Device>] Devices to reuse
+      attr_reader :devices_to_reuse
+
+      # @return [Proposal::CreatorResult] Current result containing the devices that have been created
+      attr_reader :creator_result
+
+      # @return [Devicegraph] Current devicegraph
+      attr_reader :devicegraph
+
       # Finds the best distribution for the given planned partitions
       #
-      # @param devicegraph        [Devicegraph] Devicegraph to calculate the distribution
-      # @param planned_partitions [Array<Planned::Partition>] Partitions to add
-      # @param disk_names         [Array<String>]             Names of disks to consider
-      #
       # @see Proposal::PartitionsDistributionCalculator#best_distribution
-      def best_distribution(devicegraph, planned_partitions, disk_names)
+      #
+      # @param planned_partitions [Array<Planned::Partition>] Partitions to add
+      # @return [Planned::PartitionsDistribution]
+      def best_distribution(planned_partitions)
         disks = devicegraph.disk_devices.select { |d| disk_names.include?(d.name) }
         spaces = disks.map(&:free_spaces).flatten
 
@@ -132,121 +132,105 @@ module Y2Storage
 
     private
 
+      # Sets the current creator result
+      #
+      # The current devicegraph is properly updated.
+      #
+      # @param result [Proposal::CreatorResult]
+      def creator_result=(result)
+        @creator_result = result
+        @devicegraph = result.devicegraph
+      end
+
+      # Adds devices to the list of devices to create
+      #
+      # @param planned_devices [Array<Planned::Device>]
+      def add_devices_to_create(planned_devices)
+        @devices_to_create.concat(planned_devices)
+      end
+
+      # Adds devices to the list of devices to reuse
+      #
+      # @param planned_devices [Array<Planned::Device>]
+      def add_devices_to_reuse(planned_devices)
+        @devices_to_reuse.concat(planned_devices)
+      end
+
+      # Resets values before create devices
+      #
+      # @see #populated_devicegraph
+      def reset
+        @devices_to_create = []
+        @devices_to_reuse = []
+        @creator_result = nil
+        @devicegraph = original_graph.duplicate
+      end
+
+      # Reuses and creates planned devices
+      #
+      # @return [AutoinstCreatorResult] Result with new devicegraph in which all the
+      #   planned devices have been allocated
+      def process_devices
+        process_partitions
+        # Process planned disk like devices (Xen virtual partitions and full disks)
+        process_disk_like_devs
+        process_mds
+        process_vgs
+        process_nfs_filesystems
+
+        Y2Storage::Proposal::AutoinstCreatorResult.new(creator_result, devices_to_create)
+      end
+
       # Process planned partitions
-      #
-      # The devicegraph object is modified.
-      #
-      # @param planned_devices [Array<Planned::Device>] Devices to create/reuse
-      # @param disk_names [Array<String>] Disks to consider
-      # @param devicegraph [Devicegraph] Devicegraph to work on
-      #
-      # @return [Array<Array<Planned::Partition>, Array<Planned::Partition>, CreatorResult>]
-      def process_partitions(planned_devices, disk_names, devicegraph)
+      def process_partitions
         planned_partitions = sized_partitions(planned_devices.disk_partitions)
         parts_to_reuse, parts_to_create = planned_partitions.partition(&:reuse?)
-        reuse_partitions(parts_to_reuse, devicegraph)
-        creator_result = create_partitions(devicegraph, parts_to_create, disk_names)
+        reuse_partitions(parts_to_reuse)
 
-        [parts_to_create, parts_to_reuse, creator_result]
-      end
-
-      # Process planned Mds
-      #
-      # @param planned_devices [Array<Planned::Device>] Devices to create/reuse
-      # @param devs_to_reuse [Array<Planned::Device>] Devices to reuse
-      # @param creator_result [CreatorResult] partial result
-      #
-      # @return [Array<Array<Planned::Md>, Array<Planned::Md>, CreatorResult>]
-      def process_mds(planned_devices, devs_to_reuse, creator_result)
-        mds_to_reuse, mds_to_create = planned_devices.mds.partition(&:reuse?)
-        devs_to_reuse_in_md = reusable_by_md(devs_to_reuse)
-        reuse_mds(mds_to_reuse, creator_result)
-        creator_result.merge!(create_mds(planned_devices.mds, creator_result, devs_to_reuse_in_md))
-
-        [mds_to_create, mds_to_reuse, creator_result]
-      end
-
-      # Process planned Vgs
-      #
-      # @param planned_devices [Array<Planned::Device>] Devices to create/reuse
-      # @param devs_to_reuse [Array<Planned::Device>] Devices to reuse
-      # @param creator_result [CreatorResult] partial result
-      #
-      # @return [Array<Array<Planned::Md>, Array<Planned::Md>, CreatorResult>]
-      def process_vgs(planned_devices, devs_to_reuse, creator_result)
-        planned_vgs = planned_devices.vgs
-        vgs_to_reuse = planned_vgs.select(&:reuse?)
-        creator_result = reuse_vgs(vgs_to_reuse, creator_result)
-        creator_result.merge!(set_up_lvm(planned_vgs, creator_result, devs_to_reuse))
-
-        [planned_vgs, creator_result]
+        add_devices_to_create(parts_to_create)
+        add_devices_to_reuse(parts_to_reuse)
+        self.creator_result = create_partitions(parts_to_create)
       end
 
       # Formats and/or mounts the disk like block devices (Xen virtual partitions and full disks)
       #
-      # @param planned_devices [Array<Planned::Device>] all planned devices
-      # @param devicegraph     [Devicegraph] devicegraph containing the Xen
-      #   partitions or full disks. It will be modified.
-      # @return                [Array<Planned::StrayBlkDevice,Planned::Disk>] all disk like
-      #   block devices
-      def process_disk_like_devs(planned_devices, devicegraph)
+      # Add planned disk like devices to reuse list so they can be considered for lvm and raids
+      # later on.
+      def process_disk_like_devs
         planned_devs = planned_devices.select do |dev|
           dev.is_a?(Planned::StrayBlkDevice) || dev.is_a?(Planned::Disk)
         end
+
         planned_devs.each { |d| d.reuse!(devicegraph) }
 
-        planned_devs
+        add_devices_to_reuse(planned_devs)
       end
 
-      # Creates planned partitions in the given devicegraph
-      #
-      # @param new_partitions [Array<Planned::Partition>] Devices to create
-      # @param disk_names     [Array<String>]             Disks to consider
-      # @return [PartitionCreatorResult]
-      def create_partitions(devicegraph, new_partitions, disk_names)
-        log.info "Partitions to create: #{new_partitions}"
-        primary, non_primary = new_partitions.partition(&:primary)
-        parts_to_create = primary + non_primary
+      # Process planned Mds
+      def process_mds
+        mds_to_reuse, mds_to_create = planned_devices.mds.partition(&:reuse?)
+        devs_to_reuse_in_md = reusable_by_md(devices_to_reuse)
+        reuse_mds(mds_to_reuse)
 
-        dist = best_distribution(devicegraph, parts_to_create, disk_names)
-        raise NoDiskSpaceError, "Could not find a valid partitioning distribution" if dist.nil?
-        part_creator = Proposal::PartitionCreator.new(devicegraph)
-        part_creator.create_partitions(dist)
+        add_devices_to_create(mds_to_create)
+        add_devices_to_reuse(mds_to_reuse.flat_map(&:partitions))
+        self.creator_result = create_mds(planned_devices.mds, devs_to_reuse_in_md)
       end
 
-      # Creates volume groups in the given devicegraph
-      #
-      # @param vgs             [Array<Planned::LvmVg>]     List of planned volume groups to add
-      # @param previous_result [Proposal::CreatorResult]   Starting point
-      # @param devs_to_reuse   [Array<Planned::Partition, Planned::StrayBlkDevice>] List of devices
-      #   to reuse as Physical Volumes
-      # @return                [Proposal::CreatorResult] Result containing the specified volume groups
-      def set_up_lvm(vgs, previous_result, devs_to_reuse)
-        # log separately to be more readable
-        log.info "BEGIN: set_up_lvm: vgs=#{vgs.inspect}"
-        log.info "BEGIN: set_up_lvm: previous_result=#{previous_result.inspect}"
-        log.info "BEGIN: set_up_lvm: devs_to_reuse=#{devs_to_reuse.inspect}"
-        vgs.reduce(previous_result) do |result, vg|
-          pvs = previous_result.created_names { |d| d.pv_for?(vg.volume_group_name) }
-          pvs += devs_to_reuse.select { |d| d.pv_for?(vg.volume_group_name) }.map(&:reuse_name)
-          result.merge(create_logical_volumes(result.devicegraph, vg, pvs))
-        end
+      # Process planned Vgs
+      def process_vgs
+        planned_vgs = planned_devices.vgs
+        vgs_to_reuse = planned_vgs.select(&:reuse?)
+        reuse_vgs(vgs_to_reuse)
+
+        add_devices_to_create(planned_vgs)
+        self.creator_result = set_up_lvm(planned_vgs, devices_to_reuse)
       end
 
-      # Create volume group in the given devicegraph
-      #
-      # @param devicegraph [Devicegraph]                    Starting devicegraph
-      # @param vg          [Planned::LvmVg]                 Volume group
-      # @param pvs         [Planned::Partition,Planned::Md] List of physical volumes
-      # @return            [Proposal::CreatorResult] Result containing the specified volume group
-      def create_logical_volumes(devicegraph, vg, pvs)
-        lvm_creator = Proposal::LvmCreator.new(devicegraph)
-        lvm_creator.create_volumes(vg, pvs)
-      rescue RuntimeError
-        lvm_creator = Proposal::LvmCreator.new(devicegraph)
-        new_vg = vg.clone
-        new_vg.lvs = flexible_devices(vg.lvs)
-        lvm_creator.create_volumes(new_vg, pvs)
+      # Process planned NFS filesystems
+      def process_nfs_filesystems
+        add_devices_to_create(planned_devices.nfs_filesystems)
+        self.creator_result = create_nfs_filesystems(planned_devices.nfs_filesystems)
       end
 
       # Reuses partitions for the given devicegraph
@@ -255,46 +239,55 @@ module Y2Storage
       # some space for growing ones.
       #
       # @param reused_devices  [Array<Planned::Partition>] Partitions to reuse
-      # @param devicegraph     [Devicegraph] Devicegraph to reuse partitions
-      def reuse_partitions(reused_devices, devicegraph)
+      def reuse_partitions(reused_devices)
         shrinking, not_shrinking = reused_devices.partition { |d| d.shrink?(devicegraph) }
         (shrinking + not_shrinking).each { |d| d.reuse!(devicegraph) }
       end
 
-      # Reuses volume groups for the given devicegraph
-      #
-      # @param reused_vgs  [Array<Planned::LvmVg>] Volume groups to reuse
-      # @param previous_result [Proposal::CreatorResult] Result containing the devicegraph
-      #   to work on
-      def reuse_vgs(reused_vgs, previous_result)
-        reused_vgs.each_with_object(previous_result) do |vg, result|
-          lvm_creator = Proposal::LvmCreator.new(result.devicegraph)
-          result.merge!(lvm_creator.reuse_volumes(vg))
-        end
-      end
-
       # Reuses MD RAIDs for the given devicegraph
       #
-      # @param reused_mds      [Array<Planned::Md>] Volume groups to reuse
-      # @param previous_result [Proposal::CreatorResult] Starting point
-      #   to work on
-      # @return [Proposal::CreatorResult] Result containing the reused MD RAID devices
-      def reuse_mds(reused_mds, previous_result)
-        reused_mds.each_with_object(previous_result) do |md, result|
+      # @param reused_mds [Array<Planned::Md>] MD RAIDs to reuse
+      def reuse_mds(reused_mds)
+        reused_mds.each_with_object(creator_result) do |md, result|
           md_creator = Proposal::MdCreator.new(result.devicegraph)
           result.merge!(md_creator.reuse_partitions(md))
         end
       end
 
+      # Reuses volume groups for the given devicegraph
+      #
+      # @param reused_vgs [Array<Planned::LvmVg>] Volume groups to reuse
+      def reuse_vgs(reused_vgs)
+        reused_vgs.each_with_object(creator_result) do |vg, result|
+          lvm_creator = Proposal::LvmCreator.new(result.devicegraph)
+          result.merge!(lvm_creator.reuse_volumes(vg))
+        end
+      end
+
+      # Creates planned partitions
+      #
+      # @param new_partitions [Array<Planned::Partition>] Devices to create
+      # @return [PartitionCreatorResult]
+      def create_partitions(new_partitions)
+        log.info "Partitions to create: #{new_partitions}"
+        primary, non_primary = new_partitions.partition(&:primary)
+        parts_to_create = primary + non_primary
+
+        dist = best_distribution(parts_to_create)
+        raise NoDiskSpaceError, "Could not find a valid partitioning distribution" if dist.nil?
+        part_creator = Proposal::PartitionCreator.new(devicegraph)
+        part_creator.create_partitions(dist)
+      end
+
       # Creates MD RAID devices in the given devicegraph
       #
-      # @param mds             [Array<Planned::Md>]        List of planned MD arrays to create
-      # @param previous_result [Proposal::CreatorResult]   Starting point
-      # @param devs_to_reuse   [Array<Planned::Partition, Planned::StrayBlkDevice>] List of devices
+      # @param mds [Array<Planned::Md>] List of planned MD arrays to create
+      # @param devs_to_reuse [Array<Planned::Partition, Planned::StrayBlkDevice>] List of devices
       #   to reuse
-      # @return                [Proposal::CreatorResult] Result containing the specified MD RAIDs
-      def create_mds(mds, previous_result, devs_to_reuse)
-        mds.reduce(previous_result) do |result, md|
+      #
+      # @return [Proposal::CreatorResult] Result containing the specified MD RAIDs
+      def create_mds(mds, devs_to_reuse)
+        mds.reduce(creator_result) do |result, md|
           # Normally, the profile will use the same naming convention
           # (/dev/md0 vs /dev/md/0) to define the RAID itself (in its corresponding
           # <drive> section) and to reference that RAID from its components
@@ -312,7 +305,38 @@ module Y2Storage
         end
       end
 
-      # Create a MD RAID
+      # Creates volume groups
+      #
+      # @param vgs [Array<Planned::LvmVg>] List of planned volume groups to add
+      # @param devs_to_reuse [Array<Planned::Partition, Planned::StrayBlkDevice>] List of devices
+      #   to reuse as Physical Volumes
+      #
+      # @return [Proposal::CreatorResult] Result containing the specified volume groups
+      def set_up_lvm(vgs, devs_to_reuse)
+        # log separately to be more readable
+        log.info "BEGIN: set_up_lvm: vgs=#{vgs.inspect}"
+        log.info "BEGIN: set_up_lvm: previous_result=#{creator_result.inspect}"
+        log.info "BEGIN: set_up_lvm: devs_to_reuse=#{devs_to_reuse.inspect}"
+
+        vgs.reduce(creator_result) do |result, vg|
+          pvs = creator_result.created_names { |d| d.pv_for?(vg.volume_group_name) }
+          pvs += devs_to_reuse.select { |d| d.pv_for?(vg.volume_group_name) }.map(&:reuse_name)
+          result.merge(create_logical_volumes(result.devicegraph, vg, pvs))
+        end
+      end
+
+      # Creates NFS filesystems
+      #
+      # @param nfs_filesystems [Array<Planned::Nfs>] List of planned NFS filesystems
+      # @return [Proposal::CreatorResult] Result containing the specified NFS filesystems
+      def create_nfs_filesystems(nfs_filesystems)
+        nfs_filesystems.reduce(creator_result) do |result, planned_nfs|
+          new_result = create_nfs_filesystem(result.devicegraph, planned_nfs)
+          result.merge(new_result)
+        end
+      end
+
+      # Creates a MD RAID
       #
       # @param devicegraph [Devicegraph] Starting devicegraph
       # @param md          [Planned::Md] List of planned MD arrays to create
@@ -328,6 +352,33 @@ module Y2Storage
         new_md = md.clone
         new_md.partitions = flexible_devices(md.partitions)
         md_creator.create_md(new_md, devices)
+      end
+
+      # Creates a volume group in the given devicegraph
+      #
+      # @param devicegraph [Devicegraph]                    Starting devicegraph
+      # @param vg          [Planned::LvmVg]                 Volume group
+      # @param pvs         [Planned::Partition,Planned::Md] List of physical volumes
+      # @return            [Proposal::CreatorResult] Result containing the specified volume group
+      def create_logical_volumes(devicegraph, vg, pvs)
+        lvm_creator = Proposal::LvmCreator.new(devicegraph)
+        lvm_creator.create_volumes(vg, pvs)
+      rescue RuntimeError
+        lvm_creator = Proposal::LvmCreator.new(devicegraph)
+        new_vg = vg.clone
+        new_vg.lvs = flexible_devices(vg.lvs)
+        lvm_creator.create_volumes(new_vg, pvs)
+      end
+
+      # Creates a NFS filesystem
+      #
+      # @param devicegraph [Devicegraph] Starting devicegraph
+      # @param planned_nfs [Planned::Nfs]
+      #
+      # @return [Proposal::CreatorResult] Result containing the specified NFS
+      def create_nfs_filesystem(devicegraph, planned_nfs)
+        nfs_creator = Proposal::NfsCreator.new(devicegraph)
+        nfs_creator.create_nfs(planned_nfs)
       end
 
       # Return a new planned devices with flexible limits

--- a/src/lib/y2storage/proposal/autoinst_devices_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_planner.rb
@@ -1,8 +1,6 @@
-#!/usr/bin/env ruby
-#
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -27,6 +25,7 @@ require "y2storage/proposal/autoinst_size_parser"
 require "y2storage/proposal/autoinst_disk_device_planner"
 require "y2storage/proposal/autoinst_vg_planner"
 require "y2storage/proposal/autoinst_md_planner"
+require "y2storage/proposal/autoinst_nfs_planner"
 require "y2storage/planned"
 
 module Y2Storage
@@ -51,21 +50,13 @@ module Y2Storage
         @issues_list = issues_list
       end
 
-      # Returns an array of planned devices according to the drives map
+      # Returns a collection of planned devices according to the drives map
       #
       # @param drives_map [Proposal::AutoinstDrivesMap] Drives map from AutoYaST
-      # @return [Planned::DevicesCollection] Collection of planned devices
+      # @return [Planned::DevicesCollection]
       def planned_devices(drives_map)
         devices = drives_map.each_pair.each_with_object([]) do |(disk_name, drive), memo|
-          planned_devs =
-            case drive.type
-            when :CT_DISK
-              planned_for_disk_device(drive, disk_name)
-            when :CT_LVM
-              planned_for_vg(drive)
-            when :CT_MD
-              planned_for_md(drive)
-            end
+          planned_devs = planned_for_drive(drive, disk_name)
           memo.concat(planned_devs) if planned_devs
         end
 
@@ -81,34 +72,74 @@ module Y2Storage
       # @return [AutoinstIssues::List] List of AutoYaST issues to register them
       attr_reader :issues_list
 
+      # Returns a list of planned devices according to an AutoYaST specification
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the device
+      # @param disk_name [String]
+      #
+      # @return [Array<Planned::Device>, nil] nil if the device cannot be planned
+      def planned_for_drive(drive, disk_name)
+        case drive.type
+        when :CT_DISK
+          planned_for_disk_device(drive, disk_name)
+        when :CT_LVM
+          planned_for_vg(drive)
+        when :CT_MD
+          planned_for_md(drive)
+        when :CT_NFS
+          planned_for_nfs(drive)
+        end
+      end
+
+      # Returns a list of planned partitions (or disks) according to an AutoYaST specification
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the partitions
+      # @param disk_name [String]
+      #
+      # @return [Array<Planned::Partition, Planned::StrayBlkDevice>]
       def planned_for_disk_device(drive, disk_name)
         planner = Y2Storage::Proposal::AutoinstDiskDevicePlanner.new(devicegraph, issues_list)
         drive.device = disk_name
         planner.planned_devices(drive)
       end
 
-      # Returns a planned volume group according to an AutoYaST specification
+      # Returns a list with the planned volume group according to an AutoYaST specification
       #
-      # @param drive [AutoinstProfile::DriveSection] drive section describing
-      #   the volume group
-      # @return [Planned::LvmVg] Planned volume group
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the volume group
+      # @return [Array<Planned::LvmVg>]
       def planned_for_vg(drive)
         planner = Y2Storage::Proposal::AutoinstVgPlanner.new(devicegraph, issues_list)
         planner.planned_devices(drive)
       end
 
-      # Returns a MD array according to an AutoYaST specification
+      # Returns a list of planned MDs according to an AutoYaST specification
       #
-      # @param drive [AutoinstProfile::DriveSection] drive section describing
-      #   the MD RAID
-      # @return [Planned::Md] Planned MD RAID
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the MD RAID
+      # @return [Array<Planned::Md>]
       def planned_for_md(drive)
         planner = Y2Storage::Proposal::AutoinstMdPlanner.new(devicegraph, issues_list)
         planner.planned_devices(drive)
       end
 
+      # Returns a list of planned NFS filesystems according to an AutoYaST specification
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the NFS share
+      # @return [Array<Planned::Nfs>]
+      def planned_for_nfs(drive)
+        planner = Y2Storage::Proposal::AutoinstNfsPlanner.new(devicegraph, issues_list)
+        planner.planned_devices(drive)
+      end
+
+      # Removes shadowed subvolumes from each planned device that can be mounted
+      #
+      # @param planned_devices [Array<Planned::Device>]
       def remove_shadowed_subvols(planned_devices)
         planned_devices.each do |device|
+          # Some planned devices could be mountable but not formattable (e.g., {Planned::Nfs}).
+          # Those devices might shadow some subvolumes but they do no have any subvolume to
+          # be shadowed.
+          next unless device.respond_to?(:shadowed_subvolumes)
+
           device.shadowed_subvolumes(planned_devices).each do |subvol|
             # TODO: this should be reported to the user when the shadowed
             # subvolumes was specified in the profile.

--- a/src/lib/y2storage/proposal/autoinst_drives_map.rb
+++ b/src/lib/y2storage/proposal/autoinst_drives_map.rb
@@ -1,8 +1,6 @@
-#!/usr/bin/env ruby
-#
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -34,7 +32,7 @@ module Y2Storage
       extend Forwardable
 
       # @!method each_pair
-      #   Calls block once por each disk that contains the AutoYaST specification
+      #   Calls block once per each disk that contains the AutoYaST specification
       #   passing as arguments the disk name and the corresponding
       #   AutoinstProfile::DriveSection object.
       #
@@ -63,6 +61,7 @@ module Y2Storage
         add_disks(partitioning.disk_drives, devicegraph)
         add_vgs(partitioning.lvm_drives)
         add_mds(partitioning.md_drives)
+        add_nfs_filesystems(partitioning.nfs_drives)
       end
 
       # Returns the list of disk names
@@ -186,10 +185,24 @@ module Y2Storage
         end
       end
 
-      # Find a disk using any possible name
+      # Adds NFS filesystems to the device map
       #
-      # @return [Disk,nil] Usable disk or nil if none is found
-      # @see [Y2Storage::Devicegraph#find_by_any_name]
+      # All NFS filesystems should have a "device" property.
+      #
+      # @param nfs_drives [Array<AutoinstProfile::DriveSection>] List of NFS specifications from
+      #   AutoYaST
+      def add_nfs_filesystems(nfs_drives)
+        nfs_drives.each { |d| @drives[d.device] = d }
+      end
+
+      # Finds a disk using any possible name
+      #
+      # @see Y2Storage::Devicegraph#find_by_any_name
+      #
+      # @param devicegraph [Devicegraph]
+      # @param device_name [String, nil] e.g., "/dev/sda"
+      #
+      # @return [Disk, nil] Usable disk or nil if none is found
       def find_disk(devicegraph, device_name)
         device = devicegraph.find_by_any_name(device_name)
         return nil unless device

--- a/src/lib/y2storage/proposal/autoinst_nfs_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_nfs_planner.rb
@@ -1,0 +1,235 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/proposal/autoinst_drive_planner"
+
+module Y2Storage
+  module Proposal
+    # This class converts an AutoYaST specification into a Planned::Nfs in order
+    # to set up a NFS filesystem.
+    class AutoinstNfsPlanner < AutoinstDrivePlanner
+      # Returns an array of planned NFS filesystems according to an AutoYaST specification
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing NFS filesystems
+      # @return [Array<Planned::Nfs>] Planned NFS filesystems
+      def planned_devices(drive)
+        # TODO: planned device with new format
+
+        planned_devices_old_format(drive)
+      end
+
+    private
+
+      # This hash defines mandatory profile values for a NFS share using the old AutoYaST style.
+      #
+      # Keys are the name of the section, and values are the mandatory values for such section.
+      #
+      # With old format, the partition section must contain a device and a mount value, e.g.:
+      #
+      # <drive>
+      #   <device>/dev/nfs</device>
+      #   <partitions>
+      #     <partition>
+      #       <device>192.168.56.1:/root_fs</device>
+      #       <mount>/</mount>
+      #     </partition>
+      #   </partitions>
+      # </drive>
+      OLD_FORMAT_MANDATORY_VALUES = { drive: [], partition: [:device, :mount] }.freeze
+
+      # Similar to {OLD_FORMAT_MANDATORY_VALUES}, but for the new AutoYaST style.
+      #
+      # TODO
+      NEW_FORMAT_MANDATORY_VALUES = {}.freeze
+
+      private_constant :OLD_FORMAT_MANDATORY_VALUES, :NEW_FORMAT_MANDATORY_VALUES
+
+      # Returns a list of planned NFS filesystems from the old-style AutoYaST profile
+      #
+      # Using `/dev/nfs` as device name means that the whole drive section should be treated as an
+      # old-style AutoYaST NFS description. Each partition represents an NFS filesystem and the `device`
+      # is used to indicate the NFS share (e.g., `192.168.56.1:/root_fs`).
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the list of NFS
+      #   filesystems (old-style AutoYaST)
+      # @return [Array<Planned::Nfs>] List of planned NFS filesystems
+      def planned_devices_old_format(drive)
+        drive.partitions.map { |p| planned_device_old_format(drive, p) }.compact
+      end
+
+      # Creates a planned NFS filesystem from the old-style AutoYaST profile
+      #
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing the list of NFS
+      #   filesystems
+      # @param partition_section [AutoinstProfile::PartitionSection] partition section describing
+      #   a NFS filesystem
+      #
+      # @return [Planned::Nfs]
+      def planned_device_old_format(drive, partition_section)
+        return nil unless valid_drive?(drive, partition: partition_section, profile_format: :old)
+
+        share = partition_section.device
+
+        planned_nfs = Planned::Nfs.new(server(share), path(share))
+        add_options(planned_nfs, partition_section)
+
+        planned_nfs
+      end
+
+      # Adds options to the planned NFS filesystem
+      #
+      # @param planned_nfs [Planned::Nfs]
+      # @param partition_section [AutoinstProfile::PartitionSection] partition section describing
+      #   a NFS filesystem
+      def add_options(planned_nfs, partition_section)
+        planned_nfs.mount_point = partition_section.mount
+        planned_nfs.fstab_options = partition_section.fstab_options || []
+      end
+
+      # Whether the drive section is valid
+      #
+      # Errors are registered when the section is not valid.
+      #
+      # @param drive [AutoinstProfile::DriveSection]
+      # @param partition [AutoinstProfile::PartitionSection]
+      # @param profile_format [:new, :old] whether the section is using the new or old AutoYaST style
+      #
+      # @return [Boolean]
+      def valid_drive?(drive, partition: nil, profile_format: :new)
+        partition_section = partition || drive.partitions.first
+
+        !missing_drive_values?(drive, profile_format) &&
+          !missing_partition_values?(partition_section, profile_format)
+      end
+
+      # Whether any value is missing for the drive section
+      #
+      # Errors are registered when values are missing.
+      #
+      # @param drive [AutoinstProfile::DriveSection]
+      # @param profile_format [:new, :old] whether the section is using the new or old AutoYaST style
+      #
+      # @return [Boolean]
+      def missing_drive_values?(drive, profile_format)
+        missing_any_value?(drive, mandatory_drive_values(profile_format))
+      end
+
+      # Whether any value is missing for the partition section
+      #
+      # Errors are registered when values are missing.
+      #
+      # @param partition_section [AutoinstProfile::PartitionSection]
+      # @param profile_format [:new, :old] whether the section is using the new or old AutoYaST style
+      #
+      # @return [Boolean]
+      def missing_partition_values?(partition_section, profile_format)
+        missing_any_value?(partition_section, mandatory_partition_values(profile_format))
+      end
+
+      # Whether any of the given values is missing in the given section
+      #
+      # Note: finding the first missing value is faster, but all values are checked to
+      # register all possible issues.
+      #
+      # @param section [AutoinstProfile::SectionWithAttributes]
+      # @param values [Array<Symbol>]
+      #
+      # @return [Boolean]
+      def missing_any_value?(section, values)
+        values.map { |v| missing_value?(section, v) }.any?
+      end
+
+      # Whether the given value is missing in the given section
+      #
+      # An error is registered when the value is missing.
+      #
+      # @param section [AutoinstProfile::SectionWithAttributes]
+      # @param value [Symbol]
+      #
+      # @return [Boolean]
+      def missing_value?(section, value)
+        return false if section.send(value)
+
+        issues_list.add(:missing_value, section, value)
+
+        true
+      end
+
+      # Mandatory values for the drive section
+      #
+      # @param profile_format [:new, :old] whether the section is using the new or old AutoYaST style
+      # @return [Array<Symbol>]
+      def mandatory_drive_values(profile_format)
+        mandatory_values(profile_format)[:drive]
+      end
+
+      # Mandatory values for the partition section
+      #
+      # @param profile_format [:new, :old] whether the section is using the new or old AutoYaST style
+      # @return [Array<Symbol>]
+      def mandatory_partition_values(profile_format)
+        mandatory_values(profile_format)[:partition]
+      end
+
+      # Mandatory values depending on the AutoYaST style
+      #
+      # @param profile_format [:new, :old] new or old AutoYaST style
+      # @return [Hash<Symbol, Array<Symbol>>] see {OLD_FORMAT_MANDATORY_VALUES} and
+      #   {NEW_FORMAT_MANDATORY_VALUES}
+      def mandatory_values(profile_format)
+        if profile_format == :new
+          NEW_FORMAT_MANDATORY_VALUES
+        else
+          OLD_FORMAT_MANDATORY_VALUES
+        end
+      end
+
+      # Name of the server from a NFS share
+      #
+      # @param share [String] e.g., "192.168.56.1:/root_fs"
+      # @return [String] e.g., "192.168.56.1"
+      def server(share)
+        server_and_path(share).first || ""
+      end
+
+      # Name of the shared directory from a NFS share
+      #
+      # @param share [String] e.g., "192.168.56.1:/root_fs"
+      # @return [String] e.g., "/root_fs"
+      def path(share)
+        server_and_path(share).last || ""
+      end
+
+      # Name of the server and the shared directory from a NFS share
+      #
+      # Note that the directory can be omitted (e.g., "192.168.56.1"). For more details,
+      # see {https://tools.ietf.org/html/rfc2224}.
+      #
+      # @param share [String] e.g., "192.168.56.1:/root_fs"
+      # @return [Array<String, nil>]
+      def server_and_path(share)
+        server, path = share.split(":")
+        [server, path]
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/nfs_creator.rb
+++ b/src/lib/y2storage/proposal/nfs_creator.rb
@@ -1,0 +1,53 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/planned"
+require "y2storage/proposal/creator_result"
+
+module Y2Storage
+  module Proposal
+    # Class to create a NFS filesystem according to a Planned::Nfs object
+    class NfsCreator
+      attr_reader :original_devicegraph
+
+      # Constructor
+      #
+      # @param original_devicegraph [Devicegraph] Initial devicegraph
+      def initialize(original_devicegraph)
+        @original_devicegraph = original_devicegraph
+      end
+
+      # Creates the NFS filesystem
+      #
+      # @param planned_nfs  [Planned::Nfs] planned NFS filesystem
+      # @return [CreatorResult] result containing the new NFS filesystem
+      def create_nfs(planned_nfs)
+        new_graph = original_devicegraph.duplicate
+
+        nfs = Filesystems::Nfs.create(new_graph, planned_nfs.server, planned_nfs.path)
+        nfs.mount_path = planned_nfs.mount_point
+        nfs.mount_point.mount_options = planned_nfs.fstab_options
+
+        CreatorResult.new(new_graph, nfs.share => planned_nfs)
+      end
+    end
+  end
+end

--- a/test/support/storage_helpers.rb
+++ b/test/support/storage_helpers.rb
@@ -122,6 +122,11 @@ module Yast
         add_planned_attributes(disk, attrs)
       end
 
+      def planned_nfs(attrs = {})
+        nfs = Y2Storage::Planned::Nfs.new
+        add_planned_attributes(nfs, attrs)
+      end
+
       def add_planned_attributes(device, attrs)
         attrs = attrs.dup
 

--- a/test/y2storage/autoinst_profile/partition_section_test.rb
+++ b/test/y2storage/autoinst_profile/partition_section_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -532,6 +532,26 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
       it "initializes fstab_options" do
         section = described_class.new_from_hashes(hash)
         expect(section.fstab_options).to eq(["ro", "acl"])
+      end
+    end
+
+    context "when device is present" do
+      let(:hash) { { device: nfs_share } }
+
+      let(:nfs_share) { "192.168.56.1:/root" }
+
+      it "initializes device" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.device).to eq(nfs_share)
+      end
+    end
+
+    context "when device is not present" do
+      let(:hash) { {} }
+
+      it "initializes device to nil" do
+        section = described_class.new_from_hashes(hash)
+        expect(section.device).to be_nil
       end
     end
   end

--- a/test/y2storage/autoinst_profile/partitioning_section_test.rb
+++ b/test/y2storage/autoinst_profile/partitioning_section_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -150,6 +150,7 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
     let(:drive5) { double("DriveSection", device: "/dev/md", type: :CT_MD) }
     let(:drive6) { double("DriveSection", device: "/dev/md", type: :CT_MD) }
     let(:drive7) { double("DriveSection", type: :CT_DISK) }
+    let(:drive8) { double("DriveSection", type: :CT_NFS) }
     let(:wrongdrv1) { double("DriveSection", device: "/dev/md", type: :CT_DISK) }
     let(:wrongdrv2) { double("DriveSection", device: "/dev/sdc", type: :CT_MD) }
     let(:wrongdrv3) { double("DriveSection", device: "/dev/sdd", type: :CT_WRONG) }
@@ -158,7 +159,7 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
 
     before do
       section.drives = [
-        drive1, drive2, drive3, drive4, drive5, drive6, drive7,
+        drive1, drive2, drive3, drive4, drive5, drive6, drive7, drive8,
         wrongdrv1, wrongdrv2, wrongdrv3, wrongdrv4, wrongdrv5
       ]
     end
@@ -182,6 +183,12 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
 
       it "does not include drives of other types with device='/dev/md'" do
         expect(section.md_drives).to_not include wrongdrv1
+      end
+    end
+
+    describe "#nfs_drives" do
+      it "returns drives which type is :CT_NFS, even if they look invalid" do
+        expect(section.nfs_drives).to contain_exactly(drive8)
       end
     end
   end

--- a/test/y2storage/autoinst_proposal_nfs_test.rb
+++ b/test/y2storage/autoinst_proposal_nfs_test.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+#
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+describe Y2Storage::AutoinstProposal do
+  using Y2Storage::Refinements::SizeCasts
+
+  before do
+    fake_scenario(scenario)
+
+    allow(Yast::Mode).to receive(:auto).and_return(true)
+  end
+
+  let(:scenario) { "empty_hard_disk_15GiB" }
+
+  subject(:proposal) do
+    described_class.new(
+      partitioning: partitioning, devicegraph: fake_devicegraph, issues_list: issues_list
+    )
+  end
+
+  let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
+
+  describe "#propose" do
+    context "when installing over NFS" do
+      let(:nfs_drive) do
+        {
+          "device"     => "/dev/nfs",
+          "partitions" => [
+            {
+              "device" => "192.168.56.1:/root_fs",
+              "mount"  => "/"
+            }
+          ]
+        }
+      end
+
+      let(:disk_drive) do
+        {
+          "device" => "/dev/sda",
+          "type" => :CT_DISK, "use" => "all", "initialize" => true, "disklabel" => "msdos",
+          "partitions" => [
+            {
+              "create" => true, "filesystem" => :swap, "format" => true, "mount" => "swap",
+              "size" => 2.GiB
+            }
+          ]
+        }
+      end
+
+      let(:partitioning) { [nfs_drive, disk_drive] }
+
+      it "creates a NFS filesystem for installing over it" do
+        proposal.propose
+        nfs = proposal.devices.nfs_mounts.first
+
+        expect(nfs).to_not be_nil
+        expect(nfs.mount_path).to eq("/")
+      end
+
+      it "creates local partitions when required" do
+        proposal.propose
+        sda1 = proposal.devices.find_by_name("/dev/sda1")
+
+        expect(sda1.mount_point.path).to eq("swap")
+        expect(sda1.size).to eq(2.GiB)
+      end
+
+      it "does not register any issue" do
+        proposal.propose
+        expect(issues_list).to be_empty
+      end
+    end
+  end
+end

--- a/test/y2storage/planned/devices_collection_test.rb
+++ b/test/y2storage/planned/devices_collection_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -35,7 +35,8 @@ describe Y2Storage::Planned::DevicesCollection do
   let(:lv0) { planned_lv(mount_point: "/") }
   let(:lv1) { planned_lv }
   let(:vg) { planned_vg(lvs: [lv0, lv1]) }
-  let(:devices) { [partition, disk, stray_blk_device, md, vg] }
+  let(:nfs) { planned_nfs }
+  let(:devices) { [partition, disk, stray_blk_device, md, vg, nfs] }
 
   describe "#devices" do
     context "when there are no planned devices" do
@@ -69,7 +70,7 @@ describe Y2Storage::Planned::DevicesCollection do
   describe "#all" do
     it "returns all planned devices" do
       expect(collection.all).to contain_exactly(
-        partition, disk_partition, disk, stray_blk_device, md, md_partition, lv0, lv1, vg
+        partition, disk_partition, disk, stray_blk_device, md, md_partition, lv0, lv1, vg, nfs
       )
     end
   end
@@ -116,10 +117,16 @@ describe Y2Storage::Planned::DevicesCollection do
     end
   end
 
+  describe "#nfs_filesystems" do
+    it "returns NFS filesystems" do
+      expect(collection.nfs_filesystems).to eq([nfs])
+    end
+  end
+
   describe "#mountable_devices" do
     it "returns all devices that can be mounted" do
       expect(collection.mountable_devices).to contain_exactly(
-        partition, disk, disk_partition, stray_blk_device, lv0, lv1, md, md_partition
+        partition, disk, disk_partition, stray_blk_device, lv0, lv1, md, md_partition, nfs
       )
     end
   end

--- a/test/y2storage/proposal/autoinst_devices_creator_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_creator_test.rb
@@ -2,7 +2,7 @@
 #
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -273,6 +273,28 @@ describe Y2Storage::Proposal::AutoinstDevicesCreator do
           md = devicegraph.md_raids.first
           expect(md.devices.size).to eq(2)
         end
+      end
+    end
+
+    describe "using NFS" do
+      let(:nfs0) do
+        planned_nfs(
+          server:        "192.168.56.1",
+          path:          "/root_fs",
+          mount_point:   "/",
+          fstab_options: ["rw"]
+        )
+      end
+
+      let(:planned_devices) { Y2Storage::Planned::DevicesCollection.new([nfs0]) }
+
+      it "adds the NFS filesystem" do
+        result = creator.populated_devicegraph(planned_devices, [])
+        devicegraph = result.devicegraph
+        nfs = devicegraph.nfs_mounts.first
+
+        expect(nfs).to be_a(Y2Storage::Filesystems::Nfs)
+        expect(nfs.mount_path).to eq("/")
       end
     end
 

--- a/test/y2storage/proposal/autoinst_devices_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_planner_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -59,6 +59,21 @@ describe Y2Storage::Proposal::AutoinstDevicesPlanner do
   end
 
   describe "#planned_devices" do
+    context "using NFS" do
+      let(:partitioning_array) do
+        [{
+          "device" => "/dev/nfs", "partitions" => [{ "mount" => "/", "device" => "server:path" }]
+        }]
+      end
+
+      it "plans NFS filesystems" do
+        devices = planner.planned_devices(drives_map)
+
+        expect(devices.nfs_filesystems).to_not be_empty
+        expect(devices.nfs_filesystems.first.root?).to eq(true)
+      end
+    end
+
     context "using Btrfs" do
       let(:partitioning_array) do
         [{

--- a/test/y2storage/proposal/autoinst_drives_map_test.rb
+++ b/test/y2storage/proposal/autoinst_drives_map_test.rb
@@ -127,6 +127,23 @@ describe Y2Storage::Proposal::AutoinstDrivesMap do
         end
       end
     end
+
+    context "when NFS is used" do
+      let(:partitioning_array) do
+        [
+          {
+            "device"     => "/dev/nfs",
+            "partitions" => [{ "device" => "srv:/home/a" }]
+          }
+        ]
+      end
+
+      it "uses the device name" do
+        described_class.new(fake_devicegraph, partitioning, issues_list)
+
+        expect(drives_map.disk_names).to include("/dev/nfs")
+      end
+    end
   end
 
   describe "#each" do

--- a/test/y2storage/proposal/autoinst_nfs_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_nfs_planner_test.rb
@@ -1,0 +1,136 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage/proposal/autoinst_nfs_planner"
+require "y2storage/autoinst_issues/list"
+require "y2storage/autoinst_profile/drive_section"
+
+describe Y2Storage::Proposal::AutoinstNfsPlanner do
+  before do
+    fake_scenario(scenario)
+  end
+
+  let(:scenario) { "empty_hard_disk_15GiB" }
+
+  subject(:planner) { described_class.new(fake_devicegraph, issues_list) }
+
+  let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
+
+  describe "#planned_devices" do
+    let(:drive) { Y2Storage::AutoinstProfile::DriveSection.new_from_hashes(drive_section) }
+
+    let(:drive_section) { { "device" => "/dev/nfs", "partitions" => [partition_section] } }
+
+    context "when the partition section does not contain a device value" do
+      let(:partition_section) do
+        { "mount" => "/", "fstopt" => "rw,wsize=8192" }
+      end
+
+      it "does not plan a NFS filesystem" do
+        expect(planner.planned_devices(drive)).to be_empty
+      end
+
+      it "registers an issue" do
+        planner.planned_devices(drive)
+        issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::MissingValue) }
+
+        expect(issue).to_not be_nil
+        expect(issue.attr).to eq(:device)
+      end
+    end
+
+    context "when the partition section does not contain a mount value" do
+      let(:partition_section) do
+        { "device" => "192.168.56.1:/root_fs", "fstopt" => "rw,wsize=8192" }
+      end
+
+      it "does not plan a NFS filesystem" do
+        expect(planner.planned_devices(drive)).to be_empty
+      end
+
+      it "registers an issue" do
+        planner.planned_devices(drive)
+        issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::MissingValue) }
+
+        expect(issue).to_not be_nil
+        expect(issue.attr).to eq(:mount)
+      end
+    end
+
+    context "when the partition section contains a device and a mount value" do
+      let(:partition_section) do
+        { "mount" => "/", "device" => "192.168.56.1:/root_fs", "fstopt" => fstopt }
+      end
+
+      let(:fstopt) { nil }
+
+      it "plans a NFS filesystem" do
+        expect(planner.planned_devices(drive)).to_not be_empty
+      end
+
+      it "sets the server" do
+        planned_nfs = planner.planned_devices(drive).first
+
+        expect(planned_nfs.server).to eq("192.168.56.1")
+      end
+
+      it "sets the shared path" do
+        planned_nfs = planner.planned_devices(drive).first
+
+        expect(planned_nfs.path).to eq("/root_fs")
+      end
+
+      it "sets the mount point" do
+        planned_nfs = planner.planned_devices(drive).first
+
+        expect(planned_nfs.mount_point).to eq("/")
+      end
+
+      it "does not register an issue" do
+        planner.planned_devices(drive)
+
+        expect(issues_list).to be_empty
+      end
+
+      context "and the fstab options are not given" do
+        let(:fstopt) { nil }
+
+        it "does not set the fstab options" do
+          planned_nfs = planner.planned_devices(drive).first
+
+          expect(planned_nfs.fstab_options).to be_empty
+        end
+      end
+
+      context "and the fstab options are given" do
+        let(:fstopt) { "rw,wsize=8192" }
+
+        it "sets the fstab options" do
+          planned_nfs = planner.planned_devices(drive).first
+
+          expect(planned_nfs.fstab_options).to contain_exactly("rw", "wsize=8192")
+        end
+      end
+    end
+  end
+end

--- a/test/y2storage/proposal/nfs_creator_test.rb
+++ b/test/y2storage/proposal/nfs_creator_test.rb
@@ -1,0 +1,90 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::Proposal::NfsCreator do
+  before do
+    fake_scenario(scenario)
+  end
+
+  let(:scenario) { "windows-linux-free-pc" }
+
+  subject(:creator) { described_class.new(fake_devicegraph) }
+
+  let(:planned_nfs0) do
+    planned_nfs(
+      server: server, path: path, mount_point: mount_point, fstab_options: fstab_options
+    )
+  end
+
+  let(:server) { "192.168.56.1" }
+
+  let(:path) { "/root_fs" }
+
+  let(:mount_point) { "/" }
+
+  let(:fstab_options) { ["rw", "wsize=8192", "acdirmax=120"] }
+
+  describe "#create_nfs" do
+    def nfs(devicegraph)
+      Y2Storage::Filesystems::Nfs.find_by_server_and_path(devicegraph, server, path)
+    end
+
+    it "creates a new NFS filesystem" do
+      expect(fake_devicegraph.nfs_mounts).to be_empty
+
+      result = creator.create_nfs(planned_nfs0)
+
+      expect(result.devicegraph.nfs_mounts.size).to eq(1)
+    end
+
+    it "sets the server name" do
+      result = creator.create_nfs(planned_nfs0)
+      nfs = nfs(result.devicegraph)
+
+      expect(nfs.server).to eq(server)
+    end
+
+    it "sets the path" do
+      result = creator.create_nfs(planned_nfs0)
+      nfs = nfs(result.devicegraph)
+
+      expect(nfs.path).to eq(path)
+    end
+
+    it "sets the mount path" do
+      result = creator.create_nfs(planned_nfs0)
+      nfs = nfs(result.devicegraph)
+
+      expect(nfs.mount_point.path).to eq(mount_point)
+    end
+
+    it "sets the mount options" do
+      result = creator.create_nfs(planned_nfs0)
+      nfs = nfs(result.devicegraph)
+
+      expect(nfs.mount_point.mount_options).to eq(fstab_options)
+    end
+  end
+end


### PR DESCRIPTION
Backporting PR https://github.com/yast/yast-storage-ng/pull/884.

NOTE: in SLE-15-GA, AutoYaST base code is slightly different to SP1 and master. For example, bcache is not supported at all. This PR backports https://github.com/yast/yast-storage-ng/pull/884 but adapting the code as needed.

