### PR TITLE
Fix the test of DiskSelector widget

### DIFF
--- a/test/y2storage/dialogs/guided_setup/widgets/disk_selector_test.rb
+++ b/test/y2storage/dialogs/guided_setup/widgets/disk_selector_test.rb
@@ -69,6 +69,10 @@ describe Y2Storage::Dialogs::GuidedSetup::Widgets::DiskSelector do
 
   let(:settings) { Y2Storage::ProposalSettings.new_for_current_product }
 
+  before do
+    Y2Storage::StorageManager.create_test_instance
+  end
+
   describe "#content" do
     let(:index) { 0 }
 


### PR DESCRIPTION
## Problem

The submit request for #936 failed because of `test/y2storage/dialogs/guided_setup/widgets/disk_selector_test.rb`, which is using real `VolumeSpecification` objects. In consequence, it needs to create a test instance of `StorageManager` first.

- https://build.opensuse.org/package/live_build_log/YaST:Head/yast2-storage-ng/openSUSE_Tumbleweed/x86_64

  ```
  [  157s]   1) Y2Storage::Dialogs::GuidedSetup::Widgets::DiskSelector#content contains an item per candidate disk
  [  157s]      Failure/Error: Y2Storage::VolumeSpecification.new(vol_features.merge("mount_point" => "swap")),
  [  157s]        #<InstanceDouble(::Storage::Arch) (anonymous)> was originally created in one example but has leaked into another example and can no longer be used. rspec-mocks' doubles are designed to only last for one example, and you need to create a new one in each example you wish to use it for.
  [  157s]      # ./src/lib/y2storage/storage_class_wrapper.rb:254:in `public_send'
  [  157s]      # ./src/lib/y2storage/storage_class_wrapper.rb:254:in `forward'
  [  157s]      # ./src/lib/y2storage/storage_class_wrapper.rb:198:in `block in storage_forward'
  [  157s]      # ./src/lib/y2storage/arch.rb:55:in `support_resume?'
  [  157s]      # ./src/lib/y2storage/volume_specification.rb:399:in `resume_supported?'
  [  157s]      # ./src/lib/y2storage/volume_specification.rb:355:in `adjust_features'
  [  157s]      # ./src/lib/y2storage/volume_specification.rb:182:in `initialize'
  [  157s]      # ./test/y2storage/dialogs/guided_setup/widgets/disk_selector_test.rb:44:in `new'
  [  157s]      # ./test/y2storage/dialogs/guided_setup/widgets/disk_selector_test.rb:44:in `block (2 levels) in <top (required)>'
  [  157s]      # ./test/y2storage/dialogs/guided_setup/widgets/disk_selector_test.rb:80:in `block (3 levels) in <top (required)>'
  ```

## Solution

Fix the test simply adding a 

```ruby
before do 
  Y2Storage::StorageManager.create_test_instance 
end
```
