### PR TITLE
Remove dead code

### DIFF
--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -213,13 +213,6 @@ module Y2Partitioner
 
         # Makes the changes related to the option "do not format" in the UI, which
         # implies removing any new filesystem or respecting the preexisting one.
-        #
-        # @note With the current implementation there is a corner case that
-        # doesn't work like the traditional expert partitioner. If a partition
-        # preexisting in the disk is edited (e.g. replacing the filesystem with a
-        # new one) and then we the user tries to edit it again, "do not format"
-        # will actually mean leaving the partition unformatted, not respecting the
-        # filesystem on the system.
         def dont_format
           return if filesystem.nil?
           return unless new?(filesystem)

--- a/src/lib/y2partitioner/widgets/btrfs_subvolumes_table.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_subvolumes_table.rb
@@ -80,13 +80,7 @@ module Y2Partitioner
         end
       end
 
-      # FIXME: BtrFS could belong to several devices
-      def device(filesystem)
-        filesystem.plain_blk_devices.first
-      end
-
       # Column titles
-
       def path_title
         # TRANSLATORS: table header, subvolume path e.g. "@/home"
         _("Path")


### PR DESCRIPTION
This PR does not solve a specific problem. Instead, simply removes

* A [quite confusing comment](https://github.com/yast/yast-storage-ng/commit/ac181fb3516bcdbea57c9eaf140d781ed1a730af) that we found while working on  https://github.com/yast/yast-storage-ng/pull/897. It could be interpreted in two ways

  - It is describing an old behavior and clarifying that it is no longer available in the new Partitioner, or 
  - It is a forgotten note which should have been removed [when the `BlkDeviceRestorer` was included](https://github.com/yast/yast-storage-ng/commit/6b22232d69100a6b8428774399a85198047af3b6).

  In case of the first interpretation, it seems to be not necessary nowadays. For the second one, it is simply a comment that must be removed.

* A [leftover method](https://github.com/yast/yast-storage-ng/commit/a69c815544a0588c1c6b9e3a0f250c5c59c19d9a). It is private and is not being used.

---

:warning: Version bump not required :warning: 