### PR TITLE
Add `textdomain` to fix untranslated error messages

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Nov 11 14:44:26 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Untranslated error message in 'Edit Btrfs subvolumes'/
+  'Add subvolume' (bsc#1130822)
+- Detect missing textdomain during unit testing.
+- 4.3.20
+
+-------------------------------------------------------------------
 Thu Nov  5 10:26:55 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Disable "Device" menu items for NFS shares

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.19
+Version:        4.3.20
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
+++ b/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
@@ -102,6 +102,7 @@ module Y2Partitioner
         # @param form [Dialogs::BtrfsSubvolume::Form]
         # @param filesystem [Y2Storage::Filesystems::BlkFilesystem] a btrfs filesystem
         def initialize(form, filesystem: nil)
+          textdomain "storage"
           @form = form
           @filesystem = filesystem
         end
@@ -236,6 +237,7 @@ module Y2Partitioner
         # @param form [Dialogs::BtrfsSubvolume::Form]
         # @param filesystem [Y2Storage::Filesystems::BlkFilesystem] a btrfs filesystem
         def initialize(form, filesystem: nil)
+          textdomain "storage"
           @form = form
           @filesystem = filesystem
         end

--- a/src/lib/y2partitioner/dialogs/import_mount_points.rb
+++ b/src/lib/y2partitioner/dialogs/import_mount_points.rb
@@ -87,6 +87,7 @@ module Y2Partitioner
         #
         # @param controller [Actions::Controllers::Fstabs]
         def initialize(controller)
+          textdomain "storage"
           @controller = controller
         end
 

--- a/src/lib/y2partitioner/widgets/fstab_selector.rb
+++ b/src/lib/y2partitioner/widgets/fstab_selector.rb
@@ -191,6 +191,7 @@ module Y2Partitioner
         #
         # @param fstab [Y2Storage::Fstab]
         def initialize(fstab)
+          textdomain "storage"
           @fstab = fstab
         end
 
@@ -235,6 +236,7 @@ module Y2Partitioner
         #
         # @param fstab [Y2Storage::Fstab]
         def initialize(fstab)
+          textdomain "storage"
           @fstab = fstab
         end
 

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -26,6 +26,8 @@ ENV["Y2DIR"] = SRC_PATH
 # make sure we run the tests in English locale
 # (some tests check the output which is marked for translation)
 ENV["LC_ALL"] = "en_US.UTF-8"
+# fail fast if a class does not declare textdomain (bsc#1130822)
+ENV["Y2STRICTTEXTDOMAIN"] = "1"
 
 LIBS_TO_SKIP = ["y2packager/repository"]
 


### PR DESCRIPTION
- https://trello.com/c/GZXM36ty
- https://bugzilla.suse.com/show_bug.cgi?id=1130822

A `textdomain` declaration is per *class* which means there were several cases of having several classes in a file and only one of them declaring the text domain.

![1130822_DE](https://user-images.githubusercontent.com/102056/98831325-b8618000-243b-11eb-9e89-742a9b4f867a.png)

Also added detecting a missing textdomain during unit testing (using https://github.com/yast/yast-ruby-bindings/pull/230/).