### PR TITLE
Fix bug#1134330 in SLE-15-GA

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 10 14:59:50 UTC 2019 - ancor@suse.com
+
+- AutoYaST: do not ask for a reusable filesystem when it's not
+  really needed (bsc#1134330).
+- 4.0.221
+
+-------------------------------------------------------------------
 Wed Apr 10 11:04:44 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - AutoYaST: new format for importing/exporting NFS drives.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.220
+Version:        4.0.221
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/proposal/autoinst_drive_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_drive_planner.rb
@@ -181,6 +181,10 @@ module Y2Storage
       # @param section        [AutoinstProfile::PartitionSection] AutoYaST specification
       def check_reusable_filesystem(planned_device, device, section)
         return if planned_device.reformat || device.filesystem || planned_device.component?
+        # The device to be reused doesn't have filesystem... but maybe it's not
+        # really needed, e.g. reusing a bios_boot partition (bsc#1134330)
+        return if planned_device.mount_point.nil? && planned_device.filesystem_type.nil?
+
         issues_list.add(:missing_reusable_filesystem, section)
       end
 

--- a/src/lib/y2storage/proposal/autoinst_drive_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_drive_planner.rb
@@ -216,9 +216,6 @@ module Y2Storage
         return unless partition_to_reuse
         partition.filesystem_type ||= partition_to_reuse.filesystem_type
         add_device_reuse(partition, partition_to_reuse, section)
-        if !partition.reformat && !partition_to_reuse.filesystem && !partition.component?
-          issues_list.add(:missing_reusable_filesystem, section)
-        end
       end
 
       # @param partition    [Planned::Partition] Planned partition


### PR DESCRIPTION
## Problem

AutoYaST fails when trying to reuse a non-formatted partition as-is (i.e. without formatting it). By definition, it means AutoYaST can hardly be used to reuse BIOS BOOT partitions.

- See https://bugzilla.suse.com/show_bug.cgi?id=1134330

## Solution

This fixes two issues:

- First of all, the "missing reusable filesystem" issue was always reported twice due to a code duplication.
- More important, this avoids false positives when reporting such error. If the partition is not intended to be mounted and no filesystem type is specified, is probably ok if the partition to be reused is not currently formatted.

## Testing

- Regression unit test added

## Note for reviewer

Review commit by commit, it makes more sense.
