### PR TITLE
Textdomain 1126822 sp1

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 15 15:46:04 UTC 2019 - ancor@suse.com
+
+- Partitioner: fixed translation issues related to bcache
+  (bsc#1126822).
+- 4.1.83
+
+-------------------------------------------------------------------
 Wed Apr 10 11:04:44 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - AutoYaST: new format for importing/exporting NFS drives.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.82
+Version:	4.1.83
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -102,6 +102,8 @@ module Y2Partitioner
         # @param bcaches [Array<Y2Storage::Bcache>]
         # @param pager [CWM::TreePager]
         def initialize(bcaches, pager)
+          textdomain "storage"
+
           @bcaches = bcaches
           @pager = pager
         end
@@ -160,6 +162,8 @@ module Y2Partitioner
         #
         # @param pager [CWM::TreePager]
         def initialize(pager)
+          textdomain "storage"
+
           @pager = pager
         end
 


### PR DESCRIPTION
## Problem

Some strings in the Partitioner are not being displayed in the correct language

- https://bugzilla.suse.com/show_bug.cgi?id=1126822

## Solution

Adding missing calls to `textdomain` in the widgets' constructors.

## Testing

- Tested manually with the RC2 ISO and the file modified by hand.

## Screenshots

See bug report for screenshots of the failure.

