### PR TITLE
Partitioner: fix behavior of tree sections that were initially empty

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May  2 09:21:50 UTC 2019 - ancor@suse.com
+
+- Partitioner: fixes in the navigation tree (bsc#1133686).
+- 4.2.11
+
+-------------------------------------------------------------------
 Tue Apr 30 12:30:12 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Partitioner: unify the "Type" and "FS Type" columns.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.2.10
+Version:	4.2.11
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -34,7 +34,7 @@ module Y2Partitioner
       textdomain "storage"
 
       @candidate_nodes = []
-      @open_items_ids = nil
+      @open_items = {}
       @overview_tree_pager = nil
     end
 
@@ -44,12 +44,14 @@ module Y2Partitioner
     # @return [Widgets::OverviewTreePager]
     attr_accessor :overview_tree_pager
 
-    # Items of the tree that should be expanded in the next redraw.
-    # @note Nil means that open items are not being saved yet and the default tree state should be
-    # used instead. See {Widgets::OverviewTreePager#item_open?}
+    # Hash listing all the items with children of the tree and specifying whether
+    # such item should be expanded (true) or collapsed (false) in the next redraw.
     #
-    # @return [nil, Array<String,Symbol>]
-    attr_reader :open_items_ids
+    # @note Only elements with children are stored, for the others the current state
+    # is not relevant (not having children, they are neither open or closed).
+    #
+    # @return [Hash{String => Boolean}]
+    attr_reader :open_items
 
     # Title of the section listing the MD RAIDs
     #
@@ -153,7 +155,7 @@ module Y2Partitioner
     def save_open_items
       return unless overview_tree_pager
 
-      @open_items_ids = overview_tree_pager.open_items_ids
+      @open_items = overview_tree_pager.open_items
     end
 
   protected

--- a/src/lib/y2partitioner/widgets/bcache_add_button.rb
+++ b/src/lib/y2partitioner/widgets/bcache_add_button.rb
@@ -22,11 +22,14 @@
 require "yast"
 require "cwm"
 require "y2partitioner/actions/add_bcache"
+require "y2partitioner/widgets/execute_and_redraw"
 
 module Y2Partitioner
   module Widgets
     # Button for opening a wizard to add a new Bcache device
     class BcacheAddButton < CWM::PushButton
+      include ExecuteAndRedraw
+
       # Constructor
       def initialize
         textdomain "storage"
@@ -41,8 +44,7 @@ module Y2Partitioner
       # @macro seeAbstractWidget
       # @see Actions::AddBcache
       def handle
-        res = Actions::AddBcache.new.run
-        res == :finish ? :redraw : nil
+        execute_and_redraw { Actions::AddBcache.new.run }
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/configure.rb
+++ b/src/lib/y2partitioner/widgets/configure.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "cwm"
 require "y2partitioner/widgets/reprobe"
+require "y2partitioner/widgets/execute_and_redraw"
 require "y2partitioner/icons"
 
 Yast.import "Stage"
@@ -39,6 +40,7 @@ module Y2Partitioner
     # Yast::PartitioningEpAllInclude from yast-storage
     class Configure < CWM::CustomWidget
       include Reprobe
+      include ExecuteAndRedraw
 
       # Constructor
       def initialize
@@ -67,9 +69,11 @@ module Y2Partitioner
         return nil unless action
         return nil unless warning_accepted?(action) && availability_ensured?(action)
 
-        Yast::WFM.call(action.client) if action.client
-        reprobe(activate: action.activate)
-        :redraw
+        execute_and_redraw do
+          Yast::WFM.call(action.client) if action.client
+          reprobe(activate: action.activate)
+          :finish
+        end
       end
 
       # @macro seeAbstractWidget

--- a/src/lib/y2partitioner/widgets/device_button.rb
+++ b/src/lib/y2partitioner/widgets/device_button.rb
@@ -21,6 +21,7 @@
 
 require "yast"
 require "cwm"
+require "y2partitioner/widgets/execute_and_redraw"
 
 Yast.import "Popup"
 
@@ -29,6 +30,8 @@ module Y2Partitioner
     # Base class for a button that performs some action over a specificic device,
     # e.g., edit, resize, delete, etc.
     class DeviceButton < CWM::PushButton
+      include ExecuteAndRedraw
+
       # Constructor
       # @param pager [CWM::TreePager]
       # @param device [Y2Storage::Device]
@@ -43,9 +46,7 @@ module Y2Partitioner
       def handle
         return nil unless validate_presence
 
-        UIState.instance.save_open_items
-
-        actions
+        execute_and_redraw { actions }
       end
 
     protected
@@ -73,26 +74,18 @@ module Y2Partitioner
 
       # Actions to perform when the button is clicked
       #
-      # @return [:redraw, nil] :redraw when the action is performed; nil otherwise
+      # @return [Symbol, nil] result of the action, nil if nothing is executed
       def actions
         if actions_class.nil?
           Yast::Popup.Warning("Not yet implemented")
           return nil
         end
 
-        actions_result = actions_class.new(device).run
-        result(actions_result)
+        actions_class.new(device).run
       end
 
       # @return [Actions] an Actions class name to perform the expected actions
       abstract_method :actions_class
-
-      # By default, it returns :redraw when the action is performed; nil otherwise
-      #
-      # @return [:redraw, nil]
-      def result(actions_result)
-        actions_result == :finish ? :redraw : nil
-      end
 
       # Checks whether there is a device on which to act
       #

--- a/src/lib/y2partitioner/widgets/device_menu_button.rb
+++ b/src/lib/y2partitioner/widgets/device_menu_button.rb
@@ -21,6 +21,7 @@
 
 require "yast"
 require "cwm"
+require "y2partitioner/widgets/execute_and_redraw"
 
 Yast.import "Popup"
 
@@ -32,6 +33,8 @@ module Y2Partitioner
     # Every subclass should implement {#actions} with the concrete list of
     # actions.
     class DeviceMenuButton < CWM::MenuButton
+      include ExecuteAndRedraw
+
       # Constructor
       # @param device [Y2Storage::Device]
       def initialize(device)
@@ -48,12 +51,10 @@ module Y2Partitioner
       def handle(event)
         return nil unless validate_presence
 
-        UIState.instance.save_open_items
-
         action = action_for_widget_id(event["ID"])
         return nil unless action
 
-        action_result(action)
+        execute_and_redraw { execute_action(action) }
       end
 
       # @macro seeItemsSelection
@@ -93,14 +94,6 @@ module Y2Partitioner
       # @return [Symbol] result of the action
       def execute_action(action)
         action[:class].new(device).run
-      end
-
-      # See {#handle}
-      #
-      # @param action [Hash]
-      # @return [:redraw, nil] :redraw when the action is performed; nil otherwise
-      def action_result(action)
-        execute_action(action) == :finish ? :redraw : nil
       end
 
       # Current devicegraph

--- a/src/lib/y2partitioner/widgets/execute_and_redraw.rb
+++ b/src/lib/y2partitioner/widgets/execute_and_redraw.rb
@@ -1,0 +1,50 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2partitioner/ui_state"
+
+module Y2Partitioner
+  module Widgets
+    # Mixin for widgets that need to execute an action that can modify the
+    # devicegraph and, as a result, need to redraw the Partitioner interface
+    module ExecuteAndRedraw
+      # Saves the status of the navigation tree, executes the passed block and
+      # transforms the result of that block into something the main loop of the
+      # Partitioner can understand
+      #
+      # Expects a block that must return :finish to force a reload or any other
+      # value to force a step back.
+      #
+      # @return [:redraw, nil]
+      def execute_and_redraw
+        UIState.instance.save_open_items
+        redraw_result(yield)
+      end
+
+      # By default, it returns :redraw when the action is performed; nil otherwise
+      #
+      # @return [:redraw, nil]
+      def redraw_result(result)
+        result == :finish ? :redraw : nil
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/import_mount_points_button.rb
+++ b/src/lib/y2partitioner/widgets/import_mount_points_button.rb
@@ -22,11 +22,14 @@
 require "yast"
 require "cwm/widget"
 require "y2partitioner/actions/import_mount_points"
+require "y2partitioner/widgets/execute_and_redraw"
 
 module Y2Partitioner
   module Widgets
     # Button for importing mount points from a fstab file
     class ImportMountPointsButton < CWM::PushButton
+      include ExecuteAndRedraw
+
       def initialize
         textdomain "storage"
       end
@@ -38,8 +41,7 @@ module Y2Partitioner
 
       # @return [Symbol, nil] nil when the action was not performed
       def handle
-        action_result = Actions::ImportMountPoints.new.run
-        action_result == :finish ? :redraw : nil
+        execute_and_redraw { Actions::ImportMountPoints.new.run }
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/lvm_vg_add_button.rb
+++ b/src/lib/y2partitioner/widgets/lvm_vg_add_button.rb
@@ -22,11 +22,14 @@
 require "yast"
 require "cwm"
 require "y2partitioner/actions/add_lvm_vg"
+require "y2partitioner/widgets/execute_and_redraw"
 
 module Y2Partitioner
   module Widgets
     # Button for openng a wizard to add a new LVM volume group
     class LvmVgAddButton < CWM::PushButton
+      include ExecuteAndRedraw
+
       # Constructor
       def initialize
         textdomain "storage"
@@ -41,8 +44,7 @@ module Y2Partitioner
       # @macro seeAbstractWidget
       # @see Actions::AddLvmVg
       def handle
-        res = Actions::AddLvmVg.new.run
-        res == :finish ? :redraw : nil
+        execute_and_redraw { Actions::AddLvmVg.new.run }
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/md_add_button.rb
+++ b/src/lib/y2partitioner/widgets/md_add_button.rb
@@ -22,11 +22,14 @@
 require "yast"
 require "cwm"
 require "y2partitioner/actions/add_md"
+require "y2partitioner/widgets/execute_and_redraw"
 
 module Y2Partitioner
   module Widgets
     # Button for openng a wizard to add a new MD array
     class MdAddButton < CWM::PushButton
+      include ExecuteAndRedraw
+
       # Constructor
       def initialize
         textdomain "storage"
@@ -41,8 +44,7 @@ module Y2Partitioner
       # @macro seeAbstractWidget
       # @see Actions::AddMd
       def handle
-        res = Actions::AddMd.new.run
-        res == :finish ? :redraw : nil
+        execute_and_redraw { Actions::AddMd.new.run }
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/rescan_devices_button.rb
+++ b/src/lib/y2partitioner/widgets/rescan_devices_button.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "cwm/widget"
 require "y2partitioner/widgets/reprobe"
+require "y2partitioner/widgets/execute_and_redraw"
 
 Yast.import "Popup"
 Yast.import "Mode"
@@ -31,6 +32,7 @@ module Y2Partitioner
     # Button for rescanning system devices
     class RescanDevicesButton < CWM::PushButton
       include Reprobe
+      include ExecuteAndRedraw
 
       def initialize
         textdomain "storage"
@@ -48,8 +50,10 @@ module Y2Partitioner
       def handle
         return nil unless continue?
 
-        reprobe
-        :redraw
+        execute_and_redraw do
+          reprobe
+          :finish
+        end
       end
 
       # @macro seeAbstractWidget

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -352,7 +352,7 @@ describe Y2Partitioner::UIState do
     context "if the open items has not been saved" do
       before { described_class.create_instance }
 
-      it "returns and empty hasg" do
+      it "returns and empty hash" do
         expect(ui_state.open_items).to eq({})
       end
     end

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -348,12 +348,12 @@ describe Y2Partitioner::UIState do
     end
   end
 
-  describe "#open_items_ids" do
+  describe "#open_items" do
     context "if the open items has not been saved" do
       before { described_class.create_instance }
 
-      it "returns nil" do
-        expect(ui_state.open_items_ids).to be_nil
+      it "returns and empty hasg" do
+        expect(ui_state.open_items).to eq({})
       end
     end
 
@@ -361,16 +361,16 @@ describe Y2Partitioner::UIState do
       let(:pager) { double("TreePager") }
 
       before do
-        # The first call returns [:first, :third] and the second returns [:second]
-        allow(pager).to receive(:open_items_ids)
-          .and_return([:first, :third], [:second])
+        # The first call returns {a: true, b: false} and the second returns {b: true}
+        allow(pager).to receive(:open_items)
+          .and_return({ a: true, b: false }, b: true)
 
         ui_state.overview_tree_pager = pager
         ui_state.save_open_items
       end
 
       it "returns the items that were expanded when #save_open_items was called" do
-        expect(ui_state.open_items_ids).to eq [:first, :third]
+        expect(ui_state.open_items).to eq(a: true, b: false)
       end
 
       # To ensure this does not interfere with other tests

--- a/test/y2partitioner/widgets/overview_test.rb
+++ b/test/y2partitioner/widgets/overview_test.rb
@@ -422,4 +422,38 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
       end
     end
   end
+
+  describe "#open_items" do
+    before do
+      allow(Yast::UI).to receive(:QueryWidget).with(anything, :OpenItems)
+        .and_return(ui_open_items)
+    end
+
+    let(:scenario) { "lvm-two-vgs.yml" }
+
+    let(:with_children) do
+      ["Y2Partitioner::Widgets::Pages::System", "Y2Partitioner::Widgets::Pages::Disks",
+       "Y2Partitioner::Widgets::Pages::Lvm", "disk:/dev/sda", "lvm_vg:vg0", "lvm_vg:vg1"]
+    end
+
+    let(:ui_open_items) do
+      { "Y2Partitioner::Widgets::Pages::System" => "ID", "disk:/dev/sda" => "ID" }
+    end
+
+    it "contains an entry for each item with children" do
+      expect(subject.open_items.keys).to contain_exactly(*with_children)
+    end
+
+    it "sets the value of open items to true" do
+      expect(subject.open_items["Y2Partitioner::Widgets::Pages::System"]).to eq true
+      expect(subject.open_items["disk:/dev/sda"]).to eq true
+    end
+
+    it "sets the value of closed items to false" do
+      expect(subject.open_items["Y2Partitioner::Widgets::Pages::Disks"]).to eq false
+      expect(subject.open_items["Y2Partitioner::Widgets::Pages::Lvm"]).to eq false
+      expect(subject.open_items["lvm_vg:vg0"]).to eq false
+      expect(subject.open_items["lvm_vg:vg1"]).to eq false
+    end
+  end
 end


### PR DESCRIPTION
## Problem

In theory, the Partitioner should start with all the sections (like "Hard Disks", "Volume Management", etc.) open by default, so the first level of devices is visible.

But when a section was initially empty and the first device was added, the section remained closed. That's wrong. When the very first device is added, the default behavior (open displaying the first level of devices) should be applied.

The wrong behavior can be seen at
https://openqa.opensuse.org/tests/920618#step/partitioning_full_lvm/51

Reported as [bsc#1133686](https://bugzilla.suse.com/show_bug.cgi?id=1133686)

Trello: https://trello.com/c/XYcpfC8F/957-ostumbleweed-p5-1133686-partitioner-misbehavior-of-tree-sections-that-were-initially-empty

In addition, while fixing this we noticed the status of the tree was not saved in several places in which it should (like when creating a new RAID or a new VG) and that it was saved in places where it was not needed (like rendering a DeviceMenuButton).

## Solution

To fix the problem with the empty sections, now we only store the status of only those tree entries that have children. So we do not longer confuse a closed entry with an empty one.

To fix the calls to `#save_open_items` we have introduced a new mixin that is used by all the widgets that produce an UI redrawing, so they all share the code for saving the status.

## Testing

- Tested manually so far
- Added one more unit test (+0.01 coverage)