### PR TITLE
Add support for NFS in Autoyast (new format)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 10 11:04:44 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- AutoYaST: new format for importing/exporting NFS drives.
+- Related to bsc#1130256.
+- 4.1.82
+
+-------------------------------------------------------------------
 Wed Apr 10 07:55:26 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Partitioner: when editing a block device, clean-up useless

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.81
+Version:	4.1.82
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -138,6 +138,13 @@ module Y2Storage
         end
       end
 
+      # Default drive type depending on the device name
+      #
+      # For NFS, the default type can only be inferred when using the old format. With the new
+      # format, type attribute is mandatory.
+      #
+      # @param hash [Hash]
+      # @return [Symbol]
       def default_type_for(hash)
         device_name = hash["device"].to_s
 
@@ -275,10 +282,14 @@ module Y2Storage
 
       # Whether the given name is a NFS name
       #
+      # Note that this method only recognizes a NFS name when the old format is used,
+      # that is, device attribute contains "/dev/nfs". With the new format, device
+      # contains the NFS share name (server:path), but in this case the type attribute
+      # is mandatory to identify the drive type.
+      #
       # @param device_name [String]
       # @return [Boolean]
       def nfs_name?(device_name)
-        # TODO: with the new format, device_name would be "server:path"
         device_name == "/dev/nfs"
       end
 

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -166,7 +166,7 @@ module Y2Storage
       #
       # @param device [BlkDevice] a block device that can be cloned into a
       #   <drive> section, like a disk, a DASD or an LVM volume group.
-      # @return [DriveSection]
+      # @return [DriveSection, nil] nil if the device cannot be exported
       def self.new_from_storage(device)
         result = new
         # So far, only disks (and DASD) are supported
@@ -192,6 +192,8 @@ module Y2Storage
           init_from_stray_blk_device(device)
         elsif device.is?(:bcache)
           init_from_bcache(device)
+        elsif device.is?(:nfs)
+          init_from_nfs(device)
         else
           init_from_disk(device)
         end
@@ -395,6 +397,16 @@ module Y2Storage
         @type = :CT_DISK
         @device = device.name
         @enabled_snapshots = enabled_snapshots?([device.filesystem]) if device.filesystem
+        @use = "all"
+        @disklabel = "none"
+        @partitions = [PartitionSection.new_from_storage(device)]
+
+        true
+      end
+
+      def init_from_nfs(device)
+        @type = :CT_NFS
+        @device = device.share
         @use = "all"
         @disklabel = "none"
         @partitions = [PartitionSection.new_from_storage(device)]

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -160,7 +160,7 @@ module Y2Storage
 
       # @!attribute device
       #   @return [String, nil] undocumented attribute, but used to indicate a NFS
-      #     share when installing over NFS
+      #     share when installing over NFS (with the old profile format)
 
       def init_from_hashes(hash)
         super

--- a/src/lib/y2storage/proposal/autoinst_devices_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_planner.rb
@@ -149,7 +149,7 @@ module Y2Storage
       def remove_shadowed_subvols(planned_devices)
         planned_devices.each do |device|
           # Some planned devices could be mountable but not formattable (e.g., {Planned::Nfs}).
-          # Those devices might shadow some subvolumes but they do no have any subvolume to
+          # Those devices might shadow some subvolumes but they do not have any subvolume to
           # be shadowed.
           next unless device.respond_to?(:shadowed_subvolumes)
 

--- a/src/lib/y2storage/proposal/autoinst_nfs_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_nfs_planner.rb
@@ -31,9 +31,9 @@ module Y2Storage
       # @param drive [AutoinstProfile::DriveSection] drive section describing NFS filesystems
       # @return [Array<Planned::Nfs>] Planned NFS filesystems
       def planned_devices(drive)
-        # TODO: planned device with new format
+        return planned_devices_old_format(drive) if old_format?(drive)
 
-        planned_devices_old_format(drive)
+        planned_devices_new_format(drive)
       end
 
     private
@@ -57,10 +57,24 @@ module Y2Storage
 
       # Similar to {OLD_FORMAT_MANDATORY_VALUES}, but for the new AutoYaST style.
       #
-      # TODO
-      NEW_FORMAT_MANDATORY_VALUES = {}.freeze
+      # With new format, drive section must contain a device and partition section must contain
+      # a mount value, e.g.:
+      #
+      # <drive>
+      #   <device>192.168.56.1:/root_fs</device>
+      #   <partitions>
+      #     <partition>
+      #       <mount>/</mount>
+      #     </partition>
+      #   </partitions>
+      # </drive>
+      NEW_FORMAT_MANDATORY_VALUES = { drive: [:device], partition: [:mount] }.freeze
 
       private_constant :OLD_FORMAT_MANDATORY_VALUES, :NEW_FORMAT_MANDATORY_VALUES
+
+      def old_format?(drive)
+        drive.device == "/dev/nfs" || drive.partitions.any?(&:device)
+      end
 
       # Returns a list of planned NFS filesystems from the old-style AutoYaST profile
       #
@@ -77,7 +91,6 @@ module Y2Storage
 
       # Creates a planned NFS filesystem from the old-style AutoYaST profile
       #
-      #
       # @param drive [AutoinstProfile::DriveSection] drive section describing the list of NFS
       #   filesystems
       # @param partition_section [AutoinstProfile::PartitionSection] partition section describing
@@ -87,22 +100,51 @@ module Y2Storage
       def planned_device_old_format(drive, partition_section)
         return nil unless valid_drive?(drive, partition: partition_section, profile_format: :old)
 
+        issues_list.add(:no_partitionable, drive) if drive.wanted_partitions?
+
         share = partition_section.device
 
-        planned_nfs = Planned::Nfs.new(server(share), path(share))
-        add_options(planned_nfs, partition_section)
-
-        planned_nfs
+        create_planned_nfs(share, partition_section)
       end
 
-      # Adds options to the planned NFS filesystem
+      # Returns a list of planned NFS filesystems from the new-style AutoYaST profile
       #
-      # @param planned_nfs [Planned::Nfs]
+      # @param drive [AutoinstProfile::DriveSection] drive section describing a NFS share
+      # @return [Array<Planned::Nfs>] List containing the planned NFS filesystem
+      def planned_devices_new_format(drive)
+        [planned_device_new_format(drive)].compact
+      end
+
+      # Creates a planned NFS filesystem from the new-style AutoYaST profile
+      #
+      # @param drive [AutoinstProfile::DriveSection] drive section describing a NFS share
+      # @return [Planned::Nfs]
+      def planned_device_new_format(drive)
+        return nil unless valid_drive?(drive, profile_format: :new)
+
+        issues_list.add(:no_partitionable, drive) if drive.wanted_partitions?
+        issues_list.add(:surplus_partitions, drive) if drive.partitions.size > 1
+
+        share = drive.device
+        master_partition = drive.partitions.first
+
+        create_planned_nfs(share, master_partition)
+      end
+
+      # Creates a planned NFS filesystem
+      #
+      # @param share [String] NFS share name with the format server:path
       # @param partition_section [AutoinstProfile::PartitionSection] partition section describing
       #   a NFS filesystem
-      def add_options(planned_nfs, partition_section)
+      #
+      # @return [Planned::Nfs]
+      def create_planned_nfs(share, partition_section)
+        planned_nfs = Planned::Nfs.new(server(share), path(share))
+
         planned_nfs.mount_point = partition_section.mount
         planned_nfs.fstab_options = partition_section.fstab_options || []
+
+        planned_nfs
       end
 
       # Whether the drive section is valid

--- a/test/y2storage/autoinst_profile/drive_section_test.rb
+++ b/test/y2storage/autoinst_profile/drive_section_test.rb
@@ -71,11 +71,35 @@ describe Y2Storage::AutoinstProfile::DriveSection do
         end
       end
 
+      # Old format for NFS shares
       context "and device name is /dev/nfs" do
         let(:hash) { { "device" => "/dev/nfs" } }
 
         it "initializes it to :CT_NFS" do
           expect(described_class.new_from_hashes(hash).type).to eq(:CT_NFS)
+        end
+      end
+    end
+
+    # New format for NFS shares
+    context "and the device is a NFS share (server:path)" do
+      let(:nfs_hash) { { "device" => "192.168.56.1:/root_fs" } }
+
+      context "and the type is specified (it must be CT_NFS)" do
+        let(:hash) { nfs_hash.merge("type" => :CT_NFS) }
+
+        it "sets the given type" do
+          expect(described_class.new_from_hashes(hash).type).to eq(:CT_NFS)
+        end
+      end
+
+      context "and the type is not specified" do
+        let(:hash) { nfs_hash }
+
+        # Type attribute is mandatory for NFS drives with the new format. Otherwise,
+        # the type would be wrongly initialized.
+        it "initializes it to :CT_DISK" do
+          expect(described_class.new_from_hashes(hash).type).to eq(:CT_DISK)
         end
       end
     end

--- a/test/y2storage/autoinst_profile/drive_section_test.rb
+++ b/test/y2storage/autoinst_profile/drive_section_test.rb
@@ -39,6 +39,10 @@ describe Y2Storage::AutoinstProfile::DriveSection do
     fake_devicegraph.lvm_vgs.find { |v| v.vg_name == name }
   end
 
+  def nfs(server, path)
+    Y2Storage::Filesystems::Nfs.find_by_server_and_path(fake_devicegraph, server, path)
+  end
+
   describe ".new_from_hashes" do
     let(:hash) { { "partitions" => [root] } }
 
@@ -188,6 +192,11 @@ describe Y2Storage::AutoinstProfile::DriveSection do
     it "returns a DriveSection object for a disk or DASD with exportable partitions" do
       expect(described_class.new_from_storage(device("dasdb"))).to be_a described_class
       expect(described_class.new_from_storage(device("sdc"))).to be_a described_class
+    end
+
+    it "returns a DriveSection object for a NFS filesystem" do
+      nfs = Y2Storage::Filesystems::Nfs.create(fake_devicegraph, "srv", "/foo")
+      expect(described_class.new_from_storage(nfs)).to be_a described_class
     end
 
     it "stores the exportable partitions as PartitionSection objects" do
@@ -528,6 +537,36 @@ describe Y2Storage::AutoinstProfile::DriveSection do
         it "returns nil" do
           expect(described_class.new_from_storage(device("xvda1"))).to be_nil
         end
+      end
+    end
+
+    context "given a NFS filesystems" do
+      before do
+        fake_scenario("nfs1.xml")
+      end
+
+      let(:section) { described_class.new_from_storage(nfs("srv", "/home/a")) }
+
+      it "initializes device name" do
+        expect(section.device).to eq("srv:/home/a")
+      end
+
+      it "initializes #type to :CT_NFS" do
+        expect(section.type).to eq(:CT_NFS)
+      end
+
+      it "initializes #disklabel to 'none'" do
+        expect(section.disklabel).to eq("none")
+      end
+
+      it "initializes #use to 'all'" do
+        expect(section.use).to eq("all")
+      end
+
+      it "initializes #partitions to a partition describing the NFS options" do
+        expect(section.partitions).to contain_exactly(
+          an_object_having_attributes(mount: "/test1")
+        )
       end
     end
 

--- a/test/y2storage/autoinst_profile/partition_section_test.rb
+++ b/test/y2storage/autoinst_profile/partition_section_test.rb
@@ -253,6 +253,60 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
       end
     end
 
+    context "given a NFS filesystem" do
+      let(:scenario) { "nfs1.xml" }
+
+      let(:nfs) do
+        Y2Storage::Filesystems::Nfs.find_by_server_and_path(fake_devicegraph, "srv", "/home/a")
+      end
+
+      subject(:section) { described_class.new_from_storage(nfs) }
+
+      it "initializes #create to false" do
+        expect(section.create).to eq(false)
+      end
+
+      it "initializes #size to nil" do
+        expect(section.size).to be_nil
+      end
+
+      context "if the NFS has mount point" do
+        before do
+          nfs.mount_point.mount_options = ["rw"]
+        end
+
+        it "initializes #mount" do
+          expect(section.mount).to eq("/test1")
+        end
+
+        it "initializes #mountby" do
+          expect(section.mountby).to eq(:device)
+        end
+
+        it "initializes #fstab_options" do
+          expect(section.fstab_options).to contain_exactly("rw")
+        end
+      end
+
+      context "if the NFS has no mount point" do
+        before do
+          nfs.remove_mount_point
+        end
+
+        it "initializes #mount to nil" do
+          expect(section.mount).to be_nil
+        end
+
+        it "initializes #mountby to nil" do
+          expect(section.mountby).to be_nil
+        end
+
+        it "initializes #fstab_options to nil" do
+          expect(section.fstab_options).to be_nil
+        end
+      end
+    end
+
     context "when filesystem is btrfs" do
       it "initializes subvolumes" do
         subvolumes = section_for("sdd3").subvolumes

--- a/test/y2storage/autoinst_profile/partition_section_test.rb
+++ b/test/y2storage/autoinst_profile/partition_section_test.rb
@@ -586,7 +586,7 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
     end
 
     context "when device is present" do
-      let(:hash) { { device: nfs_share } }
+      let(:hash) { { "device" => nfs_share } }
 
       let(:nfs_share) { "192.168.56.1:/root" }
 

--- a/test/y2storage/autoinst_profile/partitioning_section_test.rb
+++ b/test/y2storage/autoinst_profile/partitioning_section_test.rb
@@ -25,6 +25,7 @@ require "y2storage"
 
 describe Y2Storage::AutoinstProfile::PartitioningSection do
   subject(:section) { described_class.new }
+
   let(:sda) { { "device" => "/dev/sda", "use" => "linux" } }
   let(:sdb) { { "device" => "/dev/sdb", "use" => "all" } }
   let(:disk_section) { double("disk_section") }
@@ -33,6 +34,7 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
   let(:md_section) { double("md_section") }
   let(:stray_section) { double("stray_section") }
   let(:bcache_section) { double("bcache_section") }
+  let(:nfs_section) { double("nfs_section") }
   let(:partitioning) { [sda, sdb] }
 
   describe ".new_from_hashes" do
@@ -68,9 +70,10 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
       let(:devicegraph) do
         instance_double(
           Y2Storage::Devicegraph, disk_devices: disks, lvm_vgs: [vg], software_raids: [md],
-          stray_blk_devices: [stray], bcaches: [bcache]
+          stray_blk_devices: [stray], bcaches: [bcache], nfs_mounts: [nfs]
         )
       end
+
       let(:disks) { [disk, dasd] }
       let(:disk) { instance_double(Y2Storage::Disk) }
       let(:dasd) { instance_double(Y2Storage::Dasd) }
@@ -78,6 +81,7 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
       let(:md) { instance_double(Y2Storage::Md) }
       let(:stray) { instance_double(Y2Storage::StrayBlkDevice) }
       let(:bcache) { instance_double(Y2Storage::Bcache) }
+      let(:nfs) { instance_double(Y2Storage::Filesystems::Nfs) }
 
       before do
         allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
@@ -92,24 +96,48 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
           .with(stray).and_return(stray_section)
         allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
           .with(bcache).and_return(bcache_section)
+        allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
+          .with(nfs).and_return(nfs_section)
       end
+
+      subject(:section) { described_class.new_from_storage(devicegraph) }
 
       it "returns a new PartitioningSection object" do
-        expect(described_class.new_from_storage(devicegraph)).to be_a(described_class)
+        expect(section).to be_a(described_class)
       end
 
-      it "creates an entry in #drives for every relevant VG, disk and DASD" do
-        section = described_class.new_from_storage(devicegraph)
-        expect(section.drives)
-          .to contain_exactly(
-            bcache_section, md_section, vg_section, disk_section, dasd_section, stray_section
-          )
+      it "creates an entry in #drives for every relevant disk" do
+        expect(section.drives).to include(disk_section)
+      end
+
+      it "creates an entry in #drives for every relevant DASD" do
+        expect(section.drives).to include(dasd_section)
+      end
+
+      it "creates an entry in #drives for every relevant stray device" do
+        expect(section.drives).to include(stray_section)
+      end
+
+      it "creates an entry in #drives for every relevant LVM VG" do
+        expect(section.drives).to include(vg_section)
+      end
+
+      it "creates an entry in #drives for every relevant MD RAID" do
+        expect(section.drives).to include(md_section)
+      end
+
+      it "creates an entry in #drives for every relevant Bcache" do
+        expect(section.drives).to include(bcache_section)
+      end
+
+      it "creates an entry in #drives for every relevant NFS" do
+        expect(section.drives).to include(nfs_section)
       end
 
       it "ignores irrelevant drives" do
         allow(Y2Storage::AutoinstProfile::DriveSection).to receive(:new_from_storage)
           .with(disk).and_return(nil)
-        section = described_class.new_from_storage(devicegraph)
+
         expect(section.drives).to_not include(disk_section)
       end
     end
@@ -121,13 +149,12 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
         fake_scenario("bug_1098594.xml")
       end
 
-      it "creates only one entry in #drives, of type CT_DISK, for the BIOS RAID" do
+      it "creates only one CT_DISK entry in #drives, for the BIOS RAID" do
         section = described_class.new_from_storage(fake_devicegraph)
-        expect(section.drives.size).to eq 1
+        drive = section.drives.find { |d| d.type == :CT_DISK }
 
-        drive = section.drives.first
-        expect(drive.device).to eq "/dev/md/Volume0_0"
-        expect(drive.type).to eq :CT_DISK
+        expect(drive).to_not be_nil
+        expect(drive.device).to eq("/dev/md/Volume0_0")
       end
     end
   end

--- a/test/y2storage/autoinst_proposal_nfs_test.rb
+++ b/test/y2storage/autoinst_proposal_nfs_test.rb
@@ -43,19 +43,7 @@ describe Y2Storage::AutoinstProposal do
   let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
 
   describe "#propose" do
-    context "when installing over NFS" do
-      let(:nfs_drive) do
-        {
-          "device"     => "/dev/nfs",
-          "partitions" => [
-            {
-              "device" => "192.168.56.1:/root_fs",
-              "mount"  => "/"
-            }
-          ]
-        }
-      end
-
+    shared_examples "NFS proposal" do
       let(:disk_drive) do
         {
           "device" => "/dev/sda",
@@ -90,6 +78,41 @@ describe Y2Storage::AutoinstProposal do
       it "does not register any issue" do
         proposal.propose
         expect(issues_list).to be_empty
+      end
+
+    end
+
+    context "when installing over NFS" do
+      context "and the old NFS drive format is used" do
+        let(:nfs_drive) do
+          {
+            "device"     => "/dev/nfs",
+            "partitions" => [
+              {
+                "device" => "192.168.56.1:/root_fs",
+                "mount"  => "/"
+              }
+            ]
+          }
+        end
+
+        include_examples "NFS proposal"
+      end
+
+      context "and the new NFS drive format is used" do
+        let(:nfs_drive) do
+          {
+            "device"     => "192.168.56.1:/root_fs",
+            "type"       => :CT_NFS,
+            "partitions" => [
+              {
+                "mount" => "/"
+              }
+            ]
+          }
+        end
+
+        include_examples "NFS proposal"
       end
     end
   end

--- a/test/y2storage/proposal/autoinst_devices_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_planner_test.rb
@@ -55,7 +55,7 @@ describe Y2Storage::Proposal::AutoinstDevicesPlanner do
   end
 
   describe "#planned_devices" do
-    context "using NFS" do
+    context "using NFS with the old format" do
       let(:partitioning_array) do
         [{
           "device" => "/dev/nfs", "partitions" => [{ "mount" => "/", "device" => "server:path" }]
@@ -67,6 +67,26 @@ describe Y2Storage::Proposal::AutoinstDevicesPlanner do
 
         expect(devices.nfs_filesystems).to_not be_empty
         expect(devices.nfs_filesystems.first.root?).to eq(true)
+      end
+    end
+
+    context "using NFS with the new format" do
+      let(:partitioning_array) do
+        [{
+          "device" => "192.168.56.1:/root_fs", "type" => :CT_NFS, "partitions" => [{ "mount" => "/" }]
+        }]
+      end
+
+      it "plans NFS filesystems" do
+        devices = planner.planned_devices(drives_map)
+
+        expect(devices.nfs_filesystems).to include(
+          an_object_having_attributes(
+            mount_point: "/",
+            server:      "192.168.56.1",
+            path:        "/root_fs"
+          )
+        )
       end
     end
 

--- a/test/y2storage/proposal/autoinst_nfs_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_nfs_planner_test.rb
@@ -37,52 +37,13 @@ describe Y2Storage::Proposal::AutoinstNfsPlanner do
   let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
 
   describe "#planned_devices" do
-    let(:drive) { Y2Storage::AutoinstProfile::DriveSection.new_from_hashes(drive_section) }
-
-    let(:drive_section) { { "device" => "/dev/nfs", "partitions" => [partition_section] } }
-
-    context "when the partition section does not contain a device value" do
-      let(:partition_section) do
-        { "mount" => "/", "fstopt" => "rw,wsize=8192" }
-      end
-
-      it "does not plan a NFS filesystem" do
-        expect(planner.planned_devices(drive)).to be_empty
-      end
-
-      it "registers an issue" do
+    shared_examples "create planned NFS" do
+      it "does not register a 'missing value' issue" do
         planner.planned_devices(drive)
+
         issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::MissingValue) }
-
-        expect(issue).to_not be_nil
-        expect(issue.attr).to eq(:device)
+        expect(issue).to be_nil
       end
-    end
-
-    context "when the partition section does not contain a mount value" do
-      let(:partition_section) do
-        { "device" => "192.168.56.1:/root_fs", "fstopt" => "rw,wsize=8192" }
-      end
-
-      it "does not plan a NFS filesystem" do
-        expect(planner.planned_devices(drive)).to be_empty
-      end
-
-      it "registers an issue" do
-        planner.planned_devices(drive)
-        issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::MissingValue) }
-
-        expect(issue).to_not be_nil
-        expect(issue.attr).to eq(:mount)
-      end
-    end
-
-    context "when the partition section contains a device and a mount value" do
-      let(:partition_section) do
-        { "mount" => "/", "device" => "192.168.56.1:/root_fs", "fstopt" => fstopt }
-      end
-
-      let(:fstopt) { nil }
 
       it "plans a NFS filesystem" do
         expect(planner.planned_devices(drive)).to_not be_empty
@@ -91,25 +52,19 @@ describe Y2Storage::Proposal::AutoinstNfsPlanner do
       it "sets the server" do
         planned_nfs = planner.planned_devices(drive).first
 
-        expect(planned_nfs.server).to eq("192.168.56.1")
+        expect(planned_nfs.server).to eq(server)
       end
 
       it "sets the shared path" do
         planned_nfs = planner.planned_devices(drive).first
 
-        expect(planned_nfs.path).to eq("/root_fs")
+        expect(planned_nfs.path).to eq(path)
       end
 
       it "sets the mount point" do
         planned_nfs = planner.planned_devices(drive).first
 
-        expect(planned_nfs.mount_point).to eq("/")
-      end
-
-      it "does not register an issue" do
-        planner.planned_devices(drive)
-
-        expect(issues_list).to be_empty
+        expect(planned_nfs.mount_point).to eq(mount)
       end
 
       context "and the fstab options are not given" do
@@ -129,6 +84,234 @@ describe Y2Storage::Proposal::AutoinstNfsPlanner do
           planned_nfs = planner.planned_devices(drive).first
 
           expect(planned_nfs.fstab_options).to contain_exactly("rw", "wsize=8192")
+        end
+      end
+    end
+
+    let(:drive) { Y2Storage::AutoinstProfile::DriveSection.new_from_hashes(drive_section) }
+
+    context "when using the old profile format" do
+      let(:drive_section) do
+        { "device" => "/dev/nfs", "disklabel" => disklabel, "partitions" => partitions }
+      end
+
+      let(:disklabel) { nil }
+
+      let(:partitions) { [partition_section1, partition_section2] }
+
+      let(:partition_section1) do
+        { "device" => "server:path1", "mount" => "/", "fstopt" => "rw,wsize=8192" }
+      end
+
+      let(:partition_section2) do
+        { "device" => "server:path2", "mount" => "/home", "fstopt" => "rw" }
+      end
+
+      it "plans a NFS for each valid partition section" do
+        planned_devices = planner.planned_devices(drive)
+
+        expect(planned_devices.size).to eq(2)
+        expect(planned_devices.map(&:mount_point)).to contain_exactly("/", "/home")
+      end
+
+      context "and the partition section does not contain a device value" do
+        let(:partition_section) do
+          { "mount" => "/", "fstopt" => "rw,wsize=8192" }
+        end
+
+        let(:partitions) { [partition_section] }
+
+        it "does not plan a NFS filesystem" do
+          expect(planner.planned_devices(drive)).to be_empty
+        end
+
+        it "registers a 'missing value' issue" do
+          planner.planned_devices(drive)
+          issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::MissingValue) }
+
+          expect(issue).to_not be_nil
+          expect(issue.attr).to eq(:device)
+        end
+      end
+
+      context "and the partition section does not contain a mount value" do
+        let(:partition_section) do
+          { "device" => "192.168.56.1:/root_fs", "fstopt" => "rw,wsize=8192" }
+        end
+
+        let(:partitions) { [partition_section] }
+
+        it "does not plan a NFS filesystem" do
+          expect(planner.planned_devices(drive)).to be_empty
+        end
+
+        it "registers a 'missing value' issue" do
+          planner.planned_devices(drive)
+          issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::MissingValue) }
+
+          expect(issue).to_not be_nil
+          expect(issue.attr).to eq(:mount)
+        end
+      end
+
+      context "and the partition section contains a device and a mount value" do
+        let(:partition_section) do
+          { "mount" => mount, "device" => device, "fstopt" => fstopt }
+        end
+
+        let(:partitions) { [partition_section] }
+
+        let(:mount) { "/" }
+
+        let(:device) { "#{server}:#{path}" }
+
+        let(:server) { "192.168.56.1" }
+
+        let(:path) { "/root_fs" }
+
+        let(:fstopt) { nil }
+
+        include_examples "create planned NFS"
+
+        context "and a partition table is not required" do
+          let(:disklabel) { "none" }
+
+          it "does not register a 'no partitionable' issue" do
+            planner.planned_devices(drive)
+            issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::NoPartitionable) }
+
+            expect(issue).to be_nil
+          end
+        end
+
+        context "and a partition table is required" do
+          let(:disklabel) { "gpt" }
+
+          it "registers a 'no partitionable' issue" do
+            planner.planned_devices(drive)
+            issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::NoPartitionable) }
+
+            expect(issue).to_not be_nil
+          end
+        end
+      end
+    end
+
+    context "when using the new profile format" do
+      let(:drive_section) { { "device" => device, "partitions" => partitions } }
+
+      let(:partitions) { [] }
+
+      context "and the drive section does not contain a device value" do
+        let(:device) { nil }
+
+        it "does not plan a NFS filesystem" do
+          expect(planner.planned_devices(drive)).to be_empty
+        end
+
+        it "registers a 'missing value' issue" do
+          planner.planned_devices(drive)
+          issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::MissingValue) }
+
+          expect(issue).to_not be_nil
+          expect(issue.attr).to eq(:device)
+        end
+      end
+
+      context "and the partition section does not contain a mount value" do
+        let(:device) { "192.168.56.1:/root_fs" }
+
+        let(:partitions) { [partition_section] }
+
+        let(:partition_section) { { "mount" => nil, "fstopt" => "rw,wsize=8192" } }
+
+        it "does not plan a NFS filesystem" do
+          expect(planner.planned_devices(drive)).to be_empty
+        end
+
+        it "registers a 'missing value' issue" do
+          planner.planned_devices(drive)
+          issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::MissingValue) }
+
+          expect(issue).to_not be_nil
+          expect(issue.attr).to eq(:mount)
+        end
+      end
+
+      context "and drive and partition sections contain all the mandatory values" do
+        let(:drive_section) do
+          { "device" => device, "disklabel" => disklabel, "partitions" => partitions }
+        end
+
+        let(:device) { "#{server}:#{path}" }
+
+        let(:server) { "192.168.56.1" }
+
+        let(:path) { "/root_fs" }
+
+        let(:disklabel) { nil }
+
+        let(:partitions) { [partition_section1] }
+
+        let(:partition_section1) { { "mount" => mount, "fstopt" => fstopt } }
+
+        let(:mount) { "/" }
+
+        let(:fstopt) { nil }
+
+        include_examples "create planned NFS"
+
+        context "and a partition table is not required" do
+          let(:disklabel) { "none" }
+
+          it "does not register a 'no partitionable' issue" do
+            planner.planned_devices(drive)
+            issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::NoPartitionable) }
+
+            expect(issue).to be_nil
+          end
+        end
+
+        context "and a partition table is required" do
+          let(:disklabel) { "gpt" }
+
+          it "registers a 'no partitionable' issue" do
+            planner.planned_devices(drive)
+            issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::NoPartitionable) }
+
+            expect(issue).to_not be_nil
+          end
+        end
+
+        context "and there is only one partition section" do
+          let(:partitions) { [partition_section1] }
+
+          it "does not register a 'surplus partitions' issue" do
+            planner.planned_devices(drive)
+            issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::SurplusPartitions) }
+
+            expect(issue).to be_nil
+          end
+        end
+
+        context "and there is more than one partition section" do
+          let(:partition_section2) { { "mount" => "/home" } }
+
+          let(:partitions) { [partition_section1, partition_section2] }
+
+          it "registers a 'surplus partitions' issue" do
+            planner.planned_devices(drive)
+            issue = issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::SurplusPartitions) }
+
+            expect(issue).to_not be_nil
+          end
+
+          it "plans a NFS filesystem according to the first partition section" do
+            planned_devices = planner.planned_devices(drive)
+
+            expect(planned_devices.size).to eq(1)
+            expect(planned_devices.first.mount_point).to eq("/")
+          end
         end
       end
     end


### PR DESCRIPTION
## Problem

NFS drives are specified in the AutoYaST profile by an "undocumented" option. That is, by defining a drive with a "/dev/nfs" device, and then, each partition defines a NFS share, e.g.:

```
<drive>
  <device>/dev/nfs</device>
  <partitions>
    <partition>
      <mount>/</mount>
      <device>server:path</device>
    </partition>
  </partitions>
</drive>
```

The <partition> section contains a <device> attribute. This is quite unexpected, because a <partition> section cannot contain a <device>. In fact, the AutoYaST profile does not validate.

The support for importing this kind of drives was already implemented in [here](https://github.com/yast/yast-storage-ng/pull/890). But now we have to find a better way for defining NFS drives and be able to import/export this new format.

Note: currently, old format cannot be exported at all because we don't want to continue supporting this format for new products (from SLE-15 on).  The new format will be available for SP0 (GA), SP1 and master.

* https://bugzilla.suse.com/show_bug.cgi?id=1130256
* https://trello.com/c/wATMQ3Mo/917-5-import-export-nfs-shares-with-new-profile-format

## Solution

Added support for importing/exporting new NFS format:

```
<drive>
  <device>server:path</device>
  <type>CT_NFS</drive>
  <partitions>
    <partition>
      <mount>/</mount>
    </partition>
  </partitions>
</drive>
```

## Testing

* Added unit tests
* Tested manually
