### PR TITLE
Unit test for reusing partitions of a former LVM

### DIFF
--- a/test/data/devicegraphs/lvm-two-disks.yml
+++ b/test/data/devicegraphs/lvm-two-disks.yml
@@ -1,0 +1,37 @@
+---
+- disk:
+    name: /dev/sda
+    size: 200 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda1
+        id:           lvm
+
+- disk:
+    name: /dev/sdb
+    size: 200 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sdb1
+        id:           lvm
+
+- lvm_vg:
+    vg_name: vg0
+    lvm_pvs:
+        - lvm_pv:
+            blk_device: /dev/sda1
+        - lvm_pv:
+            blk_device: /dev/sdb1
+
+    lvm_lvs:
+        - lvm_lv:
+            size:         unlimited
+            lv_name:      lv1
+            file_system:  btrfs
+            mount_point:  /

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -286,6 +286,37 @@ describe Y2Storage::AutoinstProposal do
           )
         end
       end
+
+      context "when the reused partition is part of an LVM to be deleted" do
+        let(:scenario) { "lvm-two-disks" }
+
+        let(:partitioning) do
+          [
+            { "device" => "/dev/sda", "use" => "all", "partitions" => [root] },
+            { "device" => "/dev/sdb", "use" => "all", "partitions" => [home] }
+          ]
+        end
+
+        let(:root) do
+          { "mount" => "/", "partition_nr" => 1, "create" => false, "format" => true }
+        end
+
+        let(:home) do
+          { "filesystem" => :xfs, "mount" => "/home", "create" => true }
+        end
+
+        it "reuses the partition with the given partition number" do
+          sid = fake_devicegraph.find_by_name("/dev/sda1").sid
+          proposal.propose
+          reused_part = proposal.devices.find_by_name("/dev/sda1")
+          expect(reused_part.sid).to eq sid
+        end
+
+        it "does not register any issue" do
+          proposal.propose
+          expect(issues_list).to be_empty
+        end
+      end
     end
 
     describe "resizing partitions" do


### PR DESCRIPTION
## Problem

While discussing #921 we realized that using `Proposal::PartitionKiller` as-is in the `AutoInstProposal` code was not a good idea. `PartitionKiller` deletes some extra partitions to make more space. That can be wrong for some AutoYaST profiles.

## Solution

This PR provides a failing unit test that showcases the problem, which is relatively easy to trigger.
