### PR TITLE
AutoYaST: Fixed typo in filesystem type that caused a crash

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul  9 09:52:33 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- AutoYaST: Fixed typo in filesystem type that caused a crash
+  (bsc#1136272)
+- 4.1.85
+
+-------------------------------------------------------------------
 Fri May 10 14:59:50 UTC 2019 - ancor@suse.com
 
 - AutoYaST: do not ask for a reusable filesystem when it's not

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:	4.1.84
+Version:        4.1.85
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/planned/nfs.rb
+++ b/src/lib/y2storage/planned/nfs.rb
@@ -63,7 +63,7 @@ module Y2Storage
         {
           mount_point:  mount_point,
           size:         nil,
-          fs_type:      Filesystems::Type::Nfs,
+          fs_type:      Filesystems::Type::NFS,
           partition_id: nil
         }
       end

--- a/test/y2storage/planned/nfs_test.rb
+++ b/test/y2storage/planned/nfs_test.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env rspec
+#
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage/planned"
+
+describe Y2Storage::Planned::Nfs do
+  using Y2Storage::Refinements::SizeCasts
+
+  subject do
+    nfs = described_class.new(nfs_server, nfs_path)
+    nfs.mount_point = nfs_mount_point
+    nfs
+  end
+  let(:nfs_server) { "testserver" }
+  let(:nfs_path) { "/work/data" }
+  let(:nfs_mount_point) { "/nfs/work/data" }
+
+  describe "match_volume?" do
+    let(:volume) { Y2Storage::VolumeSpecification.new({}) }
+    let(:excludes) { [:size, :partition_id] }
+
+    before do
+      volume.fs_types = volume_fs_types
+      volume.mount_point = volume_mount_point
+    end
+
+    context "when the planned nfs has the same values" do
+      let(:volume_fs_types) { [Y2Storage::Filesystems::Type::NFS] }
+      let(:volume_mount_point) { nfs_mount_point }
+
+      it "returns true" do
+        expect(subject.match_volume?(volume, exclude: excludes)).to eq(true)
+      end
+    end
+
+    context "when the the wrong filesystem type is expected" do
+      let(:volume_fs_types) { [Y2Storage::Filesystems::Type::EXT4] }
+      let(:volume_mount_point) { nfs_mount_point }
+
+      it "returns false" do
+        expect(subject.match_volume?(volume, exclude: excludes)).to eq(false)
+      end
+    end
+
+    context "when the another mount point is expected" do
+      let(:volume_fs_types) { [Y2Storage::Filesystems::Type::EXT4] }
+      let(:volume_mount_point) { "/wrong/mount/point" }
+
+      it "returns false" do
+        expect(subject.match_volume?(volume, exclude: excludes)).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1136272

# Trello

https://trello.com/c/FQAyxSFk/

# Problem

Crash with "internal error" because of a typo in the filesystem type.

# Fix

Fixed the typo.

# Target Branch

- [x] SLE-15-SP1
- [ ] master