### PR TITLE
AutoYaST: only delete indicated partitions

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul  8 11:52:43 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- AutoYaST: do not delete related partitions if they are not
+  specifically requested (related to bsc#1096760).
+- 4.2.24
+
+-------------------------------------------------------------------
 Fri Jul  5 14:04:00 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Proposal: add control file option to make configurable to resize

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.23
+Version:        4.2.24
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/proposal/autoinst_space_maker.rb
+++ b/src/lib/y2storage/proposal/autoinst_space_maker.rb
@@ -1,8 +1,4 @@
-#!/usr/bin/env ruby
-#
-# encoding: utf-8
-
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2storage/proposal/autoinst_space_maker.rb
+++ b/src/lib/y2storage/proposal/autoinst_space_maker.rb
@@ -137,6 +137,12 @@ module Y2Storage
         delete_partitions(devicegraph, parts, reused_partitions)
       end
 
+      # Deletes the indicated partitions
+      #
+      # The {Proposal::PartitionKiller} tries to remove as many partitions as possible by default. For
+      # example, when a LVM PV is deleted, the rest of PVs are deleted too. But this is not the desired
+      # behaviour for AutoYaST. With AutoYaST, only the indicated partitions should be removed.
+      #
       # @param devicegraph     [Devicegraph]               devicegraph
       # @param parts           [Array<Planned::Partition>] parts to delete
       # @param reused_parts    [Array<String>]             reused partitions names
@@ -147,7 +153,8 @@ module Y2Storage
           partition = partition_by_sid(devicegraph, sid)
           next unless partition
 
-          partition_killer.delete_by_sid(partition.sid)
+          # Removes only this partition and nothing else.
+          partition_killer.delete_by_sid(partition.sid, delete_related_partitions: false)
         end
       end
 

--- a/src/lib/y2storage/proposal/partition_killer.rb
+++ b/src/lib/y2storage/proposal/partition_killer.rb
@@ -49,11 +49,15 @@ module Y2Storage
       #
       # @param device_sid [Integer] device sid of the partition
       # @return [Array<Integer>] device sids of all the deleted partitions
-      def delete_by_sid(device_sid)
+      def delete_by_sid(device_sid, delete_related_partitions: true)
         partition = find_partition(device_sid)
         return [] unless partition
 
-        delete_with_related_partitions(partition)
+        if delete_related_partitions
+          delete_with_related_partitions(partition)
+        else
+          delete_partitions([partition])
+        end
       end
 
       protected

--- a/src/lib/y2storage/proposal/partition_killer.rb
+++ b/src/lib/y2storage/proposal/partition_killer.rb
@@ -1,8 +1,4 @@
-#!/usr/bin/env ruby
-#
-# encoding: utf-8
-
-# Copyright (c) [2015] SUSE LLC
+# Copyright (c) [2015-2019] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2storage/proposal/partition_killer.rb
+++ b/src/lib/y2storage/proposal/partition_killer.rb
@@ -44,10 +44,15 @@ module Y2Storage
         @disks = disks
       end
 
-      # Deletes a given partition and other partitions that, as a consequence,
-      # are not longer useful.
+      # Deletes a given partition
+      #
+      # Optionally, other related partitions that, as a consequence, are not longer useful can be also
+      # deleted. For example, when a LVM PV is deleted, the sibling PVs can be deleted too. And the same
+      # happens for other devices like the devices used by an MD RAID or a multi-device Btrfs.
       #
       # @param device_sid [Integer] device sid of the partition
+      # @param delete_related_partitions [Boolean] whether related partitions should be deleted
+      #
       # @return [Array<Integer>] device sids of all the deleted partitions
       def delete_by_sid(device_sid, delete_related_partitions: true)
         partition = find_partition(device_sid)

--- a/test/data/devicegraphs/lvm-two-disks.yml
+++ b/test/data/devicegraphs/lvm-two-disks.yml
@@ -1,0 +1,37 @@
+---
+- disk:
+    name: /dev/sda
+    size: 200 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda1
+        id:           lvm
+
+- disk:
+    name: /dev/sdb
+    size: 200 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sdb1
+        id:           lvm
+
+- lvm_vg:
+    vg_name: vg0
+    lvm_pvs:
+        - lvm_pv:
+            blk_device: /dev/sda1
+        - lvm_pv:
+            blk_device: /dev/sdb1
+
+    lvm_lvs:
+        - lvm_lv:
+            size:         unlimited
+            lv_name:      lv1
+            file_system:  btrfs
+            mount_point:  /

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -286,6 +286,37 @@ describe Y2Storage::AutoinstProposal do
           )
         end
       end
+
+      context "when the reused partition is part of an LVM to be deleted" do
+        let(:scenario) { "lvm-two-disks" }
+
+        let(:partitioning) do
+          [
+            { "device" => "/dev/sda", "use" => "all", "partitions" => [root] },
+            { "device" => "/dev/sdb", "use" => "all", "partitions" => [home] }
+          ]
+        end
+
+        let(:root) do
+          { "mount" => "/", "partition_nr" => 1, "create" => false, "format" => true }
+        end
+
+        let(:home) do
+          { "filesystem" => :xfs, "mount" => "/home", "create" => true }
+        end
+
+        it "reuses the partition with the given partition number" do
+          sid = fake_devicegraph.find_by_name("/dev/sda1").sid
+          proposal.propose
+          reused_part = proposal.devices.find_by_name("/dev/sda1")
+          expect(reused_part.sid).to eq sid
+        end
+
+        it "does not register any issue" do
+          proposal.propose
+          expect(issues_list).to be_empty
+        end
+      end
     end
 
     describe "resizing partitions" do

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -305,16 +305,40 @@ describe Y2Storage::AutoinstProposal do
           { "filesystem" => :xfs, "mount" => "/home", "create" => true }
         end
 
-        it "reuses the partition with the given partition number" do
+        it "does not remove the reused partition" do
           sid = fake_devicegraph.find_by_name("/dev/sda1").sid
+
           proposal.propose
           reused_part = proposal.devices.find_by_name("/dev/sda1")
+
           expect(reused_part.sid).to eq sid
         end
+      end
 
-        it "does not register any issue" do
+      context "when the reused partition is part of a MD RAID to be deleted" do
+        let(:scenario) { "md_raid" }
+
+        let(:partitioning) do
+          [
+            { "device" => "/dev/sda", "use" => "all", "partitions" => [root, home] }
+          ]
+        end
+
+        let(:root) do
+          { "mount" => "/", "partition_nr" => 1, "create" => false, "format" => true }
+        end
+
+        let(:home) do
+          { "filesystem" => :xfs, "mount" => "/home", "create" => true }
+        end
+
+        it "does not remove the reused partition" do
+          sid = fake_devicegraph.find_by_name("/dev/sda1").sid
+
           proposal.propose
-          expect(issues_list).to be_empty
+          reused_part = proposal.devices.find_by_name("/dev/sda1")
+
+          expect(reused_part.sid).to eq(sid)
         end
       end
     end

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env rspec
 
-#
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -341,6 +341,33 @@ describe Y2Storage::AutoinstProposal do
           expect(reused_part.sid).to eq(sid)
         end
       end
+
+      context "when the reused partition is part of a multi-device Btrfs to be deleted" do
+        let(:scenario) { "btrfs-multidevice-over-partitions.xml" }
+
+        let(:partitioning) do
+          [
+            { "device" => "/dev/sda", "use" => "all", "partitions" => [root, home] }
+          ]
+        end
+
+        let(:root) do
+          { "mount" => "/", "partition_nr" => 1, "create" => false, "format" => true }
+        end
+
+        let(:home) do
+          { "filesystem" => :xfs, "mount" => "/home", "create" => true }
+        end
+
+        it "does not remove the reused partition" do
+          sid = fake_devicegraph.find_by_name("/dev/sda1").sid
+
+          proposal.propose
+          reused_part = proposal.devices.find_by_name("/dev/sda1")
+
+          expect(reused_part.sid).to eq(sid)
+        end
+      end
     end
 
     describe "resizing partitions" do

--- a/test/y2storage/proposal/autoinst_space_maker_test.rb
+++ b/test/y2storage/proposal/autoinst_space_maker_test.rb
@@ -1,8 +1,6 @@
 #!/usr/bin/env rspec
-#
-# encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #


### PR DESCRIPTION
## Problem

The Guided Proposal and AutoYaST use the `PartitionKiller` to remove partitions. When the `PartitionKiller` is told to delete a partition, it removes such partition and all the related partitions. For example, when the specified partition is a LVM PV, the rest of PVs are removed too. And something similar happens when the partition belongs to a MD RAID or to a multi-device Btrfs.

Such behavior may be useful for the Guided Proposal, but it could be a problem for AutoYaST, see https://github.com/yast/yast-storage-ng/pull/923. So, for the case of AutoYaST, the `PartitionKiller` 
should remove only the indicated partitions and nothing else.

* https://trello.com/c/9AZD9sn6/1054-2-autoyast-storage-ng-avoid-collateral-casualties-of-partitionkiller
* Related PR: https://github.com/yast/yast-storage-ng/pull/921
* Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1096760


## Solution

Now, an extra parameter can be passed to the `PartitionKiller` to indicate if the related partitions should be removed. For AutoYaST, this parameter is used, and now the rest of LVM PVs, MD devices or multi-device Btrfs devices are not removed.

## Testing

* Added unit tests

