### PR TITLE
Fix "Type" column

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Thu May  2 09:49:02 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Partitioner: fix the Btrfs filesystem icon used in "Type" column.
+- Partitioner: improve the value for the "Type" column when a volume
+  group does not have name.
+- Partitioner: fix the device name for a multidevice filesystem.
+- Partitioner: do not show label nor mount point for devices used by
+  a multidevice filesystem.
+- Part of jsc#SLE-3877.
+- 4.2.12
+
+-------------------------------------------------------------------
 Thu May  2 09:21:50 UTC 2019 - ancor@suse.com
 
 - Partitioner: fixes in the navigation tree (bsc#1133686).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.2.11
+Version:	4.2.12
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -197,6 +197,7 @@ module Y2Partitioner
       def mount_point_value(device)
         fs = filesystem(device)
         return "" if fs.nil?
+        return "" if part_of_multidevice?(device)
 
         res = fs.mount_path
         res += " *" if fs.mount_point && !fs.mount_point.active?

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -220,7 +220,8 @@ module Y2Partitioner
         partition: Icons::HD_PART,
         raid:      Icons::RAID,
         lvm_vg:    Icons::LVM,
-        lvm_lv:    Icons::LVM_LV
+        lvm_lv:    Icons::LVM_LV,
+        btrfs:     Icons::BTRFS
       }
 
       # Table icon for the device

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -145,7 +145,10 @@ module Y2Partitioner
 
       def device_value(device)
         if device.is?(:blk_filesystem)
-          device.type.to_human_string
+          device_name =  [device.type.to_human_string]
+          device_name << device.blk_device_basename if device.multidevice?
+
+          device_name.join(" ")
         else
           device.name
         end

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -187,7 +187,9 @@ module Y2Partitioner
 
       def filesystem_label_value(device)
         fs = filesystem(device)
-        # fs may be nil or a file system not supporting labels, like NFS
+        return "" if fs.nil?
+        return "" if part_of_multidevice?(device)
+        # fs may not supporting labels, like NFS
         return "" unless fs.respond_to?(:label)
         fs.label
       end
@@ -389,6 +391,17 @@ module Y2Partitioner
         return "" if type.nil?
 
         _(DEVICE_LABELS[type])
+      end
+
+      # Whether the device belongs to a multidevice filesystem
+      #
+      # @param device [Device]
+      # @return [Boolean]
+      def part_of_multidevice?(device)
+        return false unless device.is?(:blk_device)
+
+        fs = filesystem(device)
+        fs.multidevice?
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -144,13 +144,18 @@ module Y2Partitioner
       # Values
 
       def device_value(device)
-        if device.is?(:blk_filesystem)
-          device_name =  [device.type.to_human_string]
-          device_name << device.blk_device_basename if device.multidevice?
+        return device.name unless device.is?(:blk_filesystem)
 
-          device_name.join(" ")
+        if device.multidevice?
+          format(
+            # TRANSLATORS: fs_type is the filesystem type. I.e., BtrFS
+            #              device_name is the base name of the block device. I.e., sda or sda1+
+            _("%{fs_type} %{device_name}"),
+            fs_type:     device.type.to_human_string,
+            device_name: device.blk_device_basename
+          )
         else
-          device.name
+          device.type.to_human_string
         end
       end
 

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -335,6 +335,7 @@ module Y2Partitioner
         vg = device.lvm_vg
 
         return _("Orphan PV") if vg.nil?
+        return _("PV of LVM") if vg.basename.empty?
 
         # TRANSLATORS: %s is the volume group name. E.g., "vg0"
         format(_("PV of %s"), vg.basename)

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -226,7 +226,9 @@ describe Y2Partitioner::Widgets::Pages::System do
       let(:multidevice_filesystems) { current_graph.btrfs_filesystems.select(&:multidevice?) }
 
       it "contains all multidevice filesystems" do
-        expected_items = multidevice_filesystems.map(&:type).map(&:to_human_string)
+        expected_items = multidevice_filesystems.map do |fs|
+          "#{fs.type.to_human_string} #{fs.blk_device_basename}"
+        end
 
         expect(items).to include(*expected_items)
       end


### PR DESCRIPTION
## Problem

After merge #911, we realized that it contained below undesired behaviors

* It was displaying a wrong icon for a Btrfs multidevice filesystem _(because it was using the default one)_.
* It was using a wrong device name for a multidevice filesystem.
* It was displaying the label for a device which is part of a multidevice.
* It was displaying the mount point for a device which is part of a multidevice.
* It was displaying the unfinished "PV of" string in certain situation, when the VG does not have a basename (yet).

## Solution

Fix all of them.

## Testing

- Tested manually

## Screenshots

<details>
<summary>Click to show/hide</summary>

---

| Before |
|-------|
| ![Screenshot_opensusetumbleweed_2019-04-30_14:58:55](https://user-images.githubusercontent.com/1691872/56970250-a58ba100-6b5e-11e9-915d-789f992f0ee7.png) |

| After |
| -------- |
| ![Screenshot_opensusetumbleweed_2019-04-30_16:51:55](https://user-images.githubusercontent.com/1691872/56975363-90b40b00-6b68-11e9-9f63-92a06a96a6d1.png) |

---

| Before |
| ------ |
| ![Screenshot_opensusetumbleweed_2019-04-30_15:28:51](https://user-images.githubusercontent.com/1691872/56970478-1cc13500-6b5f-11e9-80c4-866c5131b41c.png) |

| After |
| -------- |
| ![Screenshot_opensusetumbleweed_2019-04-30_15:30:05](https://user-images.githubusercontent.com/1691872/56970600-601ba380-6b5f-11e9-8fab-a52149680b98.png) |


