### PR TITLE
Edit Btrfs filesystems

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 30 07:46:10 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: added option for editing Btrfs filesystems.
+- Part of jsd#SLE-3877.
+- 4.2.9
+
+-------------------------------------------------------------------
 Wed Apr 24 13:42:09 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Partitioner: BTRFS section was adapted to show both: multidevice

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.2.8
+Version:	4.2.9
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/dialogs/btrfs_options.rb
+++ b/src/lib/y2partitioner/dialogs/btrfs_options.rb
@@ -1,0 +1,61 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2partitioner/dialogs/base"
+require "y2partitioner/widgets/btrfs_options"
+
+module Y2Partitioner
+  module Dialogs
+    # Dialog to set Btrfs options like mount point, subvolumes, snapshots, etc.
+    class BtrfsOptions < Base
+      # @param controller [Actions::Controllers::Filesystem]
+      def initialize(controller)
+        super()
+
+        textdomain "storage"
+
+        @controller = controller
+      end
+
+      # @macro seeDialog
+      def title
+        @controller.wizard_title
+      end
+
+      # @macro seeDialog
+      def contents
+        HVSquash(btrfs_options_widget)
+      end
+
+    private
+
+      # @return [Actions::Controllers::Filesystem]
+      attr_reader :controller
+
+      # Widget for Btrfs options
+      #
+      # @return [Widgets::BtrfsOptions]
+      def btrfs_options_widget
+        @btrfs_options_widget ||= Widgets::BtrfsOptions.new(controller)
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/dialogs/format_and_mount.rb
+++ b/src/lib/y2partitioner/dialogs/format_and_mount.rb
@@ -65,9 +65,15 @@ module Y2Partitioner
         # @macro seeAbstractWidget
         def contents
           HBox(
-            @format_options,
+            Frame(
+              _("Formatting Options"),
+              MarginBox(1.45, 0.5, @format_options)
+            ),
             HSpacing(5),
-            @mount_options
+            Frame(
+              _("Mounting Options"),
+              MarginBox(1.45, 0.5, @mount_options)
+            )
           )
         end
 

--- a/src/lib/y2partitioner/dialogs/format_and_mount.rb
+++ b/src/lib/y2partitioner/dialogs/format_and_mount.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,8 +22,8 @@
 require "yast"
 require "yast2/popup"
 require "y2partitioner/dialogs/base"
+require "y2partitioner/widgets/filesystem_options"
 require "y2partitioner/widgets/format_and_mount"
-require "y2partitioner/filesystem_errors"
 
 module Y2Partitioner
   module Dialogs
@@ -49,20 +49,17 @@ module Y2Partitioner
 
       # Simple container widget to allow the format options and the mount
       # options widgets to refresh each other.
-      class FormatMountOptions < CWM::CustomWidget
-        include FilesystemErrors
-
+      class FormatMountOptions < Widgets::FilesystemOptions
         # Constructor
         #
         # @param controller [Y2Partitioner::Actions::Controllers::Filesystem]
         def initialize(controller)
           textdomain "storage"
 
-          @controller = controller
+          super
+
           @format_options = Widgets::FormatOptions.new(controller, self)
           @mount_options = Widgets::MountOptions.new(controller, self)
-
-          self.handle_all_events = true
         end
 
         # @macro seeAbstractWidget
@@ -72,26 +69,6 @@ module Y2Partitioner
             HSpacing(5),
             @mount_options
           )
-        end
-
-        # @macro seeAbstractWidget
-        # Whether the indicated values are valid
-        #
-        # @note A warning popup is shown if there are some warnings.
-        #
-        # @see #warnings
-        #
-        # @return [Boolean] true if the user decides to continue despite of the
-        #   warnings; false otherwise.
-        def validate
-          current_warnings = warnings
-          return true if current_warnings.empty?
-
-          message = current_warnings
-          message << _("Do you want to continue with the current setup?")
-          message = message.join("\n\n")
-
-          Yast2::Popup.show(message, headline: :warning, buttons: :yes_no) == :yes
         end
 
         # Used by the children widgets to notify they have changed the status of
@@ -106,21 +83,6 @@ module Y2Partitioner
           else
             @format_options.refresh
           end
-        end
-
-      private
-
-        # @return [Y2Partitioner::Actions::Controllers::Filesystem]
-        attr_reader :controller
-
-        # Warnings detected in the given values. For now, it only contains
-        # warnings for the selected filesystem.
-        #
-        # @see FilesysteValidation
-        #
-        # @return [Array<String>]
-        def warnings
-          filesystem_errors(controller.filesystem)
         end
       end
     end

--- a/src/lib/y2partitioner/filesystem_errors.rb
+++ b/src/lib/y2partitioner/filesystem_errors.rb
@@ -94,7 +94,9 @@ module Y2Partitioner
     def small_size_for_snapshots?(filesystem, new_size: nil)
       return false unless filesystem && filesystem_with_snapshots?(filesystem)
 
-      # FIXME: Does this check make sense for multidevice Btrfs?
+      # TODO: check size for multidevice Btrfs
+      return false if filesystem.multidevice?
+
       size = new_size || filesystem.blk_devices.first.size
       min_size = min_size_for_snapshots(filesystem)
 

--- a/src/lib/y2partitioner/filesystem_errors.rb
+++ b/src/lib/y2partitioner/filesystem_errors.rb
@@ -94,6 +94,7 @@ module Y2Partitioner
     def small_size_for_snapshots?(filesystem, new_size: nil)
       return false unless filesystem && filesystem_with_snapshots?(filesystem)
 
+      # FIXME: Does this check make sense for multidevice Btrfs?
       size = new_size || filesystem.blk_devices.first.size
       min_size = min_size_for_snapshots(filesystem)
 

--- a/src/lib/y2partitioner/widgets/btrfs_options.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_options.rb
@@ -1,0 +1,86 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2partitioner/widgets/filesystem_options"
+require "y2partitioner/widgets/format_and_mount"
+
+module Y2Partitioner
+  module Widgets
+    # Widget to set Btrfs options like mount point, subvolumes, snapshots, etc.
+    class BtrfsOptions < FilesystemOptions
+      # @macro seeAbstractWidget
+      def contents
+        VBox(
+          HBox(mount_options_widget),
+          VSpacing(0.5),
+          snapshots_widget
+        )
+      end
+
+      # @macro seeAbstractWidget
+      def init
+        refresh_snapshots_widget
+      end
+
+      # Used by the children widgets to notify they have changed the status of
+      # the controller and, thus, some of its sibling widgets may need a refresh.
+      #
+      # @param exclude [CWM::AbstractWidget] widget producing the change, and thus
+      #   not needing a forced refresh
+      def refresh_others(exclude)
+        return unless exclude == mount_options_widget
+
+        refresh_snapshots_widget
+      end
+
+    private
+
+      # Widget to set mount options
+      #
+      # @return [Widgets::MountOptions]
+      def mount_options_widget
+        @mount_options_widget ||= Widgets::MountOptions.new(controller, self)
+      end
+
+      # Widget to set snapshots
+      #
+      # @return [Widgets::Snapshots]
+      def snapshots_widget
+        @snapshots_widget ||= Widgets::Snapshots.new(controller)
+      end
+
+      # Refreshes the snapshots widget
+      #
+      # The widget is enabled/disabled according to the user selections regarding
+      # the mount point.
+      def refresh_snapshots_widget
+        if controller.snapshots_supported?
+          snapshots_widget.enable
+        else
+          controller.configure_snapper = false
+          snapshots_widget.disable
+        end
+
+        snapshots_widget.refresh
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/btrfs_options.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_options.rb
@@ -29,7 +29,7 @@ module Y2Partitioner
       # @macro seeAbstractWidget
       def contents
         VBox(
-          HBox(mount_options_widget),
+          mount_options_widget,
           VSpacing(0.5),
           snapshots_widget
         )

--- a/src/lib/y2partitioner/widgets/filesystem_options.rb
+++ b/src/lib/y2partitioner/widgets/filesystem_options.rb
@@ -1,0 +1,81 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "cwm"
+require "yast2/popup"
+require "y2partitioner/filesystem_errors"
+
+module Y2Partitioner
+  module Widgets
+    # Widget to set filesystem options
+    #
+    # Includes logic for some validations.
+    class FilesystemOptions < CWM::CustomWidget
+      include FilesystemErrors
+
+      # Constructor
+      #
+      # @param controller [Y2Partitioner::Actions::Controllers::Filesystem]
+      def initialize(controller)
+        textdomain "storage"
+
+        @controller = controller
+
+        self.handle_all_events = true
+      end
+
+      # @macro seeAbstractWidget
+      # Whether the indicated values are valid
+      #
+      # @note A warning popup is shown if there are some warnings.
+      #
+      # @see #warnings
+      #
+      # @return [Boolean] true if the user decides to continue despite of the
+      #   warnings; false otherwise.
+      def validate
+        current_warnings = warnings
+        return true if current_warnings.empty?
+
+        message = current_warnings
+        message << _("Do you want to continue with the current setup?")
+        message = message.join("\n\n")
+
+        Yast2::Popup.show(message, headline: :warning, buttons: :yes_no) == :yes
+      end
+
+    private
+
+      # @return [Y2Partitioner::Actions::Controllers::Filesystem]
+      attr_reader :controller
+
+      # Warnings detected in the given values. For now, it only contains
+      # warnings for the selected filesystem.
+      #
+      # @see FilesysteValidation
+      #
+      # @return [Array<String>]
+      def warnings
+        filesystem_errors(controller.filesystem)
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -20,13 +20,13 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "y2storage"
 require "cwm"
-require "y2partitioner/dialogs/btrfs_subvolumes"
-require "y2partitioner/widgets/fstab_options"
-require "y2partitioner/filesystems"
+require "y2storage"
 require "y2storage/mountable"
 require "y2storage/btrfs_subvolume"
+require "y2partitioner/filesystems"
+require "y2partitioner/widgets/fstab_options"
+require "y2partitioner/dialogs/btrfs_subvolumes"
 
 Yast.import "Popup"
 
@@ -665,23 +665,23 @@ module Y2Partitioner
           CWM::Empty.new("empty_widget")
         end
       end
+    end
 
-      # Button to manage btrfs subvolumes
-      class Button < CWM::PushButton
-        # @param controller [Actions::Controllers::Filesystem]
-        def initialize(controller)
-          textdomain "storage"
-          @controller = controller
-        end
+    # Button to manage btrfs subvolumes
+    class Button < CWM::PushButton
+      # @param controller [Actions::Controllers::Filesystem]
+      def initialize(controller)
+        textdomain "storage"
+        @controller = controller
+      end
 
-        def label
-          _("Subvolume Handling")
-        end
+      def label
+        _("Subvolume Handling")
+      end
 
-        def handle
-          Dialogs::BtrfsSubvolumes.new(@controller.filesystem).run
-          nil
-        end
+      def handle
+        Dialogs::BtrfsSubvolumes.new(@controller.filesystem).run
+        nil
       end
     end
 

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -118,31 +118,24 @@ module Y2Partitioner
       end
 
       def contents
-        Frame(
-          _("Formatting Options"),
-          MarginBox(
-            1.45,
-            0.5,
+        VBox(
+          RadioButtonGroup(
+            Id(:format),
             VBox(
-              RadioButtonGroup(
-                Id(:format),
+              Left(RadioButton(Id(:format_device), Opt(:notify), _("Format device"))),
+              HBox(
+                HSpacing(4),
                 VBox(
-                  Left(RadioButton(Id(:format_device), Opt(:notify), _("Format device"))),
-                  HBox(
-                    HSpacing(4),
-                    VBox(
-                      Left(@filesystem_widget),
-                      Left(@format_options)
-                    )
-                  ),
-                  Left(RadioButton(Id(:no_format_device), Opt(:notify), _("Do not format device"))),
-                  @partition_id
+                  Left(@filesystem_widget),
+                  Left(@format_options)
                 )
               ),
-              VSpacing(1),
-              Left(@encrypt_widget)
+              Left(RadioButton(Id(:no_format_device), Opt(:notify), _("Do not format device"))),
+              @partition_id
             )
-          )
+          ),
+          VSpacing(1),
+          Left(@encrypt_widget)
         )
       end
 
@@ -223,30 +216,23 @@ module Y2Partitioner
       end
 
       def contents
-        Frame(
-          _("Mounting Options"),
-          MarginBox(
-            1.45,
-            0.5,
+        VBox(
+          RadioButtonGroup(
+            Id(:mount),
             VBox(
-              RadioButtonGroup(
-                Id(:mount),
+              Left(RadioButton(Id(:mount_device), Opt(:notify), _("Mount device"))),
+              HBox(
+                HSpacing(4),
                 VBox(
-                  Left(RadioButton(Id(:mount_device), Opt(:notify), _("Mount device"))),
-                  HBox(
-                    HSpacing(4),
-                    VBox(
-                      Left(@mount_point_widget),
-                      Left(@fstab_options_widget)
-                    )
-                  ),
-                  Left(RadioButton(Id(:dont_mount_device), Opt(:notify), _("Do not mount device")))
+                  Left(@mount_point_widget),
+                  Left(@fstab_options_widget)
                 )
               ),
-              VSpacing(1),
-              Left(@btrfs_subvolumes_widget)
+              Left(RadioButton(Id(:dont_mount_device), Opt(:notify), _("Do not mount device")))
             )
-          )
+          ),
+          VSpacing(1),
+          Left(@btrfs_subvolumes_widget)
         )
       end
 

--- a/src/lib/y2partitioner/widgets/pages/btrfs.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs.rb
@@ -54,7 +54,7 @@ module Y2Partitioner
 
         # @macro seeAbstractWidget
         def label
-          devices_info
+          filesystem.blk_device_basename
         end
 
         # @macro seeCustomWidget
@@ -86,13 +86,9 @@ module Y2Partitioner
         #
         # @return [String]
         def title
-          # TRANSLATORS: BTRFS page title, where %{fs_type} is replaced by the filesystem
-          # type (i.e., Btrfs) and %{info} is replaced by the device basename (e.g., sda1).
-          format(
-            _("%{fs_type}: %{info}"),
-            fs_type: filesystem.type.to_human,
-            info:    devices_info
-          )
+          # TRANSLATORS: BTRFS page title, where %{basename} is replaced by the device
+          # basename (e.g., sda1).
+          format(_("Btrfs %{basename}"), basename: filesystem.blk_device_basename)
         end
 
         # Tabs to show the filesystem data
@@ -108,21 +104,6 @@ module Y2Partitioner
           ]
 
           Tabs.new(*tabs)
-        end
-
-        # Short information about the devices used by the filesystem
-        #
-        # When the filesystem is a non-multidevice, this method simply returns the base
-        # name of the blk device (e.g., "sda1"). And for multidevice ones, it only returns
-        # the base name of the first blk device plus a "+" symbol to indicate that the
-        # filesystem is multidevice (e.g., "sda1+").
-        #
-        # @return [String]
-        def devices_info
-          info = devices.first.basename
-          info << "+" if filesystem.multidevice?
-
-          info
         end
 
         # Devices used by the filesystem

--- a/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
@@ -45,7 +45,7 @@ module Y2Partitioner
 
         # @macro seeAbstractWidget
         def label
-          Y2Storage::Filesystems::Type::BTRFS.to_human
+          _("Btrfs")
         end
 
       private

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -112,6 +112,21 @@ module Y2Storage
       # @return [Array<BlkDevice>]
       def plain_blk_devices
         blk_devices.map(&:plain_device)
+      end
+
+      # Block device base name
+      #
+      # When the filesystem is a non-multidevice, this method simply returns the base
+      # name of the block device (e.g., "sda1"). And for multidevice ones, it only returns
+      # the base name of the first block device plus a "+" symbol to indicate that the
+      # filesystem is multidevice (e.g., "sda1+").
+      #
+      # @return [String]
+      def blk_device_basename
+        info = blk_devices.first.basename
+        info << "+" if multidevice?
+
+        info
       end
 
       # Whether it is a multidevice filesystem

--- a/test/y2partitioner/actions/edit_btrfs_test.rb
+++ b/test/y2partitioner/actions/edit_btrfs_test.rb
@@ -39,12 +39,12 @@ describe Y2Partitioner::Actions::EditBtrfs do
 
   describe "#run" do
     before do
-      allow(Y2Partitioner::Dialogs::BtrfsSubvolumes).to receive(:new).and_return(dialog)
+      allow(Y2Partitioner::Dialogs::BtrfsOptions).to receive(:new).and_return(dialog)
 
       allow(dialog).to receive(:run).and_return(dialog_result)
     end
 
-    let(:dialog) { instance_double(Y2Partitioner::Dialogs::BtrfsSubvolumes) }
+    let(:dialog) { instance_double(Y2Partitioner::Dialogs::BtrfsOptions) }
 
     let(:dialog_result) { nil }
 
@@ -52,22 +52,30 @@ describe Y2Partitioner::Actions::EditBtrfs do
 
     let(:device_name) { "/dev/sdb2" }
 
-    it "shows the dialog for editing BTRFS subvolumes" do
+    let(:controller_class) { Y2Partitioner::Actions::Controllers::Filesystem }
+
+    it "shows the dialog for editing a BTRFS filesystem" do
       expect(dialog).to receive(:run)
 
       subject.run
     end
 
+    it "includes the device base name in the title passed to the controller" do
+      expect(controller_class).to receive(:new).with(filesystem, /sdb2/)
+
+      subject.run
+    end
+
     context "and the dialog is not accepted" do
-      let(:dialog_result) { :cancel }
+      let(:dialog_result) { :abort }
 
       it "returns the result of the dialog" do
-        expect(subject.run).to eq(:cancel)
+        expect(subject.run).to eq(:abort)
       end
     end
 
     context "and the dialog is accepted" do
-      let(:dialog_result) { :ok }
+      let(:dialog_result) { :next }
 
       it "returns :finish" do
         expect(subject.run).to eq(:finish)

--- a/test/y2partitioner/dialogs/btrfs_options_test.rb
+++ b/test/y2partitioner/dialogs/btrfs_options_test.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/dialogs/btrfs_options"
+require "y2partitioner/actions/controllers/filesystem"
+
+describe Y2Partitioner::Dialogs::BtrfsOptions do
+  before do
+    devicegraph_stub(scenario)
+  end
+
+  subject { described_class.new(controller) }
+
+  let(:device) { fake_devicegraph.find_by_name(device_name) }
+
+  let(:filesystem) { device.filesystem }
+
+  let(:controller) { Y2Partitioner::Actions::Controllers::Filesystem.new(filesystem, "") }
+
+  let(:scenario) { "mixed_disks" }
+
+  let(:device_name) { "/dev/sdb2" }
+
+  include_examples "CWM::Dialog"
+
+  describe "#contents" do
+    it "has an BtrfsOptions widget" do
+      widget = subject.contents.nested_find { |i| i.is_a?(Y2Partitioner::Widgets::BtrfsOptions) }
+
+      expect(widget).to_not be_nil
+    end
+  end
+end

--- a/test/y2partitioner/widgets/btrfs_options_test.rb
+++ b/test/y2partitioner/widgets/btrfs_options_test.rb
@@ -1,0 +1,187 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/btrfs_options"
+require "y2partitioner/actions/controllers/filesystem"
+
+describe Y2Partitioner::Widgets::BtrfsOptions do
+  before do
+    devicegraph_stub(scenario)
+  end
+
+  subject { described_class.new(controller) }
+
+  let(:device) { fake_devicegraph.find_by_name(device_name) }
+
+  let(:filesystem) { device.filesystem }
+
+  let(:controller) { Y2Partitioner::Actions::Controllers::Filesystem.new(filesystem, "") }
+
+  let(:scenario) { "mixed_disks" }
+
+  let(:device_name) { "/dev/sdb2" }
+
+  include_examples "CWM::CustomWidget"
+
+  it "includes a widget to configure mount options" do
+    widget = subject.contents.nested_find { |i| i.is_a?(Y2Partitioner::Widgets::MountOptions) }
+
+    expect(widget).to_not be_nil
+  end
+
+  it "includes a widget to configure snapshots" do
+    widget = subject.contents.nested_find { |i| i.is_a?(Y2Partitioner::Widgets::Snapshots) }
+
+    expect(widget).to_not be_nil
+  end
+
+  describe "#validate" do
+    before do
+      allow(subject).to receive(:filesystem_errors).and_return(warnings)
+
+      allow(Yast2::Popup).to receive(:show)
+        .with(anything, hash_including(headline: :warning)).and_return(accept)
+    end
+
+    let(:accept) { nil }
+
+    context "if there are no warnings" do
+      let(:warnings) { [] }
+
+      it "does not show a warning popup" do
+        expect(Yast2::Popup).to_not receive(:show)
+
+        subject.validate
+      end
+
+      it "returns true" do
+        expect(subject.validate).to eq(true)
+      end
+    end
+
+    context "if there are warnings" do
+      let(:warnings) { ["warning1", "warning2"] }
+
+      it "shows a warning popup" do
+        expect(Yast2::Popup).to receive(:show).with(anything, hash_including(headline: :warning))
+
+        subject.validate
+      end
+
+      context "and the user accepts" do
+        let(:accept) { :yes }
+
+        it "returns true" do
+          expect(subject.validate).to eq(true)
+        end
+      end
+
+      context "and the user declines" do
+        let(:accept) { :no }
+
+        it "returns false" do
+          expect(subject.validate).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe "#refresh_others" do
+    let(:mount_options_widget) { instance_double(Y2Partitioner::Widgets::MountOptions) }
+    let(:snapshots_widget) { instance_double(Y2Partitioner::Widgets::Snapshots) }
+
+    before do
+      allow(Y2Partitioner::Widgets::MountOptions)
+        .to receive(:new).and_return(mount_options_widget)
+
+      allow(Y2Partitioner::Widgets::Snapshots)
+        .to receive(:new).and_return(snapshots_widget)
+
+      allow(snapshots_widget).to receive(:refresh)
+      allow(snapshots_widget).to receive(:enable)
+      allow(snapshots_widget).to receive(:disable)
+    end
+
+    context "when the MountOptions widget triggers an update" do
+      it "does not call #refresh for the widget triggering the update" do
+        expect(mount_options_widget).to_not receive(:refresh)
+
+        subject.refresh_others(mount_options_widget)
+      end
+
+      it "calls #refresh for the Snapshots widget" do
+        expect(snapshots_widget).to receive(:refresh)
+
+        subject.refresh_others(mount_options_widget)
+      end
+
+      context "when snapshots can be configured" do
+        before do
+          allow(controller).to receive(:snapshots_supported?).and_return(true)
+        end
+
+        it "enables the Snapshots widget" do
+          expect(snapshots_widget).to receive(:enable)
+
+          subject.refresh_others(mount_options_widget)
+        end
+      end
+
+      context "when snapshots cannot be configured" do
+        before do
+          allow(controller).to receive(:snapshots_supported?).and_return(false)
+        end
+
+        it "disables the Snapshots widget" do
+          expect(snapshots_widget).to receive(:disable)
+
+          subject.refresh_others(mount_options_widget)
+        end
+
+        it "resets the snapshots configuration" do
+          controller.configure_snapper = true
+
+          subject.refresh_others(mount_options_widget)
+
+          expect(controller.configure_snapper).to eq(false)
+        end
+      end
+    end
+
+    context "when the Snapshots widget triggers an update" do
+      it "does not call #refresh for the widget triggering the update" do
+        expect(snapshots_widget).to_not receive(:refresh)
+
+        subject.refresh_others(snapshots_widget)
+      end
+
+      it "does not call #refresh for the MountOptions widget" do
+        expect(mount_options_widget).to_not receive(:refresh)
+
+        subject.refresh_others(snapshots_widget)
+      end
+    end
+  end
+end

--- a/test/y2partitioner/widgets/pages/btrfs_test.rb
+++ b/test/y2partitioner/widgets/pages/btrfs_test.rb
@@ -46,29 +46,6 @@ describe Y2Partitioner::Widgets::Pages::Btrfs do
 
   include_examples "CWM::Page"
 
-  describe "label" do
-    context "for a non-multidevice BTRFS" do
-      let(:scenario) { "mixed_disks" }
-
-      let(:device_name) { "/dev/sdb2" }
-
-      it "returns the base name of its block device" do
-        expect(subject.label).to eq("sdb2")
-      end
-    end
-
-    context "for a multidevice BTRFS" do
-      let(:scenario) { "btrfs2-devicegraph.xml" }
-
-      let(:device_name) { "/dev/sdb1" }
-
-      it "returns the base name of its first block device followed by '+'" do
-        basename = filesystem.blk_devices.first.basename
-        expect(subject.label).to eq(basename + "+")
-      end
-    end
-  end
-
   describe "#contents" do
     let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
 

--- a/test/y2storage/filesystems/blk_filesystem_test.rb
+++ b/test/y2storage/filesystems/blk_filesystem_test.rb
@@ -35,6 +35,29 @@ describe Y2Storage::Filesystems::BlkFilesystem do
   let(:ntfs_part)  { "/dev/sda1" }
   subject(:filesystem) { blk_device.blk_filesystem }
 
+  describe "#blk_device_basename" do
+    context "for a non-multidevice filesystem" do
+      let(:scenario) { "mixed_disks" }
+
+      let(:dev_name) { "/dev/sdb2" }
+
+      it "returns the base name of its block device" do
+        expect(subject.blk_device_basename).to eq("sdb2")
+      end
+    end
+
+    context "for a multidevice filesystem" do
+      let(:scenario) { "btrfs2-devicegraph.xml" }
+
+      let(:dev_name) { "/dev/sdb1" }
+
+      it "returns the base name of its first block device followed by '+'" do
+        basename = filesystem.blk_devices.first.basename
+        expect(subject.blk_device_basename).to eq(basename + "+")
+      end
+    end
+  end
+
   describe "#multidevice?" do
     context "when the filesystem is over one device only" do
       let(:dev_name) { "/dev/sdb2" }


### PR DESCRIPTION
## Problem

Currently, the button for editing a Btrfs filesystem opens a dialog to manage its subvolumes. The button should open a dialog for editing the filesystem options, similar to the dialog for editing a block device.

* https://jira.suse.de/browse/SLE-3877
* https://trello.com/c/Icti2ZBT/947-3-partitioner-editing-btrfs-filesystems


## Solution

Now, the edit button opens a dialog to edit the Btrfs filesystem. The dialog allows to set the mount point, mount options, configure subvolumes, and enable/disable snapshots (this last only for root during installation).


## Testing

- Added unit tests
- Tested manually


## Screenshots

![VirtualBox_openSUSE Tumbleweed_30_04_2019_11_32_54](https://user-images.githubusercontent.com/1112304/56956324-bf67bc80-6b3b-11e9-97de-0e7062cb9f3b.png)

