### PR TITLE
Resize multi-device Btrfs

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 16 10:38:16 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: allow to resize devices used by a multi-device
+  Btrfs filesystem (part of jsc#SLE-3877).
+- 4.2.16
+
+-------------------------------------------------------------------
 Mon May 13 14:08:14 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
 
 - guided proposal frees space from existing multidevice btrfs properly

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.15
+Version:        4.2.16
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -24,8 +24,8 @@ Group:          System/YaST
 Source:         %{name}-%{version}.tar.bz2
 Url:            https://github.com/yast/yast-storage-ng
 
-# Multidevice Btrfs
-BuildRequires:	libstorage-ng-ruby >= 4.1.118
+# Resize multi-device Btrfs
+BuildRequires:	libstorage-ng-ruby >= 4.1.121
 BuildRequires:  update-desktop-files
 # CWM::Dialog#next_handler (4.1 branch) and improved CWM::Dialog
 BuildRequires:  yast2 >= 4.1.11
@@ -41,8 +41,8 @@ BuildRequires:  rubygem(ruby-dbus)
 BuildRequires:  rubygem(yast-rake)
 # findutils for xargs
 Requires:       findutils
-# Multidevice Btrfs
-Requires:       libstorage-ng-ruby >= 4.1.118
+# Resize multi-device Btrfs
+Requires:       libstorage-ng-ruby >= 4.1.121
 # CWM::Dialog#next_handler (4.1 branch) and improved CWM::Dialog
 Requires:       yast2 >= 4.1.11
 # Y2Packager::Repository

--- a/src/lib/y2partitioner/actions/controllers/blk_device.rb
+++ b/src/lib/y2partitioner/actions/controllers/blk_device.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -74,6 +74,15 @@ module Y2Partitioner
           return false unless committed_filesystem?
 
           committed_filesystem.active_mount_point?
+        end
+
+        # Whether the device is used by a multi-device filesystem (i.e., Btrfs)
+        #
+        # @return [Boolean]
+        def multidevice_filesystem?
+          return false unless device.formatted?
+
+          device.filesystem.multidevice?
         end
 
         # Whether the device exists on the system

--- a/src/lib/y2partitioner/actions/edit_blk_device.rb
+++ b/src/lib/y2partitioner/actions/edit_blk_device.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,11 +20,10 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "yast2/popup"
 require "y2partitioner/actions/transaction_wizard"
 require "y2partitioner/actions/controllers/filesystem"
 require "y2partitioner/actions/filesystem_steps"
-
-Yast.import "Popup"
 
 module Y2Partitioner
   module Actions
@@ -104,7 +103,7 @@ module Y2Partitioner
         return true if errors.empty?
 
         # Only first error is shown
-        Yast::Popup.Error(errors.first)
+        Yast2::Popup.show(errors.first, headline: :error)
 
         false
       end
@@ -113,18 +112,23 @@ module Y2Partitioner
       #
       # @return [Array<Strings>]
       def errors
-        [used_device_error, partitions_error, btrfs_error,
-         extended_partition_error, lvm_thin_pool_error].compact
+        [
+          btrfs_error,
+          used_device_error,
+          partitions_error,
+          extended_partition_error,
+          lvm_thin_pool_error
+        ].compact
       end
 
       # Error when trying to edit an used device
       #
-      # @note A device is being used when it forms part of an LVM or MD RAID.
+      # A device is being used when it forms part of another device (e.g., LVM or MD RAID).
       #
       # @return [String, nil] nil if the device is not being used.
       def used_device_error
         using_devs = device.component_of_names
-        return nil if using_devs.empty?
+        return nil if using_devs.none?
 
         format(
           # TRANSLATORS: %{name} is replaced by a device name (e.g., /dev/sda1)

--- a/src/lib/y2partitioner/actions/resize_blk_device.rb
+++ b/src/lib/y2partitioner/actions/resize_blk_device.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -101,12 +101,14 @@ module Y2Partitioner
 
       # Error when trying to resize a used device
       #
-      # @note A device is being used when it forms part of an LVM or MD RAID.
+      # A device is being used when it forms part of another device (e.g., LVM or MD RAID). The device
+      # is not considered as used when it belongs to a multi-device filesystem (i.e., Btrfs).
       #
       # @return [String, nil] nil if the device is not being used.
       def used_device_error
         using_devs = device.component_of_names
-        return nil if using_devs.empty?
+
+        return nil if controller.multidevice_filesystem? || using_devs.none?
 
         format(
           # TRANSLATORS: %{name} is replaced by a device name (e.g., /dev/sda1) and %{users} is replaced

--- a/src/lib/y2partitioner/dialogs/blk_device_resize.rb
+++ b/src/lib/y2partitioner/dialogs/blk_device_resize.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2partitioner/dialogs/blk_device_resize.rb
+++ b/src/lib/y2partitioner/dialogs/blk_device_resize.rb
@@ -93,7 +93,9 @@ module Y2Partitioner
       attr_reader :space_info
 
       def detect_space_info
-        return unless controller.committed_current_filesystem? && !swap?
+        return if controller.multidevice_filesystem? ||
+            !controller.committed_current_filesystem? || swap?
+
         begin
           @space_info = device.filesystem.detect_space_info
         rescue Storage::Exception => e

--- a/src/lib/y2partitioner/dialogs/blk_device_resize.rb
+++ b/src/lib/y2partitioner/dialogs/blk_device_resize.rb
@@ -157,15 +157,21 @@ module Y2Partitioner
 
       # Widgets to show size info of the device (current and used sizes)
       #
-      # @note Used size is only shown if space info can be detected.
+      # Used size is only shown if space info can be detected.
+      #
+      # @return [Array<CWM::WidgetTerm>]
       def size_info
         widgets = []
         widgets << current_size_info
-        widgets << used_size_info unless space_info.nil?
+        widgets << size_details_info
+        widgets.compact!
+
         VBox(*widgets)
       end
 
       # Widget for current size
+      #
+      # @return [CWM::WidgetTerm]
       def current_size_info
         size = device.size.to_human_string
         # TRANSLATORS: label for current size of the partition or LVM logical volume,
@@ -173,8 +179,30 @@ module Y2Partitioner
         Left(Label(format(_("Current size: %{size}"), size: size)))
       end
 
+      # Widget with more details about the size
+      #
+      # @return [CWM::WidgetTerm, nil] nil if there is no details to show
+      def size_details_info
+        multidevice_filesystem_info || used_size_info
+      end
+
+      # Widget with information when the device belongs to a multi-device filesystem
+      #
+      # @return [CWM::WidgetTerm, nil] nil if the device does not belong to a multi-device filesystem
+      def multidevice_filesystem_info
+        return nil unless controller.multidevice_filesystem?
+
+        # TRANSLATORS: label when the device is used by a multi-device Btrfs, where %{btrfs} is replaced
+        # by the display name of the filesystem (e.g., "Btrfs over 5 devices").
+        Left(Label(format(_("Part of %{btrfs}"), btrfs: device.filesystem.display_name)))
+      end
+
       # Widget for used size
+      #
+      # @return [CWM::WidgetTerm, nil] nil when used size cannot be calculated
       def used_size_info
+        return nil unless space_info
+
         size = used_size.to_human_string
         # TRANSLATORS: label for currently used size of the partition or LVM volume,
         # where %{size} is replaced by a size (e.g., 5.5 GiB)
@@ -258,21 +286,21 @@ module Y2Partitioner
         immediate_unmount(controller.committed_device, full_message: message, allow_continue: true)
       end
 
-      # Whether the device is going to be shrinked
+      # Whether the device is going to be shrunk
       #
       # @return [Boolean]
       def shrinking?
         selected_size < device.size
       end
 
-      # Whether the device is going to be growed
+      # Whether the device is going to be grown
       #
       # @return [Boolean]
       def growing?
         selected_size > device.size
       end
 
-      # Whether the device is going to be growed more than 50 GiB
+      # Whether the device is going to be grown more than 50 GiB
       #
       # @note Threshold to consider a big growing is defined in the old code, but there is not
       #   any kind of explanation:
@@ -283,7 +311,7 @@ module Y2Partitioner
         growing? && growing_size > Y2Storage::DiskSize.GiB(50)
       end
 
-      # How much the device is going to be growed
+      # How much the device is going to be grown
       #
       # @return [Y2Storage::DiskSize]
       def growing_size

--- a/src/lib/y2storage/lvm_pv.rb
+++ b/src/lib/y2storage/lvm_pv.rb
@@ -58,20 +58,20 @@ module Y2Storage
       blk_device.plain_device
     end
 
-    # Whether the PV is orphan (not associated to any VG)
+    # Whether the PV is unused (not associated to any VG)
     #
     # @return [Boolean]
-    def orphan?
+    def unused?
       lvm_vg.nil?
     end
 
     # Display name to represent the PV
     #
-    # Only orphan PV has its own representation.
+    # Only unused PV has its own representation.
     #
     # @return [String, nil]
     def display_name
-      return nil unless orphan?
+      return nil unless unused?
 
       textdomain "storage"
 

--- a/src/lib/y2storage/resize_info.rb
+++ b/src/lib/y2storage/resize_info.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -40,23 +40,24 @@ module Y2Storage
     # rubocop:disable Metrics/LineLength
     REASON_TEXTS =
       {
-        RB_RESIZE_NOT_SUPPORTED_BY_DEVICE:       N_("Resizing is not supported by this device."),
-        RB_MIN_MAX_ERROR:                        N_("Combined limitations of partition and filesystem prevent resizing."),
-        RB_SHRINK_NOT_SUPPORTED_BY_FILESYSTEM:   N_("This filesystem does not support shrinking."),
-        RB_GROW_NOT_SUPPORTED_BY_FILESYSTEM:     N_("This filesystem does not support growing."),
-        RB_FILESYSTEM_INCONSISTENT:              N_("Filesystem consistency check failed."),
-        RB_MIN_SIZE_FOR_FILESYSTEM:              N_("This filesystem already has the minimum possible size."),
-        RB_MAX_SIZE_FOR_FILESYSTEM:              N_("This filesystem already has the maximum possible size."),
-        RB_FILESYSTEM_FULL:                      N_("The filesystem is full."),
-        RB_NO_SPACE_BEHIND_PARTITION:            N_("There is no space behind this partition."),
-        RB_MIN_SIZE_FOR_PARTITION:               N_("This partition already has the minimum possible size."),
-        RB_EXTENDED_PARTITION:                   N_("Extended partitions cannot be resized."),
-        RB_ON_IMPLICIT_PARTITION_TABLE:          N_("The partition on an implicit partition table cannot be resized."),
-        RB_SHRINK_NOT_SUPPORTED_FOR_LVM_LV_TYPE: N_("Shrinking of this type of LVM logical volumes is not supported."),
-        RB_RESIZE_NOT_SUPPORTED_FOR_LVM_LV_TYPE: N_("Resizing of this type of LVM logical volumes is not supported."),
-        RB_NO_SPACE_IN_LVM_VG:                   N_("No space left in the LVM volume group."),
-        RB_MIN_SIZE_FOR_LVM_LV:                  N_("The LVM logical volume already has the minimum possible size."),
-        RB_MAX_SIZE_FOR_LVM_LV_THIN:             N_("The LVM thin logical volume already has the maximum size.")
+        RB_RESIZE_NOT_SUPPORTED_BY_DEVICE:                 N_("Resizing is not supported by this device."),
+        RB_MIN_MAX_ERROR:                                  N_("Combined limitations of partition and filesystem prevent resizing."),
+        RB_SHRINK_NOT_SUPPORTED_BY_FILESYSTEM:             N_("This filesystem does not support shrinking."),
+        RB_SHRINK_NOT_SUPPORTED_BY_MULTIDEVICE_FILESYSTEM: N_("This multi-device filesystem does not support shrinking."),
+        RB_GROW_NOT_SUPPORTED_BY_FILESYSTEM:               N_("This filesystem does not support growing."),
+        RB_FILESYSTEM_INCONSISTENT:                        N_("Filesystem consistency check failed."),
+        RB_MIN_SIZE_FOR_FILESYSTEM:                        N_("This filesystem already has the minimum possible size."),
+        RB_MAX_SIZE_FOR_FILESYSTEM:                        N_("This filesystem already has the maximum possible size."),
+        RB_FILESYSTEM_FULL:                                N_("The filesystem is full."),
+        RB_NO_SPACE_BEHIND_PARTITION:                      N_("There is no space behind this partition."),
+        RB_MIN_SIZE_FOR_PARTITION:                         N_("This partition already has the minimum possible size."),
+        RB_EXTENDED_PARTITION:                             N_("Extended partitions cannot be resized."),
+        RB_ON_IMPLICIT_PARTITION_TABLE:                    N_("The partition on an implicit partition table cannot be resized."),
+        RB_SHRINK_NOT_SUPPORTED_FOR_LVM_LV_TYPE:           N_("Shrinking of this type of LVM logical volumes is not supported."),
+        RB_RESIZE_NOT_SUPPORTED_FOR_LVM_LV_TYPE:           N_("Resizing of this type of LVM logical volumes is not supported."),
+        RB_NO_SPACE_IN_LVM_VG:                             N_("No space left in the LVM volume group."),
+        RB_MIN_SIZE_FOR_LVM_LV:                            N_("The LVM logical volume already has the minimum possible size."),
+        RB_MAX_SIZE_FOR_LVM_LV_THIN:                       N_("The LVM thin logical volume already has the maximum size.")
       }.freeze
     # rubocop:enable Metrics/LineLength
 

--- a/test/y2partitioner/actions/controllers/blk_device_test.rb
+++ b/test/y2partitioner/actions/controllers/blk_device_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -176,6 +176,40 @@ describe Y2Partitioner::Actions::Controllers::BlkDevice do
           it "returns true" do
             expect(controller.mounted_committed_filesystem?).to eq(true)
           end
+        end
+      end
+    end
+  end
+
+  describe "#multidevice_filesystem?" do
+    let(:scenario) { "btrfs2-devicegraph.xml" }
+
+    context "when the device is not formatted" do
+      let(:device_name) { "/dev/sda2" }
+
+      before do
+        device.delete_filesystem
+      end
+
+      it "returns false" do
+        expect(controller.multidevice_filesystem?).to eq(false)
+      end
+    end
+
+    context "when the device is formatted" do
+      context "and it used by a single-device filesystem" do
+        let(:device_name) { "/dev/sda2" }
+
+        it "returns false" do
+          expect(controller.multidevice_filesystem?).to eq(false)
+        end
+      end
+
+      context "and it used by a multi-device filesystem" do
+        let(:device_name) { "/dev/sdb1" }
+
+        it "returns true" do
+          expect(controller.multidevice_filesystem?).to eq(true)
         end
       end
     end

--- a/test/y2partitioner/actions/edit_blk_device_test.rb
+++ b/test/y2partitioner/actions/edit_blk_device_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -36,9 +36,13 @@ describe Y2Partitioner::Actions::EditBlkDevice do
   let(:device) { Y2Storage::BlkDevice.find_by_name(current_graph, dev_name) }
 
   describe "#run" do
+    before do
+      allow(Yast2::Popup).to receive(:show)
+    end
+
     RSpec.shared_examples "edit_error" do
       it "shows an error popup" do
-        expect(Yast::Popup).to receive(:Error)
+        expect(Yast2::Popup).to receive(:show).with(anything, hash_including(headline: :error))
         sequence.run
       end
 
@@ -104,7 +108,16 @@ describe Y2Partitioner::Actions::EditBlkDevice do
       let(:scenario) { "btrfs2-devicegraph.xml" }
       let(:dev_name) { "/dev/sdb1" }
 
-      include_examples "edit_error"
+      it "shows a Btrfs error popup" do
+        expect(Yast2::Popup).to receive(:show)
+          .with(/belongs to a Btrfs/, hash_including(headline: :error))
+
+        sequence.run
+      end
+
+      it "quits returning :back" do
+        expect(sequence.run).to eq :back
+      end
     end
 
     context "if called on an LVM thin pool" do

--- a/test/y2partitioner/dialogs/blk_device_resize_test.rb
+++ b/test/y2partitioner/dialogs/blk_device_resize_test.rb
@@ -230,7 +230,9 @@ describe Y2Partitioner::Dialogs::BlkDeviceResize do
       end
 
       let(:ext3) { Y2Storage::Filesystems::Type::EXT3 }
-      let(:filesystem) { instance_double("Filesystem", detect_space_info: space_info, type: ext3) }
+      let(:filesystem) do
+        instance_double("Filesystem", detect_space_info: space_info, type: ext3, multidevice?: false)
+      end
       let(:space_info) { instance_double(Y2Storage::SpaceInfo, used: 10.GiB) }
 
       context "and it is not formatted in the system" do

--- a/test/y2storage/lvm_pv_test.rb
+++ b/test/y2storage/lvm_pv_test.rb
@@ -53,14 +53,14 @@ describe Y2Storage::LvmPv do
     end
   end
 
-  describe "#orphan?" do
+  describe "#unused?" do
     context "when the PV is associated to a VG" do
       let(:scenario) { "complex-lvm-encrypt" }
 
       let(:device_name) { "/dev/sde2" }
 
       it "returns false" do
-        expect(subject.orphan?).to eq(false)
+        expect(subject.unused?).to eq(false)
       end
     end
 
@@ -70,13 +70,13 @@ describe Y2Storage::LvmPv do
       let(:device_name) { "/dev/sda2" }
 
       it "returns true" do
-        expect(subject.orphan?).to eq(true)
+        expect(subject.unused?).to eq(true)
       end
     end
   end
 
   describe "#display_name" do
-    context "when it is an orphan PV" do
+    context "when it is an unused PV" do
       let(:scenario) { "unused_lvm_pvs.xml" }
 
       let(:device_name) { "/dev/sda2" }
@@ -86,7 +86,7 @@ describe Y2Storage::LvmPv do
       end
     end
 
-    context "when it is not an orphan PV" do
+    context "when it is not an unused PV" do
       let(:scenario) { "complex-lvm-encrypt" }
 
       let(:device_name) { "/dev/sde2" }


### PR DESCRIPTION
NOTE FOR REVIEWERS: failing test is because this PR requires [this changes](https://github.com/openSUSE/libstorage-ng/pull/646) be merged. But this PR could be already reviewed anyway.

## Problem

The Expert Partitioner does not allow to resize a device when the device is being used by a multi-device Btrfs filesystem. It shows a message about device in use.

* https://jira.suse.de/browse/SLE-3877
* https://trello.com/c/mB6C51ir/973-3-libstorage-ng-resize-btrfs-with-multiple-devices
* Requires this changes: https://github.com/openSUSE/libstorage-ng/pull/646


## Solution

First of all, libstorage-ng has been adapted to allow resizing multi-device Btrfs, see https://github.com/openSUSE/libstorage-ng/pull/646. In the Expert Partitioner, the "device in use" message has been suppressed  when the device belongs to a multi-device Btrfs. As consequence, now the device can be resized, although shrinking will not be possible if the device is in use by a committed mult-device Btrfs (the library already returns the proper resize info for that). 


## Testing

- Added new unit tests
- Tested manually


## Screenshots

<details>
<summary>Show screenshots</summary>

![VirtualBox_openSUSE Tumbleweed_16_05_2019_12_03_03](https://user-images.githubusercontent.com/1112304/57849344-fc39e180-77d2-11e9-93fd-3485f8260944.png)

![VirtualBox_openSUSE Tumbleweed_16_05_2019_12_04_49](https://user-images.githubusercontent.com/1112304/57849356-00fe9580-77d3-11e9-8546-ce98b352f727.png)

![VirtualBox_openSUSE Tumbleweed_16_05_2019_12_05_30](https://user-images.githubusercontent.com/1112304/57849363-03f98600-77d3-11e9-9eaa-166ecfb7525d.png)

![VirtualBox_openSUSE Tumbleweed_16_05_2019_11_55_42](https://user-images.githubusercontent.com/1112304/57849001-263ed400-77d2-11e9-930c-f1ea0aef09d5.png)

</details>
