### PR TITLE
Partitioner: button to delete btrfs and pop-up to protect multi-device filesystems

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri May 10 12:31:21 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Partitioner: button to delete Btrfs filesystems.
+- Partitioner: prevent edition of block devices that are part of
+  a multi-device Btrfs.
+- Part of jsc#SLE-3877.
+- 4.2.14
+
+-------------------------------------------------------------------
 Wed May  8 11:59:39 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Partitioner: added option for creating Btrfs filesystems (single-

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.2.13
+Version:	4.2.14
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/actions/controllers/blk_device.rb
+++ b/src/lib/y2partitioner/actions/controllers/blk_device.rb
@@ -73,9 +73,7 @@ module Y2Partitioner
         def mounted_committed_filesystem?
           return false unless committed_filesystem?
 
-          mount_point = committed_filesystem.mount_point
-
-          !mount_point.nil? && mount_point.active?
+          committed_filesystem.active_mount_point?
         end
 
         # Whether the device exists on the system

--- a/src/lib/y2partitioner/actions/delete_btrfs.rb
+++ b/src/lib/y2partitioner/actions/delete_btrfs.rb
@@ -44,18 +44,14 @@ module Y2Partitioner
 
       # @see DeleteDevice#simple_confirm_text
       #
-      # @note The implementation in the base class relies on the #name method
-      #   of the device, which does not exist for filesystems.
+      # @note The implementation in the base class relies on the #display_name
+      #   method of the device, which returns nil for regular (non multi-device)
+      #   filesystems.
       #
       # @return [String]
       def simple_confirm_text
         _("Really delete the filesystem?")
       end
-
-      # By definition, this should never be called for a Btrfs filesystem (it
-      # cannot be a component of other bigger device), but it's redefined to
-      # stay safe (see note on {#simple_confirm_text}).
-      alias_method :recursive_confirm_text_below, :simple_confirm_text
 
       # @see DeleteDevice#committed_device
       def committed_device

--- a/src/lib/y2partitioner/actions/delete_btrfs.rb
+++ b/src/lib/y2partitioner/actions/delete_btrfs.rb
@@ -1,0 +1,83 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage"
+require "y2partitioner/actions/delete_device"
+
+module Y2Partitioner
+  module Actions
+    # Action for deleting a Btrfs filesystem
+    #
+    # @see DeleteDevice
+    class DeleteBtrfs < DeleteDevice
+      def initialize(*args)
+        super
+        textdomain "storage"
+      end
+
+    private
+
+      # Deletes the indicated filesystem (see {DeleteDevice#device})
+      def delete
+        log.info "deleting btrfs #{device}"
+        device.blk_devices.first.delete_filesystem
+      end
+
+      # @see DeleteDevice#simple_confirm_text
+      #
+      # @note The implementation in the base class relies on the #name method
+      #   of the device, which does not exist for filesystems.
+      #
+      # @return [String]
+      def simple_confirm_text
+        _("Really delete the filesystem?")
+      end
+
+      # By definition, this should never be called for a Btrfs filesystem (it
+      # cannot be a component of other bigger device), but it's redefined to
+      # stay safe (see note on {#simple_confirm_text}).
+      alias_method :recursive_confirm_text_below, :simple_confirm_text
+
+      # @see DeleteDevice#committed_device
+      def committed_device
+        @committed_device ||= system_graph.find_device(device.sid)
+      end
+
+      # @see DeleteDevice#committed_device_mounted?
+      def committed_device_mounted?
+        return false if committed_device.nil?
+        committed_device.active_mount_point?
+      end
+
+      # Devicegraph that represents the current version of the devices in the system
+      #
+      # @note To check whether a filesystem is currently mounted, it must be checked
+      #   in the system devicegraph. When a mount point is "immediate deactivated", the
+      #   mount point is set as inactive only in the system devicegraph.
+      #
+      # @return [Y2Storage::Devicegraph]
+      def system_graph
+        Y2Storage::StorageManager.instance.system
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/actions/delete_device.rb
+++ b/src/lib/y2partitioner/actions/delete_device.rb
@@ -148,7 +148,7 @@ module Y2Partitioner
       # @return [String]
       def recursive_confirm_text_below
         # TRANSLATORS %s is a kernel name like /dev/sda1
-        format(_("Really delete %s and all the affected devices?"), device.name)
+        format(_("Really delete %s and all the affected devices?"), device.display_name)
       end
 
       # Text to display in {#simple_confirm}
@@ -156,7 +156,7 @@ module Y2Partitioner
       # @return [String]
       def simple_confirm_text
         # TRANSLATORS %s is the kernel name of the device (e.g., /dev/sda1)
-        format(_("Really delete %s?"), device.name)
+        format(_("Really delete %s?"), device.display_name)
       end
 
       # Controller for a block device

--- a/src/lib/y2partitioner/actions/delete_device.rb
+++ b/src/lib/y2partitioner/actions/delete_device.rb
@@ -181,7 +181,7 @@ module Y2Partitioner
         # TRANSLATORS: Note added to the dialog for trying to unmount a device
         note = _("It cannot be deleted while mounted.")
 
-        immediate_unmount(controller.committed_device, note: note)
+        immediate_unmount(committed_device, note: note)
       end
 
       # Whether it is necessary to try unmount (i.e., when deleting a mounted block device that
@@ -189,8 +189,23 @@ module Y2Partitioner
       #
       # @return [Boolean]
       def need_try_unmount?
-        return false unless device.is?(:blk_device)
+        return false unless device.is?(:blk_device, :blk_filesystem)
 
+        committed_device_mounted?
+      end
+
+      # Device taken from the system devicegraph
+      #
+      # @return [Y2Storage::Device, nil] nil if the device does not exist on disk yet.
+      def committed_device
+        controller.committed_device
+      end
+
+      # Whether {#committed_device} exists and is mounted, according to the
+      # system devicegraph
+      #
+      # @return [Boolean]
+      def committed_device_mounted?
         controller.mounted_committed_filesystem?
       end
     end

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -189,22 +189,39 @@ module Y2Partitioner
     end
 
     # List of candidate nodes to go back after opening a device view in the tree
+    #
+    # @return [Array<Integer, String>]
     def device_page_candidates(page)
       device = page.device
+      [device.sid, device_page_parent(device)].compact
+    end
+
+    # @see #device_page_candidates
+    #
+    # @return [Integer, String, nil] nil if there is no parent tree entry
+    def device_page_parent(device)
       if device.is?(:partition)
-        [device.sid, device.partitionable.sid]
-      elsif device.is?(:md)
-        [device.sid, md_raids_label]
+        device.partitionable.sid
       elsif device.is?(:lvm_lv)
-        [device.sid, device.lvm_vg.sid]
-      elsif device.is?(:lvm_vg)
-        [device.sid, lvm_label]
-      elsif device.is?(:bcache)
-        [device.sid, bcache_label]
-      elsif device.is?(:btrfs)
-        [device.sid, btrfs_filesystems_label]
+        device.lvm_vg.sid
       else
-        [device.sid]
+        device_page_section(device)
+      end
+    end
+
+    # @see #device_page_candidates
+    # @see #device_page_section
+    #
+    # @return [Integer, String, nil] nil if there is no parent tree entry
+    def device_page_section(device)
+      if device.is?(:md)
+        md_raids_label
+      elsif device.is?(:lvm_vg)
+        lvm_label
+      elsif device.is?(:bcache)
+        bcache_label
+      elsif device.is?(:btrfs)
+        btrfs_filesystems_label
       end
     end
 

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -82,6 +82,15 @@ module Y2Partitioner
       _("Bcache")
     end
 
+    # Title of the Btrfs section
+    #
+    # @note See note on {.md_raids_label} about why this looks misplaced.
+    #
+    # @return [String]
+    def btrfs_filesystems_label
+      _("Btrfs")
+    end
+
     # @return [Integer, nil] if a row must be selected in a table with devices,
     #   this returns the sid of the associated device
     attr_reader :row_sid
@@ -192,6 +201,8 @@ module Y2Partitioner
         [device.sid, lvm_label]
       elsif device.is?(:bcache)
         [device.sid, bcache_label]
+      elsif device.is?(:btrfs)
+        [device.sid, btrfs_filesystems_label]
       else
         [device.sid]
       end

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -210,7 +210,7 @@ module Y2Partitioner
     end
 
     # @see #device_page_candidates
-    # @see #device_page_section
+    # @see #device_page_parent
     #
     # @return [Integer, String, nil] nil if there is no parent tree entry
     def device_page_section(device)

--- a/src/lib/y2partitioner/widgets/device_buttons_set.rb
+++ b/src/lib/y2partitioner/widgets/device_buttons_set.rb
@@ -172,7 +172,8 @@ module Y2Partitioner
       # Buttons to display if {#device} is a BTRFS filesystem
       def btrfs_buttons
         [
-          BtrfsModifyButton.new(device)
+          BtrfsModifyButton.new(device),
+          DeviceDeleteButton.new(pager: pager, device: device)
         ]
       end
 

--- a/src/lib/y2partitioner/widgets/device_delete_button.rb
+++ b/src/lib/y2partitioner/widgets/device_delete_button.rb
@@ -26,6 +26,7 @@ require "y2partitioner/actions/delete_partition"
 require "y2partitioner/actions/delete_lvm_vg"
 require "y2partitioner/actions/delete_lvm_lv"
 require "y2partitioner/actions/delete_md"
+require "y2partitioner/actions/delete_btrfs"
 
 module Y2Partitioner
   module Widgets
@@ -49,7 +50,8 @@ module Y2Partitioner
         lvm_vg:    Actions::DeleteLvmVg,
         lvm_lv:    Actions::DeleteLvmLv,
         md:        Actions::DeleteMd,
-        bcache:    Actions::DeleteBcache
+        bcache:    Actions::DeleteBcache,
+        btrfs:     Actions::DeleteBtrfs
       }
       private_constant :DEVICE_MAPPING
 
@@ -61,6 +63,7 @@ module Y2Partitioner
       # @see Actions::DeleteLvmVg
       # @see Actions::DeleteLvmLv
       # @see Actions::DeleteMd
+      # @see Actions::DeleteBtrfs
       #
       # @return [Actions::DeleteDevice,nil] returns nil if action is not yet implemented
       def actions_class

--- a/src/lib/y2partitioner/widgets/pages/btrfs.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs.rb
@@ -25,6 +25,7 @@ require "y2partitioner/widgets/used_devices_tab"
 require "y2partitioner/widgets/filesystem_description"
 require "y2partitioner/widgets/btrfs_edit_button"
 require "y2partitioner/widgets/used_devices_edit_button"
+require "y2partitioner/widgets/device_delete_button"
 require "y2partitioner/widgets/tabs"
 
 module Y2Partitioner
@@ -140,7 +141,8 @@ module Y2Partitioner
         # @return [Array<Widgets::DeviceButton>]
         def buttons
           [
-            BtrfsEditButton.new(device: @filesystem)
+            BtrfsEditButton.new(device: @filesystem),
+            DeviceDeleteButton.new(device: @filesystem)
           ]
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
@@ -21,6 +21,7 @@
 
 require "yast"
 require "y2partitioner/icons"
+require "y2partitioner/ui_state"
 require "y2partitioner/widgets/pages/devices_table"
 require "y2partitioner/widgets/btrfs_filesystems_table"
 require "y2partitioner/widgets/btrfs_add_button"
@@ -46,7 +47,7 @@ module Y2Partitioner
 
         # @macro seeAbstractWidget
         def label
-          _("Btrfs")
+          UIState.instance.btrfs_filesystems_label
         end
 
       private

--- a/src/lib/y2storage/disk_analyzer.rb
+++ b/src/lib/y2storage/disk_analyzer.rb
@@ -355,7 +355,7 @@ module Y2Storage
     # @param filesystem [Filesystems::Base]
     # @return [Boolean]
     def mounted_filesystem?(filesystem)
-      filesystem.mount_point && filesystem.mount_point.active?
+      filesystem.active_mount_point?
     end
 
     # Checks whether a device contains an installation repository

--- a/src/lib/y2storage/mountable.rb
+++ b/src/lib/y2storage/mountable.rb
@@ -127,5 +127,12 @@ module Y2Storage
       storage_remove_mount_point
       update_etc_status
     end
+
+    # Whether the device is mounted, according to the devicegraph
+    #
+    # @return [Boolean]
+    def active_mount_point?
+      !mount_point.nil? && mount_point.active?
+    end
   end
 end

--- a/test/data/devicegraphs/btrfs2-devicegraph.xml
+++ b/test/data/devicegraphs/btrfs2-devicegraph.xml
@@ -239,16 +239,16 @@
       <type>primary</type>
       <id>253</id>
     </Partition>
-    <Ext4>
+    <Btrfs>
       <sid>59</sid>
       <uuid>c126ff68-5a43-4513-91b1-7ae2409a411d</uuid>
-    </Ext4>
+    </Btrfs>
     <MountPoint>
       <sid>60</sid>
       <path>/</path>
       <mount-by>uuid</mount-by>
       <mount-options>acl,user_xattr</mount-options>
-      <mount-type>ext4</mount-type>
+      <mount-type>btrfs</mount-type>
       <active>true</active>
       <in-etc-fstab>true</in-etc-fstab>
       <freq>0</freq>

--- a/test/y2partitioner/actions/delete_btrfs_test.rb
+++ b/test/y2partitioner/actions/delete_btrfs_test.rb
@@ -1,0 +1,172 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/actions/delete_btrfs"
+
+describe Y2Partitioner::Actions::DeleteBtrfs do
+  before do
+    devicegraph_stub(scenario)
+  end
+
+  subject { described_class.new(filesystem) }
+
+  let(:scenario) { "btrfs2-devicegraph.xml" }
+
+  let(:filesystem) do
+    Y2Storage::BlkDevice.find_by_name(device_graph, blk_device_name).filesystem
+  end
+
+  let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+
+  describe "#run" do
+    before do
+      allow(Yast2::Popup).to receive(:show).and_return(accept)
+    end
+
+    let(:accept) { nil }
+
+    shared_examples "do not delete" do
+      it "does not delete the filesystem" do
+        subject.run
+        fs = Y2Storage::BlkDevice.find_by_name(device_graph, blk_device_name).filesystem
+        expect(fs).to_not be_nil
+      end
+
+      it "returns :back" do
+        expect(subject.run).to eq(:back)
+      end
+    end
+
+    shared_examples "confirm and delete" do
+      it "shows a confirm message" do
+        expect(Yast2::Popup).to receive(:show)
+        subject.run
+      end
+
+      context "when the confirm message is not accepted" do
+        let(:accept) { :no }
+
+        include_examples "do not delete"
+      end
+
+      context "when the confirm message is accepted" do
+        let(:accept) { :yes }
+
+        it "deletes the filesystem" do
+          subject.run
+          fs = Y2Storage::BlkDevice.find_by_name(device_graph, blk_device_name).filesystem
+          expect(fs).to be_nil
+        end
+
+        it "does not delete the associated block devices" do
+          blk_devs = filesystem.blk_devices.map(&:sid)
+
+          subject.run
+
+          blk_devs_after = blk_devs.map { |sid| device_graph.find_device(sid) }
+          expect(blk_devs_after).to_not include(nil)
+        end
+
+        it "refresh btrfs subvolumes shadowing" do
+          expect(Y2Storage::Filesystems::Btrfs).to receive(:refresh_subvolumes_shadowing)
+          subject.run
+        end
+
+        it "returns :finish" do
+          expect(subject.run).to eq(:finish)
+        end
+      end
+    end
+
+    context "when the filesystem is not mounted in the system" do
+      before do
+        allow_any_instance_of(Y2Storage::MountPoint).to receive(:active?).and_return false
+      end
+
+      context "when deleting a regular btrfs" do
+        let(:blk_device_name) { "/dev/sda2" }
+
+        it "does not ask for unmounting the partition" do
+          expect(Yast2::Popup).to_not receive(:show).with(/try to unmount/, anything)
+
+          subject.run
+        end
+
+        include_examples "confirm and delete"
+      end
+
+      context "when deleting a multi-device btrfs" do
+        let(:blk_device_name) { "/dev/sdb1" }
+
+        it "does not ask for unmounting the partition" do
+          expect(Yast2::Popup).to_not receive(:show).with(/try to unmount/, anything)
+
+          subject.run
+        end
+
+        include_examples "confirm and delete"
+      end
+    end
+
+    context "when the filesystem is mounted in the system" do
+      # All btrfs filesystems are mounted in this scenario, no need to mock
+      # #active?, just pick any btrfs
+      let(:blk_device_name) { "/dev/sdb1" }
+
+      before do
+        allow(Yast2::Popup).to receive(:show).with(/try to unmount/, anything)
+          .and_return(*unmount_answer)
+      end
+
+      let(:unmount_answer) { [:cancel] }
+
+      it "asks for unmounting the partition" do
+        expect(Yast2::Popup).to receive(:show).with(/try to unmount/, anything)
+
+        subject.run
+      end
+
+      it "shows a specific note for deleting" do
+        expect(Yast2::Popup).to receive(:show)
+          .with(/cannot be deleted while mounted/, anything)
+          .and_return(:cancel)
+
+        subject.run
+      end
+
+      context "and the user decides to continue" do
+        let(:unmount_answer) { [:continue] }
+
+        include_examples "confirm and delete"
+      end
+
+      context "and the user decides to cancel" do
+        let(:unmount_answer) { [:cancel] }
+
+        include_examples "do not delete"
+      end
+    end
+  end
+end

--- a/test/y2partitioner/actions/edit_blk_device_test.rb
+++ b/test/y2partitioner/actions/edit_blk_device_test.rb
@@ -100,6 +100,13 @@ describe Y2Partitioner::Actions::EditBlkDevice do
       include_examples "edit_error"
     end
 
+    context "if called on a device that is part of a multi-device Btrfs" do
+      let(:scenario) { "btrfs2-devicegraph.xml" }
+      let(:dev_name) { "/dev/sdb1" }
+
+      include_examples "edit_error"
+    end
+
     context "if called on an LVM thin pool" do
       let(:scenario) { "lvm-two-vgs.yml" }
 

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -250,6 +250,33 @@ describe Y2Partitioner::UIState do
         end
       end
     end
+
+    context "when the user has opened a btrfs page" do
+      let(:scenario) { "mixed_disks_btrfs" }
+      let(:device) { fake_devicegraph.find_by_name("/dev/sda2").filesystem }
+      let(:another_btrfs) { fake_devicegraph.find_by_name("/dev/sdb2").filesystem }
+
+      let(:page) { Y2Partitioner::Widgets::Pages::Btrfs.new(device, pager) }
+      let(:another_btrfs_page) { Y2Partitioner::Widgets::Pages::Btrfs.new(another_btrfs, pager) }
+
+      before { ui_state.go_to_tree_node(page) }
+
+      context "if the filesystem is still there after redrawing" do
+        before { pages.concat [page, another_btrfs_page] }
+
+        it "selects the correct btrfs page" do
+          expect(ui_state.find_tree_node(pages)).to eq page
+        end
+      end
+
+      context "if the filesystem is not longer there after redrawing" do
+        before { pages << another_btrfs_page }
+
+        it "selects the general btrfs page" do
+          expect(ui_state.find_tree_node(pages)).to eq btrfs_filesystems_page
+        end
+      end
+    end
   end
 
   describe "#find_tab" do

--- a/test/y2partitioner/widgets/device_buttons_set_test.rb
+++ b/test/y2partitioner/widgets/device_buttons_set_test.rb
@@ -175,12 +175,13 @@ describe Y2Partitioner::Widgets::DeviceButtonsSet do
       let(:scenario) { "mixed_disks" }
       let(:device) { device_graph.find_by_name("/dev/sdb2").filesystem }
 
-      it "replaces the content with a single button to edit the filesystem" do
+      it "replaces the content with buttons to edit and to delete the filesystem" do
         expect(widget).to receive(:replace) do |content|
           widgets = Yast::CWM.widgets_in_contents([content])
           expect(widgets.map(&:class)).to contain_exactly(
             Y2Partitioner::Widgets::DeviceButtonsSet::ButtonsBox,
-            Y2Partitioner::Widgets::BtrfsModifyButton
+            Y2Partitioner::Widgets::BtrfsModifyButton,
+            Y2Partitioner::Widgets::DeviceDeleteButton
           )
         end
 


### PR DESCRIPTION
## Problem

We found that treating the deletion and edition of multi-device Btrfs just like any other filesystem leaded to problems and inconsistencies. For example.

- Starting point: a Btrfs over sda1 and sdb1
- The user edits sda1 and marks it to be formatted as ext4. That deletes the Btrfs.
- The user uses sdb1 for something else (let's say LVM)
- The user edits sda1 again and chooses "Do not format"

In the regular case, "do not format" means keeping the filesystem that is currently in sda1 in the `system` devicegraph (i.e. in the real disk). But that cannot be done because a multi-device filesystem cannot be restored from the `system` devicegraph to the `current` one (first of all, sdb1 is not available anymore.

Trello card: https://trello.com/c/DdttqbRR/956-2-button-to-delete-multi-device-btrfs

## Solution

Make the deletion of the multi-device Btrfs an explicit operation done by the user, just like it happens with RAID, LVM or bcache.

In addition, prevent edition of a block device that is part of a multi-device Btrfs. Show the following pop-up.

![btrfs_popup](https://user-images.githubusercontent.com/3638289/57385217-507d0a00-71b2-11e9-94b9-c0fa5e87f44d.png)

## Testing

- Added unit tests
- Tested manually using the `partitioner_testing` client
