### PR TITLE
Add control file option to delete and resize partitions

### DIFF
--- a/doc/old_and_new_proposal.md
+++ b/doc/old_and_new_proposal.md
@@ -199,6 +199,7 @@ Besides these, there is another element:
 #### Global settings in `proposal` section
 
   * `lvm` *(boolean, default: `false`)*
+  * `delete_resize_configurable` *(boolean, default: `true`)*
   * `resize_windows` *(boolean, default: `true`)*
   * `windows_delete_mode` *(`none`, `ondemand`, `all`, default: `ondemand`)*
   * `linux_delete_mode` *(`none`, `ondemand`, `all`, default: `ondemand`)*
@@ -648,6 +649,10 @@ following options.
     Whether LVM should be used by default.
   * ~~`encrypt`
     Whether encryption should be used by default.~~
+  * `delete_resize_configurable`
+    Whether the user can modify the options related to delete or resize partitions.
+    When this option is set to `false`, the user cannot change the value of
+    `windows_delete_mode`, `linux_delete_mode`, `other_delete_mode` and `resize_windows`.
   * `windows_delete_mode`
     Default value for the automatic delete mode for
     Windows partitions. It can be `none`, `all` or `ondemand`. For more

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul  5 14:04:00 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Proposal: add control file option to make configurable to resize
+  and delete partitions (part of jsc#SLE-7238).
+- 4.2.23
+
+-------------------------------------------------------------------
 Mon Jul  1 11:12:13 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Partitioner: fix importing mount points from a multi-device

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.22
+Version:        4.2.23
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/actions_presenter.rb
+++ b/src/lib/y2storage/actions_presenter.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup.rb
+++ b/src/lib/y2storage/dialogs/guided_setup.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage/disk_analyzer"

--- a/src/lib/y2storage/dialogs/guided_setup/base.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/base.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "ui/installation_dialog"

--- a/src/lib/y2storage/dialogs/guided_setup/base.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/base.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -18,8 +18,9 @@
 # find current contact information at www.novell.com.
 
 require "yast"
-require "y2storage"
 require "ui/installation_dialog"
+require "y2storage"
+require "y2storage/dialogs/guided_setup/helpers/disk"
 
 Yast.import "Report"
 
@@ -70,16 +71,13 @@ module Y2Storage
           guided_setup.analyzer
         end
 
-        # Disk label used by dialogs.
-        # name, size, [USB] and installed systems, for example:
-        #   "/dev/sda, 10.00 GiB, Windows, OpenSUSE"
-        #   "/dev/sdb, 8.00 GiB, USB"
+        # Disk label used by dialogs
+        #
+        # @see Helpers::Disk#label
+        #
         # @return [String]
         def disk_label(disk)
-          data = [disk.name, disk.size.to_human_string]
-          data += disk_type_labels(disk)
-          data += analyzer.installed_systems(disk)
-          data.join(", ")
+          disk_helper.label(disk)
         end
 
         protected
@@ -124,33 +122,11 @@ module Y2Storage
           Yast::UI.ChangeWidget(Id(id), attr, value)
         end
 
-        # Labels to help indentifying some kind of disks, like USB ones
+        # Helper to generate a disk label
         #
-        # @see #disk_label
-        #
-        # @param disk [BlkDevice]
-        # @return [Array<String>]
-        def disk_type_labels(disk)
-          return [] unless disk.respond_to?(:transport)
-
-          trans = transport_label(disk.transport)
-          trans.empty? ? [] : [trans]
-        end
-
-        # Label for the given transport to be displayed in the dialogs
-        #
-        # @see #disk_type_labels
-        #
-        # @param transport [DataTransport]
-        # @return [String] empty string if the transport is not worth mentioning
-        def transport_label(transport)
-          if transport.is?(:usb)
-            _("USB")
-          elsif transport.is?(:sbp)
-            _("IEEE 1394")
-          else
-            ""
-          end
+        # @return [Helpers::Disk]
+        def disk_helper
+          @disk_helper ||= Helpers::Disk.new(analyzer)
         end
       end
     end

--- a/src/lib/y2storage/dialogs/guided_setup/helpers/disk.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/helpers/disk.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/helpers/disk.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/helpers/disk.rb
@@ -1,0 +1,94 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may
+# find current contact information at www.novell.com.
+
+require "yast"
+require "y2storage"
+
+module Y2Storage
+  module Dialogs
+    class GuidedSetup
+      module Helpers
+        # Helper class to generate the label of a disk
+        class Disk
+          include Yast::I18n
+
+          # Constructor
+          #
+          # @param analyzer [Y2Storage::DiskAnalayzer]
+          def initialize(analyzer)
+            textdomain "storage"
+
+            @analyzer = analyzer
+          end
+
+          # Disk label used by dialogs
+          #
+          # The label has the form: "NAME, SIZE, [USB], INSTALLED_SYSTEMS".
+          #
+          # Examples:
+          #
+          #   "/dev/sda, 10.00 GiB, Windows, OpenSUSE"
+          #   "/dev/sdb, 8.00 GiB, USB"
+          #
+          # @return [String]
+          def label(disk)
+            data = [disk.name, disk.size.to_human_string]
+            data += type_labels(disk)
+            data += analyzer.installed_systems(disk)
+            data.join(", ")
+          end
+
+          private
+
+          # @return [Y2Storage::DiskAnalyzer]
+          attr_reader :analyzer
+
+          # Labels to help indentifying some kind of disks, like USB ones
+          #
+          # @see #label
+          #
+          # @param disk [BlkDevice]
+          # @return [Array<String>]
+          def type_labels(disk)
+            return [] unless disk.respond_to?(:transport)
+
+            trans = transport_label(disk.transport)
+            trans.empty? ? [] : [trans]
+          end
+
+          # Label for the given transport to be displayed in the dialogs
+          #
+          # @see #type_labels
+          #
+          # @param transport [DataTransport]
+          # @return [String] empty string if the transport is not worth mentioning
+          def transport_label(transport)
+            if transport.is?(:usb)
+              _("USB")
+            elsif transport.is?(:sbp)
+              _("IEEE 1394")
+            else
+              ""
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/dialogs/guided_setup/select_disks.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_disks.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/select_filesystem.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_filesystem.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 module Y2Storage
   module Dialogs

--- a/src/lib/y2storage/dialogs/guided_setup/select_filesystem/base.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_filesystem/base.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/select_filesystem/legacy.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_filesystem/legacy.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/select_filesystem/ng.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_filesystem/ng.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/select_filesystem/volume_widget.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_filesystem/volume_widget.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/select_root_disk.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_root_disk.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/select_root_disk.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_root_disk.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -20,207 +20,107 @@
 require "yast"
 require "y2storage"
 require "y2storage/dialogs/guided_setup/base"
+require "y2storage/dialogs/guided_setup/widgets/root_disk_selector"
+require "y2storage/dialogs/guided_setup/widgets/partition_actions"
 
 module Y2Storage
   module Dialogs
     class GuidedSetup
-      # Dialog for root disk selection.
+      # Dialog for root disk selection and the actions to perform over Windows, Linux and other kind of
+      # partitions.
       class SelectRootDisk < Base
         extend Yast::I18n
 
+        # Constructor
+        #
+        # @see GuidedSetup::Base
         def initialize(*params)
           textdomain "storage"
           super
         end
 
-        # This dialog should be skipped when there is only one candidate
-        # disk for installation and there are not installed systems.
+        # This dialog should be skipped when there is only one candidate disk for the installation and
+        # the actions over the partitions (delete and resize) cannot be configured.
+        #
+        # @return [Boolean]
         def skip?
-          candidate_disks.size == 1 && all_partitions.empty?
+          single_candidate_disk? && !partitions_configurable?
         end
 
         # Before skipping, settings should be assigned.
+        #
+        # @see GuidedSetup::Base
         def before_skip
           settings.root_device = candidate_disks.first.name
         end
 
         protected
 
+        # @see GuidedSetup::Base
         def dialog_title
           _("Select Hard Disk(s)")
         end
 
+        # @see GuidedSetup::Base
         def dialog_content
+          content = widgets.flat_map { |w| [w.content, VSpacing(1)] }.tap(&:pop)
+
           HSquash(
             VBox(
-              root_selection_widget,
-              VSpacing(1),
-              *(activate_windows_actions? ? [windows_action_widget, VSpacing(1)] : [Empty()]),
-              linux_delete_mode_widget,
-              VSpacing(1),
-              other_delete_mode_widget
+              *content
             )
           )
         end
 
+        # Widgets of the dialog
+        #
+        # @return [Array<Widgets::Base>]
+        def widgets
+          widgets = [root_selection_widget]
+          widgets << partition_actions_widget if partition_actions?
+
+          widgets
+        end
+
+        # Widget to select the root device
+        #
+        # @return [Widgets::RootDiskSelector]
         def root_selection_widget
-          VBox(
-            Left(Label(_("Please select a disk to use as the \"root\" partition (/)"))),
-            VSpacing(0.3),
-            if need_to_select_disk?
-              RadioButtonGroup(
-                Id(:root_disk),
-                VBox(
-                  *([any_disk_widget] + candidate_disks.map { |d| disk_widget(d) })
-                )
-              )
-            else
-              Left(Label(disk_label(candidate_disks.first)))
-            end
-          )
+          @root_selection_widget ||= Widgets::RootDiskSelector.new("root_selector", settings,
+            candidate_disks: candidate_disks,
+            disk_helper:     disk_helper)
         end
 
-        def windows_action_widget
-          VBox(
-            Left(Label(_("Choose what to do with existing Windows systems"))),
-            Left(
-              ComboBox(
-                Id(:windows_action), "",
-                [
-                  Item(Id(:not_modify), _("Do not modify")),
-                  Item(Id(:resize), _("Resize if needed")),
-                  Item(Id(:remove), _("Resize or remove as needed")),
-                  Item(Id(:always_remove), _("Remove even if not needed"))
-                ]
-              )
-            )
-          )
+        # Widget to select the actions (delete or resize) over the partitions
+        #
+        # @return [Widgets::PartitionActions]
+        def partition_actions_widget
+          @partition_actions_widget ||= Widgets::PartitionActions.new("partition_actions", settings,
+            windows: windows_actions?,
+            linux:   linux_actions?,
+            other:   other_actions?)
         end
 
-        def linux_delete_mode_widget
-          VBox(
-            Left(Label(_("Choose what to do with existing Linux partitions"))),
-            Left(
-              ComboBox(
-                Id(:linux_delete_mode), "",
-                [
-                  Item(Id(:none), _("Do not modify")),
-                  Item(Id(:ondemand), _("Remove if needed")),
-                  Item(Id(:all), _("Remove even if not needed"))
-                ]
-              )
-            )
-          )
-        end
-
-        def other_delete_mode_widget
-          VBox(
-            Left(Label(_("Choose what to do with other partitions"))),
-            Left(
-              ComboBox(
-                Id(:other_delete_mode), "",
-                [
-                  Item(Id(:none), _("Do not modify")),
-                  Item(Id(:ondemand), _("Remove if needed")),
-                  Item(Id(:all), _("Remove even if not needed"))
-                ]
-              )
-            )
-          )
-        end
-
-        def any_disk_widget
-          Left(RadioButton(Id(:any_disk), _("Any disk")))
-        end
-
-        def disk_widget(disk)
-          Left(RadioButton(Id(disk.name), disk_label(disk)))
-        end
-
+        # @see GuidedSetup::Base
         def initialize_widgets
-          # Select a root disk or any option
-          widget = settings.root_device || :any_disk
-          widget_update(widget, true)
-
-          widget_update(:windows_action, windows_action) if activate_windows_actions?
-
-          widget_update(:linux_delete_mode, settings.linux_delete_mode)
-          widget_update(:linux_delete_mode, activate_linux_delete_mode?, attr: :Enabled)
-
-          widget_update(:other_delete_mode, settings.other_delete_mode)
-          widget_update(:other_delete_mode, activate_other_delete_mode?, attr: :Enabled)
+          widgets.each(&:init)
         end
 
+        # @see GuidedSetup::Base
         def update_settings!
-          root = selected_disk
-          settings.root_device = root ? root.name : nil
-
-          settings.linux_delete_mode = widget_value(:linux_delete_mode)
-          settings.other_delete_mode = widget_value(:other_delete_mode)
-
-          update_windows_settings if activate_windows_actions?
+          widgets.each(&:store)
         end
 
-        BASIC_HELP = N_(
-          "<p>" \
-          "Select the disk where to create the root filesystem. " \
-          "</p><p>" \
-          "This is also the disk where boot-related partitions " \
-          "will typically be created as necessary: /boot, ESP (EFI System " \
-          "Partition), BIOS-Grub. " \
-          "That means that this disk should be usable by the machine's " \
-          "BIOS / firmware." \
-          "</p><p>" \
-          "In this dialog you can also choose what to do with existing partitions:" \
-          "</p><p>" \
-          "<ul>" \
-          "<li>Do not modify (keep them as they are)</li>" \
-          "<li>Remove if needed</li>" \
-          "<li>Remove even if not needed (always remove)</li>" \
-          "</ul>"
-        )
-
-        ACTIVATE_WINDOWS_HELP = N_(
-          "<ul>" \
-          "<li>Resize if needed (Windows partitions only)</li>" \
-          "<li>Resize or remove if needed (Windows partitions only)</li>" \
-          "</ul>" \
-          "<p>" \
-          "That last option means to try to resize the Windows partition(s) to " \
-          "make enough disk space available for Linux, but if that is not " \
-          "enough, completely delete the Windows partition." \
-          "</p>"
-        )
-
+        # @see GuidedSetup::Base
         def help_text
-          # TRANSLATORS: Help text for root disk selection
-          msg = _(BASIC_HELP)
-
-          # TRANSLATORS: Help text for root disk selection, continued
-          msg += _(ACTIVATE_WINDOWS_HELP) if activate_windows_actions?
-
-          msg
+          widgets.map(&:help).join
         end
 
         private
 
-        def update_windows_settings
-          case widget_value(:windows_action)
-          when :not_modify
-            settings.resize_windows = false
-            settings.windows_delete_mode = :none
-          when :resize
-            settings.resize_windows = true
-            settings.windows_delete_mode = :none
-          when :remove
-            settings.resize_windows = true
-            settings.windows_delete_mode = :ondemand
-          when :always_remove
-            settings.resize_windows = false
-            settings.windows_delete_mode = :all
-          end
-        end
-
+        # Candidate disks to perform the installation
+        #
+        # @return
         def candidate_disks
           return @candidate_disks if @candidate_disks
 
@@ -228,52 +128,70 @@ module Y2Storage
           @candidate_disks = candidates.map { |d| analyzer.device_by_name(d) }
         end
 
-        def need_to_select_disk?
-          candidate_disks.size > 1
+        # Whether the actions (delete or resize) over the partitions are configurable
+        #
+        # @return [Boolean]
+        def partition_actions?
+          settings.delete_resize_configurable
         end
 
-        def selected_disk
-          if need_to_select_disk?
-            candidate_disks.detect { |d| widget_value(d.name) }
-          else
-            candidate_disks.first
-          end
-        end
-
-        def activate_windows_actions?
+        # Whether the actions (delete or resize) over Windows partitions are configurable
+        #
+        # @return [Boolean]
+        def windows_actions?
           !windows_partitions.empty?
         end
 
-        def activate_linux_delete_mode?
+        # Whether the actions (delete) over Linux partitions are configurable
+        #
+        # @return [Boolean]
+        def linux_actions?
           !linux_partitions.empty?
         end
 
-        def activate_other_delete_mode?
+        # Whether the actions (delete) over other kind of partitions are configurable
+        #
+        # @return [Boolean]
+        def other_actions?
           all_partitions.size > linux_partitions.size + windows_partitions.size
         end
 
-        def linux_partitions
-          analyzer.linux_partitions(*candidate_disks)
-        end
-
+        # Windows partitions from the candidate disks
+        #
+        # @return [Array<Y2Storage::Partition>]
         def windows_partitions
           analyzer.windows_partitions(*candidate_disks)
         end
 
+        # Linux partitions from the candidate disks
+        #
+        # @return [Array<Y2Storage::Partition>]
+        def linux_partitions
+          analyzer.linux_partitions(*candidate_disks)
+        end
+
+        # All partitions from the candidate disks
+        #
+        # @return [Array<Y2Storage::Partition>]
         def all_partitions
           @all_partitions ||= candidate_disks.map(&:partitions).flatten
         end
 
-        def windows_action
-          if settings.windows_delete_mode == :all
-            :always_remove
-          elsif settings.windows_delete_mode == :ondemand
-            :remove
-          elsif settings.resize_windows
-            :resize
-          else
-            :not_modify
-          end
+        # Whether there is only one candidate disk
+        #
+        # @return [Boolean]
+        def single_candidate_disk?
+          candidate_disks.size == 1
+        end
+
+        # Whether the partition actions can be configured by the user
+        #
+        # The partitions are configurable if there are partitions and the option to configure the
+        # partitions is not disabled in the control file.
+        #
+        # @return [Boolean]
+        def partitions_configurable?
+          all_partitions.any? && partition_actions?
         end
       end
     end

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/widgets/base.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/widgets/base.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 

--- a/src/lib/y2storage/dialogs/guided_setup/widgets/base.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/widgets/base.rb
@@ -1,0 +1,114 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may
+# find current contact information at www.novell.com.
+
+require "yast"
+
+module Y2Storage
+  module Dialogs
+    class GuidedSetup
+      module Widgets
+        # Base class for widgets in the dialogs of the Guided Setup
+        class Base
+          include Yast::UIShortcuts
+          include Yast::I18n
+
+          # @return [String]
+          attr_reader :widget_id
+
+          # Constructor
+          #
+          # @param widget_id [String]
+          # @param settings [Y2Storage::ProposalSettings]
+          def initialize(widget_id, settings)
+            @widget_id = widget_id
+            @settings = settings
+          end
+
+          # Content of the widget
+          #
+          # This method must be defined by derived classes.
+          #
+          # @return [Yast::Term, nil]
+          def content
+            nil
+          end
+
+          # Initializes the widget
+          #
+          # This method should be defined by derived classes.
+          def init
+            nil
+          end
+
+          # Stores the widget
+          #
+          # This method should be defined by derived classes.
+          def store
+            nil
+          end
+
+          # Help for the widget
+          #
+          # This method should be defined by derived classes.
+          #
+          # @return [String, nil]
+          def help
+            nil
+          end
+
+          # Value of the widget
+          #
+          # @return [Object]
+          def value
+            Yast::UI.QueryWidget(Id(widget_id), :Value)
+          end
+
+          # Setter for the value of the widget
+          #
+          # @param value [Object]
+          def value=(value)
+            Yast::UI.ChangeWidget(Id(widget_id), :Value, value)
+          end
+
+          # Enables the widget
+          def enable
+            Yast::UI.ChangeWidget(Id(widget_id), :Enabled, true)
+          end
+
+          # Disables the widget
+          def disable
+            Yast::UI.ChangeWidget(Id(widget_id), :Enabled, false)
+          end
+
+          # Whether the widget is currently enabled
+          #
+          # @return [Boolean]
+          def enabled?
+            Yast::UI.QueryWidget(Id(widget_id), :Enabled)
+          end
+
+          private
+
+          # @return [Y2Storage::ProposalSettings]
+          attr_reader :settings
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/dialogs/guided_setup/widgets/linux_partition_actions.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/widgets/linux_partition_actions.rb
@@ -1,0 +1,87 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may
+# find current contact information at www.novell.com.
+
+require "yast"
+require "y2storage"
+require "y2storage/dialogs/guided_setup/widgets/base"
+
+module Y2Storage
+  module Dialogs
+    class GuidedSetup
+      module Widgets
+        # Widget to select the actions to perform over the Linux partitions
+        class LinuxPartitionActions < Base
+          # Whether the widget should be enabled by default
+          #
+          # @return [Boolean]
+          attr_reader :enable_on_init
+
+          alias_method :enable_on_init?, :enable_on_init
+
+          # Constructor
+          #
+          # @param widget_id [String]
+          # @param settings [Y2Storage::ProposalSettings]
+          # @param enabled [Boolean]
+          def initialize(widget_id, settings, enabled: true)
+            super(widget_id, settings)
+
+            textdomain "storage"
+
+            @enable_on_init = enabled
+          end
+
+          # @see Widgets::Base
+          def content
+            VBox(
+              Left(Label(_("Choose what to do with existing Linux partitions"))),
+              Left(
+                ComboBox(
+                  Id(widget_id), "",
+                  [
+                    Item(Id(:none), _("Do not modify")),
+                    Item(Id(:ondemand), _("Remove if needed")),
+                    Item(Id(:all), _("Remove even if not needed"))
+                  ]
+                )
+              )
+            )
+          end
+
+          # Selects the default option according to the settings. The widget is enabled or disabled,
+          # depending on the configuration (see {#enable_on_init})
+          #
+          # @see Widgets::Base
+          def init
+            self.value = settings.linux_delete_mode
+
+            enable_on_init? ? enable : disable
+          end
+
+          # Sets the settings according to the selected value
+          #
+          # @see Widgets::Base
+          def store
+            settings.linux_delete_mode = value
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/dialogs/guided_setup/widgets/linux_partition_actions.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/widgets/linux_partition_actions.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/widgets/other_partition_actions.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/widgets/other_partition_actions.rb
@@ -1,0 +1,88 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may
+# find current contact information at www.novell.com.
+
+require "yast"
+require "y2storage"
+require "y2storage/dialogs/guided_setup/widgets/base"
+
+module Y2Storage
+  module Dialogs
+    class GuidedSetup
+      module Widgets
+        # Widget to select the actions to perform over other kind of partitions (neither Windows nor
+        # Linux partitions)
+        class OtherPartitionActions < Base
+          # Whether the widget should be enabled by default
+          #
+          # @return [Boolean]
+          attr_reader :enable_on_init
+
+          alias_method :enable_on_init?, :enable_on_init
+
+          # Constructor
+          #
+          # @param widget_id [String]
+          # @param settings [Y2Storage::ProposalSettings]
+          # @param enabled [Boolean]
+          def initialize(widget_id, settings, enabled: true)
+            super(widget_id, settings)
+
+            textdomain "storage"
+
+            @enable_on_init = enabled
+          end
+
+          # @see Widgets::Base
+          def content
+            VBox(
+              Left(Label(_("Choose what to do with other partitions"))),
+              Left(
+                ComboBox(
+                  Id(widget_id), "",
+                  [
+                    Item(Id(:none), _("Do not modify")),
+                    Item(Id(:ondemand), _("Remove if needed")),
+                    Item(Id(:all), _("Remove even if not needed"))
+                  ]
+                )
+              )
+            )
+          end
+
+          # Selects the default option according to the settings. The widget is enabled or disabled,
+          # depending on the configuration (see {#enable_on_init})
+          #
+          # @see Widgets::Base
+          def init
+            self.value = settings.other_delete_mode
+
+            enable_on_init? ? enable : disable
+          end
+
+          # Sets the settings according to the selected value
+          #
+          # @see Widgets::Base
+          def store
+            settings.other_delete_mode = value
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/dialogs/guided_setup/widgets/other_partition_actions.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/widgets/other_partition_actions.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/widgets/partition_actions.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/widgets/partition_actions.rb
@@ -1,0 +1,176 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may
+# find current contact information at www.novell.com.
+
+require "yast"
+require "y2storage"
+require "y2storage/dialogs/guided_setup/widgets/base"
+require "y2storage/dialogs/guided_setup/widgets/windows_partition_actions"
+require "y2storage/dialogs/guided_setup/widgets/linux_partition_actions"
+require "y2storage/dialogs/guided_setup/widgets/other_partition_actions"
+
+module Y2Storage
+  module Dialogs
+    class GuidedSetup
+      module Widgets
+        # Widget to select the actions to perform over the partitions (delete and resize)
+        class PartitionActions < Base
+          extend Yast::I18n
+
+          # Constructor
+          #
+          # @param widget_id [String]
+          # @param settings [Y2Storage::ProposalSettings]
+          # @param windows [Boolean] whether a widget for actions over Windows partitions should be shown
+          # @param linux [Boolean] whether the widget for actions over Linux partitions should be enabled
+          # @param other [Boolean] whether the widget for actions over other partitions should be enabled
+          def initialize(widget_id, settings, windows: true, linux: true, other: true)
+            super(widget_id, settings)
+
+            textdomain "storage"
+
+            self.windows_actions = windows
+            self.linux_actions = linux
+            self.other_actions = other
+          end
+
+          # @see Widgets::Base
+          def content
+            VBox(*add_spacing(widgets.map(&:content)))
+          end
+
+          # Initializes each widget
+          #
+          # @see Widgets::Base
+          def init
+            widgets.each(&:init)
+          end
+
+          # Stores each widget
+          #
+          # @see Widgets::Base
+          def store
+            widgets.each(&:store)
+          end
+
+          # @see Widgets::Base
+          def help
+            help = _(REMOVE_ACTIONS_HELP)
+
+            help += _(WINDOWS_ACTIONS_HELP) if windows_actions?
+
+            help
+          end
+
+          private
+
+          # @return [Boolean]
+          attr_accessor :windows_actions
+
+          # @return [Boolean]
+          attr_accessor :linux_actions
+
+          # @return [Boolean]
+          attr_accessor :other_actions
+
+          alias_method :windows_actions?, :windows_actions
+
+          alias_method :linux_actions?, :linux_actions
+
+          alias_method :other_actions?, :other_actions
+
+          REMOVE_ACTIONS_HELP = N_(
+            "<p>" \
+              "You can choose what to do with existing partitions:" \
+            "</p>" \
+            "<p>" \
+              "<ul>" \
+                "<li>Do not modify (keep them as they are)</li>" \
+                "<li>Remove if needed</li>" \
+                "<li>Remove even if not needed (always remove)</li>" \
+              "</ul>" \
+            "</p>"
+          )
+
+          WINDOWS_ACTIONS_HELP = N_(
+            "<p>" \
+              "And for Windows partitions, the following options are also available:" \
+              "<ul>" \
+                "<li>Resize if needed (Windows partitions only)</li>" \
+                "<li>Resize or remove if needed (Windows partitions only)</li>" \
+              "</ul>" \
+            "<p>" \
+            "<p>" \
+              "That last option means to try to resize the Windows partition(s) to " \
+              "make enough disk space available for Linux, but if that is not " \
+              "enough, completely delete the Windows partition." \
+            "</p>"
+          )
+
+          private_constant :REMOVE_ACTIONS_HELP, :WINDOWS_ACTIONS_HELP
+
+          # Widgets to show
+          #
+          # @return [Array<Widgets::Base>]
+          def widgets
+            return @widgets if @widgets
+
+            @widgets = []
+
+            @widgets << windows_actions_widget if windows_actions?
+            @widgets << linux_actions_widget
+            @widgets << other_actions_widget
+
+            @widgets
+          end
+
+          # Widget to select the actions over Windows partitions
+          #
+          # @return [Widgets::WindowsPartitionActions]
+          def windows_actions_widget
+            @windows_actions_widget ||= WindowsPartitionActions.new("#{widget_id}_windows", settings)
+          end
+
+          # Widget to select the actions over Linux partitions
+          #
+          # @return [Widgets::LinuxPartitionActions]
+          def linux_actions_widget
+            @linux_actions_widget ||=
+              LinuxPartitionActions.new("#{widget_id}_linux", settings, enabled: linux_actions?)
+          end
+
+          # Widget to select the actions over other kind of partitions
+          #
+          # @return [Widgets::OtherPartitionActions]
+          def other_actions_widget
+            @other_actions_widget ||=
+              OtherPartitionActions.new("#{widget_id}_other", settings, enabled: other_actions?)
+          end
+
+          # Adds vertical spacing between the widgets
+          #
+          # @param widgets [Array<Yast::Term>]
+          # @return [Array<Yast::Term>]
+          def add_spacing(widgets)
+            widgets.flat_map { |w| [w, VSpacing(1)] }.tap(&:pop)
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/dialogs/guided_setup/widgets/partition_actions.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/widgets/partition_actions.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/widgets/root_disk_selector.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/widgets/root_disk_selector.rb
@@ -1,0 +1,177 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may
+# find current contact information at www.novell.com.
+
+require "yast"
+require "y2storage"
+require "y2storage/dialogs/guided_setup/widgets/base"
+
+module Y2Storage
+  module Dialogs
+    class GuidedSetup
+      module Widgets
+        # Widget to select the root disk for the installation
+        class RootDiskSelector < Base
+          # Constructor
+          #
+          # @param widget_id [String]
+          # @param settings [Y2Storage::ProposalSettings]
+          # @param candidate_disks [Array<Y2Storage::Device>]
+          # @param disk_helper [Helpers::Disk]
+          def initialize(widget_id, settings, candidate_disks: [], disk_helper: nil)
+            super(widget_id, settings)
+
+            textdomain "storage"
+
+            @candidate_disks = candidate_disks
+            @disk_helper = disk_helper
+          end
+
+          # @see Widgets::Base
+          def content
+            VBox(
+              Left(Label(_("Please select a disk to use as the \"root\" partition (/)"))),
+              VSpacing(0.3),
+              if single_candidate_disk?
+                Left(Label(disk_label(candidate_disks.first)))
+              else
+                RadioButtonGroup(
+                  Id(widget_id),
+                  VBox(
+                    *([any_disk_option] + candidate_disks.map { |d| disk_option(d) })
+                  )
+                )
+              end
+            )
+          end
+
+          # Selects the initial root disk
+          #
+          # @see Widgets::Base
+          def init
+            disk_name = settings.root_device || :any_disk
+
+            self.value = disk_name
+          end
+
+          # Sets the settings with the selected root disk
+          #
+          # @see Widgets::Base
+          def store
+            settings.root_device = value
+          end
+
+          # Selected root disk
+          #
+          # @see Widgets::Base
+          #
+          # @return [String, nil] nil if no disk is selected (:any_disk option)
+          def value
+            return candidate_disks.first.name if single_candidate_disk?
+
+            candidate_disks.map(&:name).detect { |d| selected_option?(d) }
+          end
+
+          # Selects a root disk
+          #
+          # @see Widgets::Base
+          #
+          # @param value [String] disk name
+          def value=(value)
+            return if single_candidate_disk?
+
+            select_option(value)
+          end
+
+          # @see Widgets::Base
+          def help
+            _(
+              "<p>" \
+                "Select the disk where to create the root filesystem. " \
+              "</p>" \
+              "<p>" \
+                "This is also the disk where boot-related partitions " \
+                "will typically be created as necessary: /boot, ESP (EFI System " \
+                "Partition), BIOS-Grub. " \
+                "That means that this disk should be usable by the machine's " \
+                "BIOS / firmware." \
+              "</p>"
+            )
+          end
+
+          private
+
+          # @return [Array<Y2Storage::Device>]
+          attr_reader :candidate_disks
+
+          # @return [Helpers::Disk]
+          attr_reader :disk_helper
+
+          # Radio button to select "any disk" option
+          #
+          # @return [Yast::Term]
+          def any_disk_option
+            Left(RadioButton(Id(:any_disk), _("Any disk")))
+          end
+
+          # Radio button to select a disk
+          #
+          # @param disk [Y2Storage::Device]
+          # @return [Yast::Term]
+          def disk_option(disk)
+            Left(RadioButton(Id(disk.name), disk_label(disk)))
+          end
+
+          # Label for a disk
+          #
+          # @see Helpers::Disk#label
+          #
+          # @param disk [Y2Storage::Device]
+          # @return [String]
+          def disk_label(disk)
+            return disk.name unless disk_helper
+
+            disk_helper.label(disk)
+          end
+
+          # Whether there is only one candidate disk
+          #
+          # @return [Boolean]
+          def single_candidate_disk?
+            candidate_disks.size == 1
+          end
+
+          # Whether a radio button is selected
+          #
+          # @param id [String]
+          # @return [Boolean]
+          def selected_option?(id)
+            Yast::UI.QueryWidget(Id(id), :Value)
+          end
+
+          # Selects a radio button
+          #
+          # @param id [String]
+          def select_option(id)
+            Yast::UI.ChangeWidget(Id(id), :Value, true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/dialogs/guided_setup/widgets/root_disk_selector.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/widgets/root_disk_selector.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/widgets/windows_partition_actions.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/widgets/windows_partition_actions.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage"

--- a/src/lib/y2storage/dialogs/guided_setup/widgets/windows_partition_actions.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/widgets/windows_partition_actions.rb
@@ -1,0 +1,105 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may
+# find current contact information at www.novell.com.
+
+require "yast"
+require "y2storage"
+require "y2storage/dialogs/guided_setup/widgets/base"
+
+module Y2Storage
+  module Dialogs
+    class GuidedSetup
+      module Widgets
+        # Widget to select the actions to perform over the Windows partitions (delete and resize)
+        class WindowsPartitionActions < Base
+          # Constructor
+          #
+          # @param widget_id [String]
+          # @param settings [Y2Storage::ProposalSettings]
+          def initialize(widget_id, settings)
+            super
+
+            textdomain "storage"
+          end
+
+          # @see Widgets::Base
+          def content
+            VBox(
+              Left(Label(_("Choose what to do with existing Windows systems"))),
+              Left(
+                ComboBox(
+                  Id(widget_id), "",
+                  [
+                    Item(Id(:not_modify), _("Do not modify")),
+                    Item(Id(:resize), _("Resize if needed")),
+                    Item(Id(:remove), _("Resize or remove as needed")),
+                    Item(Id(:always_remove), _("Remove even if not needed"))
+                  ]
+                )
+              )
+            )
+          end
+
+          # Selects an option according to the settings (see {#windows_action})
+          #
+          # @see Widgets::Base
+          def init
+            self.value = windows_action
+          end
+
+          # Updates the settings according to the selected option
+          #
+          # @see Widgets::Base
+          def store
+            case value
+            when :not_modify
+              settings.resize_windows = false
+              settings.windows_delete_mode = :none
+            when :resize
+              settings.resize_windows = true
+              settings.windows_delete_mode = :none
+            when :remove
+              settings.resize_windows = true
+              settings.windows_delete_mode = :ondemand
+            when :always_remove
+              settings.resize_windows = false
+              settings.windows_delete_mode = :all
+            end
+          end
+
+          private
+
+          # Option to selected according to the settings
+          #
+          # @return [Symbol]
+          def windows_action
+            if settings.windows_delete_mode == :all
+              :always_remove
+            elsif settings.windows_delete_mode == :ondemand
+              :remove
+            elsif settings.resize_windows
+              :resize
+            else
+              :not_modify
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "yast2/popup"

--- a/src/lib/y2storage/encrypt_password_checker.rb
+++ b/src/lib/y2storage/encrypt_password_checker.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -113,23 +113,23 @@ module Y2Storage
     attr_accessor :subvolumes
 
     # @note :legacy and :ng formats
-    # @return [String] device name of the disk in which / must be placed. If set
-    #   to nil, the proposal will try to find a good candidate
-    attr_accessor :root_device
-
-    # @note :legacy and :ng formats
-    # @return [Boolean] whether to resize Windows systems if needed
-    attr_accessor :resize_windows
-
-    # @note :legacy and :ng formats
     # @return [Array<String>] device names of the disks that can be used for the
     #   installation. If nil, the proposal will try find suitable devices
     attr_accessor :candidate_devices
+
+    # @note :legacy and :ng formats
+    # @return [String] device name of the disk in which / must be placed. If set
+    #   to nil, the proposal will try to find a good candidate
+    attr_accessor :root_device
 
     # @!attribute encryption_password
     #   @note :legacy and :ng formats
     #   @return [String] password to use when creating new encryption devices
     secret_attr :encryption_password
+
+    # @note :legacy and :ng formats
+    # @return [Boolean] whether to resize Windows systems if needed
+    attr_accessor :resize_windows
 
     # What to do regarding removal of existing partitions hosting a Windows system.
     #
@@ -157,6 +157,15 @@ module Y2Storage
     #   don't fit in #windows_delete_mode or #linux_delete_mode.
     #   @see #windows_delete_mode for the possible values and exceptions
     attr_reader :other_delete_mode
+
+    # Whether the delete mode of the partitions and the resize option for windows can be
+    # configured. When this option is set to `false`, the {#windows_delete_mode}, {#linux_delete_mode},
+    # {#other_delete_mode} and {#resize_windows} options cannot be modified by the user.
+    #
+    # @note :ng format
+    #
+    # @return [Boolean]
+    attr_accessor :delete_resize_configurable
 
     # When the user decides to use LVM, strategy to decide the size of the volume
     # group (and, thus, the number and size of created physical volumes).
@@ -334,14 +343,15 @@ module Y2Storage
     # FIXME: Improve implementation. Use composition to encapsulate logic for
     # ng and legacy formats
     def apply_ng_defaults
-      self.lvm                 ||= false
-      self.separate_vgs        ||= false
-      self.resize_windows      ||= true
-      self.windows_delete_mode ||= :ondemand
-      self.linux_delete_mode   ||= :ondemand
-      self.other_delete_mode   ||= :ondemand
-      self.lvm_vg_strategy     ||= :use_available
-      self.volumes             ||= []
+      self.lvm                        ||= false
+      self.separate_vgs               ||= false
+      self.resize_windows             ||= true
+      self.windows_delete_mode        ||= :ondemand
+      self.linux_delete_mode          ||= :ondemand
+      self.other_delete_mode          ||= :ondemand
+      self.delete_resize_configurable ||= true
+      self.lvm_vg_strategy            ||= :use_available
+      self.volumes                    ||= []
     end
 
     # FIXME: Improve implementation. Use composition to encapsulate logic for
@@ -353,6 +363,7 @@ module Y2Storage
       load_feature(:proposal, :windows_delete_mode)
       load_feature(:proposal, :linux_delete_mode)
       load_feature(:proposal, :other_delete_mode)
+      load_feature(:proposal, :delete_resize_configurable)
       load_feature(:proposal, :lvm_vg_strategy)
       load_size_feature(:proposal, :lvm_vg_size)
       load_volumes_feature(:volumes)
@@ -447,6 +458,7 @@ module Y2Storage
       "    linux_delete_mode: #{linux_delete_mode}\n" \
       "    other_delete_mode: #{other_delete_mode}\n" \
       "    resize_windows: #{resize_windows}\n" \
+      "    delete_resize_configurable: #{delete_resize_configurable}\n" \
       "    lvm_vg_strategy: #{lvm_vg_strategy}\n" \
       "    lvm_vg_size: #{lvm_vg_size}\n" \
       "  volumes:\n" \

--- a/src/lib/y2storage/subvol_specification.rb
+++ b/src/lib/y2storage/subvol_specification.rb
@@ -13,10 +13,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 

--- a/src/lib/y2storage/volume_specification.rb
+++ b/src/lib/y2storage/volume_specification.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "yast"
 require "y2storage/partitioning_features"

--- a/src/lib/y2storage/volume_specification_builder.rb
+++ b/src/lib/y2storage/volume_specification_builder.rb
@@ -12,10 +12,10 @@
 # more details.
 #
 # You should have received a copy of the GNU General Public License along
-# with this program; if not, contact Novell, Inc.
+# with this program; if not, contact SUSE LLC.
 #
-# To contact Novell about this file by physical or electronic mail, you may
-# find current contact information at www.novell.com.
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require "y2storage/filesystems/type"
 require "y2storage/partition_id"

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,20 +1,21 @@
-# Copyright (c) 2016 SUSE LLC.
-#  All Rights Reserved.
-
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of version 2 or 3 of the GNU General
-#  Public License as published by the Free Software Foundation.
-
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
-#  GNU General Public License for more details.
-
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, contact SUSE LLC.
-
-#  To contact Novell about this file by physical or electronic mail,
-#  you may find current contact information at www.suse.com
+# Copyright (c) [2016] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 # Set the paths
 SRC_PATH = File.expand_path("../src", __dir__)

--- a/test/support/guided_setup_context.rb
+++ b/test/support/guided_setup_context.rb
@@ -19,51 +19,17 @@
 # find current contact information at www.suse.com.
 
 require_relative "../spec_helper"
+require_relative "#{TEST_PATH}/support/widgets_context"
 require "y2storage/dialogs/guided_setup"
 
 Yast.import "Wizard"
-Yast.import "UI"
 Yast.import "Popup"
 Yast.import "Report"
 
 RSpec.shared_context "guided setup requirements" do
-  include Yast::UIShortcuts
+  include_context "widgets"
 
-  def term_with_id(regexp, content)
-    content.nested_find do |nested|
-      next unless nested.is_a?(Yast::Term)
-
-      nested.params.any? { |i| i.is_a?(Yast::Term) && i.value == :id && regexp.match?(i.params.first) }
-    end
-  end
-
-  def expect_select(id, value = true)
-    expect(Yast::UI).to receive(:ChangeWidget).once.with(Id(id), :Value, value)
-  end
-
-  def expect_not_select(id, value = true)
-    expect(Yast::UI).not_to receive(:ChangeWidget).with(Id(id), :Value, value)
-  end
-
-  def expect_enable(id)
-    expect(Yast::UI).to receive(:ChangeWidget).once.with(Id(id), :Enabled, true)
-  end
-
-  def expect_not_enable(id)
-    expect(Yast::UI).not_to receive(:ChangeWidget).with(Id(id), :Enabled, true)
-  end
-
-  def expect_disable(id)
-    expect(Yast::UI).to receive(:ChangeWidget).once.with(Id(id), :Enabled, false)
-  end
-
-  def select_widget(id, value = true)
-    allow(Yast::UI).to receive(:QueryWidget).with(Id(id), :Value).and_return(value)
-  end
-
-  def not_select_widget(id)
-    allow(Yast::UI).to receive(:QueryWidget).with(Id(id), :Value).and_return(false)
-  end
+  alias_method :term_with_id, :find_widget
 
   def select_disks(disks)
     disks.each { |d| select_widget(d) }
@@ -96,9 +62,6 @@ RSpec.shared_context "guided setup requirements" do
     allow(Yast::Report).to receive(:Warning).and_return(true)
 
     allow(Yast::UI).to receive(:UserInput).and_return(:next, :abort)
-
-    allow(Yast::UI).to receive(:ChangeWidget).and_call_original
-    allow(Yast::UI).to receive(:QueryWidget).and_call_original
 
     allow(guided_setup).to receive(:settings).and_return(settings)
 

--- a/test/support/widgets_context.rb
+++ b/test/support/widgets_context.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+
+Yast.import "UI"
+
+RSpec.shared_context "widgets" do
+  include Yast::UIShortcuts
+
+  def find_widget(regexp, content)
+    regexp = regexp.to_s unless regexp.is_a?(Regexp)
+
+    content.nested_find do |element|
+      next unless element.is_a?(Yast::Term)
+
+      element.params.any? do |param|
+        param.is_a?(Yast::Term) &&
+          param.value == :id &&
+          regexp.match?(param.params.first.to_s)
+      end
+    end
+  end
+
+  def expect_select(id, value = true)
+    expect(Yast::UI).to receive(:ChangeWidget).once.with(Id(id), :Value, value)
+  end
+
+  def expect_not_select(id, value = true)
+    expect(Yast::UI).not_to receive(:ChangeWidget).with(Id(id), :Value, value)
+  end
+
+  def expect_enable(id)
+    expect(Yast::UI).to receive(:ChangeWidget).once.with(Id(id), :Enabled, true)
+  end
+
+  def expect_not_enable(id)
+    expect(Yast::UI).not_to receive(:ChangeWidget).with(Id(id), :Enabled, true)
+  end
+
+  def expect_disable(id)
+    expect(Yast::UI).to receive(:ChangeWidget).once.with(Id(id), :Enabled, false)
+  end
+
+  def select_widget(id, value = true)
+    allow(Yast::UI).to receive(:QueryWidget).with(Id(id), :Value).and_return(value)
+  end
+
+  def not_select_widget(id)
+    allow(Yast::UI).to receive(:QueryWidget).with(Id(id), :Value).and_return(false)
+  end
+
+  before do
+    allow(Yast::UI).to receive(:ChangeWidget).and_call_original
+    allow(Yast::UI).to receive(:QueryWidget).and_call_original
+  end
+end

--- a/test/y2storage/dialogs/guided_setup/helpers/disk_test.rb
+++ b/test/y2storage/dialogs/guided_setup/helpers/disk_test.rb
@@ -1,0 +1,82 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../spec_helper.rb"
+require "y2storage/dialogs/guided_setup/helpers/disk"
+
+describe Y2Storage::Dialogs::GuidedSetup::Helpers::Disk do
+  using Y2Storage::Refinements::SizeCasts
+
+  subject { described_class.new(analyzer) }
+
+  let(:analyzer) { instance_double(Y2Storage::DiskAnalyzer) }
+
+  describe "#label" do
+    before do
+      allow(disk).to receive(:name).and_return(name)
+      allow(disk).to receive(:size).and_return(20.GiB)
+      allow(disk).to receive(:respond_to?).with(anything)
+      allow(disk).to receive(:respond_to?).with(:transport).and_return(true)
+      allow(disk).to receive(:transport).and_return(transport)
+
+      allow(transport).to receive(:is?).with(:usb).and_return(usb)
+      allow(transport).to receive(:is?).with(:sbp).and_return(sbp)
+
+      allow(analyzer).to receive(:installed_systems).with(disk).and_return(installed_systems)
+    end
+
+    let(:disk) { instance_double(Y2Storage::Disk) }
+
+    let(:transport) { instance_double(Y2Storage::DataTransport) }
+
+    let(:name) { "/dev/sda" }
+    let(:usb) { false }
+    let(:sbp) { false }
+    let(:installed_systems) { [] }
+
+    it "contains the disk name and the size" do
+      expect(subject.label(disk)).to match(/\/dev\/sda, 20.00 GiB/)
+    end
+
+    context "when the disk transport is usb" do
+      let(:usb) { true }
+
+      it "includes the 'USB' label" do
+        expect(subject.label(disk)).to match(/USB/)
+      end
+    end
+
+    context "when the disk transport is sbp" do
+      let(:sbp) { true }
+
+      it "includes the 'IEEE 1394' label" do
+        expect(subject.label(disk)).to match(/IEEE 1394/)
+      end
+    end
+
+    context "when the disk contains installed systems" do
+      let(:installed_systems) { ["Windows", "Linux"] }
+
+      it "includes the installed systems" do
+        expect(subject.label(disk)).to match(/Windows, Linux/)
+      end
+    end
+  end
+end

--- a/test/y2storage/dialogs/guided_setup/widgets/linux_partition_actions_test.rb
+++ b/test/y2storage/dialogs/guided_setup/widgets/linux_partition_actions_test.rb
@@ -1,0 +1,79 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../spec_helper.rb"
+require_relative "#{TEST_PATH}/support/widgets_context"
+require "y2storage/dialogs/guided_setup/widgets/linux_partition_actions"
+
+describe Y2Storage::Dialogs::GuidedSetup::Widgets::LinuxPartitionActions do
+  include_context "widgets"
+
+  subject { described_class.new(:linux_actions, settings, enabled: enabled) }
+
+  let(:settings) { Y2Storage::ProposalSettings.new }
+
+  let(:enabled) { nil }
+
+  describe "#init" do
+    before do
+      settings.linux_delete_mode = :ondemand
+    end
+
+    it "selects the default option according to the settings" do
+      expect_select(:linux_actions, :ondemand)
+
+      subject.init
+    end
+
+    context "when the :enabled option is set to true" do
+      let(:enabled) { true }
+
+      it "enables the widget" do
+        expect_enable(:linux_actions)
+
+        subject.init
+      end
+    end
+
+    context "when the :enabled option is set to false" do
+      let(:enabled) { false }
+
+      it "disables the widget" do
+        expect_disable(:linux_actions)
+
+        subject.init
+      end
+    end
+  end
+
+  describe "#store" do
+    before do
+      select_widget(:linux_actions, :ondemand)
+    end
+
+    it "sets settings.linux_delete_mode according to the selected value" do
+      expect(settings.linux_delete_mode).to_not eq(:ondemand)
+
+      subject.store
+
+      expect(settings.linux_delete_mode).to eq(:ondemand)
+    end
+  end
+end

--- a/test/y2storage/dialogs/guided_setup/widgets/other_partition_actions_test.rb
+++ b/test/y2storage/dialogs/guided_setup/widgets/other_partition_actions_test.rb
@@ -1,0 +1,79 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../spec_helper.rb"
+require_relative "#{TEST_PATH}/support/widgets_context"
+require "y2storage/dialogs/guided_setup/widgets/other_partition_actions"
+
+describe Y2Storage::Dialogs::GuidedSetup::Widgets::OtherPartitionActions do
+  include_context "widgets"
+
+  subject { described_class.new(:other_actions, settings, enabled: enabled) }
+
+  let(:settings) { Y2Storage::ProposalSettings.new }
+
+  let(:enabled) { nil }
+
+  describe "#init" do
+    before do
+      settings.other_delete_mode = :ondemand
+    end
+
+    it "selects the default option according to the settings" do
+      expect_select(:other_actions, :ondemand)
+
+      subject.init
+    end
+
+    context "when the :enabled option is set to true" do
+      let(:enabled) { true }
+
+      it "enables the widget" do
+        expect_enable(:other_actions)
+
+        subject.init
+      end
+    end
+
+    context "when the :enabled option is set to false" do
+      let(:enabled) { false }
+
+      it "disables the widget" do
+        expect_disable(:other_actions)
+
+        subject.init
+      end
+    end
+  end
+
+  describe "#store" do
+    before do
+      select_widget(:other_actions, :ondemand)
+    end
+
+    it "sets settings.other_delete_mode according to the selected value" do
+      expect(settings.other_delete_mode).to_not eq(:ondemand)
+
+      subject.store
+
+      expect(settings.other_delete_mode).to eq(:ondemand)
+    end
+  end
+end

--- a/test/y2storage/dialogs/guided_setup/widgets/partition_actions_test.rb
+++ b/test/y2storage/dialogs/guided_setup/widgets/partition_actions_test.rb
@@ -1,0 +1,181 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../spec_helper.rb"
+require "y2storage/dialogs/guided_setup/widgets/partition_actions"
+
+describe Y2Storage::Dialogs::GuidedSetup::Widgets::PartitionActions do
+  subject { described_class.new(widget_id, settings, windows: windows, linux: linux, other: other) }
+
+  let(:widget_id) { "partition_actions" }
+
+  let(:settings) { Y2Storage::ProposalSettings.new }
+
+  let(:windows) { nil }
+
+  let(:linux) { nil }
+
+  let(:other) { nil }
+
+  describe "#content" do
+    context "when :windows option is set to true" do
+      let(:windows) { true }
+
+      it "contains a widget for the Windows partitions actions" do
+        expect(Y2Storage::Dialogs::GuidedSetup::Widgets::WindowsPartitionActions)
+          .to receive(:new).and_call_original
+
+        subject.content
+      end
+    end
+
+    context "when :windows option is set to false" do
+      let(:windows) { false }
+
+      it "does not contain a widget for the Windows partitions actions" do
+        expect(Y2Storage::Dialogs::GuidedSetup::Widgets::WindowsPartitionActions).to_not receive(:new)
+
+        subject.content
+      end
+    end
+
+    context "when :linux option is set to true" do
+      let(:linux) { true }
+
+      it "contains an enabled widget for the Linux partitions actions" do
+        expect(Y2Storage::Dialogs::GuidedSetup::Widgets::LinuxPartitionActions)
+          .to receive(:new).with(anything, anything, hash_including(enabled: true)).and_call_original
+
+        subject.content
+      end
+    end
+
+    context "when :linux option is set to false" do
+      let(:linux) { false }
+
+      it "contains a disabled widget for the Linux partitions actions" do
+        expect(Y2Storage::Dialogs::GuidedSetup::Widgets::LinuxPartitionActions)
+          .to receive(:new).with(anything, anything, hash_including(enabled: false)).and_call_original
+
+        subject.content
+      end
+    end
+
+    context "when :other option is set to true" do
+      let(:other) { true }
+
+      it "contains an enabled widget for the other partitions actions" do
+        expect(Y2Storage::Dialogs::GuidedSetup::Widgets::OtherPartitionActions)
+          .to receive(:new).with(anything, anything, hash_including(enabled: true)).and_call_original
+
+        subject.content
+      end
+    end
+
+    context "when :other option is set to false" do
+      let(:other) { false }
+
+      it "contains a disabled widget for the other partitions actions" do
+        expect(Y2Storage::Dialogs::GuidedSetup::Widgets::OtherPartitionActions)
+          .to receive(:new).with(anything, anything, hash_including(enabled: false)).and_call_original
+
+        subject.content
+      end
+    end
+  end
+
+  shared_context "all widgets" do
+    before do
+      allow(Y2Storage::Dialogs::GuidedSetup::Widgets::WindowsPartitionActions)
+        .to receive(:new).and_return(windows_widget)
+
+      allow(Y2Storage::Dialogs::GuidedSetup::Widgets::LinuxPartitionActions)
+        .to receive(:new).and_return(linux_widget)
+
+      allow(Y2Storage::Dialogs::GuidedSetup::Widgets::OtherPartitionActions)
+        .to receive(:new).and_return(other_widget)
+    end
+
+    let(:windows_widget) do
+      instance_double(Y2Storage::Dialogs::GuidedSetup::Widgets::WindowsPartitionActions,
+        init: true, store: true)
+    end
+
+    let(:linux_widget) do
+      instance_double(Y2Storage::Dialogs::GuidedSetup::Widgets::LinuxPartitionActions,
+        init: true, store: true)
+    end
+
+    let(:other_widget) do
+      instance_double(Y2Storage::Dialogs::GuidedSetup::Widgets::OtherPartitionActions,
+        init: true, store: true)
+    end
+  end
+
+  describe "#init" do
+    include_context "all widgets"
+
+    let(:windows) { true }
+
+    it "initializes all widgets" do
+      expect(windows_widget).to receive(:init)
+      expect(linux_widget).to receive(:init)
+      expect(other_widget).to receive(:init)
+
+      subject.init
+    end
+  end
+
+  describe "#store" do
+    include_context "all widgets"
+
+    let(:windows) { true }
+
+    it "stores all widgets" do
+      expect(windows_widget).to receive(:store)
+      expect(linux_widget).to receive(:store)
+      expect(other_widget).to receive(:store)
+
+      subject.store
+    end
+  end
+
+  describe "#help" do
+    it "includes help for general options" do
+      expect(subject.help).to match(/what to do with existing partitions/)
+    end
+
+    context "and :windows option is set to true" do
+      let(:windows) { true }
+
+      it "includes help for Windows options" do
+        expect(subject.help).to match(/for Windows partitions/)
+      end
+    end
+
+    context "and :windows option is set to false" do
+      let(:windows) { false }
+
+      it "does not include help for Windows options" do
+        expect(subject.help).to_not match(/for Windows partitions/)
+      end
+    end
+  end
+end

--- a/test/y2storage/dialogs/guided_setup/widgets/root_disk_selector_test.rb
+++ b/test/y2storage/dialogs/guided_setup/widgets/root_disk_selector_test.rb
@@ -1,0 +1,217 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../spec_helper.rb"
+require_relative "#{TEST_PATH}/support/widgets_context"
+require "y2storage/dialogs/guided_setup/widgets/root_disk_selector"
+
+describe Y2Storage::Dialogs::GuidedSetup::Widgets::RootDiskSelector do
+  include_context "widgets"
+
+  before do
+    fake_scenario(scenario)
+  end
+
+  subject { described_class.new(widget_id, settings, candidate_disks: candidate_disks) }
+
+  let(:widget_id) { "root_disk_selector" }
+
+  let(:settings) { Y2Storage::ProposalSettings.new }
+
+  let(:candidate_disks) { [] }
+
+  let(:scenario) { "empty_disks" }
+
+  let(:sda) { fake_devicegraph.find_by_name("/dev/sda") }
+
+  let(:sdb) { fake_devicegraph.find_by_name("/dev/sdb") }
+
+  describe "#content" do
+    context "when there is only one candidate disk" do
+      let(:candidate_disks) { [sda] }
+
+      it "does not allow to select a candidate disk" do
+        widget = find_widget(widget_id, subject.content)
+
+        expect(widget).to be_nil
+      end
+
+      it "contains a label with the name of the candidate disk" do
+        widget = subject.content.nested_find do |w|
+          w.is_a?(Yast::Term) && w.value == :Label && w.params.first == "/dev/sda"
+        end
+
+        expect(widget).to_not be_nil
+      end
+    end
+
+    context "when there are several candidate disks" do
+      let(:candidate_disks) { [sda, sdb] }
+
+      it "allows to select a candidate disk" do
+        widget = find_widget(widget_id, subject.content)
+
+        expect(widget).to_not be_nil
+      end
+
+      it "contains an option to select any disk" do
+        widget = find_widget(:any_disk, subject.content)
+
+        expect(widget).to_not be_nil
+      end
+
+      it "contains an option to select each candidate disk" do
+        sda_widget = find_widget("/dev/sda", subject.content)
+        sdb_widget = find_widget("/dev/sdb", subject.content)
+
+        expect(sda_widget).to_not be_nil
+        expect(sdb_widget).to_not be_nil
+      end
+    end
+  end
+
+  describe "#init" do
+    context "when the settings has a root device" do
+      before do
+        settings.root_device = "/dev/sda"
+      end
+
+      it "selects the root device" do
+        expect_select("/dev/sda")
+
+        subject.init
+      end
+    end
+
+    context "when the settings has no root device" do
+      before do
+        settings.root_device = nil
+      end
+
+      it "selects the 'any disk' option" do
+        expect_select(:any_disk)
+
+        subject.init
+      end
+    end
+  end
+
+  describe "#store" do
+    context "when there is only one candidate disk" do
+      let(:candidate_disks) { [sda] }
+
+      it "updates the settings with root_device as the candidate disk" do
+        subject.store
+
+        expect(settings.root_device).to eq("/dev/sda")
+      end
+    end
+
+    context "when there are several candidate disks" do
+      let(:candidate_disks) { [sda, sdb] }
+
+      context "and 'any disk' option is selected" do
+        before do
+          select_widget(:any_disk)
+        end
+
+        it "updates settings with root_device to nil" do
+          subject.store
+
+          expect(settings.root_device).to be_nil
+        end
+      end
+
+      context "and a disk option is selected" do
+        before do
+          select_widget("/dev/sdb")
+        end
+
+        it "updates settings with root_device as the selected disk" do
+          subject.store
+
+          expect(settings.root_device).to eq("/dev/sdb")
+        end
+      end
+    end
+  end
+
+  describe "#value" do
+    context "when there is only one candidate disk" do
+      let(:candidate_disks) { [sda] }
+
+      it "returns the name of the candidate disk" do
+        expect(subject.value).to eq("/dev/sda")
+      end
+    end
+
+    context "when there are several candidate disks" do
+      let(:candidate_disks) { [sda, sdb] }
+
+      context "and 'any disk' option is selected" do
+        before do
+          select_widget(:any_disk)
+        end
+
+        it "returns nil" do
+          expect(subject.value).to be_nil
+        end
+      end
+
+      context "and a disk option is selected" do
+        before do
+          select_widget("/dev/sda")
+        end
+
+        it "returns the name of the selected disk" do
+          expect(subject.value).to eq("/dev/sda")
+        end
+      end
+    end
+  end
+
+  describe "#value=" do
+    context "when there is only one candidate disk" do
+      let(:candidate_disks) { [sda] }
+
+      it "does not select any option" do
+        expect(Yast::UI).to_not receive(:ChangeWidget)
+
+        subject.value = "/dev/sdc"
+      end
+    end
+
+    context "when there are several candidate disks" do
+      let(:candidate_disks) { [sda, sdb] }
+
+      it "selects the givem option" do
+        expect_select("/dev/sda")
+
+        subject.value = "/dev/sda"
+      end
+    end
+  end
+
+  describe "#help" do
+    it "returns the help text" do
+      expect(subject.help).to match(/Select the disk/)
+    end
+  end
+end

--- a/test/y2storage/dialogs/guided_setup/widgets/windows_partition_actions_test.rb
+++ b/test/y2storage/dialogs/guided_setup/widgets/windows_partition_actions_test.rb
@@ -1,0 +1,157 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../spec_helper.rb"
+require_relative "#{TEST_PATH}/support/widgets_context"
+require "y2storage/dialogs/guided_setup/widgets/windows_partition_actions"
+
+describe Y2Storage::Dialogs::GuidedSetup::Widgets::WindowsPartitionActions do
+  include_context "widgets"
+
+  subject { described_class.new(widget_id, settings) }
+
+  let(:widget_id) { :windows_actions }
+
+  let(:settings) { Y2Storage::ProposalSettings.new }
+
+  describe "#init" do
+    context "when settings.windows_delete_mode is set to :all" do
+      before do
+        settings.windows_delete_mode = :all
+      end
+
+      it "sets the Windows action to :always_remove" do
+        expect_select(:windows_actions, :always_remove)
+
+        subject.init
+      end
+    end
+
+    context "when settings.windows_delete_mode is set to :ondemand" do
+      before do
+        settings.windows_delete_mode = :ondemand
+      end
+
+      it "sets the Windows action to :remove" do
+        expect_select(:windows_actions, :remove)
+
+        subject.init
+      end
+    end
+
+    context "when settings.windows_delete_mode is set to :none" do
+      before do
+        settings.windows_delete_mode = :none
+      end
+
+      context "and resizing is allowed" do
+        before do
+          settings.resize_windows = true
+        end
+
+        it "sets the Windows action to :resize" do
+          expect_select(:windows_actions, :resize)
+
+          subject.init
+        end
+      end
+
+      context "and resizing is not allowed" do
+        before do
+          settings.resize_windows = false
+        end
+
+        it "sets the Windows action to :not_modify" do
+          expect_select(:windows_actions, :not_modify)
+
+          subject.init
+        end
+      end
+    end
+  end
+
+  describe "#store" do
+    context "when :not_modify option is selected" do
+      before do
+        select_widget(:windows_actions, :not_modify)
+      end
+
+      it "sets settings.windows_delete_mode to :none" do
+        subject.store
+
+        expect(settings.windows_delete_mode).to eq(:none)
+      end
+
+      it "sets settings.resize_windows to false" do
+        subject.store
+
+        expect(settings.resize_windows).to eq(false)
+      end
+    end
+
+    context "if :resize option is selected" do
+      before do
+        select_widget(:windows_actions, :resize)
+      end
+
+      it "sets settings.windows_delete_mode to :none" do
+        subject.store
+
+        expect(settings.windows_delete_mode).to eq(:none)
+      end
+
+      it "sets settings.resize_windows to true" do
+        subject.store
+
+        expect(settings.resize_windows).to eq(true)
+      end
+    end
+
+    context "if :remove option is selected" do
+      before do
+        select_widget(:windows_actions, :remove)
+      end
+
+      it "sets settings.windows_delete_mode to :ondemand" do
+        subject.store
+
+        expect(settings.windows_delete_mode).to eq(:ondemand)
+      end
+
+      it "sets settings.resize_windows to true" do
+        subject.store
+
+        expect(settings.resize_windows).to eq(true)
+      end
+    end
+
+    context "if :always_remove option is selected" do
+      before do
+        select_widget(:windows_actions, :always_remove)
+      end
+
+      it "sets settings.windows_delete_mode to :all" do
+        subject.store
+
+        expect(settings.windows_delete_mode).to eq(:all)
+      end
+    end
+  end
+end

--- a/test/y2storage/proposal_settings_test.rb
+++ b/test/y2storage/proposal_settings_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -532,6 +532,13 @@ describe Y2Storage::ProposalSettings do
         expect(settings.lvm).to eq true
         read_feature("lvm", false)
         expect(settings.lvm).to eq false
+      end
+
+      it "sets 'delete_resize_configurable' based on the feature in the 'proposal' section" do
+        read_feature("delete_resize_configurable", true)
+        expect(settings.delete_resize_configurable).to eq true
+        read_feature("delete_resize_configurable", false)
+        expect(settings.delete_resize_configurable).to eq false
       end
 
       it "sets 'resize_windows' based on the feature in the 'proposal' section" do

--- a/test/y2storage/spec_helper.rb
+++ b/test/y2storage/spec_helper.rb
@@ -1,19 +1,20 @@
-# Copyright (c) 2017 SUSE LLC.
-#  All Rights Reserved.
-
-#  This program is free software; you can redistribute it and/or
-#  modify it under the terms of version 2 or 3 of the GNU General
-#  Public License as published by the Free Software Foundation.
-
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
-#  GNU General Public License for more details.
-
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, contact SUSE LLC.
-
-#  To contact Novell about this file by physical or electronic mail,
-#  you may find current contact information at www.suse.com
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
 
 require_relative "../spec_helper"


### PR DESCRIPTION
NOTE FOR REVIEWERS: please, mark codeclimate complaints as wontfix. For some reason, I cannot do it by myself.

## Problem

SUMA uses its particular wizard for the storage proposal. During the installation, SUMA always removes all existing partitions from the target devices, so it does not require to ask the user what to do with the existing partitions.

In the future, more products could have similar expectations about allowing the user to decide what to do with existing partitions. So, the control file should have a specific setting to indicate whether the user can modify the setting about deleting and resizing partitions.  

* https://trello.com/c/9T83F9me/1096-3-suma-proposal-non-configurable-delete-modes-and-resizewindows
* https://jira.suse.com/browse/SLE-7238
* Related card: https://trello.com/c/XnJnPdw6/1092-5-suma-proposal-new-wizard-implies-change-in-proposalsettings

## Solution

Added new option `delete_resize_configurable` in the control file. The user cannot modify the delete and resize options when `delete_resize_configurable` is set to false.

And now, if there is only one candidate disk for the installation and the value of this new option is `false`, the second step of the Guided Setup is skipped.

Bonus: widgets to select the delete/resize modes have been extracted to separated classes to make easy to reuse them in other dialogs (e.g., SUMA dialogs).

## Testing

* Added unit test
* Tested manually

