### PR TITLE
[Partitioner] Remember the tree state

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Mon Apr 22 22:56:55 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Partitioner: by default, initialize the tree with sections
+  expanded and devices collapsed.
+- Partitioner: improves the user experience preserving, between
+  every redraw, the tree items as the were: expanded or collapsed.
+- Lightly related to fate#318196.
+- 4.2.7
+
+-------------------------------------------------------------------
 Mon Apr 15 15:46:04 UTC 2019 - ancor@suse.com
 
 - Partitioner: fixed translation issues related to bcache

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.2.6
+Version:	4.2.7
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/dialogs/main.rb
+++ b/src/lib/y2partitioner/dialogs/main.rb
@@ -57,10 +57,17 @@ module Y2Partitioner
       end
 
       def contents
+        # NOTE: Since this method is used as first parameter of {Yast::CWM.show} every time that
+        # {#run} calls `super`, a new {OverviewTreePager} will be created in every dialog redraw.
+        # So, let's keep a reference to it in the {UIState} to query the open items and preserve
+        # their state in new instances.
+        overview_tree_pager = Widgets::OverviewTreePager.new(hostname)
+        UIState.instance.overview_tree_pager = overview_tree_pager
+
         MarginBox(
           0.5,
           0.5,
-          Widgets::OverviewTreePager.new(hostname)
+          overview_tree_pager
         )
       end
 

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -32,8 +32,16 @@ module Y2Partitioner
     # means default for each widget will be honored).
     def initialize
       textdomain "storage"
+
       @candidate_nodes = []
+      @overview_tree_pager = nil
     end
+
+    # A reference to the overview tree pager, which is a new instance every dialog redraw. See note
+    # in {Dialogs::Main#contents}
+    #
+    # @return [Widgets::OverviewTreePager]
+    attr_accessor :overview_tree_pager
 
     # Title of the section listing the MD RAIDs
     #

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -34,6 +34,7 @@ module Y2Partitioner
       textdomain "storage"
 
       @candidate_nodes = []
+      @open_items_ids = nil
       @overview_tree_pager = nil
     end
 
@@ -42,6 +43,13 @@ module Y2Partitioner
     #
     # @return [Widgets::OverviewTreePager]
     attr_accessor :overview_tree_pager
+
+    # Items of the tree that should be expanded in the next redraw.
+    # @note Nil means that open items are not being saved yet and the default tree state should be
+    # used instead. See {Widgets::OverviewTreePager#item_open?}
+    #
+    # @return [nil, Array<String,Symbol>]
+    attr_reader :open_items_ids
 
     # Title of the section listing the MD RAIDs
     #
@@ -139,6 +147,13 @@ module Y2Partitioner
     def find_tab(pages)
       return nil unless tab
       pages.find { |page| page.label == tab }
+    end
+
+    # Stores the ids of the tree items that are open
+    def save_open_items
+      return unless overview_tree_pager
+
+      @open_items_ids = overview_tree_pager.open_items_ids
     end
 
   protected

--- a/src/lib/y2partitioner/widgets/device_button.rb
+++ b/src/lib/y2partitioner/widgets/device_button.rb
@@ -42,6 +42,9 @@ module Y2Partitioner
       # @macro seeAbstractWidget
       def handle
         return nil unless validate_presence
+
+        UIState.instance.save_open_items
+
         actions
       end
 

--- a/src/lib/y2partitioner/widgets/device_menu_button.rb
+++ b/src/lib/y2partitioner/widgets/device_menu_button.rb
@@ -48,6 +48,8 @@ module Y2Partitioner
       def handle(event)
         return nil unless validate_presence
 
+        UIState.instance.save_open_items
+
         action = action_for_widget_id(event["ID"])
         return nil unless action
 

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -318,9 +318,9 @@ module Y2Partitioner
       # The OverviewTreePager has two kinds of items: section or device. Sections always has icon
       # and starts expanded; devices has not icon and starts collapsed. See also {device_item}.
       #
-      # @param [CWM::Page] page
-      # @param [Icons] icon
-      # @param [Array<CWM::PagerTreeItem>] children
+      # @param page [CWM::Page]
+      # @param icon [Icons]
+      # @param children [Array<CWM::PagerTreeItem>]
       #
       # @return [CWM::PagerTreeItem]
       def section_item(page, icon, children: [])
@@ -329,24 +329,24 @@ module Y2Partitioner
 
       # Generates a `device` tree item for given page
       #
-      # The OverviewTreePager has two kinds of items: section or device. Sections always has icon
-      # and starts expanded; devices has not icon and starts collapsed. See also {section_item}.
+      # @see #section_item
       #
-      # @param [CWM::Page] page
-      # @param [Array<CWM::PagerTreeItem>] children
+      # @param page [CWM::Page]
+      # @param children [Array<CWM::PagerTreeItem>]
       #
       # @return [CWM::PagerTreeItem]
       def device_item(page, children: [])
         CWM::PagerTreeItem.new(page, children: children, open: item_open?(page, false))
       end
 
-      # Whether the tree item for given page should be open (expanded) or close (collapsed)
+      # Whether the tree item for given page should be open or closed
       #
-      # If open items are unknown (i.e., during the overview initialization), it uses the default
-      # value.
+      # When open items are not initialized, the default value will be used. For better
+      # understanding, see the note about the {OverviewTreePager} redrawing in
+      # {Dialogs::Main#contents}
       #
-      # @param [CWM::Page] page
-      # @param [Boolean] default the value to be used the open items are unknown yet (first render)
+      # @param page [CWM::Page]
+      # @param default [Boolean] value when open items are not initialized yet
       #
       # @return [Boolean] true when item must be expanded; false if must be collapsed
       def item_open?(page, default)

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -339,7 +339,7 @@ module Y2Partitioner
         CWM::PagerTreeItem.new(page, children: children, open: item_open?(page, false))
       end
 
-      # Whether the tree item for given page should be open or closed
+      # Whether the tree item for given page should be open (expanded) or closed (collapsed)
       #
       # When open items are not initialized, the default value will be used. For better
       # understanding, see the note about the {OverviewTreePager} redrawing in

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -86,8 +86,6 @@ module Y2Partitioner
           *graph_items,
           summary_item,
           settings_item
-          # TODO: Bring this back to life - disabled for now (bsc#1078849)
-          # item_for("settings", _("Settings"), icon: Icons::SETTINGS)
         ]
       end
 
@@ -188,15 +186,15 @@ module Y2Partitioner
       def system_items
         page = Pages::System.new(hostname, self)
         children = [
-          disks_items,
-          raids_items,
-          lvm_items,
-          bcache_items,
+          disks_section,
+          raids_section,
+          lvm_section,
+          bcache_section,
           # TODO: Bring this back to life - disabled for now (bsc#1078849)
           # crypt_files_items,
           # device_mapper_items,
-          nfs_items,
-          btrfs_items
+          nfs_section,
+          btrfs_section
           # TODO: Bring this back to life - disabled for now (bsc#1078849)
           # unused_items
         ].compact
@@ -205,7 +203,7 @@ module Y2Partitioner
       end
 
       # @return [CWM::PagerTreeItem]
-      def disks_items
+      def disks_section
         devices = device_graph.disk_devices + device_graph.stray_blk_devices
 
         page = Pages::Disks.new(devices, self)
@@ -235,7 +233,7 @@ module Y2Partitioner
       end
 
       # @return [CWM::PagerTreeItem]
-      def raids_items
+      def raids_section
         devices = device_graph.software_raids
         page = Pages::MdRaids.new(self)
         children = devices.map { |m| raid_items(m) }
@@ -250,7 +248,7 @@ module Y2Partitioner
       end
 
       # @return [CWM::PagerTreeItem]
-      def bcache_items
+      def bcache_section
         return nil unless Y2Storage::Bcache.supported?
         devices = device_graph.bcaches
         page = Pages::Bcaches.new(devices, self)
@@ -259,7 +257,7 @@ module Y2Partitioner
       end
 
       # @return [CWM::PagerTreeItem]
-      def lvm_items
+      def lvm_section
         devices = device_graph.lvm_vgs
         page = Pages::Lvm.new(self)
         children = devices.map { |v| lvm_vg_items(v) }
@@ -280,13 +278,13 @@ module Y2Partitioner
       end
 
       # @return [CWM::PagerTreeItem]
-      def nfs_items
+      def nfs_section
         page = Pages::NfsMounts.new(self)
         section_item(page, Icons::NFS)
       end
 
       # @return [CWM::PagerTreeItem]
-      def btrfs_items
+      def btrfs_section
         page = Pages::Btrfs.new(self)
         section_item(page, Icons::BTRFS)
       end

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -104,6 +104,15 @@ module Y2Partitioner
         UIState.instance.find_tree_node(@pages) || super
       end
 
+      # Obtains the ids of open/expanded items
+      #
+      # @return [Array<String,Symbol>] ids of open/expanded items
+      def open_items_ids
+        Yast::UI
+          .QueryWidget(Id(tree.widget_id), :OpenItems)
+          .keys
+      end
+
       # Obtains the page associated to a specific device
       # @return [CWM::Page, nil]
       def device_page(device)
@@ -124,6 +133,8 @@ module Y2Partitioner
       end
 
     private
+
+      attr_reader :tree
 
       # Checks whether the current setup is valid, that is, it contains necessary
       # devices for booting (e.g., /boot/efi) and for the system runs properly (e.g., /).

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -345,4 +345,34 @@ describe Y2Partitioner::UIState do
       end
     end
   end
+
+  describe "#open_items_ids" do
+    context "if the open items has not been saved" do
+      before { described_class.create_instance }
+
+      it "returns nil" do
+        expect(ui_state.open_items_ids).to be_nil
+      end
+    end
+
+    context "after calling #save_open_items" do
+      let(:pager) { double("TreePager") }
+
+      before do
+        # The first call returns [:first, :third] and the second returns [:second]
+        allow(pager).to receive(:open_items_ids)
+          .and_return([:first, :third], [:second])
+
+        ui_state.overview_tree_pager = pager
+        ui_state.save_open_items
+      end
+
+      it "returns the items that were expanded when #save_open_items was called" do
+        expect(ui_state.open_items_ids).to eq [:first, :third]
+      end
+
+      # To ensure this does not interfere with other tests
+      after { ui_state.overview_tree_pager = nil }
+    end
+  end
 end


### PR DESCRIPTION
## Problem

> In the old partitioner is possible to open and collapse branches of the tree and it remains as it is set.

However, 

> in the new one (the tree) is always fully extended, with no collapsed branch.

- https://trello.com/c/dVI060Q3/206-3-partitioner-remember-the-state-of-the-tree-at-least-branches-closed-by-the-user

## Solution

Based on method proposed by @jreidinger in https://github.com/yast/yast-yast2/pull/734 and [holding a reference to the `OverviewPagerTree` in `UIState`](https://github.com/yast/yast-storage-ng/blob/9a1a5e07830498724d1487617bec7586734d6d82/src/lib/y2partitioner/dialogs/main.rb#L65), it is now possible to query and save open items of the tree [to preserve their state between instances](https://github.com/yast/yast-storage-ng/blob/9a1a5e07830498724d1487617bec7586734d6d82/src/lib/y2partitioner/dialogs/main.rb#L60-L63).

Also, has been done a distinction between [_sections_](https://github.com/yast/yast-storage-ng/blob/9a1a5e07830498724d1487617bec7586734d6d82/src/lib/y2partitioner/widgets/overview.rb#L326) (items with icon) and [_devices_](https://github.com/yast/yast-storage-ng/blob/9a1a5e07830498724d1487617bec7586734d6d82/src/lib/y2partitioner/widgets/overview.rb#L339) (items without icon) to define easily the default behavior:

  * Sections will be open (aka expanded)
  * Devices will be closed (aka collapsed)

Last but not least, the user changes are respected.

## Testing

- Added a test for the new functionality of `Y2Partitioner::UIState`
- Tested manually with the testing client

## Screencast

:hourglass_flowing_sand:

