### PR TITLE
Allow to create multi-device Btrfs

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed May  8 11:59:39 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: added option for creating Btrfs filesystems (single-
+  and multidevice).
+- Partitioner: added option for editing devices used by a Btrfs.
+- Part of jsc#SLE-3877.
+- 4.2.13
+
+-------------------------------------------------------------------
 Thu May  2 09:49:02 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Partitioner: fix the Btrfs filesystem icon used in "Type" column.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.2.12
+Version:	4.2.13
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -26,8 +26,8 @@ Source:		%{name}-%{version}.tar.bz2
 Requires:	yast2 >= 4.1.11
 # for AbortException and handle direct abort
 Requires:	yast2-ruby-bindings >= 4.0.6
-# Bcache#remove_bcache_cset
-Requires:	libstorage-ng-ruby >= 4.1.89
+# Multidevice Btrfs
+Requires:	libstorage-ng-ruby >= 4.1.118
 # communicate with udisks
 Requires:	rubygem(ruby-dbus)
 # Y2Packager::Repository
@@ -36,8 +36,8 @@ Requires:	yast2-packager >= 3.3.7
 Requires:	findutils
 
 BuildRequires:	update-desktop-files
-# Bcache#remove_bcache_cset
-BuildRequires:	libstorage-ng-ruby >= 4.1.89
+# Multidevice Btrfs
+BuildRequires:	libstorage-ng-ruby >= 4.1.118
 BuildRequires:	yast2-ruby-bindings
 BuildRequires:	yast2-devtools
 # yast2-xml dependency is added by yast2 but ignored in the

--- a/src/lib/y2partitioner/actions/add_btrfs.rb
+++ b/src/lib/y2partitioner/actions/add_btrfs.rb
@@ -1,0 +1,99 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast2/popup"
+require "y2partitioner/actions/transaction_wizard"
+require "y2partitioner/actions/controllers/filesystem"
+require "y2partitioner/actions/controllers/btrfs_devices"
+require "y2partitioner/dialogs/btrfs_devices"
+require "y2partitioner/dialogs/btrfs_options"
+
+module Y2Partitioner
+  module Actions
+    # Action for creating a new Btrfs filesystem (sigle or multidevice)
+    class AddBtrfs < TransactionWizard
+      # Constructor
+      def initialize
+        super
+
+        textdomain "storage"
+      end
+
+      # Wizard step to select the devices used for creating the Btrfs
+      #
+      # The metadata and data RAID levels can be also selected.
+      #
+      # @see Dialogs::BtrfsDevices
+      def devices
+        Dialogs::BtrfsDevices.run(controller)
+      end
+
+      # Wizard step to select the filesystem options (mount point, subvolumes, snapshots, etc)
+      #
+      # @see Dialogs::BtrfsOptions
+      def options
+        fs_controller = Controllers::Filesystem.new(controller.filesystem, title)
+
+        Dialogs::BtrfsOptions.run(fs_controller)
+      end
+
+    protected
+
+      # @return Controllers::BtrfsDevices
+      attr_reader :controller
+
+      # @see TransactionWizard
+      def sequence_hash
+        {
+          "ws_start" => "devices",
+          "devices"  => { next: "options" },
+          "options"  => { next: :finish }
+        }
+      end
+
+      # @see TransactionWizard
+      def init_transaction
+        # The controller object must be created within the transaction
+        @controller = Controllers::BtrfsDevices.new(wizard_title: title)
+      end
+
+      # Wizard title
+      #
+      # @return [String]
+      def title
+        # TRANSLATORS: wizard title when creating a new Btrfs filesystem.
+        _("Add Btrfs")
+      end
+
+      # @see TransactionWizard
+      def run?
+        return true if controller.available_devices.any?
+
+        # TRANSLATORS: error message
+        error = _("There are not enough suitable unused devices to create a Btrfs.")
+
+        Yast2::Popup.show(error, headline: :error)
+        false
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/actions/controllers/available_devices.rb
+++ b/src/lib/y2partitioner/actions/controllers/available_devices.rb
@@ -1,0 +1,142 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Partitioner
+  module Actions
+    module Controllers
+      # Mixin offering method to query all available block devices from a devicegraph
+      #
+      # In this context, an available device means that it is not currently being
+      # used by another device (e.g., RAID, LVM VG, etc). In case the device is
+      # directly formatted, it is also considered as available if the filesystem is
+      # not mounted.
+      module AvailableDevices
+        # Method to query all available block devices from a devicegraph
+        #
+        # A block can be given to filter the list of available devices.
+        #
+        # @param devicegraph [Y2Storage::Devicegraph]
+        # @yield [Y2Storage::BlkDevice]
+        #
+        # @return [Array<Y2Storage::BlkDevice>]
+        def available_devices(devicegraph, &block)
+          finder = Finder.new(devicegraph)
+
+          finder.available_devices(&block)
+        end
+
+        # Helper class to find available devices
+        class Finder
+          # Constructor
+          #
+          # @param devicegraph [Y2Storage::Devicegraph]
+          def initialize(devicegraph)
+            @devicegraph = devicegraph
+          end
+
+          # All available devices
+          #
+          # A block can be given to filter the list of available devices.
+          #
+          # @see #available_device?
+          #
+          # @yield [Y2Storage::BlkDevice]
+          # @return [Array<Y2Storage::BlkDevice>]
+          def available_devices(&block)
+            devices = all_devices.select { |d| available_device?(d) }
+
+            return devices unless block_given?
+
+            devices.select { |d| block.call(d) }
+          end
+
+        private
+
+          # @return [Controllers::BtrfsDevices]
+          attr_reader :devicegraph
+
+          # All block devices
+          #
+          # @return [Array<Y2Storage::BlkDevice>]
+          def all_devices
+            devicegraph.blk_devices
+          end
+
+          # Whether the given device is available
+          #
+          # A device is available when it is not used by another device (e.g., RAID),
+          # its filesystem is not mounted, it is not partitioned and it is not a
+          # zero-sized device.
+          #
+          # @param device [Y2Storage::BlkDevice]
+          # @return [Boolean]
+          def available_device?(device)
+            !used?(device) &&
+              !formatted_and_mounted?(device) &&
+              !partitions?(device) &&
+              !extended_partition?(device) &&
+              !zero_size?(device)
+          end
+
+          # Whether the device is already in use (e.g., as LVM PV, as RAID disk, etc)
+          #
+          # @param device [Y2Storage::BlkDevice]
+          # @return [Boolean]
+          def used?(device)
+            device.component_of.any?
+          end
+
+          # Whether the device is formatted and mounted
+          #
+          # @param device [Y2Storage::BlkDevice]
+          # @return [Boolean]
+          def formatted_and_mounted?(device)
+            device.formatted? && device.filesystem.mount_point
+          end
+
+          # Whether the device has partitions
+          #
+          # @param device [Y2Storage::BlkDevice]
+          # @return [Boolean]
+          def partitions?(device)
+            device.respond_to?(:partitions) && device.partitions.any?
+          end
+
+          # Whether the device is an extended partition
+          #
+          # @param device [Y2Storage::BlkDevice]
+          # @return [Boolean]
+          def extended_partition?(device)
+            device.is?(:partition) && device.type.is?(:extended)
+          end
+
+          # Whether the device is a zero-sized device
+          #
+          # @param device [Y2Storage::BlkDevice]
+          # @return [Boolean]
+          def zero_size?(device)
+            device.size.zero?
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/actions/controllers/btrfs_devices.rb
+++ b/src/lib/y2partitioner/actions/controllers/btrfs_devices.rb
@@ -137,11 +137,17 @@ module Y2Partitioner
         # Adds a device to the Btrfs
         #
         # If the filesystem does not exist, a new one is created when adding the first device.
-        # Any previous children (like filesystems) is removed from the device.
+        #
+        # Any previous children (like filesystems) are removed from the device (only encryption layer
+        # is preserved).
         #
         # @param device [Y2Storage::BlkDevice]
         def add_device(device)
+          # When the selected device is a partition, its partition id is set to linux.
+          device.id = Y2Storage::PartitionId::LINUX if device.is?(:partition)
+
           device = device.encryption if device.encrypted?
+
           device.remove_descendants
 
           if filesystem.nil?

--- a/src/lib/y2partitioner/actions/controllers/btrfs_devices.rb
+++ b/src/lib/y2partitioner/actions/controllers/btrfs_devices.rb
@@ -1,0 +1,237 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage"
+require "y2partitioner/device_graphs"
+require "y2partitioner/ui_state"
+require "y2partitioner/blk_device_restorer"
+require "y2partitioner/actions/controllers/available_devices"
+
+module Y2Partitioner
+  module Actions
+    module Controllers
+      # Controller class to deal with all stuff related to adding or removing devices to
+      # a Btrfs filesystem
+      class BtrfsDevices
+        include Yast::I18n
+
+        include AvailableDevices
+
+        # @return [Y2Storage::Filesystems::Btrfs]
+        attr_reader :filesystem
+
+        # @return [String]
+        attr_reader :wizard_title
+
+        # Constructor
+        #
+        # If the filesystem is not given, then a new one is created when the first device is selected.
+        #
+        # @param filesystem [Y2Storage::Filesystems::Btrfs]
+        # @param wizard_title [String]
+        def initialize(filesystem: nil, wizard_title: "")
+          textdomain "storage"
+
+          @filesystem = filesystem
+          @wizard_title = wizard_title
+
+          @metadata_raid_level = Y2Storage::BtrfsRaidLevel::DEFAULT
+          @data_raid_level = Y2Storage::BtrfsRaidLevel::DEFAULT
+
+          UIState.instance.select_row(filesystem) if filesystem
+        end
+
+        # Metadata RAID level for the filesystem
+        #
+        # @return [Y2Storage::BtrfsRaidLevel]
+        def metadata_raid_level
+          raid_level(:metadata)
+        end
+
+        # Data RAID level for the filesystem
+        #
+        # @return [Y2Storage::BtrfsRaidLevel]
+        def data_raid_level
+          raid_level(:data)
+        end
+
+        # Sets the metadata RAID level for the filesystem
+        #
+        # @param value [Y2Storage::BtrfsRaidLevel]
+        def metadata_raid_level=(value)
+          save_raid_level(:metadata, value)
+        end
+
+        # Sets the data RAID level for the filesystem
+        #
+        # @param value [Y2Storage::BtrfsRaidLevel]
+        def data_raid_level=(value)
+          save_raid_level(:data, value)
+        end
+
+        # All possible RAID levels
+        #
+        # Btrfs requires a minimum number of devices for some RAID levels
+        #
+        # @return [Array<Y2Storage::BtrfsRaidLevel>]
+        def raid_levels
+          [
+            Y2Storage::BtrfsRaidLevel::DEFAULT,
+            Y2Storage::BtrfsRaidLevel::SINGLE,
+            Y2Storage::BtrfsRaidLevel::DUP,
+            Y2Storage::BtrfsRaidLevel::RAID0,
+            Y2Storage::BtrfsRaidLevel::RAID1,
+            Y2Storage::BtrfsRaidLevel::RAID10
+          ]
+        end
+
+        # Allowed RAID levels depending on the selected devices
+        #
+        # @param data [:metadata, :data]
+        # @return [Array<Y2Storage::BtrfsRaidLevel>]
+        def allowed_raid_levels(data)
+          raid_levels = [Y2Storage::BtrfsRaidLevel::DEFAULT]
+
+          raid_levels += filesystem.send("allowed_#{data}_raid_levels")
+
+          raid_levels - forbidden_raid_levels
+        end
+
+        # Devices that can be selected for being used by the Btrfs
+        #
+        # @see AvailableDevices
+        #
+        # @return [Array<Y2Storage::BlkDevice>]
+        def available_devices
+          super(current_graph) { |d| valid_device?(d) }
+        end
+
+        # Devices used by the Btrfs
+        #
+        # @return [Array<Y2Storage::BlkDevice>]
+        def selected_devices
+          return [] unless filesystem
+
+          filesystem.plain_blk_devices
+        end
+
+        # Adds a device to the Btrfs
+        #
+        # If the filesystem does not exist, a new one is created when adding the first device.
+        # Any previous children (like filesystems) is removed from the device.
+        #
+        # @param device [Y2Storage::BlkDevice]
+        def add_device(device)
+          device = device.encryption if device.encrypted?
+          device.remove_descendants
+
+          if filesystem.nil?
+            create_filesystem(device)
+          else
+            filesystem.add_device(device)
+          end
+        end
+
+        # Removes a device from the Btrfs
+        #
+        # @param device [Y2Storage::BlkDevice]
+        def remove_device(device)
+          device = device.encryption if device.encrypted?
+          filesystem.remove_device(device)
+          BlkDeviceRestorer.new(device.plain_device).restore_from_checkpoint
+        end
+
+      private
+
+        # Helper method to get the RAID level (metadata or data)
+        #
+        # @param data [:metadata, :data]
+        # @return [Y2Storage::BtrfsRaidLevel]
+        def raid_level(data)
+          # When the filesystem does not exist yet, the value is taken from the class attribute.
+          # Otherwise, the filesystem value is taken.
+          return instance_variable_get("@#{data}_raid_level") unless filesystem
+
+          filesystem.send("#{data}_raid_level")
+        end
+
+        # Helper method to set the RAID level (metadata or data)
+        #
+        # @param data [:metadata, :data]
+        # @param value [Y2Storage::BtrfsRaidLevel]
+        def save_raid_level(data, value)
+          if filesystem
+            filesystem.send("#{data}_raid_level=", value)
+          else
+            instance_variable_set("@#{data}_raid_level", value)
+          end
+        end
+
+        # Forbidden RAID levels
+        #
+        # RAID5 and RAID6 are not offered because Btrfs does not fully support them.
+        #
+        # @return [Array<Y2Storage::BtrfsRaidLevel>]
+        def forbidden_raid_levels
+          [Y2Storage::BtrfsRaidLevel::RAID5, Y2Storage::BtrfsRaidLevel::RAID6]
+        end
+
+        # Whether the available device is valid for being used by the Btrfs
+        #
+        # @param device [Y2Storage::BlkDevice]
+        # @return [Boolean]
+        def valid_device?(device)
+          !device.is?(:encryption) && !selected_device?(device)
+        end
+
+        # Whether the device is already selected for being used by the Btrfs
+        #
+        # @param device [Y2Storage::BlkDevice]
+        # @return [Boolean]
+        def selected_device?(device)
+          selected_devices.include?(device)
+        end
+
+        # Creates a Btrfs filesystem over the given device
+        #
+        # @param device [Y2Storage::BlkDevice]
+        # @return [Y2Storage::Filesystems::Btrfs]
+        def create_filesystem(device)
+          filesystem = device.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
+          filesystem.metadata_raid_level = @metadata_raid_level
+          filesystem.data_raid_level = @data_raid_level
+
+          UIState.instance.select_row(filesystem)
+
+          @filesystem = filesystem
+        end
+
+        # Current devicegraph
+        #
+        # @return [Y2Storage::Devicegraph]
+        def current_graph
+          DeviceGraphs.instance.current
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/actions/controllers/md.rb
+++ b/src/lib/y2partitioner/actions/controllers/md.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -24,6 +24,7 @@ require "y2storage"
 require "y2partitioner/device_graphs"
 require "y2partitioner/ui_state"
 require "y2partitioner/blk_device_restorer"
+require "y2partitioner/actions/controllers/available_devices"
 
 module Y2Partitioner
   module Actions
@@ -33,6 +34,9 @@ module Y2Partitioner
       # dialogs can always work directly on a real Md object in the devicegraph.
       class Md
         include Yast::I18n
+
+        include AvailableDevices
+
         extend Forwardable
 
         def_delegators :md, :md_level, :md_level=, :md_name,
@@ -68,9 +72,9 @@ module Y2Partitioner
         #
         # @return [Array<Y2Storage::BlkDevice>]
         def available_devices
-          # StrayBlkDevice not offered. They are used for very concrete
-          # use cases in which RAID makes probably no sense.
-          (available_disks + available_partitions).sort { |a, b| a.compare_by_name(b) }
+          devices = super(working_graph) { |d| valid_device?(d) }
+
+          devices.sort { |a, b| a.compare_by_name(b) }
         end
 
         # Partitions that are already part of the MD array, sorted by position
@@ -258,53 +262,42 @@ module Y2Partitioner
           md
         end
 
-        # Partitions to be offered as "Available Devices" in the UI
-        #
-        # @return [Array<Y2Storage::Partition]
-        def available_partitions
-          working_graph.partitions.select { |d| valid_for_md?(d) && available?(d) }
-        end
-
-        # Disk-like devices to be offered as "Available Devices" in the UI
-        #
-        # @return [Array<Y2Storage::BlkDevice]
-        def available_disks
-          disks = working_graph.disk_devices.select { |i| i.is?(:disk, :multipath) }
-          disks.select { |d| d.partitions.empty? && available?(d) }
-        end
-
-        # Whether the partition is valid to be used in a MD RAID
-        #
-        # @note An available partition (see {#available?}) is valid to be used
-        #   in a MD RAID if it is not a based on another RAID, it is not
-        #   extended and it is a linux system partition.
-        #
-        # The reasons to filter RAID partitions out (basically possible
-        # complications with booting and/or auto-assembling) are explained in
-        # doc/sle15_features_in_partitioner.md.
-        #
-        # @param partition [Y2Storage::Partition]
-        # @return [Boolean] true if it is valid; false otherwise.
-        def valid_for_md?(partition)
-          partition.id.is?(:linux_system) &&
-            !partition.type.is?(:extended) &&
-            !partition.partitionable.is?(:raid)
-        end
-
-        # Whether the device is available to be used in a MD RAID
-        #
-        # A device is available if it is not already used by a RAID or
-        # used as physical volume or assigned to a mount point.
-        #
-        # @note This method does not check if the device is suitable (correct
-        # type, etc.), only if it's not already in use.
+        # Whether an available device is valid to be used in a MD RAID
         #
         # @param device [Y2Storage::BlkDevice]
-        # @return [Boolean] true if can be used for a MD RAID; false otherwise.
-        def available?(device)
-          return false unless device.component_of.empty?
+        # @return [Boolean]
+        def valid_device?(device)
+          if device.is?(:partition)
+            valid_partition_for_md?(device)
+          else
+            valid_device_for_md?(device)
+          end
+        end
 
-          device.filesystem.nil? || device.filesystem.mount_point.nil?
+        # Whether an available partition is valid to be used in a MD RAID
+        #
+        # The partition can be used if its id is linux, lvm, swap or raid, and it is not created over a
+        # RAID.
+        #
+        # The reasons to filter RAID partitions out (basically possible complications with booting and/or
+        # auto-assembling) are explained in doc/sle15_features_in_partitioner.md.
+        #
+        # @param partition [Y2Storage::Partition]
+        # @return [Boolean]
+        def valid_partition_for_md?(partition)
+          partition.id.is?(:linux_system) && !partition.partitionable.is?(:raid)
+        end
+
+        # Whether an available device is valid to be used in a MD RAID
+        #
+        # The device can be used if its has a proper type.
+        #
+        # @param device [Y2Storage::BlkDevice]
+        # @return [Boolean]
+        def valid_device_for_md?(device)
+          # StrayBlkDevice are not offered. They are used for very concrete
+          # use cases in which RAID makes probably no sense.
+          device.is?(:disk, :multipath)
         end
 
         def min_chunk_size

--- a/src/lib/y2partitioner/actions/edit_btrfs_devices.rb
+++ b/src/lib/y2partitioner/actions/edit_btrfs_devices.rb
@@ -1,0 +1,135 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast2/popup"
+require "y2partitioner/actions/transaction_wizard"
+require "y2partitioner/actions/controllers/btrfs_devices"
+require "y2partitioner/dialogs/btrfs_devices"
+require "y2partitioner/device_graphs"
+
+Yast.import "Popup"
+
+module Y2Partitioner
+  module Actions
+    # Action for editing the devices of a Btrfs filesystem
+    class EditBtrfsDevices < TransactionWizard
+      # Constructor
+      #
+      # @param filesystem [Y2Storage::Filesystems::Btrfs]
+      def initialize(filesystem)
+        super()
+        textdomain "storage"
+
+        @device_sid = filesystem.sid
+      end
+
+      # Calls the dialog for editing the devices (and metadata/data RAID levels)
+      #
+      # @return [Symbol]
+      def devices
+        Dialogs::BtrfsDevices.run(controller)
+      end
+
+    private
+
+      # @return [Controllers::BtrfsDevices]
+      attr_reader :controller
+
+      alias_method :filesystem, :device
+
+      # @see TransactionWizard
+      def sequence_hash
+        {
+          "ws_start" => "devices",
+          "devices"  => { next: :finish }
+        }
+      end
+
+      # @see TransactionWizard
+      def init_transaction
+        # The controller object must be created within the transaction
+        @controller = Controllers::BtrfsDevices.new(filesystem: filesystem, wizard_title: title)
+      end
+
+      # Wizard title
+      #
+      # @return [String]
+      def title
+        format(_("Edit devices of Btrfs %{name}"), name: filesystem.blk_device_basename)
+      end
+
+      # Whether it is possible to edit the used devices
+      #
+      # An error popup is shown when the filesystem already exists on disk.
+      #
+      # @see TransactionWizard
+      #
+      # @return [Boolean]
+      def run?
+        current_errors = errors
+
+        return true if current_errors.none?
+
+        message = current_errors.join("\n\n")
+
+        Yast2::Popup.show(message, headline: :error)
+        false
+      end
+
+      # Errors that avoid to edit the devices
+      #
+      # @return [Array<String>]
+      def errors
+        [committed_error].compact
+      end
+
+      # Error the filesystem exists on disk
+      #
+      # @return [String, nil] nil if the filesystem does not exist on disk yet.
+      def committed_error
+        return nil unless committed?
+
+        # TRANSLATORS: error message, where %{name} is replaced by a device base name (e.g., sda1)
+        format(
+          _("The Btrfs %{name} is already created on disk and its used devices\n" \
+            "cannot be modified. To modify the used devices, remove the Btrfs\n" \
+            "and create it again."),
+          name: filesystem.blk_device_basename
+        )
+      end
+
+      # Whether the filesystem is already created on disk
+      #
+      # @return [Boolean]
+      def committed?
+        filesystem.exists_in_devicegraph?(system_graph)
+      end
+
+      # Devicegraph representing the system status
+      #
+      # @return [Y2Storage::Devicegraph]
+      def system_graph
+        Y2Partitioner::DeviceGraphs.instance.system
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/actions/resize_blk_device.rb
+++ b/src/lib/y2partitioner/actions/resize_blk_device.rb
@@ -109,13 +109,13 @@ module Y2Partitioner
         return nil if using_devs.empty?
 
         format(
-          # TRANSLATORS: %{name} is replaced by a device name (e.g., /dev/sda1).
-          # and %{users} is replaced by a comma-separated list of name devices
-          # (devices using the first one).
-          _("The device %{name} is in use (%{users}).\n" \
+          # TRANSLATORS: %{name} is replaced by a device name (e.g., /dev/sda1) and %{users} is replaced
+          # by a list of name devices (devices using the first one).
+          _("The device %{name} is being used by:\n" \
+            "%{users}\n\n" \
             "It cannot be resized.\n" \
             "To resize %{name}, make sure it is not used."),
-          name: device.name, users: using_devs.join(", ")
+          name: device.name, users: using_devs.join("\n")
         )
       end
 

--- a/src/lib/y2partitioner/blk_device_restorer.rb
+++ b/src/lib/y2partitioner/blk_device_restorer.rb
@@ -32,6 +32,8 @@ module Y2Partitioner
   # restores the filesystem or the empty partition table that was associated
   # to the device when it was initially added to the MD or LVM).
   class BlkDeviceRestorer
+    include Yast::Logger
+
     # Target device
     #
     # This device must be associated to the current devicegraph (see

--- a/src/lib/y2partitioner/confirm_recursive_delete.rb
+++ b/src/lib/y2partitioner/confirm_recursive_delete.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -119,9 +119,7 @@ module Y2Partitioner
     # @param device [Y2Storage::Device] device to delete
     # @return [Array<String>] name of dependent devices
     def dependent_devices(device)
-      device.descendants.map do |dev|
-        dev.name if dev.respond_to?(:name)
-      end.compact
+      device.descendants.map(&:display_name).compact
     end
   end
 end

--- a/src/lib/y2partitioner/dialogs/bcache.rb
+++ b/src/lib/y2partitioner/dialogs/bcache.rb
@@ -163,9 +163,7 @@ module Y2Partitioner
         end
 
         def item_for_device(device)
-          label = device.is?(:bcache_cset) ? device.display_name : device.name
-
-          [device.sid.to_s, label]
+          [device.sid.to_s, device.display_name]
         end
       end
 

--- a/src/lib/y2partitioner/dialogs/btrfs_devices.rb
+++ b/src/lib/y2partitioner/dialogs/btrfs_devices.rb
@@ -1,0 +1,61 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2partitioner/dialogs/base"
+require "y2partitioner/widgets/btrfs_devices"
+
+module Y2Partitioner
+  module Dialogs
+    # Dialog to set the Btrfs devices and the metadata/data RAID levels
+    class BtrfsDevices < Base
+      # @param controller [Actions::Controllers::BtrfsDevices]
+      def initialize(controller)
+        super()
+
+        textdomain "storage"
+
+        @controller = controller
+      end
+
+      # @macro seeDialog
+      def title
+        @controller.wizard_title
+      end
+
+      # @macro seeDialog
+      def contents
+        VBox(btrfs_devices_widget)
+      end
+
+    private
+
+      # @return [Actions::Controllers::BtrfsDevices]
+      attr_reader :controller
+
+      # Widget to select devices and metadata/data RAID levels
+      #
+      # @return [Widgets::BtrfsDevices]
+      def btrfs_devices_widget
+        @btrfs_devices_widget ||= Widgets::BtrfsDevices.new(controller)
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -339,7 +339,7 @@ module Y2Partitioner
       def lvm_pv_type_label(device)
         vg = device.lvm_vg
 
-        return _("Orphan PV") if vg.nil?
+        return _("Unused LVM PV") if vg.nil?
         return _("PV of LVM") if vg.basename.empty?
 
         # TRANSLATORS: %s is the volume group name. E.g., "vg0"

--- a/src/lib/y2partitioner/widgets/btrfs_add_button.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_add_button.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm"
+require "y2partitioner/actions/add_btrfs"
+require "y2partitioner/widgets/execute_and_redraw"
+
+module Y2Partitioner
+  module Widgets
+    # Button for opening a wizard to add a new Bcache device
+    class BtrfsAddButton < CWM::PushButton
+      include ExecuteAndRedraw
+
+      # Constructor
+      def initialize
+        textdomain "storage"
+      end
+
+      # @macro seeAbstractWidget
+      def label
+        # TRANSLATORS: button label to add a new Bcache device
+        _("Add Btrfs...")
+      end
+
+      # @macro seeAbstractWidget
+      # @see Actions::AddBcache
+      def handle
+        execute_and_redraw { Actions::AddBtrfs.new.run }
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/btrfs_data_raid_level.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_data_raid_level.rb
@@ -1,0 +1,77 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm"
+require "y2storage/btrfs_raid_level"
+
+module Y2Partitioner
+  module Widgets
+    # Widget to select the data RAID level for a Btrfs filesystem
+    class BtrfsDataRaidLevel < CWM::ComboBox
+      # Constructor
+      #
+      # @param controller [Actions::Controllers::BtrfsDevices]
+      def initialize(controller)
+        textdomain "storage"
+
+        @controller = controller
+      end
+
+      # @macro seeAbstractWidget
+      def label
+        # TRANSLATORS: widget label
+        _("Data RAID Level")
+      end
+
+      # @macro seeAbstractWidget
+      def help
+        # TRANSLATORS: widget help, where %{label} is replaced by the label of the widget.
+        format(
+          _("<p><b>%{label}:</b> RAID level for the Btrfs data.</p>"),
+          label: label
+        )
+      end
+
+      # @macro seeAbstractWidget
+      def opt
+        [:notify]
+      end
+
+      # @macro seeAbstractWidget
+      def items
+        @controller.raid_levels.map { |p| [p.to_s, p.to_human_string] }
+      end
+
+      # @macro seeAbstractWidget
+      def init
+        self.value = @controller.data_raid_level.to_s
+      end
+
+      # @macro seeAbstractWidget
+      def handle
+        @controller.data_raid_level = Y2Storage::BtrfsRaidLevel.find(value)
+
+        nil
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/btrfs_data_raid_level.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_data_raid_level.rb
@@ -39,7 +39,7 @@ module Y2Partitioner
       # @macro seeAbstractWidget
       def label
         # TRANSLATORS: widget label
-        _("Data RAID Level")
+        _("RAID Level")
       end
 
       # @macro seeAbstractWidget

--- a/src/lib/y2partitioner/widgets/btrfs_devices.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_devices.rb
@@ -1,0 +1,228 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast2/popup"
+require "cwm"
+require "y2partitioner/widgets/btrfs_metadata_raid_level"
+require "y2partitioner/widgets/btrfs_data_raid_level"
+require "y2partitioner/widgets/btrfs_devices_selector"
+
+module Y2Partitioner
+  module Widgets
+    # Widget grouping a set of widgets related to the selection of Btrfs devices
+    #
+    # It contains widgets to select the metadata/data RAID levels and also to select the devices
+    # used by the filesystem.
+    class BtrfsDevices < CWM::CustomWidget
+      # Constructor
+      #
+      # @param controller [Actions::Controllers::BtrfsDevices]
+      def initialize(controller)
+        textdomain "storage"
+
+        @controller = controller
+      end
+
+      # @macro seeCustomWidget
+      def contents
+        VBox(
+          Left(
+            HVSquash(
+              HBox(
+                metadata_raid_level_widget,
+                HSpacing(1),
+                data_raid_level_widget
+              )
+            )
+          ),
+          VSpacing(1),
+          btrfs_devices_selector_widget
+        )
+      end
+
+      # @macro seeCustomWidget
+      def help
+        help_for_raid_levels + help_for_default_raid_level
+      end
+
+      # @macro seeAbstractWidget
+      #
+      # Validates the selected values
+      #
+      # An error popup is shown when there are errors in the selected values.
+      #
+      # @return [Boolean]
+      def validate
+        current_errors = errors
+        return true if current_errors.none?
+
+        message = current_errors.join("\n\n")
+        Yast2::Popup.show(message, headline: :error)
+
+        false
+      end
+
+    private
+
+      # @return [Actions::Controllers::BtrfsDevices]
+      attr_reader :controller
+
+      # Widget to select the metadata RAID level
+      #
+      # @return [Widgets::BtrfsMetadataRaidLevel]
+      def metadata_raid_level_widget
+        @metadata_raid_level_widget ||= Widgets::BtrfsMetadataRaidLevel.new(controller)
+      end
+
+      # Widget to select the data RAID level
+      #
+      # @return [Widgets::BtrfsDataRaidLevel]
+      def data_raid_level_widget
+        @data_raid_level_widget ||= Widgets::BtrfsDataRaidLevel.new(controller)
+      end
+
+      # Widget to select devices used by the filesystem
+      #
+      # @return [Widgets::BtrfsDevicesSelector]
+      def btrfs_devices_selector_widget
+        @btrfs_devices_widget ||= Widgets::BtrfsDevicesSelector.new(controller)
+      end
+
+      # Btrfs RAID levels help
+      #
+      # @return [String]
+      def help_for_raid_levels
+        _("<h4><b>Btrfs RAID levels</b></h4>" \
+          "<p> Btrfs supports the following RAID levels for both, metadata and data:" \
+            "<ul>" \
+              "<li>" \
+                "<b>DUP:</b> stores two copies of each piece of data on the same device. " \
+                "This is similar to RAID1, and protects against block-level errors on the device, " \
+                "but does not provide any guarantees if the device fails. Only one device must be " \
+                "be selected to use DUP." \
+              "</li>" \
+              "<li>" \
+                "<b>SINGLE:</b> stores a single copy of each piece of data. Btrfs requires a minimum " \
+                "of one device to use SINGLE." \
+              "</li>" \
+              "<li>" \
+                "<b>RAID0:</b> provides no form of error recovery, but stripes a " \
+                "single copy of data across multiple devices for performance purpose. Btrfs requires " \
+                "a minimum of two devices to use RAID0." \
+              "</li>" \
+              "<li>" \
+                "<b>RAID1:</b> stores two complete copies of each piece of data. " \
+                "Each copy is stored on a different device. Btrfs requires a minimum of two devices " \
+                "to use RAID1." \
+              "</li>" \
+              "<li>" \
+                "<b>RAID10:</b> stores two complete copies of each piece of data, and also stripes " \
+                "each copy across multiple devices for performance. Btrfs requires a minimum of five " \
+                "devices to use RAID10" \
+              "</li>" \
+            "</ul>" \
+          "</p>")
+      end
+
+      # Btrfs default RAID level help
+      #
+      # @return [String]
+      def help_for_default_raid_level
+        _("<p>" \
+            "When <b>DEFAULT</b> RAID level is used, Btrfs will select a RAID level depending on " \
+            "whether the filesystem is being created on top of multiple devices or using only one " \
+            "device. For a single-device Btrfs, the tool also will distinguish between rotational " \
+            "or not-rotational devices to choose the default value." \
+          "</p>")
+      end
+
+      # Errors for the selected values
+      #
+      # @return [Array<String>]
+      def errors
+        [
+          metadata_devices_error,
+          data_devices_error
+        ].compact
+      end
+
+      # Error when the selected metadata RAID level cannot be used (according to the number of selected
+      # devices)
+      #
+      # @return [String, nil] nil if there is no error
+      def metadata_devices_error
+        raid_level_devices_error(:metadata)
+      end
+
+      # Error when the selected data RAID level cannot be used (according to the number of selected
+      # devices)
+      #
+      # @return [String, nil] nil if there is no error
+      def data_devices_error
+        raid_level_devices_error(:data)
+      end
+
+      # Helper method to get the metadata/data error according to the number of selected devices.
+      #
+      # @param data [:metadata, :data]
+      # @return [String, nil]
+      def raid_level_devices_error(data)
+        return nil unless filesystem
+
+        allowed_raid_levels = allowed_raid_levels(data)
+        selected_raid_level = selected_raid_level(data)
+
+        return nil if allowed_raid_levels.include?(selected_raid_level)
+
+        format(
+          _("According to the selected devices, only the following %{data}\n" \
+            "RAID levels can be used: %{levels}."),
+          data:   data.to_s,
+          levels: allowed_raid_levels.map(&:to_human_string).join(", ")
+        )
+      end
+
+      # RAID levels that can be used according to the selected devices
+      #
+      # @param data [:metadata, :data]
+      # @return [Array<Y2Storage::BtrfsRaidLevel>]
+      def allowed_raid_levels(data)
+        controller.allowed_raid_levels(data)
+      end
+
+      # RAID level currently selected
+      #
+      # @param data [:metadata, :data]
+      # @return [Y2Storage::BtrfsRaidLevel]
+      def selected_raid_level(data)
+        controller.send("#{data}_raid_level")
+      end
+
+      # Current filesystem
+      #
+      # @return [Y2Storage::Filesystems::Btrfs]
+      def filesystem
+        controller.filesystem
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/btrfs_devices_selector.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_devices_selector.rb
@@ -1,0 +1,146 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast2/popup"
+require "y2partitioner/widgets/devices_selection"
+
+Yast.import "Popup"
+
+module Y2Partitioner
+  module Widgets
+    # Widget making possible to add and remove devices to a Btrfs filesystem
+    class BtrfsDevicesSelector < Widgets::DevicesSelection
+      # Constructor
+      #
+      # @param controller [Actions::Controllers::BtrfsDevices]
+      def initialize(controller)
+        @controller = controller
+        super()
+
+        textdomain "storage"
+      end
+
+      # @macro seeCustomWidget
+      def help
+        help_for_available_devices + help_for_selected_devices
+      end
+
+      # @see Widgets::DevicesSelection#selected
+      def selected
+        controller.selected_devices
+      end
+
+      # @see Widgets::DevicesSelection#unselected
+      def unselected
+        controller.available_devices
+      end
+
+      # @see Widgets::DevicesSelection#select
+      def select(sids)
+        filter_devices(unselected, sids).each do |device|
+          controller.add_device(device)
+        end
+      end
+
+      # @see Widgets::DevicesSelection#unselect
+      def unselect(sids)
+        filter_devices(selected, sids).each do |device|
+          controller.remove_device(device)
+        end
+      end
+
+      # Returns nil to not show the selected size (makes non sense for Btrfs)
+      def selected_size
+        nil
+      end
+
+      # Returns nil to not show the unselected size (for UI uniformity because the selected size is
+      # not shown either)
+      def unselected_size
+        nil
+      end
+
+      # @macro seeAbstractWidget
+      #
+      # Validates the selected devices
+      #
+      # An error popup is shown when there is some error in selected devices.
+      #
+      # @return [Boolean]
+      def validate
+        error = selected_devices_error
+        return true unless error
+
+        Yast2::Popup.show(error, headline: :error, buttons: :ok)
+
+        false
+      end
+
+    private
+
+      # @return [Actions::Controllers::BtrfsDevices]
+      attr_reader :controller
+
+      # Help text for the available devices
+      #
+      # @return [String]
+      def help_for_available_devices
+        # TRANSLATORS: help text, where %{label} is a widget label
+        format(
+          _("<p><b>%{label}</b> Unused devices that can be used for a Btrfs filesystem.</p>"),
+          label: unselected_label
+        )
+      end
+
+      # Help text for the selected devices
+      #
+      # @return [String]
+      def help_for_selected_devices
+        # TRANSLATORS: help text, where %{label} is a widget label
+        format(
+          _("<p><b>%{label}</b> Devices selected to be part of the Btrfs.</p>"),
+          label: selected_label
+        )
+      end
+
+      # Error when there are no selected devices
+      #
+      # @return [String, nil] nil when at least one device is selected
+      def selected_devices_error
+        return nil if controller.selected_devices.any?
+
+        # TRANSLATORS: Error message when no device is selected
+        _("Select at least one device.")
+      end
+
+      # Filters devices with the given sids
+      #
+      # @param devices [Array<Y2Storage::BlkDevice>]
+      # @param sids [Array<Integer>]
+      #
+      # @return [Array<Y2Storage::BlkDevice>]
+      def filter_devices(devices, sids)
+        devices.select { |d| sids.include?(d.sid) }
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/btrfs_filesystems_table.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_filesystems_table.rb
@@ -44,15 +44,15 @@ module Y2Partitioner
       #
       # @return [Array<Symbol>]
       def fs_columns
-        [:btrfs_devices, :mount_point, :label, :uuid]
+        [:btrfs_id, :mount_point, :label, :btrfs_devices, :uuid]
       end
 
       # Column label
       #
       # @return [String]
-      def btrfs_devices_title
+      def btrfs_id_title
         # TRANSLATORS: label of a table column
-        _("Devices")
+        _("Id")
       end
 
       # Column label
@@ -66,9 +66,33 @@ module Y2Partitioner
       # Column label
       #
       # @return [String]
+      def btrfs_devices_title
+        # TRANSLATORS: label of a table column
+        _("Devices")
+      end
+
+      # Column label
+      #
+      # @return [String]
       def uuid_title
         # TRANSLATORS: label of a table column
         _("UUID")
+      end
+
+      # Column value
+      #
+      # @param filesystem [Y2Storage::Filesystems::Btrfs]
+      # @return [String] e.g., "sda1" or "(sda1...)"
+      def btrfs_id_value(filesystem)
+        filesystem.blk_device_basename
+      end
+
+      # Column value
+      #
+      # @param filesystem [Y2Storage::Filesystems::Btrfs]
+      # @return [String] e.g., "data"
+      def label_value(filesystem)
+        filesystem.label
       end
 
       # Column value
@@ -78,15 +102,7 @@ module Y2Partitioner
       # @param filesystem [Y2Storage::Filesystems::Btrfs]
       # @return [String] e.g., "/dev/sda1, /dev/sda2"
       def btrfs_devices_value(filesystem)
-        filesystem.blk_devices.map(&:name).join(", ")
-      end
-
-      # Column value
-      #
-      # @param filesystem [Y2Storage::Filesystems::Btrfs]
-      # @return [String] e.g., "data"
-      def label_value(filesystem)
-        filesystem.label
+        filesystem.plain_blk_devices.map(&:name).sort.join(", ")
       end
 
       # Column value

--- a/src/lib/y2partitioner/widgets/btrfs_metadata_raid_level.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_metadata_raid_level.rb
@@ -1,0 +1,75 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm"
+require "y2storage/btrfs_raid_level"
+
+module Y2Partitioner
+  module Widgets
+    # Widget to select the metadata RAID level for a Btrfs filesystem
+    class BtrfsMetadataRaidLevel < CWM::ComboBox
+      # @param controller [Actions::Controllers::BtrfsDevices]
+      def initialize(controller)
+        textdomain "storage"
+
+        @controller = controller
+      end
+
+      # @macro seeAbstractWidget
+      def label
+        # TRANSLATORS: widget label
+        _("Metadata RAID Level")
+      end
+
+      # @macro seeAbstractWidget
+      def help
+        # TRANSLATORS: widget help, where %{label} is replaced by the label of the widget.
+        format(
+          _("<p><b>%{label}:</b> RAID level for the Btrfs metadata.</p>"),
+          label: label
+        )
+      end
+
+      # @macro seeAbstractWidget
+      def opt
+        [:notify]
+      end
+
+      # @macro seeAbstractWidget
+      def items
+        @controller.raid_levels.map { |p| [p.to_s, p.to_human_string] }
+      end
+
+      # @macro seeAbstractWidget
+      def init
+        self.value = @controller.metadata_raid_level.to_s
+      end
+
+      # @macro seeAbstractWidget
+      def handle
+        @controller.metadata_raid_level = Y2Storage::BtrfsRaidLevel.find(value)
+
+        nil
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/btrfs_metadata_raid_level.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_metadata_raid_level.rb
@@ -37,7 +37,7 @@ module Y2Partitioner
       # @macro seeAbstractWidget
       def label
         # TRANSLATORS: widget label
-        _("Metadata RAID Level")
+        _("RAID Level for Metadata")
       end
 
       # @macro seeAbstractWidget

--- a/src/lib/y2partitioner/widgets/btrfs_modify_button.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_modify_button.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2018-2019] SUSE LLC
+# Copyright (c) [2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,16 +20,14 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "y2partitioner/widgets/device_button"
-require "y2partitioner/actions/edit_md_devices"
+require "y2partitioner/widgets/device_menu_button"
+require "y2partitioner/actions/edit_btrfs"
 require "y2partitioner/actions/edit_btrfs_devices"
-
-Yast.import "Popup"
 
 module Y2Partitioner
   module Widgets
-    # Button for editing the used devices (e.g., by a Software RAID)
-    class UsedDevicesEditButton < DeviceButton
+    # Menu button for modifying a Btrfs filesystem
+    class BtrfsModifyButton < DeviceMenuButton
       def initialize(*args)
         super
         textdomain "storage"
@@ -37,23 +35,30 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def label
-        # TRANSLATORS: label for button to edit used devices
-        _("Change...")
+        _("&Modify")
       end
 
     private
 
-      # Returns the proper Actions class to edit the used devices
+      # @see DeviceMenuButton#actions
       #
-      # @see DeviceButton#actions
-      # @see Actions::EditMdDevices
+      # @see Actions::EditBtrfs
       # @see Actions::EditBtrfsDevices
-      def actions_class
-        if device.is?(:software_raid)
-          Actions::EditMdDevices
-        elsif device.is?(:btrfs)
-          Actions::EditBtrfsDevices
-        end
+      #
+      # @return [Array<Hash>]
+      def actions
+        [
+          {
+            id:    :edit,
+            label: _("Edit Btrfs..."),
+            class: Actions::EditBtrfs
+          },
+          {
+            id:    :devices,
+            label: _("Change Used Devices..."),
+            class: Actions::EditBtrfsDevices
+          }
+        ]
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/description_section/filesystem.rb
+++ b/src/lib/y2partitioner/widgets/description_section/filesystem.rb
@@ -47,7 +47,16 @@ module Y2Partitioner
 
         # @see DescriptionSection::Base#entries
         def entries
-          [:fs_type, :mount_point, :mount_by, :label, :uuid]
+          [:fs_type, :mount_point, :mount_by, :label, :uuid] + btrfs_entries
+        end
+
+        # Extra entries when the filesystem is Btrfs
+        #
+        # @return [Array<Symbol>]
+        def btrfs_entries
+          return [] unless filesystem && filesystem.is?(:btrfs)
+
+          [:btrfs_metadata_raid_level, :btrfs_data_raid_level]
         end
 
         # Information about the filesystem type
@@ -104,6 +113,26 @@ module Y2Partitioner
           # TRANSLATORS: Filesystem UUID information, where %s is replaced by the
           # filesystem UUID
           format(_("UUID: %s"), uuid)
+        end
+
+        # Information about the metadata RAID level
+        #
+        # @return [String]
+        def btrfs_metadata_raid_level_value
+          level = filesystem.metadata_raid_level.to_human_string
+
+          # TRANSLATORS: Btrfs metadata information, where %s is replaced by a RAID level (e.g., RAID0).
+          format(_("Metadata RAID Level: %s"), level)
+        end
+
+        # Information about the data RAID level
+        #
+        # @return [String]
+        def btrfs_data_raid_level_value
+          level = filesystem.data_raid_level.to_human_string
+
+          # TRANSLATORS: Btrfs data information, where %s is replaced by a RAID level (e.g., RAID0).
+          format(_("Data RAID Level: %s"), level)
         end
 
         # Whether the mount point is inactive

--- a/src/lib/y2partitioner/widgets/description_section/filesystem.rb
+++ b/src/lib/y2partitioner/widgets/description_section/filesystem.rb
@@ -56,7 +56,7 @@ module Y2Partitioner
         def btrfs_entries
           return [] unless filesystem && filesystem.is?(:btrfs)
 
-          [:btrfs_metadata_raid_level, :btrfs_data_raid_level]
+          [:btrfs_data_raid_level, :btrfs_metadata_raid_level]
         end
 
         # Information about the filesystem type
@@ -115,6 +115,16 @@ module Y2Partitioner
           format(_("UUID: %s"), uuid)
         end
 
+        # Information about the data RAID level
+        #
+        # @return [String]
+        def btrfs_data_raid_level_value
+          level = filesystem.data_raid_level.to_human_string
+
+          # TRANSLATORS: Btrfs data information, where %s is replaced by a RAID level (e.g., RAID0).
+          format(_("RAID Level: %s"), level)
+        end
+
         # Information about the metadata RAID level
         #
         # @return [String]
@@ -123,16 +133,6 @@ module Y2Partitioner
 
           # TRANSLATORS: Btrfs metadata information, where %s is replaced by a RAID level (e.g., RAID0).
           format(_("Metadata RAID Level: %s"), level)
-        end
-
-        # Information about the data RAID level
-        #
-        # @return [String]
-        def btrfs_data_raid_level_value
-          level = filesystem.data_raid_level.to_human_string
-
-          # TRANSLATORS: Btrfs data information, where %s is replaced by a RAID level (e.g., RAID0).
-          format(_("Data RAID Level: %s"), level)
         end
 
         # Whether the mount point is inactive

--- a/src/lib/y2partitioner/widgets/device_buttons_set.rb
+++ b/src/lib/y2partitioner/widgets/device_buttons_set.rb
@@ -31,7 +31,7 @@ require "y2partitioner/widgets/partitions_button"
 require "y2partitioner/widgets/lvm_logical_volumes_button"
 require "y2partitioner/widgets/device_delete_button"
 require "y2partitioner/widgets/blk_device_edit_button"
-require "y2partitioner/widgets/btrfs_edit_button"
+require "y2partitioner/widgets/btrfs_modify_button"
 
 module Y2Partitioner
   module Widgets
@@ -172,7 +172,7 @@ module Y2Partitioner
       # Buttons to display if {#device} is a BTRFS filesystem
       def btrfs_buttons
         [
-          BtrfsEditButton.new(pager: pager, device: device)
+          BtrfsModifyButton.new(device)
         ]
       end
 

--- a/src/lib/y2partitioner/widgets/devices_selection.rb
+++ b/src/lib/y2partitioner/widgets/devices_selection.rb
@@ -120,13 +120,17 @@ module Y2Partitioner
 
       # Updates the UI to reflect the size of both lists of devices
       def refresh_sizes
-        # TRANSLATORS: %s is a disk size. E.g. "10.5 GiB"
-        widget = Left(Label(_("Resulting size: %s") % selected_size.to_human_string))
-        Yast::UI.ReplaceWidget(Id(:selected_size), widget)
+        if selected_size
+          # TRANSLATORS: %s is a disk size. E.g. "10.5 GiB"
+          widget = Left(Label(_("Resulting size: %s") % selected_size.to_human_string))
+          Yast::UI.ReplaceWidget(Id(:selected_size), widget)
+        end
 
-        # TRANSLATORS: %s is a disk size. E.g. "10.5 GiB"
-        widget = Left(Label(_("Total size: %s") % unselected_size.to_human_string))
-        Yast::UI.ReplaceWidget(Id(:unselected_size), widget)
+        if unselected_size
+          # TRANSLATORS: %s is a disk size. E.g. "10.5 GiB"
+          widget = Left(Label(_("Total size: %s") % unselected_size.to_human_string))
+          Yast::UI.ReplaceWidget(Id(:unselected_size), widget)
+        end
       end
 
     protected

--- a/src/lib/y2partitioner/widgets/help.rb
+++ b/src/lib/y2partitioner/widgets/help.rb
@@ -14,110 +14,121 @@ module Y2Partitioner
 
       # helptexts for table column and overview entry
       TEXTS = {
-        bios_id:          N_("<b>BIOS ID</b> shows the BIOS ID of the hard\ndisk. This field can " \
-          "be empty."),
+        bios_id:                   N_("<b>BIOS ID</b> shows the BIOS ID of the hard\n" \
+                                      "disk. This field can be empty."),
 
-        bus:              N_("<b>Bus</b> shows how the device is connected to\nthe system. " \
-          "This field can be empty, e.g. for multipath disks."),
+        bus:                       N_("<b>Bus</b> shows how the device is connected to\n" \
+                                      "the system. This field can be empty, e.g. for multipath disks."),
 
-        chunk_size:       N_("<b>Chunk Size</b> shows the chunk size for RAID\ndevices."),
+        chunk_size:                N_("<b>Chunk Size</b> shows the chunk size for RAID\ndevices."),
 
-        cyl_size:         N_("<b>Cylinder Size</b> shows the size of the\ncylinders " \
+        cyl_size:                  N_("<b>Cylinder Size</b> shows the size of the\ncylinders " \
           "of the hard disk."),
 
-        sectors:          N_("<b>Number of Sectors</b> shows how many sectors the hard disk has."),
+        sectors:                   N_("<b>Number of Sectors</b> shows how many sectors the hard " \
+                                      "disk has."),
 
-        sector_size:      N_("<b>Sector Size</b> shows the size of the\nsectors of the hard disk."),
+        sector_size:               N_("<b>Sector Size</b> shows the size of the\n" \
+                                      "sectors of the hard disk."),
 
-        device:           N_("<b>Device</b> shows the kernel name of the\ndevice."),
+        device:                    N_("<b>Device</b> shows the kernel name of the\ndevice."),
 
-        disk_label:       N_("<b>Partition Table</b> shows the partition table\ntype of the disk, " \
-              "e.g <tt>MS-DOS</tt> or <tt>GPT</tt>."),
+        disk_label:                N_("<b>Partition Table</b> shows the partition table\n" \
+                                      "type of the disk, e.g <tt>MS-DOS</tt> or <tt>GPT</tt>."),
 
-        encrypted:        N_("<b>Encrypted</b> shows whether the device is\nencrypted."),
+        encrypted:                 N_("<b>Encrypted</b> shows whether the device is\nencrypted."),
 
-        end:              N_("<b>End</b> shows the end block of\nthe partition."),
+        end:                       N_("<b>End</b> shows the end block of\nthe partition."),
 
-        fc_fcp_lun:       N_("<b>LUN</b> shows the Logical Unit Number for\nFibre Channel disks."),
+        fc_fcp_lun:                N_("<b>LUN</b> shows the Logical Unit Number for\n" \
+                                      "Fibre Channel disks."),
 
-        fc_port_id:       N_("<b>Port ID</b> shows the port id for Fibre\nChannel disks."),
+        fc_port_id:                N_("<b>Port ID</b> shows the port id for Fibre\nChannel disks."),
 
-        fc_wwpn:          N_("<b>WWPN</b> shows the World Wide Port Name for\nFibre Channel " \
-          "disks."),
+        fc_wwpn:                   N_("<b>WWPN</b> shows the World Wide Port Name for\n" \
+                                      "Fibre Channel disks."),
 
-        file_path:        N_("<b>File Path</b> shows the path of the file for\nan encrypted " \
+        file_path:                 N_("<b>File Path</b> shows the path of the file for\nan encrypted " \
           "loop device."),
 
-        format:           N_("<b>Format</b> shows some flags: <tt>F</tt>\nmeans the device " \
-              "is selected to be formatted."),
+        format:                    N_("<b>Format</b> shows some flags: <tt>F</tt>\n" \
+                                      "means the device is selected to be formatted."),
 
-        partition_id:     N_("<b>Partition ID</b> shows the partition id."),
+        partition_id:              N_("<b>Partition ID</b> shows the partition id."),
 
-        fs_type:          N_("<b>FS Type</b> shows the file system type."),
+        fs_type:                   N_("<b>FS Type</b> shows the file system type."),
 
-        label:            N_("<b>Label</b> shows the label of the file\nsystem."),
+        label:                     N_("<b>Label</b> shows the label of the file\nsystem."),
 
-        lvm_metadata:     N_("<b>Metadata</b> shows the LVM metadata type for\nvolume groups."),
+        lvm_metadata:              N_("<b>Metadata</b> shows the LVM metadata type for\n" \
+                                      "volume groups."),
 
-        model:            N_("<b>Model</b> shows the device model."),
+        model:                     N_("<b>Model</b> shows the device model."),
 
-        mount_by:         N_("<b>Mount by</b> indicates how the file system\nis mounted: " \
-            "(Kernel) by kernel name, (Label) by file system label, (UUID) by\n file system " \
-            "UUID, (ID) by device ID, and (Path) by device path.\n"),
+        mount_by:                  N_("<b>Mount by</b> indicates how the file system\n" \
+                                      "is mounted: (Kernel) by kernel name, (Label) by " \
+                                      "file system label, (UUID) by\n file system " \
+                                      "UUID, (ID) by device ID, and (Path) by device path.\n"),
 
-        mount_point:      N_("<b>Mount Point</b> shows where the file system\nis mounted."),
+        mount_point:               N_("<b>Mount Point</b> shows where the file system\nis mounted."),
 
-        num_cyl:          N_("<b>Number of Cylinders</b> shows how many\ncylinders the hard disk " \
-          "has."),
+        num_cyl:                   N_("<b>Number of Cylinders</b> shows how many\n" \
+                                      "cylinders the hard disk has."),
 
-        parity_algorithm: N_("<b>Parity Algorithm</b> shows the parity\nalgorithm for RAID " \
-          "devices with RAID type 5, 6 or 10."),
+        parity_algorithm:          N_("<b>Parity Algorithm</b> shows the parity\n" \
+                                      "algorithm for RAID devices with RAID type 5, 6 or 10."),
 
-        pe_size:          N_("<b>PE Size</b> shows the physical extent size\nfor LVM volume " \
-        "groups."),
+        pe_size:                   N_("<b>PE Size</b> shows the physical extent size\n" \
+                                      "for LVM volume groups."),
 
-        raid_version:     N_("<b>RAID Version</b> shows the RAID version."),
+        raid_version:              N_("<b>RAID Version</b> shows the RAID version."),
 
-        raid_type:        N_("<b>RAID Type</b> shows the RAID type, also\ncalled RAID level, " \
-        "for RAID devices."),
+        raid_type:                 N_("<b>RAID Type</b> shows the RAID type, also\n" \
+                                      "called RAID level, for RAID devices."),
 
-        size:             N_("<b>Size</b> shows the size of the device."),
+        size:                      N_("<b>Size</b> shows the size of the device."),
 
-        start:            N_("<b>Start</b> shows the start block\nof the partition."),
+        start:                     N_("<b>Start</b> shows the start block\nof the partition."),
 
-        stripes:          N_("<b>Stripes</b> shows the stripe number for LVM\nlogical volumes " \
-          "and, if greater than one, the stripe size in parenthesis.\n"),
+        stripes:                   N_("<b>Stripes</b> shows the stripe number for LVM\n" \
+                                      "logical volumes and, if greater than one, the stripe size " \
+                                      "in parenthesis."),
 
-        type:             N_("<b>Type</b> gives a general overview about the\ndevice type."),
+        type:                      N_("<b>Type</b> gives a general overview about the\ndevice type."),
 
-        udev_id:          N_("<b>Device ID</b> shows the persistent device\nIDs. This field " \
-        "can be empty."),
+        udev_id:                   N_("<b>Device ID</b> shows the persistent device\n" \
+                                      "IDs. This field can be empty."),
 
-        udev_path:        N_("<b>Device Path</b> shows the persistent device\npath. This field " \
-        "can be empty."),
+        udev_path:                 N_("<b>Device Path</b> shows the persistent device\n" \
+                                      "path. This field can be empty."),
 
-        used_by:          N_("<b>Used By</b> shows if a device is used by\ne.g. RAID or LVM. " \
-              "If not, this column is empty."),
+        used_by:                   N_("<b>Used By</b> shows if a device is used by\n" \
+                                      "e.g. RAID or LVM. If not, this column is empty."),
 
-        uuid:             N_("<b>UUID</b> shows the Universally Unique\nIdentifier of the file " \
-          "system."),
+        uuid:                      N_("<b>UUID</b> shows the Universally Unique\n" \
+                                      "Identifier of the file system."),
 
-        vendor:           N_("<b>Vendor</b> shows the device vendor."),
+        vendor:                    N_("<b>Vendor</b> shows the device vendor."),
 
-        backing_device:   N_("<b>Backing Device</b> shows the device used as backing device " \
-                             "for bcache."),
+        backing_device:            N_("<b>Backing Device</b> shows the device used as backing " \
+                                      "device for bcache."),
 
-        caching_uuid:     N_("<b>Caching UUID</b> shows the UUID of the used caching set. This " \
-                             "field is empty if no caching is used."),
+        caching_uuid:              N_("<b>Caching UUID</b> shows the UUID of the used caching set. " \
+                                      "This field is empty if no caching is used."),
 
-        caching_device:   N_("<b>Caching Device</b> shows the device used for caching. This field " \
-                             "is empty if no caching is used."),
+        caching_device:            N_("<b>Caching Device</b> shows the device used for caching. " \
+                                      "This field is empty if no caching is used."),
 
-        cache_mode:       N_("<b>Cache Mode</b> shows the operating mode for bcache. Currently there " \
-                             "are four supported modes: Writethrough, Writeback, Writearound and None."),
+        cache_mode:                N_("<b>Cache Mode</b> shows the operating mode for bcache. " \
+                                      "Currently there are four supported modes: Writethrough, " \
+                                      "Writeback, Writearound and None."),
 
-        btrfs_devices:    N_("<b>Btrfs Devices</b> shows the kernel name of the devices used by a "\
-                             "Btrfs file system.")
+        btrfs_devices:             N_("<b>Devices</b> shows the kernel name of the devices used by a "\
+                                      "Btrfs file system."),
+        btrfs_metadata_raid_level: N_("<b>Metadata RAID Level</b> shows the RAID level for the Btrfs " \
+                                      "metadata."),
+
+        btrfs_data_raid_level:     N_("<b>Data RAID Level</b> shows the RAID level for the Btrfs data.")
       }.freeze
 
       # help texts that are appended to the common help only in Mode.normal

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -288,7 +288,7 @@ module Y2Partitioner
 
       # @return [CWM::PagerTreeItem]
       def btrfs_section
-        filesystems = device_graph.btrfs_filesystems
+        filesystems = device_graph.btrfs_filesystems.sort_by(&:blk_device_basename)
 
         page = Pages::BtrfsFilesystems.new(filesystems, self)
         children = filesystems.map { |f| btrfs_item(f) }

--- a/src/lib/y2partitioner/widgets/pages/btrfs.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs.rb
@@ -24,6 +24,7 @@ require "y2partitioner/icons"
 require "y2partitioner/widgets/used_devices_tab"
 require "y2partitioner/widgets/filesystem_description"
 require "y2partitioner/widgets/btrfs_edit_button"
+require "y2partitioner/widgets/used_devices_edit_button"
 require "y2partitioner/widgets/tabs"
 
 module Y2Partitioner
@@ -100,17 +101,10 @@ module Y2Partitioner
         def tabs
           tabs = [
             FilesystemTab.new(filesystem, initial: true),
-            UsedDevicesTab.new(devices, pager)
+            BtrfsDevicesTab.new(filesystem, pager)
           ]
 
           Tabs.new(*tabs)
-        end
-
-        # Devices used by the filesystem
-        #
-        # @return [Array<Y2Storage::BlkDevice>]
-        def devices
-          filesystem.blk_devices
         end
       end
 
@@ -148,6 +142,39 @@ module Y2Partitioner
           [
             BtrfsEditButton.new(device: @filesystem)
           ]
+        end
+      end
+
+      # A Tab for the devices used by a Btrfs
+      class BtrfsDevicesTab < UsedDevicesTab
+        # Constructor
+        #
+        # @param filesystem [Y2Storage::Filesystems::Btrfs]
+        # @param pager [CWM::TreePager]
+        def initialize(filesystem, pager)
+          @filesystem = filesystem
+
+          super(devices, pager)
+        end
+
+        # @macro seeCustomWidget
+        def contents
+          @contents ||= VBox(
+            table,
+            Right(UsedDevicesEditButton.new(device: filesystem))
+          )
+        end
+
+      private
+
+        # @return [Y2Storage::Filesystems::Btrfs]
+        attr_reader :filesystem
+
+        # Devices used by the filesystem
+        #
+        # @return [Array<Y2Storage::BlkDevice>]
+        def devices
+          filesystem.blk_devices
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/pages/btrfs.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs.rb
@@ -174,7 +174,7 @@ module Y2Partitioner
         #
         # @return [Array<Y2Storage::BlkDevice>]
         def devices
-          filesystem.blk_devices
+          filesystem.plain_blk_devices
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
@@ -23,6 +23,7 @@ require "yast"
 require "y2partitioner/icons"
 require "y2partitioner/widgets/pages/devices_table"
 require "y2partitioner/widgets/btrfs_filesystems_table"
+require "y2partitioner/widgets/btrfs_add_button"
 require "y2partitioner/widgets/device_buttons_set"
 require "y2storage/filesystems/type"
 
@@ -56,6 +57,11 @@ module Y2Partitioner
         # @see DevicesTable
         def icon
           Icons::BTRFS
+        end
+
+        # @see DevicesTable
+        def table_buttons
+          BtrfsAddButton.new
         end
 
         # @return [ConfigurableBlkDevicesTable]

--- a/src/lib/y2storage.rb
+++ b/src/lib/y2storage.rb
@@ -59,6 +59,7 @@ require "y2storage/align_type"
 require "y2storage/resize_info"
 require "y2storage/space_info"
 require "y2storage/mount_point"
+require "y2storage/btrfs_raid_level"
 
 require "y2storage/exceptions"
 require "y2storage/boot_requirements_checker"

--- a/src/lib/y2storage/bcache_cset.rb
+++ b/src/lib/y2storage/bcache_cset.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -61,7 +61,9 @@ module Y2Storage
       "<BcacheCset uuid:#{uuid} #{blk_devices.inspect}>"
     end
 
-    # Gets user friendly name for caching set. It is translated and ready to show to user.
+    # Display name to represent the caching set
+    #
+    # @return [String]
     def display_name
       textdomain "storage"
       devices = bcaches.map(&:basename).sort.join(", ")

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -432,11 +432,15 @@ module Y2Storage
     # (directly or through an encryption) or any RAID having this device as
     # one of its members.
     #
+    # For directly formatted devices, its filesystem is included if it is a multidevice filesystem.
+    #
     # @return [Array<Device>] a collection of MD RAIDs, DM RAIDs, volume groups,
     #   multipath, bcache and bcache_cset devices
     def component_of
       vg = lvm_pv ? lvm_pv.lvm_vg : nil
-      (dm_raids + [vg, md, multipath, bcache, in_bcache_cset]).compact
+      fs = formatted? && filesystem.multidevice? ? filesystem : nil
+
+      (dm_raids + [vg, md, multipath, bcache, in_bcache_cset, fs]).compact
     end
 
     # Equivalent of {#component_of} in which each device is represented by a

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -448,16 +448,7 @@ module Y2Storage
     #
     # @return [Array<String>]
     def component_of_names
-      # So far, all the possible elements on the array respond to #name
-      component_of.map do |dev|
-        if dev.respond_to?(:name)
-          dev.name
-        elsif dev.respond_to?(:display_name)
-          dev.display_name
-        else
-          raise "Unexpected type of device #{dev.inspect}"
-        end
-      end
+      component_of.map(&:display_name).compact
     end
 
     # Label of the filesystem, if any

--- a/src/lib/y2storage/btrfs_raid_level.rb
+++ b/src/lib/y2storage/btrfs_raid_level.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "storage"
+require "y2storage/storage_enum_wrapper"
+
+module Y2Storage
+  # Class to represent all the possible Btrfs RAID levels
+  #
+  # This is a wrapper for the Storage::BtrfsRaidLevel enum
+  class BtrfsRaidLevel
+    include StorageEnumWrapper
+
+    wrap_enum "BtrfsRaidLevel"
+
+    # Returns human readable representation of enum which is already translated
+    #
+    # @return [String]
+    def to_human_string
+      Storage.btrfs_raid_level_name(to_storage_value)
+    end
+  end
+end

--- a/src/lib/y2storage/btrfs_raid_level.rb
+++ b/src/lib/y2storage/btrfs_raid_level.rb
@@ -19,6 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast/i18n"
 require "storage"
 require "y2storage/storage_enum_wrapper"
 
@@ -27,15 +28,40 @@ module Y2Storage
   #
   # This is a wrapper for the Storage::BtrfsRaidLevel enum
   class BtrfsRaidLevel
+    include Yast::I18n
+    extend Yast::I18n
+
     include StorageEnumWrapper
 
     wrap_enum "BtrfsRaidLevel"
 
-    # Returns human readable representation of enum which is already translated
+    TRANSLATIONS = {
+      unknown: N_("Unknown"),
+      default: N_("Default"),
+      # TRANSLATORS: this is one of the RAID modes used by Btrfs, likely to be left as-is
+      single:  N_("SINGLE"),
+      # TRANSLATORS: this is one of the RAID modes used by Btrfs, likely to be left as-is
+      dup:     N_("DUP"),
+      raid0:   N_("RAID0"),
+      raid1:   N_("RAID1"),
+      raid5:   N_("RAID5"),
+      raid6:   N_("RAID6"),
+      raid10:  N_("RAID10")
+    }
+
+    private_constant :TRANSLATIONS
+
+    # Returns human readable representation of enum which is already translated.
+    #
+    # @raise [RuntimeError] when called on enum value for which translation is not defined yet.
     #
     # @return [String]
     def to_human_string
-      Storage.btrfs_raid_level_name(to_storage_value)
+      textdomain "storage"
+
+      value = TRANSLATIONS[to_sym] or raise "Unhandled Btrfs RAID level value '#{inspect}'"
+
+      _(value)
     end
   end
 end

--- a/src/lib/y2storage/device.rb
+++ b/src/lib/y2storage/device.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -175,7 +175,7 @@ module Y2Storage
     protected :userdata, :userdata=
 
     # @!method devicegraph
-    # 	Devicegraph to which the device is associated
+    #   Devicegraph to which the device is associated
     #
     #   @return [Devicegraph]
     storage_forward :devicegraph, as: "Devicegraph"
@@ -369,6 +369,15 @@ module Y2Storage
     def remove_descendants
       storage_remove_descendants
       update_etc_status
+    end
+
+    # Name to represent the device
+    #
+    # @return [String, nil] nil if the device has no representation
+    def display_name
+      return nil unless respond_to?(:name)
+
+      name
     end
 
   protected

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -19,6 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast/i18n"
 require "y2storage/storage_class_wrapper"
 require "y2storage/filesystems/base"
 
@@ -28,6 +29,8 @@ module Y2Storage
     #
     # This is a wrapper for Storage::BlkFilesystem
     class BlkFilesystem < Base
+      include Yast::I18n
+
       wrap_class Storage::BlkFilesystem, downcast_to: ["Filesystems::Btrfs"]
 
       # @!method self.all(devicegraph)
@@ -117,15 +120,20 @@ module Y2Storage
       # Block device base name
       #
       # When the filesystem is single-device, this method simply returns the base name of the block
-      # device (e.g., "sda1"). And for multi-device ones, it returns the first base name plus a "+"
-      # symbol to indicate that the filesystem is multi-device (e.g., "sda1+").
+      # device (e.g., "sda1"). And for multi-device ones, it returns the first base name between brackets
+      # and followed by horizontal ellipsis (e.g., "(sda1...)").
       #
       # @return [String]
       def blk_device_basename
-        info = blk_devices.map(&:basename).sort.first
-        info << "+" if multidevice?
+        basename = plain_blk_devices.map(&:basename).sort.first
 
-        info
+        return basename unless multidevice?
+
+        textdomain "storage"
+
+        # TRANSLATORS: block device basename for a multi-device filesystem, where %{basename} is replaced
+        # by the basename of the first block device (e.g., "(sda1...)").
+        format(_("(%{basename}\u2026)"), basename: basename)
       end
 
       # Whether it is a multidevice filesystem

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -116,14 +116,13 @@ module Y2Storage
 
       # Block device base name
       #
-      # When the filesystem is a non-multidevice, this method simply returns the base
-      # name of the block device (e.g., "sda1"). And for multidevice ones, it only returns
-      # the base name of the first block device plus a "+" symbol to indicate that the
-      # filesystem is multidevice (e.g., "sda1+").
+      # When the filesystem is single-device, this method simply returns the base name of the block
+      # device (e.g., "sda1"). And for multi-device ones, it returns the first base name plus a "+"
+      # symbol to indicate that the filesystem is multi-device (e.g., "sda1+").
       #
       # @return [String]
       def blk_device_basename
-        info = blk_devices.first.basename
+        info = blk_devices.map(&:basename).sort.first
         info << "+" if multidevice?
 
         info

--- a/src/lib/y2storage/filesystems/btrfs.rb
+++ b/src/lib/y2storage/filesystems/btrfs.rb
@@ -19,6 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast/i18n"
 require "y2storage/storage_class_wrapper"
 require "y2storage/filesystems/blk_filesystem"
 require "y2storage/btrfs_subvolume"
@@ -31,6 +32,8 @@ module Y2Storage
   module Filesystems
     # This is a wrapper for Storage::Btrfs
     class Btrfs < BlkFilesystem
+      include Yast::I18n
+
       wrap_class Storage::Btrfs
 
       # @!method top_level_btrfs_subvolume
@@ -489,6 +492,24 @@ module Y2Storage
 
         ensure_default_btrfs_subvolume(path: spec.btrfs_default_subvolume)
         add_btrfs_subvolumes(spec.subvolumes) if spec.subvolumes
+      end
+
+      # Display name to represent the filesystem
+      #
+      # Only multidevice Btrfs has its own representation
+      #
+      # @return [String, nil]
+      def display_name
+        return nil unless multidevice?
+
+        textdomain "storage"
+
+        # TRANSLATORS: display name when the Btrfs is multidevice
+        format(
+          _("Btrfs %{name} over %{num_devices} devices"),
+          name:        blk_device_basename,
+          num_devices: blk_devices.size
+        )
       end
 
     protected

--- a/src/lib/y2storage/filesystems/btrfs.rb
+++ b/src/lib/y2storage/filesystems/btrfs.rb
@@ -79,32 +79,20 @@ module Y2Storage
       storage_forward :configure_snapper
       storage_forward :configure_snapper=
 
-      # @!method metadata_raid_level
+      # @!attribute metadata_raid_level
       #
-      #   Gets the metadata RAID level
+      #   Setting the metadata RAID level is not supported for Btrfs already existing on disk.
       #
       #   @return [BtrfsRaidLevel]
       storage_forward :metadata_raid_level, as: "BtrfsRaidLevel"
-
-      # @!method metadata_raid_level=(level)
-      #
-      #   Sets the metadata RAID level. Not supported for Btrfs already existing on disk.
-      #
-      #   @param level [BtrfsRaidLevel]
       storage_forward :metadata_raid_level=
 
-      # @!method data_raid_level
+      # @!attribute data_raid_level
       #
-      #   Gets the data RAID level
+      #   Setting the data RAID level is not supported for Btrfs already existing on disk.
       #
       #   @return [BtrfsRaidLevel]
       storage_forward :data_raid_level, as: "BtrfsRaidLevel"
-
-      # @!method data_raid_level=(level)
-      #
-      #   Sets the data RAID level. Not supported for Btrfs already existing on disk.
-      #
-      #   @param level [BtrfsRaidLevel]
       storage_forward :data_raid_level=
 
       # @!method allowed_metadata_raid_levels
@@ -504,11 +492,12 @@ module Y2Storage
 
         textdomain "storage"
 
-        # TRANSLATORS: display name when the Btrfs is multidevice
+        # TRANSLATORS: display name when the Btrfs is multidevice, where %{num_devices} is replaced by
+        # a number (e.g., "2") and %{name} is replaced by a device representation (e.g., "(sda1...)").
         format(
-          _("Btrfs %{name} over %{num_devices} devices"),
-          name:        blk_device_basename,
-          num_devices: blk_devices.size
+          _("Btrfs over %{num_devices} devices %{name}"),
+          num_devices: blk_devices.size,
+          name:        blk_device_basename
         )
       end
 

--- a/src/lib/y2storage/filesystems/btrfs.rb
+++ b/src/lib/y2storage/filesystems/btrfs.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,6 +22,7 @@
 require "y2storage/storage_class_wrapper"
 require "y2storage/filesystems/blk_filesystem"
 require "y2storage/btrfs_subvolume"
+require "y2storage/btrfs_raid_level"
 require "y2storage/subvol_specification"
 
 Yast.import "ProductFeatures"
@@ -74,6 +75,68 @@ module Y2Storage
       #   @return [Boolean]
       storage_forward :configure_snapper
       storage_forward :configure_snapper=
+
+      # @!method metadata_raid_level
+      #
+      #   Gets the metadata RAID level
+      #
+      #   @return [BtrfsRaidLevel]
+      storage_forward :metadata_raid_level, as: "BtrfsRaidLevel"
+
+      # @!method metadata_raid_level=(level)
+      #
+      #   Sets the metadata RAID level. Not supported for Btrfs already existing on disk.
+      #
+      #   @param level [BtrfsRaidLevel]
+      storage_forward :metadata_raid_level=
+
+      # @!method data_raid_level
+      #
+      #   Gets the data RAID level
+      #
+      #   @return [BtrfsRaidLevel]
+      storage_forward :data_raid_level, as: "BtrfsRaidLevel"
+
+      # @!method data_raid_level=(level)
+      #
+      #   Sets the data RAID level. Not supported for Btrfs already existing on disk.
+      #
+      #   @param level [BtrfsRaidLevel]
+      storage_forward :data_raid_level=
+
+      # @!method allowed_metadata_raid_levels
+      #
+      #   Gets the allowed metadata RAID levels for the Btrfs. So far, this depends on the number of
+      #   devices. Levels for which mkfs.btrfs warns that they are not recommended are not included here.
+      #   Additionally DEFAULT is allowed when creating a btrfs.
+      #
+      #   @return [Array<BtrfsRaidLevel>]
+      storage_forward :allowed_metadata_raid_levels, as: "BtrfsRaidLevel"
+
+      # @!method allowed_data_raid_levels
+      #
+      #   Gets the allowed data RAID levels for the Btrfs. So far, this depends on the number of
+      #   devices. Levels for which mkfs.btrfs warns that they are not recommended are not included here.
+      #   Additionally DEFAULT is allowed when creating a btrfs.
+      #
+      #   @return [Array<BtrfsRaidLevel>]
+      storage_forward :allowed_data_raid_levels, as: "BtrfsRaidLevel"
+
+      # @!method add_device(device)
+      #
+      #   Adds a block device to the Btrfs
+      #
+      #   @param device [BlkDevice]
+      #   @raise [Storage::WrongNumberOfChildren] if the device cannot be added
+      storage_forward :add_device
+
+      # @!method remove_device(device)
+      #
+      #   Removes a block device from the Btrfs. Not supported for Btrfs already existing on disk.
+      #
+      #   @param device [BlkDevice]
+      #   @raise [Storage::Exception] if the device cannot be removed
+      storage_forward :remove_device
 
       # Only Btrfs should support subvolumes
       def supports_btrfs_subvolumes?

--- a/src/lib/y2storage/lvm_pv.rb
+++ b/src/lib/y2storage/lvm_pv.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -19,6 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast/i18n"
 require "y2storage/storage_class_wrapper"
 require "y2storage/device"
 
@@ -27,6 +28,8 @@ module Y2Storage
   #
   # This is a wrapper for Storage::LvmPv
   class LvmPv < Device
+    include Yast::I18n
+
     wrap_class Storage::LvmPv
 
     # @!method self.all(devicegraph)
@@ -53,6 +56,27 @@ module Y2Storage
     # @return [BlkDevice]
     def plain_blk_device
       blk_device.plain_device
+    end
+
+    # Whether the PV is orphan (not associated to any VG)
+    #
+    # @return [Boolean]
+    def orphan?
+      lvm_vg.nil?
+    end
+
+    # Display name to represent the PV
+    #
+    # Only orphan PV has its own representation.
+    #
+    # @return [String, nil]
+    def display_name
+      return nil unless orphan?
+
+      textdomain "storage"
+
+      # TRANSLATORS: display name when the PV has no associated VG
+      format(_("Orphan PV on %{device}"), device: plain_blk_device.name)
     end
 
   protected

--- a/src/lib/y2storage/lvm_pv.rb
+++ b/src/lib/y2storage/lvm_pv.rb
@@ -75,8 +75,9 @@ module Y2Storage
 
       textdomain "storage"
 
-      # TRANSLATORS: display name when the PV has no associated VG
-      format(_("Orphan PV on %{device}"), device: plain_blk_device.name)
+      # TRANSLATORS: display name when the PV has no associated VG, where %{device} is replaced by a
+      # device name (e.g., "/dev/sda1").
+      format(_("Unused LVM PV on %{device}"), device: plain_blk_device.name)
     end
 
   protected

--- a/test/y2partitioner/actions/add_btrfs_test.rb
+++ b/test/y2partitioner/actions/add_btrfs_test.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2partitioner/device_graphs"
+require "y2partitioner/actions/add_btrfs"
+
+describe Y2Partitioner::Actions::AddBtrfs do
+  before do
+    allow(Yast::Popup).to receive(:Error)
+    allow(Yast::Wizard).to receive(:OpenNextBackDialog)
+    allow(Yast::Wizard).to receive(:CloseDialog)
+
+    devicegraph_stub(devicegraph)
+  end
+
+  subject(:sequence) { described_class.new }
+  let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+
+  describe "#run" do
+    before do
+      allow(Yast2::Popup).to receive(:show)
+    end
+
+    context "when there are not enough available devices" do
+      let(:devicegraph) { "formatted_md.yml" }
+
+      it "shows an error" do
+        expect(Yast2::Popup).to receive(:show).with(anything, hash_including(headline: :error))
+
+        sequence.run
+      end
+
+      it "quits returning :back" do
+        expect(sequence.run).to eq :back
+      end
+    end
+
+    context "when there are enough available devices" do
+      let(:devicegraph) { "complex-lvm-encrypt.yml" }
+
+      context "if the user goes forward through all the dialogs" do
+        let(:controller) { Y2Partitioner::Actions::Controllers::BtrfsDevices.new }
+
+        before do
+          allow(Y2Partitioner::Actions::Controllers::Filesystem).to receive(:new)
+          allow_any_instance_of(Y2Partitioner::Actions::Controllers::BtrfsDevices).to receive(:new)
+            .and_return(controller)
+          allow(Y2Partitioner::Dialogs::BtrfsDevices).to receive(:run).and_return :next
+          allow(Y2Partitioner::Dialogs::BtrfsOptions).to receive(:run).and_return :next
+        end
+
+        it "returns :finish" do
+          expect(sequence.run).to eq :finish
+        end
+
+        it "creates a new Btrfs filesytem" do
+          expect(current_graph.btrfs_filesystems.size).to eq 0
+
+          device = current_graph.find_by_name("/dev/sda3")
+          controller.add_device(device)
+          sequence.run
+
+          expect(current_graph.btrfs_filesystems.size).to eq 1
+        end
+      end
+
+      context "if the user aborts the process at some point" do
+        before do
+          allow(Y2Partitioner::Actions::Controllers::Filesystem).to receive(:new)
+          allow(Y2Partitioner::Dialogs::BtrfsDevices).to receive(:run).and_return :next
+          allow(Y2Partitioner::Dialogs::BtrfsOptions).to receive(:run).and_return :abort
+        end
+
+        it "returns :abort" do
+          expect(sequence.run).to eq :abort
+        end
+
+        it "does not create a new Btrfs filesystem in the devicegraph" do
+          expect { sequence.run }.to_not change { current_graph.btrfs_filesystems }
+        end
+      end
+    end
+  end
+end

--- a/test/y2partitioner/actions/controllers/btrfs_devices_test.rb
+++ b/test/y2partitioner/actions/controllers/btrfs_devices_test.rb
@@ -343,6 +343,20 @@ describe Y2Partitioner::Actions::Controllers::BtrfsDevices do
   end
 
   describe "#add_device" do
+    shared_examples "partition id" do
+      context "if the device is a partition" do
+        let(:device_name) { "/dev/sda1" }
+
+        it "sets linux partition id" do
+          expect(device.id.is?(:linux)).to eq(false)
+
+          subject.add_device(device)
+
+          expect(device.id.is?(:linux)).to eq(true)
+        end
+      end
+    end
+
     context "if there is no filesystem yet" do
       let(:filesystem) { nil }
 
@@ -358,6 +372,8 @@ describe Y2Partitioner::Actions::Controllers::BtrfsDevices do
         expect(subject.filesystem.is?(:btrfs)).to eq(true)
         expect(subject.filesystem).to eq(device.filesystem)
       end
+
+      include_examples "partition id"
     end
 
     context "if there is already a filesystem" do
@@ -389,6 +405,8 @@ describe Y2Partitioner::Actions::Controllers::BtrfsDevices do
           expect(device.filesystem.type.is?(:btrfs)).to eq(true)
           expect(device.filesystem).to eq(subject.filesystem)
         end
+
+        include_examples "partition id"
       end
 
       context "and the device was encrypted" do
@@ -404,6 +422,8 @@ describe Y2Partitioner::Actions::Controllers::BtrfsDevices do
 
           expect(device.encrypted?).to eq(true)
         end
+
+        include_examples "partition id"
       end
     end
   end

--- a/test/y2partitioner/actions/controllers/btrfs_devices_test.rb
+++ b/test/y2partitioner/actions/controllers/btrfs_devices_test.rb
@@ -1,0 +1,440 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2partitioner/device_graphs"
+require "y2partitioner/actions/controllers/btrfs_devices"
+
+describe Y2Partitioner::Actions::Controllers::BtrfsDevices do
+  using Y2Storage::Refinements::SizeCasts
+
+  before do
+    devicegraph_stub(scenario)
+  end
+
+  subject { described_class.new(filesystem: filesystem) }
+
+  let(:filesystem) { nil }
+
+  let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+
+  let(:device) { current_graph.find_by_name(device_name) }
+
+  let(:scenario) { "mixed_disks" }
+
+  describe "#metadata_raid_level" do
+    before do
+      subject.metadata_raid_level = raid1
+    end
+
+    let(:raid1) { Y2Storage::BtrfsRaidLevel::RAID1 }
+
+    it "returns the selected metadata RAID level" do
+      expect(subject.metadata_raid_level).to eq(raid1)
+    end
+  end
+
+  describe "#metadata_raid_level=" do
+    let(:filesystem) { device.filesystem }
+
+    let(:device_name) { "/dev/sdc" }
+
+    let(:raid1) { Y2Storage::BtrfsRaidLevel::RAID1 }
+
+    before do
+      device.remove_descendants
+      device.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
+    end
+
+    it "sets the metadata RAID level" do
+      subject.metadata_raid_level = raid1
+
+      expect(subject.metadata_raid_level).to eq(raid1)
+      expect(filesystem.metadata_raid_level).to eq(raid1)
+    end
+  end
+
+  describe "#data_raid_level" do
+    before do
+      subject.data_raid_level = raid1
+    end
+
+    let(:raid1) { Y2Storage::BtrfsRaidLevel::RAID1 }
+
+    it "returns the selected data RAID level" do
+      expect(subject.data_raid_level).to eq(raid1)
+    end
+  end
+
+  describe "#data_raid_level=" do
+    let(:filesystem) { device.filesystem }
+
+    let(:device_name) { "/dev/sdc" }
+
+    let(:raid1) { Y2Storage::BtrfsRaidLevel::RAID1 }
+
+    before do
+      device.remove_descendants
+      device.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
+    end
+
+    it "sets the data RAID level" do
+      subject.data_raid_level = raid1
+
+      expect(subject.data_raid_level).to eq(raid1)
+      expect(filesystem.data_raid_level).to eq(raid1)
+    end
+  end
+
+  describe "#raid_levels" do
+    it "returns a list of BtrfsRaidLevel" do
+      expect(subject.raid_levels).to all(be_a(Y2Storage::BtrfsRaidLevel))
+    end
+
+    it "does not include RAID5" do
+      expect(subject.raid_levels).to_not include(Y2Storage::BtrfsRaidLevel::RAID5)
+    end
+
+    it "does not include RAID6" do
+      expect(subject.raid_levels).to_not include(Y2Storage::BtrfsRaidLevel::RAID6)
+    end
+  end
+
+  describe "#allowed_raid_levels" do
+    let(:filesystem) { device.filesystem }
+
+    let(:device_name) { "/dev/sdc" }
+
+    before do
+      device.remove_descendants
+      device.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
+    end
+
+    shared_examples "raid levels" do
+      let(:default_level) { Y2Storage::BtrfsRaidLevel::DEFAULT }
+      let(:single_level) { Y2Storage::BtrfsRaidLevel::SINGLE }
+      let(:dup_level) { Y2Storage::BtrfsRaidLevel::DUP }
+      let(:raid0) { Y2Storage::BtrfsRaidLevel::RAID0 }
+      let(:raid1) { Y2Storage::BtrfsRaidLevel::RAID1 }
+      let(:raid5) { Y2Storage::BtrfsRaidLevel::RAID5 }
+      let(:raid6) { Y2Storage::BtrfsRaidLevel::RAID6 }
+      let(:raid10) { Y2Storage::BtrfsRaidLevel::RAID10 }
+
+      it "returns a list of BtrfsRaidLevel" do
+        expect(subject.allowed_raid_levels(data)).to all(be_a(Y2Storage::BtrfsRaidLevel))
+      end
+
+      context "when it is a single-device Btrfs" do
+        it "contains DEFAULT, SINGLE and DUP" do
+          expect(subject.allowed_raid_levels(data))
+            .to contain_exactly(default_level, single_level, dup_level)
+        end
+      end
+
+      context "when it is a multi-device Btrfs" do
+        context "and the filesystem has up to 3 devices" do
+          before do
+            sdb1 = current_graph.find_by_name("/dev/sdb1")
+            sdb2 = current_graph.find_by_name("/dev/sdb2")
+
+            sdb1.remove_descendants
+            sdb2.remove_descendants
+
+            filesystem.add_device(sdb1)
+            filesystem.add_device(sdb2)
+          end
+
+          it "contains DEFAULT, SINGLE, RAID0 and RAID1" do
+            expect(subject.filesystem.blk_devices.size).to eq(3)
+
+            expect(subject.allowed_raid_levels(data))
+              .to contain_exactly(default_level, single_level, raid0, raid1)
+          end
+        end
+
+        context "and the filesystem has more than 3 devices" do
+          before do
+            sdb1 = current_graph.find_by_name("/dev/sdb1")
+            sdb2 = current_graph.find_by_name("/dev/sdb2")
+            sdb3 = current_graph.find_by_name("/dev/sdb3")
+
+            sdb1.remove_descendants
+            sdb2.remove_descendants
+            sdb3.remove_descendants
+
+            filesystem.add_device(sdb1)
+            filesystem.add_device(sdb2)
+            filesystem.add_device(sdb3)
+          end
+
+          it "contains DEFAULT, SINGLE, RAID0, RAID1 and RAID10" do
+            expect(subject.filesystem.blk_devices.size).to eq(4)
+
+            expect(subject.allowed_raid_levels(data))
+              .to contain_exactly(default_level, single_level, raid0, raid1, raid10)
+          end
+        end
+      end
+    end
+
+    context "for metadata" do
+      let(:data) { :metadata }
+
+      include_examples "raid levels"
+    end
+
+    context "for data" do
+      let(:data) { :data }
+
+      include_examples "raid levels"
+    end
+  end
+
+  describe "#available_devices" do
+    it "returns an list of block devices" do
+      expect(subject.available_devices).to be_a(Array)
+      expect(subject.available_devices).to all(be_a(Y2Storage::BlkDevice))
+    end
+
+    context "when a device already belongs to the Btrfs" do
+      let(:scenario) { "mixed_disks_btrfs" }
+
+      let(:device_name) { "/dev/sdb3" }
+
+      let(:filesystem) { device.filesystem }
+
+      it "does not include the device" do
+        expect(subject.available_devices).to_not include(device)
+      end
+    end
+
+    context "when a device is formatted" do
+      context "and the filesystem is not mounted" do
+        let(:device_name) { "/dev/sdb3" }
+
+        it "includes the device" do
+          expect(subject.available_devices).to include(device)
+        end
+      end
+
+      context "and the filesystem is mounted" do
+        let(:device_name) { "/dev/sdb2" }
+
+        it "does not include the device" do
+          expect(subject.available_devices).to_not include(device)
+        end
+      end
+    end
+
+    context "when a device is not formatted" do
+      context "and the device is an extended partition" do
+        let(:device_name) { "/dev/sdb4" }
+
+        it "does not include the device" do
+          expect(subject.available_devices).to_not include(device)
+        end
+      end
+
+      context "and the device has zero-size" do
+        let(:scenario) { "zero-size_disk" }
+
+        let(:device_name) { "/dev/sda" }
+
+        it "does not include the device" do
+          expect(subject.available_devices).to_not include(device)
+        end
+      end
+
+      context "and the device contains a partition table" do
+        context "and it does not contain partitions" do
+          let(:device_name) { "/dev/sdc" }
+
+          before do
+            device.create_partition_table(Y2Storage::PartitionTables::Type::GPT)
+          end
+
+          it "includes the device" do
+            expect(subject.available_devices).to include(device)
+          end
+        end
+
+        context "and it contains partitions" do
+          let(:device_name) { "/dev/sda" }
+
+          it "does not include the device" do
+            expect(subject.available_devices).to_not include(device)
+          end
+        end
+      end
+
+      context "when the device does not contain a partition table" do
+        let(:device_name) { "/dev/sdc" }
+
+        context "and the device is not component of another device" do
+          it "includes the device" do
+            expect(subject.available_devices).to include(device)
+          end
+        end
+
+        context "and the device is component of another device" do
+          before do
+            md = Y2Storage::Md.create(current_graph, "/dev/md0")
+            device.remove_descendants
+            md.add_device(device)
+          end
+
+          it "does not include the device" do
+            expect(subject.available_devices).to_not include(device)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#selected_devices" do
+    let(:scenario) { "complex-lvm-encrypt" }
+
+    let(:cr_sda4) { current_graph.find_by_name("/dev/mapper/cr_sda4") }
+    let(:sda3) { current_graph.find_by_name("/dev/sda3") }
+
+    let(:device_name) { "/dev/sdb" }
+
+    let(:filesystem) { device.filesystem }
+
+    before do
+      device.remove_descendants
+      device.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
+
+      cr_sda4.remove_descendants
+      device.filesystem.add_device(cr_sda4)
+      device.filesystem.add_device(sda3)
+    end
+
+    it "includes the devices directly used by the Btrfs" do
+      expect(subject.selected_devices).to include(sda3)
+    end
+
+    it "includes the devices used by the Btrfs through an encryption device" do
+      expect(subject.selected_devices).to include(cr_sda4.blk_device)
+    end
+
+    it "does not include the encryption devices used by the Btrfs" do
+      expect(subject.selected_devices).to_not include(cr_sda4)
+    end
+  end
+
+  describe "#add_device" do
+    context "if there is no filesystem yet" do
+      let(:filesystem) { nil }
+
+      let(:device_name) { "/dev/sdc" }
+
+      it "creates a new Btrfs filesystem over the device" do
+        expect(subject.filesystem).to be_nil
+        expect(device.filesystem).to be_nil
+
+        subject.add_device(device)
+
+        expect(subject.filesystem).to_not be_nil
+        expect(subject.filesystem.is?(:btrfs)).to eq(true)
+        expect(subject.filesystem).to eq(device.filesystem)
+      end
+    end
+
+    context "if there is already a filesystem" do
+      let(:sdc) { current_graph.find_by_name("/dev/sdc") }
+
+      let(:filesystem) { sdc.filesystem }
+
+      let(:device_name) { "/dev/sdb6" }
+
+      before do
+        sdc.remove_descendants
+        sdc.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
+      end
+
+      it "adds the device to the used devices of the Btrfs" do
+        expect(filesystem.blk_devices).to contain_exactly(sdc)
+
+        subject.add_device(device)
+
+        expect(filesystem.blk_devices).to contain_exactly(sdc, device)
+      end
+
+      context "and the device was formatted" do
+        it "removes the previous filesystem from the device" do
+          expect(device.filesystem.type.is?(:xfs)).to eq(true)
+
+          subject.add_device(device)
+
+          expect(device.filesystem.type.is?(:btrfs)).to eq(true)
+          expect(device.filesystem).to eq(subject.filesystem)
+        end
+      end
+
+      context "and the device was encrypted" do
+        before do
+          device.remove_descendants
+          device.create_encryption("cr_device")
+        end
+
+        it "does not remove the previous encryption from the device" do
+          expect(device.encrypted?).to eq(true)
+
+          subject.add_device(device)
+
+          expect(device.encrypted?).to eq(true)
+        end
+      end
+    end
+  end
+
+  describe "#remove_device" do
+    let(:sdc) { current_graph.find_by_name("/dev/sdc") }
+
+    let(:filesystem) { sdc.filesystem }
+
+    let(:device_name) { "/dev/sdb6" }
+
+    before do
+      sdc.remove_descendants
+      sdc.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
+
+      device.remove_descendants
+      sdc.filesystem.add_device(device)
+    end
+
+    it "removes the device from the Btrfs" do
+      expect(subject.filesystem.blk_devices).to include(device)
+
+      subject.remove_device(device)
+
+      expect(subject.filesystem.blk_devices).to_not include(device)
+    end
+
+    it "does not remove any other device from the Btrfs" do
+      subject.remove_device(device)
+
+      expect(subject.filesystem.blk_devices).to include(sdc)
+    end
+  end
+end

--- a/test/y2partitioner/actions/controllers/lvm_vg_test.rb
+++ b/test/y2partitioner/actions/controllers/lvm_vg_test.rb
@@ -337,8 +337,11 @@ describe Y2Partitioner::Actions::Controllers::LvmVg do
 
     it "includes unused MD Raids" do
       sdb = dev("/dev/sdb")
+      sdc = dev("/dev/mapper/cr_sdc")
       md = Y2Storage::Md.create(current_graph, "/dev/md0")
+      md.md_level = Y2Storage::MdLevel::RAID0
       md.add_device(sdb)
+      md.add_device(sdc)
 
       expect(controller.available_devices.map(&:name)).to include("/dev/md0")
     end
@@ -378,8 +381,8 @@ describe Y2Partitioner::Actions::Controllers::LvmVg do
     end
 
     it "excludes zero-size devices" do
-      Y2Storage::Disk.create(current_graph, "/dev/sde", 0)
-      expect(controller.available_devices.map(&:name)).to_not include("/dev/sde")
+      Y2Storage::Disk.create(current_graph, "/dev/sdh", 0)
+      expect(controller.available_devices.map(&:name)).to_not include("/dev/sdh")
     end
 
     it "includes partitions with a linux system ID (linux, LVM, RAID, swap)" do

--- a/test/y2partitioner/actions/edit_btrfs_devices_test.rb
+++ b/test/y2partitioner/actions/edit_btrfs_devices_test.rb
@@ -1,0 +1,93 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2partitioner/device_graphs"
+require "y2partitioner/actions/edit_btrfs_devices"
+
+describe Y2Partitioner::Actions::EditBtrfsDevices do
+  before do
+    devicegraph_stub(scenario)
+
+    allow(Yast2::Popup).to receive(:show)
+
+    allow(Yast::Wizard).to receive(:OpenNextBackDialog)
+    allow(Yast::Wizard).to receive(:CloseDialog)
+  end
+
+  subject { described_class.new(filesystem) }
+
+  let(:filesystem) { device.filesystem }
+
+  let(:device) { current_graph.find_by_name(device_name) }
+
+  let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+
+  describe "#run" do
+    context "if the filesystem already exists on disk" do
+      let(:scenario) { "mixed_disks" }
+
+      let(:device_name) { "/dev/sdb2" }
+
+      it "shows an error" do
+        expect(Yast2::Popup).to receive(:show).with(anything, hash_including(headline: :error))
+
+        subject.run
+      end
+
+      it "quits returning :back" do
+        expect(subject.run).to eq(:back)
+      end
+    end
+
+    context "if the filesystem does not exist on disk" do
+      let(:scenario) { "mixed_disks" }
+
+      let(:device_name) { "/dev/sdc" }
+
+      before do
+        device.remove_descendants
+        device.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
+      end
+
+      context "and the user goes forward in the dialog" do
+        before do
+          allow(Y2Partitioner::Dialogs::BtrfsDevices).to receive(:run).and_return(:next)
+        end
+
+        it "returns :finish" do
+          expect(subject.run).to eq(:finish)
+        end
+      end
+
+      context "and the user aborts the process" do
+        before do
+          allow(Y2Partitioner::Dialogs::BtrfsDevices).to receive(:run).and_return(:abort)
+        end
+
+        it "returns :abort" do
+          expect(subject.run).to eq(:abort)
+        end
+      end
+    end
+  end
+end

--- a/test/y2partitioner/dialogs/btrfs_devices_test.rb
+++ b/test/y2partitioner/dialogs/btrfs_devices_test.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "yast"
+require "cwm/rspec"
+require "y2partitioner/dialogs/btrfs_devices"
+require "y2partitioner/actions/controllers/btrfs_devices"
+
+Yast.import "UI"
+
+describe Y2Partitioner::Dialogs::BtrfsDevices do
+  let(:controller) do
+    Y2Partitioner::Actions::Controllers::BtrfsDevices.new
+  end
+
+  subject { described_class.new(controller) }
+
+  include_examples "CWM::Dialog"
+
+  describe "#contents" do
+    it "contains the btrfs devices widget" do
+      btrfs_devices_widget = subject.contents.detect do |i|
+        i.is_a?(Y2Partitioner::Widgets::BtrfsDevices)
+      end
+
+      expect(btrfs_devices_widget).to_not be_nil
+    end
+  end
+end

--- a/test/y2partitioner/widgets/btrfs_add_button_test.rb
+++ b/test/y2partitioner/widgets/btrfs_add_button_test.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/btrfs_add_button"
+
+describe Y2Partitioner::Widgets::BtrfsAddButton do
+  subject(:button) { described_class.new }
+
+  let(:sequence) { double("AddBtrfs") }
+
+  before do
+    devicegraph_stub("one-empty-disk.yml")
+    allow(Y2Partitioner::Actions::AddBtrfs).to receive(:new).and_return sequence
+    allow(sequence).to receive(:run)
+  end
+
+  include_examples "CWM::PushButton"
+
+  describe "#handle" do
+    it "starts an AddBtrfs sequence" do
+      expect(sequence).to receive(:run)
+      button.handle
+    end
+
+    it "returns :redraw if the sequence returns :finish" do
+      allow(sequence).to receive(:run).and_return :finish
+      expect(button.handle).to eq :redraw
+    end
+
+    it "returns nil if the sequence does not return :finish" do
+      allow(sequence).to receive(:run).and_return :back
+      expect(button.handle).to be_nil
+    end
+  end
+end

--- a/test/y2partitioner/widgets/btrfs_data_raid_level_test.rb
+++ b/test/y2partitioner/widgets/btrfs_data_raid_level_test.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "yast"
+require "cwm/rspec"
+require "y2partitioner/actions/controllers/btrfs_devices"
+require "y2partitioner/widgets/btrfs_data_raid_level"
+
+describe Y2Partitioner::Widgets::BtrfsDataRaidLevel do
+  subject(:widget) { described_class.new(controller) }
+
+  let(:controller) do
+    Y2Partitioner::Actions::Controllers::BtrfsDevices.new
+  end
+
+  before do
+    allow(Yast::UI).to receive(:QueryWidget).and_return :raid10
+  end
+
+  include_examples "CWM::ComboBox"
+
+  describe "#handle" do
+    it "sets the data raid level" do
+      expect(controller).to receive(:data_raid_level=).with(Y2Storage::BtrfsRaidLevel::RAID10)
+
+      widget.handle
+    end
+  end
+end

--- a/test/y2partitioner/widgets/btrfs_devices_selector_test.rb
+++ b/test/y2partitioner/widgets/btrfs_devices_selector_test.rb
@@ -1,0 +1,291 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require_relative "#{TEST_PATH}/support/devices_selector_context"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/btrfs_devices_selector"
+require "y2partitioner/actions/controllers/btrfs_devices"
+
+describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
+  include_context "devices selector"
+
+  subject(:widget) { described_class.new(controller) }
+  let(:controller) { Y2Partitioner::Actions::Controllers::BtrfsDevices.new }
+  let(:devicegraph) { "complex-lvm-encrypt" }
+
+  let(:available_devices_names) do
+    ["/dev/sda1", "/dev/sda2", "/dev/sda3", "/dev/sda4", "/dev/sdb", "/dev/sdc", "/dev/sde3",
+     "/dev/sdf1", "/dev/vg0/lv2", "/dev/vg1/lv1", "/dev/vg1/lv2"]
+  end
+
+  let(:selected_devices_names) do
+    ["/dev/sde3", "/dev/sda3"]
+  end
+
+  let(:unselected_devices_names) do
+    available_devices_names - selected_devices_names
+  end
+
+  let(:selected_items) { selected_table.items }
+  let(:unselected_items) { unselected_table.items }
+  let(:expected_selected_items) { selected_devices_names.map { |device_name| "^#{device_name}$" } }
+  let(:expected_unselected_items) { unselected_devices_names.map { |device_name| "^#{device_name}$" } }
+
+  before do
+    devicegraph_stub(devicegraph)
+
+    # Pre-select some devices
+    selected_devices_names.each do |device_name|
+      device = dev(device_name)
+      controller.add_device(device)
+    end
+  end
+
+  context "right after initialization" do
+    describe "#contents" do
+      it "displays all the unselected devices in the corresponding table" do
+        expect(rows_match?(unselected_items, *expected_unselected_items)).to eq true
+      end
+
+      it "displays all the selected devices in the corresponding table" do
+        expect(rows_match?(selected_items, *expected_selected_items)).to eq true
+      end
+    end
+  end
+
+  context "pushing the 'Add All' button" do
+    let(:event) { { "ID" => :add_all } }
+
+    before do
+      widget.handle(event)
+    end
+
+    describe "#handle" do
+      it "leaves no available devices" do
+        expect(controller.available_devices).to be_empty
+      end
+
+      it "selects all the available devices" do
+        expect(controller.selected_devices.map(&:name)).to match_array(available_devices_names)
+      end
+    end
+
+    describe "#contents" do
+      it "displays all the selected devices in the corresponding table" do
+        expect(rows_match?(selected_items, *expected_selected_items)).to eq true
+      end
+
+      it "displays none device as unselected" do
+        expect(unselected_items).to be_empty
+      end
+    end
+  end
+
+  context "pushing the 'Add' button" do
+    let(:event) { { "ID" => :add } }
+
+    before do
+      allow(unselected_table).to receive(:value).and_return selection
+    end
+
+    context "if there were no selected item in the 'unselected' table" do
+      let(:selection) { [] }
+
+      describe "#handle" do
+        it "does not alter the selected devices" do
+          expect { widget.handle(event) }.to_not change { controller.selected_devices }
+        end
+
+        it "does not alter the unselected devices" do
+          expect { widget.handle(event) }.to_not change { controller.available_devices }
+        end
+      end
+
+      describe "#contents" do
+        before do
+          widget.handle(event)
+        end
+
+        it "displays all the selected devices in the corresponding table" do
+          expect(rows_match?(selected_items, *expected_selected_items)).to eq true
+        end
+
+        it "displays all the available devices in the corresponding table" do
+          expect(rows_match?(unselected_items, *expected_unselected_items)).to eq true
+        end
+      end
+    end
+  end
+
+  context "pushing the 'Remove All' button" do
+    let(:event) { { "ID" => :remove_all } }
+
+    before do
+      widget.handle(event)
+    end
+
+    describe "#handle" do
+      it "removes all devices from the selected devices" do
+        expect(controller.selected_devices).to be_empty
+      end
+
+      it "makes all devices available" do
+        expect(controller.available_devices.map(&:name)).to match_array(available_devices_names)
+      end
+    end
+
+    describe "#contents" do
+      it "does not display selected devices" do
+        expect(selected_items).to be_empty
+      end
+
+      it "displays all the available devices as unselected" do
+        expect(rows_match?(unselected_items, *expected_unselected_items)).to eq true
+      end
+    end
+  end
+
+  context "pushing the 'Remove' button" do
+    let(:event) { { "ID" => :remove } }
+
+    before do
+      allow(selected_table).to receive(:value).and_return selection
+    end
+
+    context "if there were no selected item in the 'selected' table" do
+      let(:selection) { [] }
+
+      describe "#handle" do
+        it "does not change selected devices" do
+          expect { widget.handle(event) }.to_not change { controller.selected_devices }
+        end
+
+        it "does not change available devices" do
+          expect { widget.handle(event) }.to_not change { controller.available_devices }
+        end
+      end
+
+      describe "#contents" do
+        before do
+          widget.handle(event)
+        end
+
+        it "displays all the selected devices in the corresponding table and order" do
+          expect(rows_match?(selected_items, *expected_selected_items)).to eq true
+        end
+
+        it "displays all the available devices in the corresponding table and order" do
+          expect(rows_match?(unselected_items, *expected_unselected_items)).to eq true
+        end
+      end
+    end
+
+    context "if some items where selected in the 'selected' table" do
+      let(:device_name) { "/dev/sda3" }
+      let(:selected_device) { dev(device_name) }
+      let(:selection) { ["selected:device:#{selected_device.sid}"] }
+
+      before do
+        widget.handle(event)
+      end
+
+      describe "#handle" do
+        it "removes the selected device from selected devices" do
+          expect(controller.selected_devices).to_not include(selected_device)
+        end
+
+        it "makes the device available" do
+          expect(controller.available_devices).to include(selected_device)
+        end
+      end
+
+      describe "#contents" do
+        it "displays all the selected devices in the corresponding table" do
+          expected_items = expected_selected_items.reject { |item| item.include?(device_name) }
+
+          expect(rows_match?(selected_items, *expected_items)).to eq true
+        end
+
+        it "displays all the available devices in the corresponding" do
+          expected_items = expected_unselected_items.append("#{device_name}$")
+
+          expect(rows_match?(unselected_items, *expected_items)).to eq true
+        end
+      end
+    end
+  end
+
+  describe "#contents" do
+    it "does not display the selected size" do
+      expect(Yast).to_not receive(:Id).with(:selected_size)
+      expect(Yast::UI).to_not receive(:ReplaceWidget)
+
+      subject.refresh
+    end
+
+    it "does not display the unselected size" do
+      expect(Yast).to_not receive(:Id).with(:unselected_size)
+      expect(Yast::UI).to_not receive(:ReplaceWidget)
+
+      subject.refresh
+    end
+  end
+
+  describe "#validate" do
+    before do
+      allow(Yast2::Popup).to receive(:show)
+    end
+
+    context "when there is any device selected" do
+      it "returns true" do
+        expect(subject.validate).to eq(true)
+      end
+
+      it "do not display errors" do
+        expect(Yast2::Popup).to_not receive(:show)
+
+        subject.validate
+      end
+    end
+
+    context "when there is none device selected" do
+      before do
+        selected_devices_names.each do |device_name|
+          device = dev(device_name)
+          controller.remove_device(device)
+        end
+      end
+
+      it "returns false" do
+        expect(subject.validate).to eq(false)
+      end
+
+      it "displays an error popup" do
+        expect(Yast2::Popup).to receive(:show).with(anything, hash_including(headline: :error))
+
+        subject.validate
+      end
+    end
+  end
+end

--- a/test/y2partitioner/widgets/btrfs_devices_test.rb
+++ b/test/y2partitioner/widgets/btrfs_devices_test.rb
@@ -211,6 +211,60 @@ describe Y2Partitioner::Widgets::BtrfsDevices do
       end
     end
 
+    context "when data and metadata RAID levels are wrong" do
+      before do
+        controller.data_raid_level = data_raid_level
+        controller.metadata_raid_level = metadata_raid_level
+        controller.add_device(dev("/dev/sda3"))
+      end
+
+      let(:data_raid_level) { Y2Storage::BtrfsRaidLevel::RAID10 }
+
+      let(:metadata_raid_level) { Y2Storage::BtrfsRaidLevel::RAID10 }
+
+      it "indicates that both RAID levels are wrong" do
+        expect(Yast2::Popup).to receive(:show).with(/RAID levels do not match/, anything)
+
+        subject.validate
+      end
+    end
+
+    context "when only the data RAID level is wrong" do
+      before do
+        controller.data_raid_level = data_raid_level
+        controller.metadata_raid_level = metadata_raid_level
+        controller.add_device(dev("/dev/sda3"))
+      end
+
+      let(:data_raid_level) { Y2Storage::BtrfsRaidLevel::RAID10 }
+
+      let(:metadata_raid_level) { Y2Storage::BtrfsRaidLevel::DEFAULT }
+
+      it "indicates that data RAID level is wrong" do
+        expect(Yast2::Popup).to receive(:show).with(/The RAID level does not match/, anything)
+
+        subject.validate
+      end
+    end
+
+    context "when only the metadata RAID level is wrong" do
+      before do
+        controller.data_raid_level = data_raid_level
+        controller.metadata_raid_level = metadata_raid_level
+        controller.add_device(dev("/dev/sda3"))
+      end
+
+      let(:data_raid_level) { Y2Storage::BtrfsRaidLevel::DEFAULT }
+
+      let(:metadata_raid_level) { Y2Storage::BtrfsRaidLevel::RAID10 }
+
+      it "indicates that metadata RAID level is wrong" do
+        expect(Yast2::Popup).to receive(:show).with(/metadata RAID level does not match/, anything)
+
+        subject.validate
+      end
+    end
+
     context "when changing the metadata raid level" do
       before do
         controller.metadata_raid_level = raid_level

--- a/test/y2partitioner/widgets/btrfs_devices_test.rb
+++ b/test/y2partitioner/widgets/btrfs_devices_test.rb
@@ -1,0 +1,230 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "yast"
+require "cwm/rspec"
+require "y2partitioner/widgets/btrfs_devices"
+require "y2partitioner/actions/controllers/btrfs_devices"
+
+Yast.import "UI"
+
+describe Y2Partitioner::Widgets::BtrfsDevices do
+  before do
+    devicegraph_stub(scenario)
+
+    allow(Yast2::Popup).to receive(:show)
+  end
+
+  let(:controller) do
+    Y2Partitioner::Actions::Controllers::BtrfsDevices.new
+  end
+
+  subject { described_class.new(controller) }
+
+  let(:scenario) { "complex-lvm-encrypt.yml" }
+
+  include_examples "CWM::CustomWidget"
+
+  describe "#contents" do
+    it "contains a widget for selecting the metadata raid level" do
+      widget = subject.contents.nested_find do |i|
+        i.is_a?(Y2Partitioner::Widgets::BtrfsMetadataRaidLevel)
+      end
+
+      expect(widget).to_not be_nil
+    end
+
+    it "contains a widget for selecting the data raid level" do
+      widget = subject.contents.nested_find do |i|
+        i.is_a?(Y2Partitioner::Widgets::BtrfsDataRaidLevel)
+      end
+
+      expect(widget).to_not be_nil
+    end
+
+    it "contains a widget for selecting the devices" do
+      widget = subject.contents.nested_find do |i|
+        i.is_a?(Y2Partitioner::Widgets::BtrfsDevicesSelector)
+      end
+      expect(widget).to_not be_nil
+    end
+  end
+
+  describe "#validate" do
+    def dev(name)
+      Y2Storage::BlkDevice.find_by_name(current_graph, name)
+    end
+
+    let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+
+    RSpec.shared_examples "do not validate" do
+      it "returns false" do
+        expect(subject.validate).to eq(false)
+      end
+
+      it "displays an error popup" do
+        expect(Yast2::Popup).to receive(:show).with(anything, hash_including(headline: :error))
+
+        subject.validate
+      end
+    end
+
+    RSpec.shared_examples "validates" do
+      it "returns true" do
+        expect(subject.validate).to eq(true)
+      end
+
+      it "displays an error popup" do
+        expect(Yast2::Popup).to_not receive(:show)
+
+        subject.validate
+      end
+    end
+
+    RSpec.shared_examples "raid levels validations" do
+      context "DEFAULT" do
+        let(:raid_level) { Y2Storage::BtrfsRaidLevel::DEFAULT }
+
+        include_examples "validates"
+      end
+
+      context "DUP" do
+        let(:raid_level) { Y2Storage::BtrfsRaidLevel::DUP }
+
+        context "and there is only one device selected" do
+          before do
+            controller.add_device(dev("/dev/sda3"))
+          end
+
+          include_examples "validates"
+        end
+
+        context "but there is more than one device selected" do
+          before do
+            controller.add_device(dev("/dev/sda3"))
+            controller.add_device(dev("/dev/sde3"))
+          end
+
+          include_examples "do not validate"
+        end
+      end
+
+      context "RAID0" do
+        let(:raid_level) { Y2Storage::BtrfsRaidLevel::RAID0 }
+
+        context "and there is only one device selected" do
+          before do
+            controller.add_device(dev("/dev/sda3"))
+          end
+
+          include_examples "do not validate"
+        end
+
+        context "but there is more than one device selected" do
+          before do
+            controller.add_device(dev("/dev/sda3"))
+            controller.add_device(dev("/dev/sde3"))
+          end
+
+          include_examples "validates"
+        end
+      end
+
+      context "RAID1" do
+        let(:raid_level) { Y2Storage::BtrfsRaidLevel::RAID1 }
+
+        context "and there is only one device selected" do
+          before do
+            controller.add_device(dev("/dev/sda3"))
+          end
+
+          include_examples "do not validate"
+        end
+
+        context "but there is more than one device selected" do
+          before do
+            controller.add_device(dev("/dev/sda3"))
+            controller.add_device(dev("/dev/sde3"))
+          end
+
+          include_examples "validates"
+        end
+      end
+
+      context "RAID10" do
+        let(:raid_level) { Y2Storage::BtrfsRaidLevel::RAID10 }
+
+        context "and there are less than four devices selected" do
+          before do
+            controller.add_device(dev("/dev/sda3"))
+            controller.add_device(dev("/dev/sde3"))
+            controller.add_device(dev("/dev/sdf"))
+          end
+
+          include_examples "do not validate"
+        end
+
+        context "and there are at least four devices selected" do
+          before do
+            controller.add_device(dev("/dev/sda3"))
+            controller.add_device(dev("/dev/sde3"))
+            controller.add_device(dev("/dev/sdf"))
+            controller.add_device(dev("/dev/vg1/lv1"))
+          end
+
+          include_examples "validates"
+        end
+
+        context "and there are more than four devices selected" do
+          before do
+            controller.add_device(dev("/dev/sda3"))
+            controller.add_device(dev("/dev/sde3"))
+            controller.add_device(dev("/dev/sdf"))
+            controller.add_device(dev("/dev/vg1/lv1"))
+            controller.add_device(dev("/dev/vg1/lv2"))
+            controller.add_device(dev("/dev/vg0/lv2"))
+          end
+
+          include_examples "validates"
+        end
+      end
+    end
+
+    context "when changing the metadata raid level" do
+      before do
+        controller.metadata_raid_level = raid_level
+      end
+
+      include_examples "raid levels validations"
+    end
+
+    context "when changing data raid level" do
+      before do
+        controller.data_raid_level = raid_level
+      end
+
+      include_examples "raid levels validations"
+    end
+  end
+end

--- a/test/y2partitioner/widgets/btrfs_metadata_raid_level_test.rb
+++ b/test/y2partitioner/widgets/btrfs_metadata_raid_level_test.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "yast"
+require "cwm/rspec"
+require "y2partitioner/actions/controllers/btrfs_devices"
+require "y2partitioner/widgets/btrfs_metadata_raid_level"
+
+describe Y2Partitioner::Widgets::BtrfsMetadataRaidLevel do
+  subject(:widget) { described_class.new(controller) }
+
+  let(:controller) do
+    Y2Partitioner::Actions::Controllers::BtrfsDevices.new
+  end
+
+  before do
+    allow(Yast::UI).to receive(:QueryWidget).and_return :raid10
+  end
+
+  include_examples "CWM::ComboBox"
+
+  describe "#handle" do
+    it "sets the data raid level" do
+      expect(controller).to receive(:metadata_raid_level=).with(Y2Storage::BtrfsRaidLevel::RAID10)
+
+      widget.handle
+    end
+  end
+end

--- a/test/y2partitioner/widgets/btrfs_modify_button_test.rb
+++ b/test/y2partitioner/widgets/btrfs_modify_button_test.rb
@@ -1,0 +1,108 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/btrfs_modify_button"
+
+describe Y2Partitioner::Widgets::BtrfsModifyButton do
+  before do
+    devicegraph_stub(scenario)
+  end
+
+  subject(:button) { described_class.new(device) }
+
+  let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+
+  let(:device) { current_graph.find_by_name(device_name) }
+
+  let(:scenario) { "mixed_disks" }
+
+  let(:device_name) { "/dev/sdb2" }
+
+  describe "#items" do
+    it "returns a list" do
+      expect(button.items).to be_a(Array)
+    end
+  end
+
+  describe "#label" do
+    it "returns a string with keyboard shortcut" do
+      expect(button.label).to be_a String
+      expect(button.label).to include "&"
+    end
+  end
+
+  describe "#handle" do
+    let(:widget_id) { subject.widget_id }
+
+    let(:event) { { "ID" => selected_option } }
+
+    let(:action) { instance_double("Action", run: nil) }
+
+    RSpec.shared_examples "handle btrfs action result" do
+      it "returns :redraw if the workflow returns :finish" do
+        allow(action).to receive(:run).and_return :finish
+
+        expect(button.handle(event)).to eq :redraw
+      end
+
+      it "returns nil if the workflow does not return :finish" do
+        allow(action).to receive(:run).and_return :back
+
+        expect(button.handle(event)).to be_nil
+      end
+    end
+
+    context "when the option for editing the btrfs is selected" do
+      let(:selected_option) { :"#{widget_id}_edit" }
+
+      before do
+        allow(Y2Partitioner::Actions::EditBtrfs).to receive(:new).and_return(action)
+      end
+
+      it "opens the workflow for editing the Btrfs" do
+        expect(Y2Partitioner::Actions::EditBtrfs).to receive(:new)
+
+        button.handle(event)
+      end
+
+      include_examples "handle btrfs action result"
+    end
+
+    context "when the option for editing the devices is selected" do
+      let(:selected_option) { :"#{widget_id}_devices" }
+
+      before do
+        allow(Y2Partitioner::Actions::EditBtrfsDevices).to receive(:new).and_return(action)
+      end
+
+      it "opens the workflow for editing the devices" do
+        expect(Y2Partitioner::Actions::EditBtrfsDevices).to receive(:new)
+
+        button.handle(event)
+      end
+
+      include_examples "handle btrfs action result"
+    end
+  end
+end

--- a/test/y2partitioner/widgets/description_section/filesystem_test.rb
+++ b/test/y2partitioner/widgets/description_section/filesystem_test.rb
@@ -75,8 +75,8 @@ describe Y2Partitioner::Widgets::DescriptionSection::Filesystem do
       expect(subject.value).to_not match(/Metadata RAID Level:/)
     end
 
-    it "does ot include an entry about the data raid level" do
-      expect(subject.value).to_not match(/Data RAID Level:/)
+    it "does not include an entry about the data raid level" do
+      expect(subject.value).to_not match(/RAID Level:/)
     end
 
     it "contains (not mounted) if mount point is not active" do
@@ -96,7 +96,7 @@ describe Y2Partitioner::Widgets::DescriptionSection::Filesystem do
       end
 
       it "includes an entry about the data raid level" do
-        expect(subject.value).to match(/Data RAID Level:/)
+        expect(subject.value).to match(/RAID Level:/)
       end
     end
   end

--- a/test/y2partitioner/widgets/device_buttons_set_test.rb
+++ b/test/y2partitioner/widgets/device_buttons_set_test.rb
@@ -180,7 +180,7 @@ describe Y2Partitioner::Widgets::DeviceButtonsSet do
           widgets = Yast::CWM.widgets_in_contents([content])
           expect(widgets.map(&:class)).to contain_exactly(
             Y2Partitioner::Widgets::DeviceButtonsSet::ButtonsBox,
-            Y2Partitioner::Widgets::BtrfsEditButton
+            Y2Partitioner::Widgets::BtrfsModifyButton
           )
         end
 

--- a/test/y2partitioner/widgets/pages/btrfs_filesystems_test.rb
+++ b/test/y2partitioner/widgets/pages/btrfs_filesystems_test.rb
@@ -34,8 +34,6 @@ describe Y2Partitioner::Widgets::Pages::BtrfsFilesystems do
 
   let(:btrfs_filesystems) { current_graph.btrfs_filesystems }
 
-  let(:btrfs_devices) { btrfs_filesystems.map(&:blk_devices).flatten }
-
   subject { described_class.new(btrfs_filesystems, pager) }
 
   let(:pager) { double("OverviewTreePager") }
@@ -49,12 +47,11 @@ describe Y2Partitioner::Widgets::Pages::BtrfsFilesystems do
       table = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDevicesTable) }
 
       expect(table).to_not be_nil
-      expect(table.items.size).to eq(5)
 
-      devices_name = btrfs_devices.map(&:name)
-      items_name = table.items.map { |i| i[1] }
+      id_values = btrfs_filesystems.map(&:blk_device_basename)
+      first_column = table.items.map { |i| i[1] }
 
-      expect(items_name.sort).to eq(devices_name.sort)
+      expect(first_column).to contain_exactly(*id_values)
     end
 
     it "shows a buttons set" do

--- a/test/y2partitioner/widgets/pages/btrfs_test.rb
+++ b/test/y2partitioner/widgets/pages/btrfs_test.rb
@@ -51,11 +51,13 @@ describe Y2Partitioner::Widgets::Pages::Btrfs do
 
     it "shows a BTRFS overview tab" do
       expect(Y2Partitioner::Widgets::Pages::FilesystemTab).to receive(:new)
+
       subject.contents
     end
 
     it "shows an used devices tab" do
-      expect(Y2Partitioner::Widgets::UsedDevicesTab).to receive(:new)
+      expect(Y2Partitioner::Widgets::Pages::BtrfsDevicesTab).to receive(:new)
+
       subject.contents
     end
   end
@@ -75,6 +77,30 @@ describe Y2Partitioner::Widgets::Pages::Btrfs do
 
       it "shows a button for editing the filesystem" do
         button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BtrfsEditButton) }
+        expect(button).to_not be_nil
+      end
+    end
+  end
+
+  describe Y2Partitioner::Widgets::Pages::BtrfsDevicesTab do
+    subject { described_class.new(filesystem, pager) }
+    let(:pager) { double("Y2Partitioner::Widgets::OverviewTreePager") }
+
+    include_examples "CWM::Tab"
+
+    describe "#contents" do
+      let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
+
+      it "shows the table with used devices" do
+        used_devices_table = widgets.detect do |i|
+          i.is_a?(Y2Partitioner::Widgets::ConfigurableBlkDevicesTable)
+        end
+
+        expect(used_devices_table).to_not be_nil
+      end
+
+      it "shows a button for editing used devices" do
+        button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::UsedDevicesEditButton) }
         expect(button).to_not be_nil
       end
     end

--- a/test/y2partitioner/widgets/used_devices_edit_button_test.rb
+++ b/test/y2partitioner/widgets/used_devices_edit_button_test.rb
@@ -26,40 +26,71 @@ require "cwm/rspec"
 require "y2partitioner/widgets/used_devices_edit_button"
 
 describe Y2Partitioner::Widgets::UsedDevicesEditButton do
-  before do
-    devicegraph_stub(scenario)
-
-    allow(Y2Partitioner::Actions::EditMdDevices).to receive(:new).and_return(action)
-  end
-
-  let(:action) { instance_double(Y2Partitioner::Actions::EditMdDevices, run: :finish) }
-
   subject(:button) { described_class.new(device: device) }
-
-  let(:device) { device_graph.find_by_name(device_name) }
 
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
 
-  let(:scenario) { "formatted_md" }
+  let(:scenario) { "mixed_disks" }
 
-  let(:device_name) { "/dev/md0" }
+  let(:device_name) { "/dev/sda" }
+
+  let(:device) { device_graph.find_by_name(device_name) }
+
+  before do
+    devicegraph_stub(scenario)
+  end
 
   include_examples "CWM::PushButton"
 
   describe "#handle" do
     context "when the device is not a Software RAID" do
-      let(:scenario) { "mixed_disks" }
-
-      let(:device_name) { "/dev/sda" }
-
       it "returns nil" do
         expect(button.handle).to be(nil)
       end
     end
 
     context "when the device is a Software RAID" do
+      let(:scenario) { "formatted_md" }
+      let(:device_name) { "/dev/md0" }
+      let(:action) { instance_double(Y2Partitioner::Actions::EditMdDevices, run: :finish) }
+
+      before do
+        allow(Y2Partitioner::Actions::EditMdDevices).to receive(:new).and_return(action)
+      end
+
       it "calls the action to edit the used devices" do
         expect(Y2Partitioner::Actions::EditMdDevices).to receive(:new).with(device)
+
+        button.handle
+      end
+
+      it "returns :redraw if the action was successful" do
+        allow(action).to receive(:run).and_return(:finish)
+
+        expect(button.handle).to eq(:redraw)
+      end
+
+      it "returns nil if the action was not successful" do
+        allow(action).to receive(:run).and_return(:back)
+
+        expect(button.handle).to be_nil
+      end
+    end
+
+    context "when the device is a Btrfs filesystem" do
+      subject(:button) { described_class.new(device: fs) }
+
+      let(:scenario) { "btrfs_on_disk" }
+      let(:device_name) { "/dev/sda" }
+      let(:fs) { device.filesystem }
+      let(:action) { instance_double(Y2Partitioner::Actions::EditBtrfsDevices, run: :finish) }
+
+      before do
+        allow(Y2Partitioner::Actions::EditBtrfsDevices).to receive(:new).and_return(action)
+      end
+
+      it "calls the action to edit the used devices" do
+        expect(Y2Partitioner::Actions::EditBtrfsDevices).to receive(:new).with(fs)
 
         button.handle
       end

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -714,7 +714,7 @@ describe Y2Storage::BlkDevice do
   end
 
   describe "#component_of" do
-    context "for a device not used in an LVM or in a RAID or in multipath" do
+    context "for a device not used in an LVM or in a RAID or in multipath or in a Btrfs multidevice" do
       let(:scenario) { "mixed_disks" }
       let(:device_name) { "/dev/sda1" }
 
@@ -840,6 +840,16 @@ describe Y2Storage::BlkDevice do
       # considered to be a component of their own cset!).
       it "returns an empty array" do
         expect(device.component_of).to eq []
+      end
+    end
+
+    context "for a device directly used in an multidevice Btrfs filesystem" do
+      let(:scenario) { "btrfs2-devicegraph.xml" }
+      let(:device_name) { "/dev/sdb1" }
+
+      it "returns an array with the Btrfs filesystems" do
+        expect(device.component_of.size).to eq 1
+        expect(device.component_of.first).to be_a Y2Storage::Filesystems::Btrfs
       end
     end
   end

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -855,26 +855,12 @@ describe Y2Storage::BlkDevice do
   end
 
   describe "#component_of_names" do
-    context "component has name" do
-      let(:scenario) { "bcache1.xml" }
-      let(:device_name) { "/dev/vdc" }
+    let(:scenario) { "bcache1.xml" }
+    let(:device_name) { "/dev/vdb" }
 
-      it "returns name for that component" do
-        expect(device.component_of_names.size).to eq 1
-        expect(device.component_of_names.first).to eq "/dev/bcache0"
-      end
-    end
-
-    context "component has display name" do
-      let(:scenario) { "bcache1.xml" }
-      let(:device_name) { "/dev/vdb" }
-
-      it "returns display name for that component" do
-        expect(device.component_of_names.size).to eq 1
-        expect(device.component_of_names.first).to(
-          eq("Cache set (bcache0, bcache1, bcache2)")
-        )
-      end
+    it "returns the display name of the component devices" do
+      expect(device.component_of_names.size).to eq(1)
+      expect(device.component_of_names).to contain_exactly("Cache set (bcache0, bcache1, bcache2)")
     end
   end
 

--- a/test/y2storage/btrfs_raid_level_test.rb
+++ b/test/y2storage/btrfs_raid_level_test.rb
@@ -25,8 +25,24 @@ require "y2storage/btrfs_raid_level"
 
 describe Y2Storage::BtrfsRaidLevel do
   describe "#to_human_string" do
-    it "returns translatable string for enum value" do
-      expect(described_class::RAID1.to_human_string).to be_a(::String)
+    context "when there is a translation" do
+      it "returns the translated string" do
+        described_class.all.each do |value|
+          expect(value.to_human_string).to be_a(::String)
+        end
+      end
+    end
+
+    context "when there is no translation" do
+      subject { described_class.all.first }
+
+      before do
+        allow(subject).to receive(:to_sym).and_return(:crazy_stuff)
+      end
+
+      it "raises a RuntimeError" do
+        expect { subject.to_human_string }.to raise_error(RuntimeError)
+      end
     end
   end
 end

--- a/test/y2storage/btrfs_raid_level_test.rb
+++ b/test/y2storage/btrfs_raid_level_test.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage/btrfs_raid_level"
+
+describe Y2Storage::BtrfsRaidLevel do
+  describe "#to_human_string" do
+    it "returns translatable string for enum value" do
+      expect(described_class::RAID1.to_human_string).to be_a(::String)
+    end
+  end
+end

--- a/test/y2storage/cache_mode_test.rb
+++ b/test/y2storage/cache_mode_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -25,9 +25,23 @@ require "y2storage"
 
 describe Y2Storage::CacheMode do
   describe "#to_human_string" do
-    it "returns string for all known cache mode" do
-      Y2Storage::CacheMode.all.each do |mode|
-        expect { mode.to_human_string }.to_not raise_error
+    context "when there is a translation" do
+      it "returns the translated string" do
+        described_class.all.each do |value|
+          expect(value.to_human_string).to be_a(::String)
+        end
+      end
+    end
+
+    context "when there is no translation" do
+      subject { described_class.all.first }
+
+      before do
+        allow(subject).to receive(:to_sym).and_return(:crazy_stuff)
+      end
+
+      it "raises a RuntimeError" do
+        expect { subject.to_human_string }.to raise_error(RuntimeError)
       end
     end
   end

--- a/test/y2storage/device_test.rb
+++ b/test/y2storage/device_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -191,6 +191,34 @@ describe Y2Storage::Device do
       it "returns false" do
         expect(device.exists_in_raw_probed?).to eq(true)
         expect(device.exists_in_probed?).to eq(false)
+      end
+    end
+  end
+
+  describe "#display_name" do
+    let(:device) { devicegraph.find_by_name(device_name) }
+
+    let(:devicegraph) { Y2Storage::StorageManager.instance.staging }
+
+    let(:scenario) { "mixed_disks" }
+
+    context "if the device has name" do
+      subject { device }
+
+      let(:device_name) { "/dev/sda" }
+
+      it "returns the device name" do
+        expect(subject.display_name).to eq(device_name)
+      end
+    end
+
+    context "if the device has no name" do
+      subject { device.filesystem }
+
+      let(:device_name) { "/dev/sda1" }
+
+      it "returns nil" do
+        expect(subject.display_name).to be_nil
       end
     end
   end

--- a/test/y2storage/filesystems/blk_filesystem_test.rb
+++ b/test/y2storage/filesystems/blk_filesystem_test.rb
@@ -51,10 +51,10 @@ describe Y2Storage::Filesystems::BlkFilesystem do
 
       let(:dev_name) { "/dev/sdb1" }
 
-      it "returns the base name of its first block device followed by '+'" do
+      it "returns the base name of its first block device between brackets" do
         # NOTE that must be the first block device base name after sort them alphabetically,
-        # so "sdb1+" is expected
-        expect(subject.blk_device_basename).to eq("sdb1+")
+        # so "(sdb1...)" is expected
+        expect(subject.blk_device_basename).to match(/\(sdb1.*\)/)
       end
     end
   end

--- a/test/y2storage/filesystems/blk_filesystem_test.rb
+++ b/test/y2storage/filesystems/blk_filesystem_test.rb
@@ -52,8 +52,9 @@ describe Y2Storage::Filesystems::BlkFilesystem do
       let(:dev_name) { "/dev/sdb1" }
 
       it "returns the base name of its first block device followed by '+'" do
-        basename = filesystem.blk_devices.first.basename
-        expect(subject.blk_device_basename).to eq(basename + "+")
+        # NOTE that must be the first block device base name after sort them alphabetically,
+        # so "sdb1+" is expected
+        expect(subject.blk_device_basename).to eq("sdb1+")
       end
     end
   end

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -950,6 +950,28 @@ describe Y2Storage::Filesystems::Btrfs do
       filesystem.mount_point.mount_by = Y2Storage::Filesystems::MountByType::UUID
       expect(btrfs_mount_by).to eq :uuid
       expect(subvol_mount_bys).to all(eq :label)
+    end
+  end
+
+  describe "#display_name" do
+    context "when it is a multi-device Btrfs" do
+      let(:scenario) { "btrfs2-devicegraph.xml" }
+
+      let(:dev_name) { "/dev/sdb1" }
+
+      it "returns a name representing the filesystem" do
+        expect(subject.display_name).to match(/Btrfs .* over .*/)
+      end
+    end
+
+    context "when it is a single-device Btrfs" do
+      let(:scenario) { "mixed_disks" }
+
+      let(:dev_name) { "/dev/sdb2" }
+
+      it "returns nil" do
+        expect(subject.display_name).to be_nil
+      end
     end
   end
 end

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -960,7 +960,7 @@ describe Y2Storage::Filesystems::Btrfs do
       let(:dev_name) { "/dev/sdb1" }
 
       it "returns a name representing the filesystem" do
-        expect(subject.display_name).to match(/Btrfs .* over .*/)
+        expect(subject.display_name).to match(/Btrfs over .* devices .*/)
       end
     end
 

--- a/test/y2storage/lvm_pv_test.rb
+++ b/test/y2storage/lvm_pv_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -25,19 +25,21 @@ require "y2storage"
 
 describe Y2Storage::LvmPv do
   before do
-    fake_scenario("complex-lvm-encrypt")
+    fake_scenario(scenario)
   end
 
+  subject { device.lvm_pv }
+
+  let(:device) { fake_devicegraph.find_by_name(device_name) }
+
   describe "#plain_blk_device" do
-    subject(:pv) do
-      Y2Storage::LvmPv.all(fake_devicegraph).detect { |p| p.blk_device.name == device_name }
-    end
+    let(:scenario) { "complex-lvm-encrypt" }
 
     context "for a non encrypted PV" do
       let(:device_name) { "/dev/sde2" }
 
       it "returns the device directly hosting the PV" do
-        expect(pv.plain_blk_device).to eq pv.blk_device
+        expect(subject.plain_blk_device).to eq(subject.blk_device)
       end
     end
 
@@ -45,8 +47,52 @@ describe Y2Storage::LvmPv do
       let(:device_name) { "/dev/mapper/cr_sde1" }
 
       it "returns the plain version of the encrypted device" do
-        expect(pv.plain_blk_device).to_not eq pv.blk_device
-        expect(pv.plain_blk_device).to eq pv.blk_device.plain_device
+        expect(subject.plain_blk_device).to_not eq(subject.blk_device)
+        expect(subject.plain_blk_device).to eq(subject.blk_device.plain_device)
+      end
+    end
+  end
+
+  describe "#orphan?" do
+    context "when the PV is associated to a VG" do
+      let(:scenario) { "complex-lvm-encrypt" }
+
+      let(:device_name) { "/dev/sde2" }
+
+      it "returns false" do
+        expect(subject.orphan?).to eq(false)
+      end
+    end
+
+    context "when the PV is not associated to a VG" do
+      let(:scenario) { "unused_lvm_pvs.xml" }
+
+      let(:device_name) { "/dev/sda2" }
+
+      it "returns true" do
+        expect(subject.orphan?).to eq(true)
+      end
+    end
+  end
+
+  describe "#display_name" do
+    context "when it is an orphan PV" do
+      let(:scenario) { "unused_lvm_pvs.xml" }
+
+      let(:device_name) { "/dev/sda2" }
+
+      it "returns a name representing the PV" do
+        expect(subject.display_name).to match(/Orphan PV .*/)
+      end
+    end
+
+    context "when it is not an orphan PV" do
+      let(:scenario) { "complex-lvm-encrypt" }
+
+      let(:device_name) { "/dev/sde2" }
+
+      it "returns nil" do
+        expect(subject.display_name).to be_nil
       end
     end
   end

--- a/test/y2storage/lvm_pv_test.rb
+++ b/test/y2storage/lvm_pv_test.rb
@@ -82,7 +82,7 @@ describe Y2Storage::LvmPv do
       let(:device_name) { "/dev/sda2" }
 
       it "returns a name representing the PV" do
-        expect(subject.display_name).to match(/Orphan PV .*/)
+        expect(subject.display_name).to match(/Unused LVM PV .*/)
       end
     end
 

--- a/test/y2storage/md_level_test.rb
+++ b/test/y2storage/md_level_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -25,15 +25,24 @@ require "y2storage/md_level"
 
 describe Y2Storage::MdLevel do
   describe "#to_human_string" do
-    it "returns translatable string for enum value" do
-      expect(described_class.new(1).to_human_string).to be_a(::String)
-      expect(described_class.new(2).to_human_string).to be_a(::String)
+    context "when there is a translation" do
+      it "returns the translated string" do
+        described_class.all.each do |value|
+          expect(value.to_human_string).to be_a(::String)
+        end
+      end
     end
 
-    it "raises RuntimeError when unknown enum value is used" do
-      enum = described_class.new(1)
-      allow(enum).to receive(:to_sym).and_return(:crazy_stuff)
-      expect { enum.to_human_string }.to raise_error(RuntimeError)
+    context "when there is no translation" do
+      subject { described_class.all.first }
+
+      before do
+        allow(subject).to receive(:to_sym).and_return(:crazy_stuff)
+      end
+
+      it "raises a RuntimeError" do
+        expect { subject.to_human_string }.to raise_error(RuntimeError)
+      end
     end
   end
 end

--- a/test/y2storage/md_parity_test.rb
+++ b/test/y2storage/md_parity_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -25,15 +25,24 @@ require "y2storage/md_parity"
 
 describe Y2Storage::MdParity do
   describe "#to_human_string" do
-    it "returns translatable string for enum value" do
-      expect(described_class.new(1).to_human_string).to be_a(::String)
-      expect(described_class.new(2).to_human_string).to be_a(::String)
+    context "when there is a translation" do
+      it "returns the translated string" do
+        described_class.all.each do |value|
+          expect(value.to_human_string).to be_a(::String)
+        end
+      end
     end
 
-    it "raises RuntimeError when unknown enum value is used" do
-      enum = described_class.new(1)
-      allow(enum).to receive(:to_sym).and_return(:crazy_stuff)
-      expect { enum.to_human_string }.to raise_error(RuntimeError)
+    context "when there is no translation" do
+      subject { described_class.all.first }
+
+      before do
+        allow(subject).to receive(:to_sym).and_return(:crazy_stuff)
+      end
+
+      it "raises a RuntimeError" do
+        expect { subject.to_human_string }.to raise_error(RuntimeError)
+      end
     end
   end
 end


### PR DESCRIPTION
NOTE FOR REVIEWERS: codeclimate strikes again. Please, mark it as wontfix (for some reason, I am not allowed to do it).

## Problem

The Expert Partitioner shows existing multi-device Btrfs, but there is no way to create a new one.

* https://jira.suse.de/browse/SLE-3877
* https://trello.com/c/C7o44w3f/948-5-partitioner-adding-and-modifying-multi-device-btrfs

## Solution

Added button to the Expert Partitioner to create a new Btrfs. That button opens a wizard with two steps:

* step 1: allows to select metadata/data RAID levels, and the devices to use for the new Btrfs.
* step2: allows to select mount point, fstab options, subvolumes, etc.

Moreover, a button for editing the used devices was added. Right now, the devices can only be edited when the filesystem does no exist on disk yet. 

## Testing

- Added unit tests
- Tested manually


## Screenshots

<details>
<summary>Show screenshots</summary>

![VirtualBox_openSUSE Tumbleweed_10_05_2019_08_48_40](https://user-images.githubusercontent.com/1112304/57511521-6baa5f80-7301-11e9-8d4c-0e0b9d92986f.png)

![VirtualBox_openSUSE Tumbleweed_10_05_2019_08_48_59](https://user-images.githubusercontent.com/1112304/57511531-6fd67d00-7301-11e9-9845-79b50e772714.png)

![VirtualBox_openSUSE Tumbleweed_10_05_2019_08_49_39](https://user-images.githubusercontent.com/1112304/57511539-749b3100-7301-11e9-854f-8f05efc794a6.png)

![VirtualBox_openSUSE Tumbleweed_10_05_2019_08_50_11](https://user-images.githubusercontent.com/1112304/57511555-7a911200-7301-11e9-9db3-9d8c6b841816.png)

![VirtualBox_openSUSE Tumbleweed_10_05_2019_08_50_44](https://user-images.githubusercontent.com/1112304/57511559-7d8c0280-7301-11e9-9923-76e60fd3b3dc.png)

![VirtualBox_openSUSE Tumbleweed_10_05_2019_08_51_17](https://user-images.githubusercontent.com/1112304/57511572-8086f300-7301-11e9-86be-525c6337dfef.png)

![VirtualBox_openSUSE Tumbleweed_10_05_2019_08_51_40](https://user-images.githubusercontent.com/1112304/57511585-85e43d80-7301-11e9-99e5-25d64ca44e66.png)

![VirtualBox_openSUSE Tumbleweed_10_05_2019_08_52_22](https://user-images.githubusercontent.com/1112304/57511592-88df2e00-7301-11e9-8b20-bbe3246127c5.png)

![VirtualBox_openSUSE Tumbleweed_10_05_2019_08_54_17](https://user-images.githubusercontent.com/1112304/57511597-8b418800-7301-11e9-8124-fbf807255689.png)

![VirtualBox_openSUSE Tumbleweed_10_05_2019_08_54_59](https://user-images.githubusercontent.com/1112304/57511602-8e3c7880-7301-11e9-9ff9-336d119e9561.png)

</details>
