### PR TITLE
Merge bugfix for bug#1134330 into SLE-15-SP1

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 10 14:59:50 UTC 2019 - ancor@suse.com
+
+- AutoYaST: do not ask for a reusable filesystem when it's not
+  really needed (bsc#1134330).
+- 4.1.84
+
+-------------------------------------------------------------------
 Mon Apr 15 15:46:04 UTC 2019 - ancor@suse.com
 
 - Partitioner: fixed translation issues related to bcache

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.83
+Version:	4.1.84
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/proposal/autoinst_drive_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_drive_planner.rb
@@ -181,6 +181,10 @@ module Y2Storage
       # @param section        [AutoinstProfile::PartitionSection] AutoYaST specification
       def check_reusable_filesystem(planned_device, device, section)
         return if planned_device.reformat || device.filesystem || planned_device.component?
+        # The device to be reused doesn't have filesystem... but maybe it's not
+        # really needed, e.g. reusing a bios_boot partition (bsc#1134330)
+        return if planned_device.mount_point.nil? && planned_device.filesystem_type.nil?
+
         issues_list.add(:missing_reusable_filesystem, section)
       end
 
@@ -216,9 +220,6 @@ module Y2Storage
         return unless partition_to_reuse
         partition.filesystem_type ||= partition_to_reuse.filesystem_type
         add_device_reuse(partition, partition_to_reuse, section)
-        if !partition.reformat && !partition_to_reuse.filesystem && !partition.component?
-          issues_list.add(:missing_reusable_filesystem, section)
-        end
       end
 
       # @param partition    [Planned::Partition] Planned partition

--- a/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
@@ -384,6 +384,33 @@ describe Y2Storage::Proposal::AutoinstDiskDevicePlanner do
         end
       end
 
+      # Regression test for bsc#1134330: when a bios_boot partition (which
+      # contains no filesystem by definition) is specified to be reused, a bogus
+      # MissingReusableFilesystem issue is registered
+      context "when the partition is not formatted and should be reused as-is" do
+        let(:scenario) { "autoyast_drive_examples" }
+
+        let(:disk_spec) do
+          { "device" => "/dev/sdh", "partitions" => [grub_spec] }
+        end
+
+        let(:grub_spec) do
+          { "create" => false, "format" => false, "partition_nr" => 2 }
+        end
+
+        it "reuses the partition" do
+          disk = planner.planned_devices(drive).first
+          grub = disk.partitions.first
+          expect(grub.reuse_name).to eq("/dev/sdh2")
+        end
+
+        it "does not register any issue" do
+          expect(issues_list).to be_empty
+          planner.planned_devices(drive)
+          expect(issues_list).to be_empty
+        end
+      end
+
       context "when no partition number or label is specified" do
         let(:root_spec) do
           { "create" => false, "mount" => "/", "filesystem" => :btrfs }


### PR DESCRIPTION
## Problem

Bug#1134330 was fixed for SLE-15-GA and verified by the reporter at #922. Merging to other branches is still missing.

## Solution

This merges #922 into SLE-15-SP1

## Trello

https://trello.com/c/mimudxBQ/987-l3-sled15-1134330-ay-on-nvme-disks-could-not-find-a-reusable-filesystem