### PR TITLE
Use new "Type" column

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Apr 30 12:30:12 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Partitioner: unify the "Type" and "FS Type" columns.
+- Partitioner: show multidevice filesystems in the system section.
+- Part of jsd#SLE-3877.
+- 4.2.10
+
+-------------------------------------------------------------------
 Tue Apr 30 07:46:10 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Partitioner: added option for editing Btrfs filesystems.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.2.9
+Version:	4.2.10
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -144,7 +144,11 @@ module Y2Partitioner
       # Values
 
       def device_value(device)
-        device.name
+        if device.is?(:blk_filesystem)
+          device.type.to_human_string
+        else
+          device.name
+        end
       end
 
       def size_value(device)

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -255,7 +255,7 @@ module Y2Partitioner
         partition:     N_("Partition")
       }
 
-      # Label for device and filesystem types (e.g., PV of vg1, Ext4 RAID, Part of BtrFS sda1+, etc)
+      # Label for device and filesystem types (e.g., PV of vg1, Ext4 RAID, Part of Btrfs sda1+, etc)
       #
       # @param device [Y2Storage::Device]
       # @return [String]
@@ -333,13 +333,13 @@ module Y2Partitioner
         format(_("PV of %s"), vg.basename)
       end
 
-      # Type label when the device belongs to a multidevice BtrFS filesystem
+      # Type label when the device belongs to a multidevice Btrfs filesystem
       #
       # @param fs [Y2Storage::Filesystems::Base]
       # @return [String]
       def btrfs_multidevice_type_label(fs)
         # TRANSLATORS: %s is a device base name. E.g., sda1+
-        format(_("Part of BtrFS %s"), "#{fs.blk_devices.first.basename}+")
+        format(_("Part of Btrfs %s"), fs.blk_device_basename)
       end
 
       # Type label when the device is used as caching device in Bcache

--- a/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
@@ -160,7 +160,6 @@ module Y2Partitioner
         :format,
         :encrypted,
         :type,
-        :filesystem_type,
         :filesystem_label,
         :mount_point,
         :start,

--- a/src/lib/y2partitioner/widgets/fstab_selector.rb
+++ b/src/lib/y2partitioner/widgets/fstab_selector.rb
@@ -244,7 +244,7 @@ module Y2Partitioner
         attr_reader :fstab
 
         def columns
-          [:device, :size, :type, :filesystem_type, :filesystem_label, :mount_point]
+          [:device, :size, :type, :filesystem_label, :mount_point]
         end
 
         # For each row, the device is a fstab entry

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -133,7 +133,7 @@ module Y2Partitioner
         #
         # @return [Array<Y2Storage::Device>]
         def devices
-          disk_devices + software_raids + lvm_vgs + nfs_devices + bcaches
+          disk_devices + software_raids + lvm_vgs + nfs_devices + bcaches + multidevice_filesystems
         end
 
         # @return [Array<Y2Storage::Device>]
@@ -180,6 +180,11 @@ module Y2Partitioner
             devices << bcache
             devices.concat(bcache.partitions)
           end
+        end
+
+        # @return [Array<Y2Storage::Filesystem>]
+        def multidevice_filesystems
+          device_graph.filesystems.select { |fs| fs.respond_to?(:multidevice?) && fs.multidevice? }
         end
 
         def device_graph

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -182,9 +182,9 @@ module Y2Partitioner
           end
         end
 
-        # @return [Array<Y2Storage::Filesystem>]
+        # @return [Array<Y2Storage::Filesystems::Base>]
         def multidevice_filesystems
-          device_graph.filesystems.select { |fs| fs.respond_to?(:multidevice?) && fs.multidevice? }
+          device_graph.blk_filesystems.select(&:multidevice?)
         end
 
         def device_graph

--- a/src/lib/y2storage/partition.rb
+++ b/src/lib/y2storage/partition.rb
@@ -275,6 +275,13 @@ module Y2Storage
       type.is?(:primary) && id.is?(:windows_system)
     end
 
+    # Whether it is a (valid) EFI System partition
+    #
+    # @return [Boolean]
+    def efi_system?
+      id.is?(:esp) && formatted_as?(:vfat)
+    end
+
   protected
 
     # Values for volume specification matching

--- a/test/data/devicegraphs/efi_not_mounted.yml
+++ b/test/data/devicegraphs/efi_not_mounted.yml
@@ -17,11 +17,3 @@
         file_system:  ext4
         label:        root
         mount_point:  "/"
-
-    - partition:
-        size:         2 GiB
-        name:         /dev/sda3
-        file_system:   ext2
-        id:            esp
-
-

--- a/test/data/devicegraphs/efi_not_mounted.yml
+++ b/test/data/devicegraphs/efi_not_mounted.yml
@@ -18,4 +18,10 @@
         label:        root
         mount_point:  "/"
 
+    - partition:
+        size:         2 GiB
+        name:         /dev/sda3
+        file_system:   ext2
+        id:            esp
+
 

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -221,6 +221,17 @@ describe Y2Partitioner::Widgets::Pages::System do
       end
     end
 
+    context "when there are multidevice filesystems" do
+      let(:scenario) { "btrfs2-devicegraph.xml" }
+      let(:multidevice_filesystems) { current_graph.btrfs_filesystems.select(&:multidevice?) }
+
+      it "contains all multidevice filesystems" do
+        expected_items = multidevice_filesystems.map(&:type).map(&:to_human_string)
+
+        expect(items).to include(*expected_items)
+      end
+    end
+
     describe "caching" do
       let(:scenario) { "empty_hard_disk_15GiB" }
       let(:pager) { Y2Partitioner::Widgets::OverviewTreePager.new("hostname") }

--- a/test/y2storage/partition_test.rb
+++ b/test/y2storage/partition_test.rb
@@ -583,4 +583,36 @@ describe Y2Storage::Partition do
       end
     end
   end
+
+  describe "#efi_system?" do
+    let(:scenario) { "efi_not_mounted" }
+
+    subject(:partition) { fake_devicegraph.find_by_name(device_name) }
+
+    context "when does have an EFI System id" do
+      context "and it is formatted as VFAT" do
+        let(:device_name) { "/dev/sda1" }
+
+        it "returns true" do
+          expect(subject.efi_system?).to eq(true)
+        end
+      end
+
+      context "and it is not formatted as VFAT" do
+        let(:device_name) { "/dev/sda3" }
+
+        it "returns false" do
+          expect(subject.efi_system?).to eq(false)
+        end
+      end
+    end
+
+    context "when does not have an EFI System id" do
+      let(:device_name) { "/dev/sda2" }
+
+      it "returns false" do
+        expect(subject.efi_system?).to eq(false)
+      end
+    end
+  end
 end

--- a/test/y2storage/partition_test.rb
+++ b/test/y2storage/partition_test.rb
@@ -590,16 +590,19 @@ describe Y2Storage::Partition do
     subject(:partition) { fake_devicegraph.find_by_name(device_name) }
 
     context "when does have an EFI System id" do
-      context "and it is formatted as VFAT" do
-        let(:device_name) { "/dev/sda1" }
+      let(:device_name) { "/dev/sda1" }
 
+      context "and it is formatted as VFAT" do
         it "returns true" do
           expect(subject.efi_system?).to eq(true)
         end
       end
 
       context "and it is not formatted as VFAT" do
-        let(:device_name) { "/dev/sda3" }
+        before do
+          subject.delete_filesystem
+          subject.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
+        end
 
         it "returns false" do
           expect(subject.efi_system?).to eq(false)


### PR DESCRIPTION
## Problem

According to ["BtrFS in partitioner" document](https://github.com/yast/yast-storage-ng/blob/master/doc/btrfs_in_partitioner.md) document, column "Fs Type" does not have sense any more and the value for "Type" must be change to fullfill requirements described in ["Partitioner with multidevice BTRFS" gist](https://gist.github.com/joseivanlopez/06e92d5784da7efad7a6feeeb8e2eac6).

Part of https://trello.com/c/BUuCsg5A/945-2-partitioner-new-type-column-and-multi-device-btrfs-in-general-list

## Solution

* Removed the "Fs Type" column
* Changed the content of "Type" column

## Testing

- Tested manually using the _partitioner_testing_ client.

## Screenshots
<details>
<summary>Click to show/hide</summary>

---


| Partitioner using the `yast.xml` file attached in the linked gist |
|-------------------------------------------------------------------|
| ![partitioner](https://user-images.githubusercontent.com/1691872/56817086-bd9cb100-683c-11e9-8e4b-b4a17ddec8a6.png) |

| Partitioner using the `btrfs2-devicegraph.xml` available in [test/data/devicegrahs](https://github.com/yast/yast-storage-ng/tree/master/test/data/devicegraphs) |
|-------------------------------------------------------------------|
| ![btrfs_multidevice](https://user-images.githubusercontent.com/1691872/56915812-5cc8df00-6aaf-11e9-9e02-b95178aa8289.png) |

| Partitioner using the `efi_not_mounted.xml` available in [test/data/devicegrahs](https://github.com/yast/yast-storage-ng/tree/master/test/data/devicegraphs) |
|-------------------------------------------------------------------|
| ![efi_system_partition](https://user-images.githubusercontent.com/1691872/56915849-7702bd00-6aaf-11e9-9db4-b48bd62c716a.png) |
</details>

