### PR TITLE
Proposal: support for separate VGs

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 18 10:56:58 UTC 2019 - ancor@suse.com
+
+- Proposal: initial support for several separate LVM volume groups
+  (part of jsc#SLE-7238).
+- 4.2.20
+
+-------------------------------------------------------------------
 Mon Jun 10 11:54:40 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - AutoYaST: add support for multi-device Btrfs filesystems.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:	4.2.19
+Version:	4.2.20
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/planned/lvm_vg.rb
+++ b/src/lib/y2storage/planned/lvm_vg.rb
@@ -147,6 +147,7 @@ module Y2Storage
         pv = minimal_pv_partition
         pv.min_size = real_pv_size(missing_space)
         pv.max_size = real_pv_size(max_size)
+        pv.weight = lvs_weight
         pv
       end
 
@@ -268,6 +269,13 @@ module Y2Storage
       # @return [DiskSize]
       def max_size
         DiskSize.sum(lvs.map(&:max_size), rounding: extent_size)
+      end
+
+      # Total weight of all the planned LVs
+      #
+      # @return [Integer]
+      def lvs_weight
+        lvs.map { |lv| lv.weight || 0 }.reduce(:+)
       end
 
       # Portion of a newly created physical volume that couldn't be used to

--- a/src/lib/y2storage/planned/lvm_vg.rb
+++ b/src/lib/y2storage/planned/lvm_vg.rb
@@ -23,7 +23,9 @@
 
 require "yast"
 require "y2storage/planned/device"
+require "y2storage/secret_attributes"
 require "y2storage/planned/mixins"
+require "y2storage/planned/partition"
 
 module Y2Storage
   module Planned
@@ -33,9 +35,15 @@ module Y2Storage
     # @see Device
     class LvmVg < Device
       include Planned::HasSize
+      include SecretAttributes
 
       DEFAULT_EXTENT_SIZE = DiskSize.MiB(4)
       private_constant :DEFAULT_EXTENT_SIZE
+
+      # This is just an estimation chosen to match libstorage hardcoded value
+      # See LvmVg::Impl::calculate_region() in storage-ng
+      USELESS_PV_SPACE = DiskSize.MiB(1)
+      private_constant :USELESS_PV_SPACE
 
       # @return [String] name to use for Y2Storage::LvmVg#vg_name
       attr_accessor :volume_group_name
@@ -54,6 +62,19 @@ module Y2Storage
       #   all old logical volumes (:remove) or not remove any logical
       #   volume (:keep).
       attr_accessor :make_space_policy
+
+      # @!attribute pvs_encryption_password
+      #   @return [String, nil] password used to encrypt the newly created
+      #     physical volumes. If nil, the PVs will not be encrypted.
+      secret_attr :pvs_encryption_password
+
+      # Strategy used by the guided proposal to calculate the size of the resulting
+      # volume group
+      #
+      # @see ProposalSettings#lvm_vg_strategy
+      #
+      # @return [Symbol]
+      attr_accessor :size_strategy
 
       # Builds a new instance based on a real VG
       #
@@ -81,6 +102,7 @@ module Y2Storage
         @volume_group_name = volume_group_name
         @lvs = lvs
         @pvs = pvs
+        @pvs_encryption_password = nil
         @make_space_policy = :needed
       end
 
@@ -93,6 +115,46 @@ module Y2Storage
         @pvs = real_vg.lvm_pvs.map { |v| v.blk_device.name }
         @lvs = real_vg.lvm_lvs.map { |v| LvmLv.from_real_lv(v) }
         self.reuse_name = real_vg.vg_name
+      end
+
+      # Min size that a partition (or any other block device) must have to be useful as PV
+      #
+      # @return [DiskSize]
+      def min_pv_size
+        extent_size + useless_pv_space
+      end
+
+      # Planned partition representing an LVM physical volume with the minimum
+      # possible size
+      #
+      # @return [Planned::Partition]
+      def minimal_pv_partition
+        res = Planned::Partition.new(nil)
+        res.partition_id = PartitionId::LVM
+        res.lvm_volume_group_name = volume_group_name
+        res.encryption_password = pvs_encryption_password
+        res.min_size = min_pv_size
+        res
+      end
+
+      # Part of a physical volume that can be used to allocate planned volumes
+      #
+      # @param size [DiskSize] total size of the partition
+      # @return [DiskSize] usable size after substracting LVM overhead and
+      #     space wasted by rounding
+      def useful_pv_space(size)
+        size -= useless_pv_space
+        size.floor(extent_size)
+      end
+
+      # Total size that a partition (or other block device) must have in order to
+      # provide the given useful size to the volume group. Inverse of #useful_pv_space
+      # @see #useful_pv_space
+      #
+      # @param useful_size [DiskSize] size usable to allocate logical volumes
+      # @return [DiskSize] real size of the partition
+      def real_pv_size(useful_size)
+        useful_size.ceil(extent_size) + useless_pv_space
       end
 
       # Returns the size of each extent
@@ -134,6 +196,49 @@ module Y2Storage
         lvs.select { |v| v.lv_type == LvType::THIN_POOL }
       end
 
+      # Space that must be added to the final volume group in order to make
+      # possible to allocate all the LVM planned volumes.
+      #
+      # This method takes into account the size of the extents and all the
+      # related roundings.
+      #
+      # If this represents a reused volume group, the method assumes all the space
+      # in that volume group can be reclaimed for the guided proposal purposes.
+      #
+      # @return [DiskSize]
+      def missing_space
+        return DiskSize.zero if !lvs || lvs.empty?
+        substract_reused_vg_size(target_size)
+      end
+
+      # Space that must be added to the volume group to fulfill the max size
+      # requirements for all the LVM planned volumes.
+      #
+      # This method takes into account the size of the extents and all the
+      # related roundings.
+      #
+      # If this represents a reused volume group, the method assumes all the space
+      # in that volume group can be reclaimed for the guided proposal purposes.
+      #
+      # @return [DiskSize]
+      def max_extra_space
+        return DiskSize.zero if !lvs || lvs.empty?
+
+        max = max_size
+        return max if max.unlimited? || !reuse?
+
+        substract_reused_vg_size(max)
+      end
+
+      # Portion of a newly created physical volume that couldn't be used to
+      # allocate logical volumes because it would be reserved for LVM metadata
+      # and other data structures.
+      #
+      # @return [DiskSize]
+      def useless_pv_space
+        pvs_encrypt? ? USELESS_PV_SPACE + Planned::Partition.encryption_overhead : USELESS_PV_SPACE
+      end
+
       def self.to_string_attrs
         [:reuse_name, :volume_group_name]
       end
@@ -143,6 +248,30 @@ module Y2Storage
       def device_to_reuse(devicegraph)
         return nil unless reuse?
         Y2Storage::LvmVg.find_by_vg_name(devicegraph, reuse_name)
+      end
+
+      # Whether the created PVs should be encrypted
+      #
+      # @see #pvs_encryption_password
+      #
+      # @return [Boolean]
+      def pvs_encrypt?
+        !pvs_encryption_password.nil?
+      end
+
+      # Max space needed to acommodate all the LVs of this volume group
+      #
+      # @return [DiskSize]
+      def max_size
+        DiskSize.sum(lvs.map(&:max_size), rounding: extent_size)
+      end
+
+      def substract_reused_vg_size(size)
+        if total_size < size
+          size - total_size
+        else
+          DiskSize.zero
+        end
       end
     end
   end

--- a/src/lib/y2storage/proposal/autoinst_devices_creator.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_creator.rb
@@ -427,9 +427,9 @@ module Y2Storage
 
       # Creates a volume group in the given devicegraph
       #
-      # @param devicegraph [Devicegraph]                    Starting devicegraph
-      # @param vg          [Planned::LvmVg]                 Volume group
-      # @param pvs         [Planned::Partition,Planned::Md] List of physical volumes
+      # @param devicegraph [Devicegraph]             Starting devicegraph
+      # @param vg          [Planned::LvmVg]          Volume group
+      # @param pvs         [Array<String>]           List of device names of the physical volumes
       # @return            [Proposal::CreatorResult] Result containing the specified volume group
       def create_logical_volumes(devicegraph, vg, pvs)
         lvm_creator = Proposal::LvmCreator.new(devicegraph)

--- a/src/lib/y2storage/proposal/devicegraph_generator.rb
+++ b/src/lib/y2storage/proposal/devicegraph_generator.rb
@@ -54,23 +54,59 @@ module Y2Storage
         # good citizen and do it in our own copy
         planned_devices = planned_devices.map(&:dup)
 
-        partitions, lvm_lvs = planned_devices.partition { |v| v.is_a?(Planned::Partition) }
+        lvm_lvs, part_devices = planned_devices.partition { |dev| dev.is_a?(Planned::LvmLv) }
+        partitions = part_devices.map { |dev| planned_partition_for(dev) }
 
         lvm_helper = LvmHelper.new(lvm_lvs, settings)
         space_result = provide_space(partitions, initial_graph, lvm_helper, space_maker)
 
         refine_planned_partitions!(partitions, space_result[:deleted_partitions])
-        graph = create_partitions(space_result[:partitions_distribution], space_result[:devicegraph])
-        reuse_partitions!(partitions, graph)
+        creator_result = create_partitions(
+          space_result[:partitions_distribution], space_result[:devicegraph]
+        )
+        reuse_partitions!(partitions, creator_result.devicegraph)
+
+        graph = create_separate_vgs(planned_devices, creator_result).devicegraph
 
         if settings.use_lvm
           new_pvs = new_physical_volumes(space_result[:devicegraph], graph)
           graph = lvm_helper.create_volumes(graph, new_pvs)
         end
+
         graph
       end
 
     protected
+
+      # Planned partition that will hold the given planned device
+      #
+      # @param device [Planned::Device] a planned partition (so no transformation
+      #   is required) or a planned VG (so a PV partition for the VG is calculated)
+      # @return [Planned::Partition]
+      def planned_partition_for(device)
+        return device if device.is_a?(Planned::Partition)
+
+        pv = device.single_pv_partition
+        pv.weight = device.lvs.first.weight
+        pv
+      end
+
+      # Creates the corresponding LVM devices for all the planned VGs in the
+      # list of planned devices
+      #
+      # @param devices [Array<Planned::Device>] all planned devices
+      # @param creator_result [Proposal::CreatorResult] result of the previous step,
+      #     in which the partitions that must hold the PVs were created
+      # @return [Proposal::CreatorResult]
+      def create_separate_vgs(devices, creator_result)
+        vgs = devices.select { |dev| dev.is_a?(Planned::LvmVg) }
+
+        vgs.reduce(creator_result) do |result, vg|
+          pvs = creator_result.created_names { |d| d.pv_for?(vg.volume_group_name) }
+          creator = LvmCreator.new(result.devicegraph)
+          result.merge(creator.create_volumes(vg, pvs))
+        end
+      end
 
       # Provides free disk space in the proposal devicegraph to fit the
       # planned partitions in.
@@ -124,14 +160,16 @@ module Y2Storage
         result
       end
 
-      # List of partitions with LVM id (i.e. potential physical volumes) that
+      # List of unused partitions with LVM id (i.e. potential physical volumes) that
       # are present in the new devicegraph but were not there in the old one.
       #
       # @param old_devicegraph [Devicegraph]
       # @param new_devicegraph [Devicegraph]
       # @return [Array<String>] device names of the partitions
       def new_physical_volumes(old_devicegraph, new_devicegraph)
-        all_pvs = new_devicegraph.partitions.select { |p| p.id.is?(:lvm) }
+        all_pvs = new_devicegraph.partitions.select do |part|
+          part.id.is?(:lvm) && !part.part_of_lvm_or_md?
+        end
         old_pv_sids = old_devicegraph.partitions.select { |p| p.id.is?(:lvm) }.map(&:sid)
         all_pvs.reject { |pv| old_pv_sids.include?(pv.sid) }.map(&:name)
       end
@@ -170,11 +208,10 @@ module Y2Storage
       # @param distribution [Planned::PartitionsDistribution]
       # @param initial_graph [Devicegraph] initial devicegraph
       #
-      # @return [Devicegraph]
+      # @return [Proposal::CreatorResult]
       def create_partitions(distribution, initial_graph)
         partition_creator = PartitionCreator.new(initial_graph)
-        result = partition_creator.create_partitions(distribution)
-        result.devicegraph
+        partition_creator.create_partitions(distribution)
       end
 
       # Adjusts pre-existing (not created by us) partitions assigning its

--- a/src/lib/y2storage/proposal/devicegraph_generator.rb
+++ b/src/lib/y2storage/proposal/devicegraph_generator.rb
@@ -84,11 +84,7 @@ module Y2Storage
       #   is required) or a planned VG (so a PV partition for the VG is calculated)
       # @return [Planned::Partition]
       def planned_partition_for(device)
-        return device if device.is_a?(Planned::Partition)
-
-        pv = device.single_pv_partition
-        pv.weight = device.lvs.first.weight
-        pv
+        device.is_a?(Planned::Partition) ? device : device.single_pv_partition
       end
 
       # Creates the corresponding LVM devices for all the planned VGs in the

--- a/src/lib/y2storage/proposal/devices_planner_strategies/base.rb
+++ b/src/lib/y2storage/proposal/devices_planner_strategies/base.rb
@@ -73,8 +73,11 @@ module Y2Storage
         # @param planned_devices [Array<Planned::Device>] devices that have been planned
         # @return [Array<Planned::Device>]
         def planned_boot_devices(planned_devices)
+          flat = planned_devices.flat_map do |dev|
+            dev.respond_to?(:lvs) ? dev.lvs : dev
+          end
           checker = BootRequirementsChecker.new(
-            devicegraph, planned_devices: planned_devices, boot_disk_name: settings.root_device
+            devicegraph, planned_devices: flat, boot_disk_name: settings.root_device
           )
           checker.needed_partitions(target)
         rescue BootRequirementsChecker::Error => error

--- a/src/lib/y2storage/proposal/partitions_distribution_calculator.rb
+++ b/src/lib/y2storage/proposal/partitions_distribution_calculator.rb
@@ -146,25 +146,10 @@ module Y2Storage
         if lvm?
           # Let's assume the best possible case - if we need to create a PV it
           # will be only one
-          pvs_to_create = 1
-          needed += lvm_space_to_make(pvs_to_create)
+          needed += planned_vg.single_pv_partition.min_size
           log.info "#impossible? with LVM - needed: #{needed}"
         end
         needed > available_space(free_spaces)
-      end
-
-      # Space that needs to be dedicated to new physical volumes in order to
-      # have a chance to calculate an acceptable space distribution. The result
-      # depends on the number of PV that would be created, since every PV
-      # introduces an overhead.
-      #
-      # @param new_pvs [Integer] max number of PVs that would be created,
-      #     if needed. This is by definition an estimation (you never know the
-      #     exact number of PVs until you calculate the space distribution)
-      # @return [DiskSize]
-      def lvm_space_to_make(new_pvs)
-        return DiskSize.zero unless lvm?
-        planned_vg.missing_space + planned_vg.useless_pv_space * new_pvs
       end
 
       # Returns the sum of available spaces
@@ -402,19 +387,7 @@ module Y2Storage
 
         # In the LVM case, assume the worst case - that there will be only
         # one big PV and we have to make room for it as well.
-        planned_partitions + [planned_single_pv]
-      end
-
-      # Planned partition that would be needed to accumulate all the necessary
-      # LVM space in a single physical volume
-      #
-      # @see #all_planned_partitions
-      #
-      # @return [Planned::Partition]
-      def planned_single_pv
-        res = Planned::Partition.new(nil)
-        res.min_size = lvm_space_to_make(1)
-        res
+        planned_partitions + [planned_vg.single_pv_partition]
       end
 
       # Size that is missing in the space marked as "growing" in order to

--- a/src/lib/y2storage/proposal/phys_vol_calculator.rb
+++ b/src/lib/y2storage/proposal/phys_vol_calculator.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2015] SUSE LLC
+# Copyright (c) [2015-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -37,13 +37,12 @@ module Y2Storage
       #
       # @param all_spaces [Array<FreeDiskSpace>] Disk spaces that could
       #     potentially contain physical volumes
-      # @param lvm_helper [Proposal::LvmHelper] contains information about the
-      #     LVM planned volumes and how to make space for them
-      def initialize(all_spaces, lvm_helper)
+      # @param planned_vg [Planned::LvmVg] volume group to create the PVs for
+      def initialize(all_spaces, planned_vg)
         @all_spaces = all_spaces
-        @lvm_helper = lvm_helper
+        @planned_vg = planned_vg
 
-        strategy = lvm_helper.vg_strategy
+        strategy = planned_vg.size_strategy
         if STRATEGIES[strategy]
           @strategy_class = STRATEGIES[strategy]
         else
@@ -65,7 +64,7 @@ module Y2Storage
       # @return [Planned::PartitionsDistribution, nil] nil if it's
       #     impossible to allocate all the needed physical volumes
       def add_physical_volumes(distribution)
-        @strategy_class.new(distribution, @all_spaces, @lvm_helper).add_physical_volumes
+        @strategy_class.new(distribution, @all_spaces, @planned_vg).add_physical_volumes
       end
     end
   end

--- a/src/lib/y2storage/proposal/phys_vol_strategies/use_available.rb
+++ b/src/lib/y2storage/proposal/phys_vol_strategies/use_available.rb
@@ -45,7 +45,7 @@ module Y2Storage
         # volumes to as many spaces as possible.
         #
         # Returns nil if it's not possible to create a distribution of physical
-        # volumes that guarantees the requirements set by lvm_helper.
+        # volumes that guarantees the requirements set by the planned VG.
         #
         # @param spaces [Array<FreeDiskSpace>]
         # @return [Planned::PartitionsDistribution, nil]
@@ -64,8 +64,8 @@ module Y2Storage
           adjust_sizes(result)
           remember_combination(spaces)
 
-          sizes = pv_partitions.values.map { |part| lvm_helper.useful_pv_space(part.min_size) }
-          return nil if DiskSize.sum(sizes) < lvm_helper.missing_space
+          sizes = pv_partitions.values.map { |part| planned_vg.useful_pv_space(part.min_size) }
+          return nil if DiskSize.sum(sizes) < planned_vg.missing_space
 
           adjust_weights(result)
           result
@@ -87,7 +87,7 @@ module Y2Storage
           # This one is optimistic, the other one is realistic (so still needed
           # in some corner cases).
           useful_sizes = spaces.map { |s| useful_size(s) }
-          return false if DiskSize.sum(useful_sizes) < lvm_helper.missing_space
+          return false if DiskSize.sum(useful_sizes) < planned_vg.missing_space
 
           return true if @checked_combinations.nil?
           @checked_combinations.none? do |checked|
@@ -126,7 +126,7 @@ module Y2Storage
         #
         # @return [DiskSize]
         def needed_in_single_pv
-          @needed_in_single_pv ||= lvm_helper.real_pv_size(lvm_helper.missing_space)
+          @needed_in_single_pv ||= planned_vg.real_pv_size(planned_vg.missing_space)
         end
       end
     end

--- a/src/lib/y2storage/proposal/space_maker.rb
+++ b/src/lib/y2storage/proposal/space_maker.rb
@@ -70,7 +70,7 @@ module Y2Storage
       #
       def provide_space(original_graph, planned_partitions, lvm_helper)
         @original_graph = original_graph
-        @dist_calculator = PartitionsDistributionCalculator.new(lvm_helper)
+        @dist_calculator = PartitionsDistributionCalculator.new(lvm_helper.volume_group)
 
         # update storage ids of reused volumes in planned volumes list
         planned_partitions.select(&:reuse?).each do |part|

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2015] SUSE LLC
+# Copyright (c) [2015-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -39,6 +39,15 @@ module Y2Storage
     # @note :legacy format
     # @return [Boolean] whether to use LVM
     attr_accessor :use_lvm
+
+    # Whether the volumes specifying a separate_vg_name should
+    # be indeed created as separate volume groups
+    #
+    # @note :ng format
+    #
+    # @return [Boolean] if false, all volumes will be treated equally (no
+    #   special handling resulting in separate volume groups)
+    attr_accessor :separate_vgs
 
     # @note :legacy format
     # @return [Filesystems::Type] type to use for the root filesystem
@@ -326,6 +335,7 @@ module Y2Storage
     # ng and legacy formats
     def apply_ng_defaults
       self.lvm                 ||= false
+      self.separate_vgs        ||= false
       self.resize_windows      ||= true
       self.windows_delete_mode ||= :ondemand
       self.linux_delete_mode   ||= :ondemand
@@ -338,6 +348,7 @@ module Y2Storage
     # ng and legacy formats
     def load_ng_features
       load_feature(:proposal, :lvm)
+      load_feature(:proposal, :separate_vgs)
       load_feature(:proposal, :resize_windows)
       load_feature(:proposal, :windows_delete_mode)
       load_feature(:proposal, :linux_delete_mode)

--- a/src/lib/y2storage/volume_specification.rb
+++ b/src/lib/y2storage/volume_specification.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -119,6 +119,10 @@ module Y2Storage
     # @return [Numeric] order to disable volumes if needed to make the initial proposal
     attr_accessor :disable_order
 
+    # @return [String] name of a separate LVM volume group that will be created to
+    #   host only this volume, if the option separate_vgs is active in the settings
+    attr_accessor :separate_vg_name
+
     alias_method :proposed?, :proposed
     alias_method :proposed_configurable?, :proposed_configurable
     alias_method :adjust_by_ram?, :adjust_by_ram
@@ -206,6 +210,13 @@ module Y2Storage
       mount_point && mount_point == "swap"
     end
 
+    # Whether this volume defines a {#separate_vg_name}
+    #
+    # @return [Boolean]
+    def separate_vg?
+      !!separate_vg_name
+    end
+
     # Min size taking into account snapshots requirements
     #
     # @note If there are no special size requirements for snapshots, the
@@ -268,6 +279,7 @@ module Y2Storage
       snapshots_percentage:       :integer,
       weight:                     :integer,
       disable_order:              :integer,
+      separate_vg_name:           :string,
       subvolumes:                 :subvolumes
     }.freeze
 

--- a/src/lib/y2storage/volume_specification.rb
+++ b/src/lib/y2storage/volume_specification.rb
@@ -119,8 +119,21 @@ module Y2Storage
     # @return [Numeric] order to disable volumes if needed to make the initial proposal
     attr_accessor :disable_order
 
-    # @return [String] name of a separate LVM volume group that will be created to
-    #   host only this volume, if the option separate_vgs is active in the settings
+    # Name of a separate LVM volume group that will be created to host only this volume,
+    # if the option separate_vgs is active in the settings
+    #
+    # Only one PV will be created to back the volume group, unlike the default
+    # "system" volume group that may be defined on top of several physical
+    # volumes if needed.
+    #
+    # In the future we may consider to break both aspects in different settings.
+    # #vg_name to specify the volume group name (with "system" as default) and
+    # #isolated_vg to enforce just one PV for a particular volume group.
+    #
+    # If that ever happens, separate_vg_name=foo would become some kind of alias
+    # for vg_name=foo + isolated_vg=true.
+    #
+    # @return [String]
     attr_accessor :separate_vg_name
 
     alias_method :proposed?, :proposed

--- a/test/data/control_files/separate_vgs.xml
+++ b/test/data/control_files/separate_vgs.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<productDefines xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+
+  <partitioning>
+    <proposal>
+      <windows_delete_mode config:type="symbol">all</windows_delete_mode>
+      <linux_delete_mode config:type="symbol">all</linux_delete_mode>
+      <other_delete_mode config:type="symbol">ondemand</other_delete_mode>
+    </proposal>
+
+    <volumes config:type="list">
+      <volume>
+        <mount_point>/</mount_point>
+        <fs_type>xfs</fs_type>
+        <desired_size config:type="disksize">10 GiB</desired_size>
+        <min_size config:type="disksize">5 GiB</min_size>
+        <max_size config:type="disksize">30 GiB</max_size>
+        <weight config:type="integer">20</weight>
+
+        <snapshots config:type="boolean">false</snapshots>
+        <snapshots_configurable config:type="boolean">true</snapshots_configurable>
+        <snapshots_percentage config:type="integer">300</snapshots_percentage>
+      </volume>
+
+      <!-- /var/spacewalk, potentially as separate LVM VG -->
+      <volume>
+        <mount_point>/var/spacewalk</mount_point>
+        <fs_type>xfs</fs_type>
+        <fs_types>xfs,ext3,ext4</fs_types>
+
+        <proposed config:type="boolean">true</proposed>
+        <proposed_configurable config:type="boolean">true</proposed_configurable>
+
+        <separate_vg_name>spacewalk</separate_vg_name>
+
+        <desired_size config:type="disksize">15 GiB</desired_size>
+        <min_size config:type="disksize">5 GiB</min_size>
+        <max_size config:type="disksize">unlimited</max_size>
+        <weight config:type="integer">70</weight>
+        <fallback_for_max_size>/</fallback_for_max_size>
+      </volume>
+
+      <!-- swap partition -->
+      <volume>
+        <mount_point>swap</mount_point>
+        <fs_type>swap</fs_type>
+
+        <desired_size config:type="disksize">1 GiB</desired_size>
+        <min_size config:type="disksize">512 MiB</min_size>
+        <max_size config:type="disksize">2 GiB</max_size>
+        <weight config:type="integer">5</weight>
+      </volume>
+
+      <!-- /srv, potentially as separate LVM VG -->
+      <volume>
+        <mount_point>/srv</mount_point>
+        <fs_type>xfs</fs_type>
+        <fs_types>xfs</fs_types>
+
+        <proposed config:type="boolean">true</proposed>
+        <proposed_configurable config:type="boolean">true</proposed_configurable>
+
+        <separate_vg_name>srv_vg</separate_vg_name>
+
+        <desired_size config:type="disksize">5 GiB</desired_size>
+        <min_size config:type="disksize">3 GiB</min_size>
+        <max_size config:type="disksize">10</max_size>
+        <weight config:type="integer">5</weight>
+        <fallback_for_max_size>/</fallback_for_max_size>
+      </volume>
+    </volumes>
+   </partitioning>
+ </productDefines>

--- a/test/y2storage/planned/lvm_vg_test.rb
+++ b/test/y2storage/planned/lvm_vg_test.rb
@@ -2,7 +2,7 @@
 #
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -25,14 +25,17 @@ require_relative "../spec_helper"
 require "y2storage/planned"
 
 describe Y2Storage::Planned::LvmVg do
+  using Y2Storage::Refinements::SizeCasts
+
   subject(:lvm_vg) { described_class.new(volume_group_name: name) }
 
   let(:lv_root) { Y2Storage::Planned::LvmLv.new("/", :ext4) }
   let(:name) { "system" }
+  let(:scenario) { "lvm-two-vgs" }
   let(:vg0) { fake_devicegraph.lvm_vgs.find { |v| v.vg_name == "vg0" } }
 
   before do
-    fake_scenario("lvm-two-vgs")
+    fake_scenario(scenario)
   end
 
   describe ".from_real_vg" do
@@ -91,6 +94,104 @@ describe Y2Storage::Planned::LvmVg do
 
     it "returns all logical volumes even those included in thin pools" do
       expect(lvm_vg.all_lvs).to eq([lvm_lv, thin_lv])
+    end
+  end
+
+  describe "#missing_space" do
+    let(:scenario) { "lvm-big-pe" }
+    let(:vg_big_pe) { Y2Storage::LvmVg.find_by_vg_name(fake_devicegraph, "vg0") }
+
+    before { lvm_vg.lvs = volumes }
+
+    context "if no LVM volumes are planned" do
+      let(:volumes) { [] }
+
+      it "returns zero" do
+        expect(lvm_vg.missing_space).to be_zero
+      end
+    end
+
+    context "if some LVM volumes are planned" do
+      let(:volumes) { [planned_lv(mount_point: "/1", type: :ext4, min: desired)] }
+
+      context "and no volume group is being reused" do
+        let(:desired) { 10.GiB - 2.MiB }
+
+        it "returns the target size rounded up to the default extent size" do
+          expect(lvm_vg.missing_space).to eq 10.GiB
+        end
+      end
+
+      context "and a big-enough volume group is being reused" do
+        subject(:lvm_vg) { Y2Storage::Planned::LvmVg.from_real_vg(vg_big_pe) }
+        let(:desired) { 10.GiB }
+
+        it "returns zero" do
+          expect(lvm_vg.missing_space).to be_zero
+        end
+      end
+
+      context "and a volume group that needs to be extended is being reused" do
+        subject(:lvm_vg) { Y2Storage::Planned::LvmVg.from_real_vg(vg_big_pe) }
+        let(:desired) { 20.GiB + 2.MiB }
+
+        it "returns the missing size rounded up to the VG extent size" do
+          missing = desired - vg_big_pe.size
+          # Extent size of vg_big_pe is 64 MiB
+          rounding = 62.MiB
+          expect(lvm_vg.missing_space).to eq(missing + rounding)
+        end
+      end
+    end
+  end
+
+  describe "#max_extra_space" do
+    let(:scenario) { "lvm-big-pe" }
+    let(:vg_big_pe) { Y2Storage::LvmVg.find_by_vg_name(fake_devicegraph, "vg0") }
+
+    before { lvm_vg.lvs = volumes }
+
+    context "if no LVM volumes are planned" do
+      let(:volumes) { [] }
+
+      it "returns zero" do
+        expect(lvm_vg.max_extra_space).to be_zero
+      end
+    end
+
+    context "if some LVM volumes are planned" do
+      let(:volumes) { [planned_lv(mount_point: "/1", type: :ext4, min: 1.GiB, max: max)] }
+
+      context "and the max size is unlimited" do
+        let(:reused_vg) { nil }
+        let(:unlimited) { Y2Storage::DiskSize.unlimited }
+        let(:max) { unlimited }
+
+        it "returns unlimited" do
+          expect(lvm_vg.max_extra_space).to eq unlimited
+        end
+      end
+
+      context "and no volume group is being reused" do
+        let(:reused_vg) { nil }
+        let(:max) { 30.GiB - 1.MiB }
+
+        it "returns the max size rounded up to the default extent size" do
+          expect(lvm_vg.max_extra_space).to eq 30.GiB
+        end
+      end
+
+      context "and a volume group is being reused" do
+        subject(:lvm_vg) { Y2Storage::Planned::LvmVg.from_real_vg(vg_big_pe) }
+        let(:max) { 30.GiB + 2.MiB }
+
+        it "returns the extra size rounded up to the VG extent size" do
+          extra = max - vg_big_pe.size
+          # Extent size of vg_big_pe is 64 MiB
+          rounding = 62.MiB
+          expect(lvm_vg.max_extra_space).to eq(extra + rounding)
+        end
+      end
     end
   end
 end

--- a/test/y2storage/proposal/partitions_distribution_calculator_test.rb
+++ b/test/y2storage/proposal/partitions_distribution_calculator_test.rb
@@ -32,6 +32,7 @@ describe Y2Storage::Proposal::PartitionsDistributionCalculator do
   let(:enc_password) { nil }
   let(:lvm_vg_strategy) { :use_needed }
   let(:lvm_helper) { Y2Storage::Proposal::LvmHelper.new(lvm_volumes, settings) }
+  let(:planned_vg) { lvm_helper.volume_group }
 
   before do
     settings.encryption_password = enc_password
@@ -39,7 +40,7 @@ describe Y2Storage::Proposal::PartitionsDistributionCalculator do
     fake_scenario(scenario)
   end
 
-  subject(:calculator) { described_class.new(lvm_helper) }
+  subject(:calculator) { described_class.new(planned_vg) }
 
   describe "#best_distribution" do
     let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 1.GiB, max: 3.GiB, weight: 1) }
@@ -540,12 +541,12 @@ describe Y2Storage::Proposal::PartitionsDistributionCalculator do
         include_examples "configuration of PVs"
 
         it "sets min_size for all PVs to sum lvm_size" do
-          useful_min_sizes = pv_vols.map { |v| lvm_helper.useful_pv_space(v.min_size) }
+          useful_min_sizes = pv_vols.map { |v| planned_vg.useful_pv_space(v.min_size) }
           expect(useful_min_sizes.reduce(:+)).to eq lvm_size
         end
 
         it "sets max_size for all PVs to sum lvm_max" do
-          useful_max_sizes = pv_vols.map { |v| lvm_helper.useful_pv_space(v.max_size) }
+          useful_max_sizes = pv_vols.map { |v| planned_vg.useful_pv_space(v.max_size) }
           expect(useful_max_sizes.reduce(:+)).to eq lvm_max
         end
 
@@ -619,7 +620,7 @@ describe Y2Storage::Proposal::PartitionsDistributionCalculator do
         include_examples "configuration of PVs"
 
         it "sets min_size for all PVs to be as big as needed" do
-          useful_min_sizes = pv_vols.map { |v| lvm_helper.useful_pv_space(v.min_size) }
+          useful_min_sizes = pv_vols.map { |v| planned_vg.useful_pv_space(v.min_size) }
           expect(useful_min_sizes.reduce(:+)).to be >= lvm_size
         end
 

--- a/test/y2storage/proposal_separate_vgs_test.rb
+++ b/test/y2storage/proposal_separate_vgs_test.rb
@@ -1,0 +1,107 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "storage"
+require "y2storage"
+require_relative "#{TEST_PATH}/support/proposal_examples"
+require_relative "#{TEST_PATH}/support/proposal_context"
+
+describe Y2Storage::GuidedProposal do
+  describe "#propose" do
+    include_context "proposal"
+
+    subject(:proposal) { described_class.new(settings: settings) }
+    let(:architecture) { :x86 }
+    let(:settings_format) { :ng }
+    let(:control_file) { "separate_vgs.xml" }
+    let(:scenario) { "empty_disks" }
+    before { settings.separate_vgs = separate_vgs }
+
+    let(:mounted_devices) do
+      Y2Storage::MountPoint.all(proposal.devices).map { |i| i.filesystem.blk_devices.first }
+    end
+
+    context "when ProposalSettings#lvm is set to true" do
+      let(:lvm) { true }
+
+      context "and ProposalSettings#separate_vgs is set to true" do
+        let(:separate_vgs) { true }
+
+        it "proposes an LVM VG for every separate volume and another for system volumes" do
+          proposal.propose
+          vgs = proposal.devices.lvm_vgs
+
+          expect(vgs.map(&:vg_name)).to contain_exactly("system", "spacewalk", "srv_vg")
+          is_lv = mounted_devices.map { |i| i.is?(:lvm_lv) }
+          expect(is_lv).to all(eq(true))
+        end
+      end
+
+      context "but ProposalSettings#separate_vgs is set to false" do
+        let(:separate_vgs) { false }
+
+        it "proposes only the system LVM VG containing all logical volumes" do
+          proposal.propose
+          vgs = proposal.devices.lvm_vgs
+
+          expect(vgs.size).to eq 1
+          expect(vgs.first.vg_name).to eq "system"
+          is_lv = mounted_devices.map { |i| i.is?(:lvm_lv) }
+          expect(is_lv).to all(eq(true))
+        end
+      end
+    end
+
+    context "when ProposalSettings#lvm is set to false" do
+      let(:lvm) { false }
+
+      context "but ProposalSettings#separate_vgs is set to true" do
+        let(:separate_vgs) { true }
+
+        it "proposes some system partitions plus an LVM VG for every separate volume" do
+          proposal.propose
+          vgs = proposal.devices.lvm_vgs
+
+          expect(vgs.map(&:vg_name)).to contain_exactly("spacewalk", "srv_vg")
+          lvs = mounted_devices.select { |i| i.is?(:lvm_lv) }
+          partitions = mounted_devices.select { |i| i.is?(:partition) }
+          expect(lvs.size).to eq 2
+          expect(partitions.size).to eq 2
+        end
+      end
+
+      context "and ProposalSettings#separate_vgs is set to false" do
+        let(:separate_vgs) { false }
+
+        it "proposes everything as partitions with no LVM VGs" do
+          proposal.propose
+          vgs = proposal.devices.lvm_vgs
+
+          expect(vgs).to be_empty
+          is_partition = mounted_devices.map { |i| i.is?(:partition) }
+          expect(is_partition).to all(eq(true))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

For SUSE Manager we want the storage proposal to work in a different way than the regular (open)SUSE.

There will be a new `separate_vgs` setting to indicate the proposal must allocate some volumes as a LVM logical volume in its own separate dedicated volume group.

In the control file, some volumes will have a new attribute `separate_vg_name` to indicate they can be allocated like that. The rest of the <partitioning> section of control.xml would stay as it is now.

* See [description of the feature](https://gist.github.com/ancorgs/c7c9d7ccd3feb38b3f40e85d58e4a671) from the UI perspective.
* See [card describing the feature](https://trello.com/c/aIAbysbE/)
* See [PBI for this first step](https://trello.com/c/k5ZZNKdJ/)

## Solution

This PBI includes some previous refactoring needed to implement this cleanly.

It also includes the modifications to the Guided Proposal needed to implement this behavior.

So better review commit by commit.

## Testing

Includes some very basic unit tests. Testing more thoroughly probably makes no sense at this early stage of the feature.