### PR TITLE
Fix caching in the initial proposal

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 18 15:11:15 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed some errors calculating the initial proposal, before the
+  user has executed the Guided Setup (related to jsc#SLE-7238).
+- 4.2.29
+
+-------------------------------------------------------------------
 Mon Jul 15 13:32:36 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Complain if user attempts to put /boot on a thin LVM or a BCache

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.28
+Version:        4.2.29
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/initial_guided_proposal.rb
+++ b/src/lib/y2storage/initial_guided_proposal.rb
@@ -174,12 +174,16 @@ module Y2Storage
       end
     end
 
-    # Resets the settings by assigning the initial settings
-    #
-    # @note The SpaceMaker object needs to be created again when the candidate
-    #   devices have changed.
-    def reset_settings
+    # Redefines this method from the base class to ensure the SpaceMaker object
+    # and the clean devicegraph are recreated before trying
+    def try_with_each_target_size
       self.space_maker = nil
+      @clean_graph = nil
+      super
+    end
+
+    # Resets the settings by assigning the initial settings
+    def reset_settings
       self.settings = initial_settings
     end
 

--- a/test/support/storage_helpers.rb
+++ b/test/support/storage_helpers.rb
@@ -180,6 +180,15 @@ module Yast
         pool2.create_lvm_lv("thin3", Y2Storage::LvType::THIN, Y2Storage::DiskSize.GiB(2))
       end
 
+      # Creates a primary partition in the first free slot of the given disk
+      #
+      # @param disk [Y2Storage::Partitionable]
+      def create_next_partition(disk)
+        disk.ensure_partition_table
+        slot = disk.partition_table.unused_partition_slots.first
+        disk.partition_table.create_partition(slot.name, slot.region, Y2Storage::PartitionType::PRIMARY)
+      end
+
       def space_dist(vols_by_space)
         Y2Storage::Planned::PartitionsDistribution.new(vols_by_space)
       end

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -932,12 +932,6 @@ describe Y2Storage::Devicegraph do
 
     subject(:devicegraph) { fake_devicegraph }
 
-    def create_partition(disk)
-      disk.ensure_partition_table
-      slot = disk.partition_table.unused_partition_slots.first
-      disk.partition_table.create_partition(slot.name, slot.region, Y2Storage::PartitionType::PRIMARY)
-    end
-
     it "returns a string" do
       expect(devicegraph.to_xml).to be_a(String)
     end
@@ -947,7 +941,7 @@ describe Y2Storage::Devicegraph do
       expect(devicegraph.to_xml.scan(/\<Disk\>/).size).to eq(1)
       expect(devicegraph.to_xml.scan(/\<Partition\>/).size).to eq(0)
 
-      create_partition(devicegraph.disks.first)
+      create_next_partition(devicegraph.disks.first)
 
       expect(devicegraph.to_xml.scan(/\<Partition\>/).size).to eq(1)
     end

--- a/test/y2storage/disk_analyzer_test.rb
+++ b/test/y2storage/disk_analyzer_test.rb
@@ -183,11 +183,6 @@ describe Y2Storage::DiskAnalyzer do
       device.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
     end
 
-    def create_partition(device)
-      slot = device.partition_table.unused_partition_slots.first
-      device.partition_table.create_partition(slot.name, slot.region, Y2Storage::PartitionType::PRIMARY)
-    end
-
     let(:scenario) { "empty_disks" }
 
     let(:devicegraph) { Y2Storage::StorageManager.instance.probed }
@@ -325,7 +320,7 @@ describe Y2Storage::DiskAnalyzer do
           before do
             md.ensure_partition_table
 
-            partition = create_partition(md)
+            partition = create_next_partition(md)
             format_device(partition)
 
             partition.filesystem.mount_path = "/foo"

--- a/test/y2storage/initial_guided_proposal_test.rb
+++ b/test/y2storage/initial_guided_proposal_test.rb
@@ -396,11 +396,6 @@ describe Y2Storage::InitialGuidedProposal do
 
     # This context is here to add a couple of regression tests, see below
     context "with :device as allocate mode and :all for the delete modes" do
-      def create_partition(disk)
-        slot = disk.partition_table.unused_partition_slots.first
-        disk.partition_table.create_partition(slot.name, slot.region, Y2Storage::PartitionType::PRIMARY)
-      end
-
       include_context "candidate devices"
 
       let(:control_file_content) do
@@ -447,9 +442,9 @@ describe Y2Storage::InitialGuidedProposal do
       before do
         # Ensure all the disks contain partitions, so we can check whether they
         # are deleted
-        create_partition(sda)
-        create_partition(sdb)
-        create_partition(sdc)
+        create_next_partition(sda)
+        create_next_partition(sdb)
+        create_next_partition(sdc)
       end
 
       context "when there are mandatory volumes that don't fit in the disks" do

--- a/test/y2storage/initial_guided_proposal_test.rb
+++ b/test/y2storage/initial_guided_proposal_test.rb
@@ -393,5 +393,108 @@ describe Y2Storage::InitialGuidedProposal do
         expect { proposal.propose }.to raise_error(Y2Storage::Error)
       end
     end
+
+    # This context is here to add a couple of regression tests, see below
+    context "with :device as allocate mode and :all for the delete modes" do
+      def create_partition(disk)
+        slot = disk.partition_table.unused_partition_slots.first
+        disk.partition_table.create_partition(slot.name, slot.region, Y2Storage::PartitionType::PRIMARY)
+      end
+
+      include_context "candidate devices"
+
+      let(:control_file_content) do
+        {
+          "partitioning" => {
+            "proposal" => {
+              "allocate_volume_mode" => :device,
+              "windows_delete_mode"  => :all,
+              "linux_delete_mode"    => :all,
+              "other_delete_mode"    => :all
+            },
+            "volumes"  => volumes_spec
+          }
+        }
+      end
+
+      let(:volumes_spec) do
+        [
+          {
+            "mount_point"           => "/",
+            "fs_type"               => "ext4",
+            "desired_size"          => "900GiB",
+            "min_size"              => "900GiB",
+            "proposed_configurable" => false
+          },
+          {
+            "mount_point"           => "/var/one",
+            "fs_type"               => "ext4",
+            "desired_size"          => second_volume_size,
+            "min_size"              => second_volume_size,
+            "proposed_configurable" => false
+          },
+          {
+            "mount_point"           => "/var/two",
+            "fs_type"               => "ext4",
+            "desired_size"          => "900GiB",
+            "min_size"              => "900GiB",
+            "proposed_configurable" => true,
+            "disable_order"         => "1"
+          }
+        ]
+      end
+
+      before do
+        # Ensure all the disks contain partitions, so we can check whether they
+        # are deleted
+        create_partition(sda)
+        create_partition(sdb)
+        create_partition(sdc)
+      end
+
+      context "when there are mandatory volumes that don't fit in the disks" do
+        let(:second_volume_size) { "500GiB" }
+
+        # Regression test: this used to produce an infinite loop because the SpaceMaker
+        # object was reset in #reset_settings instead of in #try_with_each_target_size.
+        # As a consequence, it contained an outdated list of candidate disks and was
+        # unsuccessfully trying to delete the same partition over and over.
+        it "raises an error" do
+          expect { proposal.propose }.to raise_error(Y2Storage::Error)
+        end
+      end
+
+      # Regression test: this used to apply the xxx_delete_mode :all to the wrong
+      # disk(s) because @clean_graph was not reset on every attempt
+      context "when a proposal is possible after switching to another disk" do
+        let(:sda_usb) { true }
+        let(:second_volume_size) { "20GiB" }
+
+        it "wipes all partitions from the used disks" do
+          sda_partitions = sda.partitions.map(&:sid)
+
+          proposal.propose
+          # Let's ensure sda was used, otherwise the subsequent check makes no sense
+          expect(used_devices).to contain_exactly("/dev/sda")
+
+          partitions_after = proposal.devices.partitions.map(&:sid)
+          expect(partitions_after).to_not include(*sda_partitions)
+        end
+
+        it "does not wipe disks that are not used" do
+          sdb_partitions = sdb.partitions.map(&:sid)
+          sdc_partitions = sdc.partitions.map(&:sid)
+
+          proposal.propose
+          # Let's ensure only sda was used, otherwise the subsequent checks
+          # would not make sense
+          expect(used_devices).to contain_exactly("/dev/sda")
+
+          partitions_after = proposal.devices.partitions.map(&:sid)
+          expect(partitions_after).to include(*sdb_partitions)
+          expect(partitions_after).to include(*sdc_partitions)
+        end
+      end
+    end
   end
 end

--- a/test/y2storage/reusing_efi_test.rb
+++ b/test/y2storage/reusing_efi_test.rb
@@ -46,11 +46,6 @@ describe Y2Storage::BootRequirementsChecker do
 
   subject(:checker) { described_class.new(devicegraph) }
 
-  def create_partition(disk)
-    slot = disk.partition_table.unused_partition_slots.first
-    disk.partition_table.create_partition(slot.name, slot.region, Y2Storage::PartitionType::PRIMARY)
-  end
-
   RSpec.shared_examples "not_reuse_efi" do
     it "does not reuse the partition" do
       expect(checker.needed_partitions).to contain_exactly(
@@ -103,7 +98,7 @@ describe Y2Storage::BootRequirementsChecker do
 
   context "if there is a partition without filesystem" do
     before do
-      create_partition(disk)
+      create_next_partition(disk)
       partition.id = partition_id
       partition.size = size
     end
@@ -113,7 +108,7 @@ describe Y2Storage::BootRequirementsChecker do
 
   context "if there is a partition with a non VFAT filesystem" do
     before do
-      create_partition(disk)
+      create_next_partition(disk)
       partition.create_filesystem(Y2Storage::Filesystems::Type::EXT3)
       partition.id = partition_id
       partition.size = size
@@ -124,7 +119,7 @@ describe Y2Storage::BootRequirementsChecker do
 
   context "if there is a partition formatted as VFAT" do
     before do
-      create_partition(disk)
+      create_next_partition(disk)
       partition.create_filesystem(Y2Storage::Filesystems::Type::VFAT)
       partition.id = partition_id
       partition.size = size


### PR DESCRIPTION
## Problem

While executing the manual tests of the new SUMA proposal (see [the blog post for details](https://lizards.opensuse.org/2019/07/16/suse-manager-guided-setup/)) I realized it was possible for the initial proposal (the one that is auto-calculated before the user has executed the Guided Setup) to enter an infinite loop.

While debugging that, I also noticed there is a chance for the initial proposal to apply the settings `xxx_delete_mode=all` wrongly.

More details about the nature of both bugs in the comments of the corresponding regression unit tests.

## Solution

Stop the excessive caching of the internal SpaceMaker object (to fix the infinite loop) and of the cleaned devicegraph (to fix the other problem).


## Testing

- Added new unit tests with descriptions of the original problems
- Tested manually
