### PR TITLE
Import mount point from multi-device Btrfs

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul  1 11:12:13 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: fix importing mount points from a multi-device
+  Btrfs filesystem (bsc#1137997).
+- 4.2.22
+
+-------------------------------------------------------------------
 Mon Jul  1 10:28:48 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - adopt new rubocop to be able to use the latest ruby features

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:	4.2.21
+Version:        4.2.22
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/fstabs.rb
+++ b/src/lib/y2partitioner/actions/controllers/fstabs.rb
@@ -355,16 +355,53 @@ module Y2Partitioner
           filesystem.mount_point.mount_options = entry.mount_options if entry.mount_options.any?
         end
 
-        # Performs any additional final step needed for the new block
-        # filesystem (Btrfs stuff, so far)
+        # Performs any additional final step needed for the new block filesystem (Btrfs stuff, so far)
         #
         # @param filesystem [Y2Storage::Filesystems::BlkFilesystem]
         def setup_blk_filesystem(filesystem)
+          add_filesystem_devices(filesystem)
+
           if filesystem.can_configure_snapper?
             filesystem.configure_snapper = filesystem.default_configure_snapper?
           end
 
           filesystem.setup_default_btrfs_subvolumes if filesystem.supports_btrfs_subvolumes?
+        end
+
+        # Adds missing devices to the filesystem when the original filesystem was a multi-device Btrfs
+        #
+        # @param filesystem [Y2Storage::Filesystems::BlkFilesystem]
+        def add_filesystem_devices(filesystem)
+          original_filesystem = original_filesystem(filesystem)
+
+          return unless original_filesystem && original_filesystem.multidevice?
+
+          devices = original_filesystem.blk_devices.map { |d| current_graph.find_device(d.sid) }.compact
+
+          devices.each { |d| add_filesystem_device(filesystem, d) }
+        end
+
+        # Adds a device to the filesystem
+        #
+        # @param filesystem [Y2Storage::Filesystems::BlkFilesystem]
+        # @param device [Y2Storage::BlkDevice]
+        def add_filesystem_device(filesystem, device)
+          return if filesystem.blk_devices.map(&:sid).include?(device.sid)
+
+          filesystem.add_device(device)
+        end
+
+        # Original version of the filesystem in the system graph
+        #
+        # @param filesystem [Y2Storage::Filesystems::BlkFilesystem]
+        # @return [Y2Storage::Filesystems::BlkFilesystem, nil] nil if the filesystem cannot be found in
+        #   system graph.
+        def original_filesystem(filesystem)
+          original_device = system_graph.find_device(filesystem.blk_devices.first.sid)
+
+          return nil unless original_device && original_device.formatted?
+
+          original_device.filesystem
         end
 
         # Device indicated in the fstab entry

--- a/src/lib/y2partitioner/actions/controllers/fstabs.rb
+++ b/src/lib/y2partitioner/actions/controllers/fstabs.rb
@@ -374,7 +374,7 @@ module Y2Partitioner
         def add_filesystem_devices(filesystem)
           original_filesystem = original_filesystem(filesystem)
 
-          return unless original_filesystem && original_filesystem.multidevice?
+          return unless original_filesystem&.multidevice?
 
           devices = original_filesystem.blk_devices.map { |d| current_graph.find_device(d.sid) }.compact
 
@@ -399,7 +399,7 @@ module Y2Partitioner
         def original_filesystem(filesystem)
           original_device = system_graph.find_device(filesystem.blk_devices.first.sid)
 
-          return nil unless original_device && original_device.formatted?
+          return nil unless original_device&.formatted?
 
           original_device.filesystem
         end

--- a/test/y2partitioner/actions/controllers/fstabs_test.rb
+++ b/test/y2partitioner/actions/controllers/fstabs_test.rb
@@ -605,6 +605,34 @@ describe Y2Partitioner::Actions::Controllers::Fstabs do
       end
     end
 
+    context "when the fstab contains a multi-device Btrfs entry" do
+      let(:scenario) { "btrfs2-devicegraph.xml" }
+
+      let(:entries) do
+        [
+          fstab_entry("UUID=b7b96325-feb5-4e7e-a7f4-014ce2402e71", "/", btrfs, ["defaults"], 0, 0)
+        ]
+      end
+
+      it "imports mount point and mount options for the multi-device Btrfs entry" do
+        subject.import_mount_points
+
+        filesystem = current_graph.find_by_name("/dev/sdb1").filesystem
+
+        expect(filesystem.mount_path).to eq("/")
+        expect(filesystem.mount_options).to eq(["defaults"])
+      end
+
+      it "creates the multi-device Btrfs with all the devices" do
+        subject.import_mount_points
+
+        filesystem = current_graph.find_by_name("/dev/sdb1").filesystem
+
+        expect(filesystem.blk_devices.map(&:basename))
+          .to contain_exactly("sdb1", "sdc1", "sdd1", "sde1")
+      end
+    end
+
     context "when the imported root is Btrfs" do
       using Y2Storage::Refinements::SizeCasts
 


### PR DESCRIPTION
## Problem

The Expert Partitioner has a feature to import mount points from the fstab file of a previous installation. When an imported fstab entry points to a multi-device Btrfs in the previous system, the multi-device filesystem is not restored in the new system being installed. Instead of that, a single-device Btrfs is created.  

* https://trello.com/c/50a33VHa/1084-ostumbleweed-p5-1137997-expert-partitioner-import-multi-device-btrfs-mount-points

* https://bugzilla.suse.com/show_bug.cgi?id=1137997


## Solution

Now on, the multi-device Btrfs is re-created in the new system when importing the mount point.


## Testing

- Added unit tests
- Tested manually


## Screenshots

<details>
<summary>Show screenshots</summary>

* Storage layout from the initial proposal:

![VirtualBox_SLE-15-2_21_06_2019_12_12_44](https://user-images.githubusercontent.com/1112304/59920524-b0f29e80-9422-11e9-9599-0cd03474fbdd.png)

* Importing mount points from a previous system with multi-device Btrfs:

![VirtualBox_SLE-15-2_21_06_2019_12_13_27](https://user-images.githubusercontent.com/1112304/59920537-be0f8d80-9422-11e9-8f37-e23cb05a4c15.png)

* Result after importing mount points:

![VirtualBox_SLE-15-2_21_06_2019_12_13_42](https://user-images.githubusercontent.com/1112304/59920545-c36cd800-9422-11e9-8194-19d84b787b82.png)

</details>
