### PR TITLE
fixed exception when removing devices from btrfs

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 29 21:52:18 CEST 2019 - aschnell@suse.com
+
+- Fixed exception when removing devices from btrfs (bsc#1142669)
+- 4.2.30
+
+-------------------------------------------------------------------
 Thu Jul 18 15:11:15 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Fixed some errors calculating the initial proposal, before the

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -2,6 +2,7 @@
 Mon Jul 29 21:52:18 CEST 2019 - aschnell@suse.com
 
 - Fixed exception when removing devices from btrfs (bsc#1142669)
+- Sort selected devices in LVM VG and btrfs dialog by name
 - 4.2.30
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.29
+Version:        4.2.30
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/btrfs_devices.rb
+++ b/src/lib/y2partitioner/actions/controllers/btrfs_devices.rb
@@ -129,7 +129,7 @@ module Y2Partitioner
         def selected_devices
           return [] unless filesystem
 
-          filesystem.plain_blk_devices
+          filesystem.plain_blk_devices.sort { |a, b| a.compare_by_name(b) }
         end
 
         # Adds a device to the Btrfs

--- a/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
@@ -154,7 +154,7 @@ module Y2Partitioner
         #
         # @return [Array<Y2Storage::BlkDevice>]
         def devices_in_vg
-          vg.lvm_pvs.map(&:plain_blk_device)
+          vg.lvm_pvs.map(&:plain_blk_device).sort { |a, b| a.compare_by_name(b) }
         end
 
         # Devices used by committed physical volumes of the current volume group

--- a/src/lib/y2partitioner/blk_device_restorer.rb
+++ b/src/lib/y2partitioner/blk_device_restorer.rb
@@ -197,6 +197,8 @@ module Y2Partitioner
         log.error "The device has more than one parent, that's unexpected: #{source.sid}"
         raise "Unexpected error restoring the status of device #{source.sid}"
       end
+      return if source.exists_in_devicegraph?(raw_current_graph)
+
       source.copy_to_devicegraph(raw_current_graph)
       source.in_holders[0].copy_to_devicegraph(raw_current_graph)
     end

--- a/test/data/devicegraphs/trivial_btrfs.yml
+++ b/test/data/devicegraphs/trivial_btrfs.yml
@@ -1,0 +1,11 @@
+---
+- disk:
+    name: /dev/sda
+    size: 2 TiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size:         1 TiB
+        name:         /dev/sda1
+        file_system:  btrfs

--- a/test/y2partitioner/blk_device_restorer_test.rb
+++ b/test/y2partitioner/blk_device_restorer_test.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+
+require "y2partitioner/blk_device_restorer"
+
+describe Y2Partitioner::BlkDeviceRestorer do
+
+  let(:devicegraph) { "trivial_btrfs" }
+
+  before do
+    devicegraph_stub(devicegraph)
+  end
+
+  describe "#restore_from_checkpoint" do
+    it "does not crash when restoring device used by filesystem itself" do
+      device = Y2Partitioner::DeviceGraphs.instance.current.find_by_name("/dev/sda1")
+      filesystem = device.direct_blk_filesystem
+
+      # same sequence as in Controllers::BtrfsDevices.remove_device
+      filesystem.remove_device(device)
+      Y2Partitioner::BlkDeviceRestorer.new(device).restore_from_checkpoint
+    end
+  end
+
+end

--- a/test/y2partitioner/blk_device_restorer_test.rb
+++ b/test/y2partitioner/blk_device_restorer_test.rb
@@ -30,14 +30,32 @@ describe Y2Partitioner::BlkDeviceRestorer do
     devicegraph_stub(devicegraph)
   end
 
-  describe "#restore_from_checkpoint" do
-    it "does not crash when restoring device used by filesystem itself" do
-      device = Y2Partitioner::DeviceGraphs.instance.current.find_by_name("/dev/sda1")
-      filesystem = device.direct_blk_filesystem
+  subject { described_class.new(device) }
 
-      # same sequence as in Controllers::BtrfsDevices.remove_device
-      filesystem.remove_device(device)
-      Y2Partitioner::BlkDeviceRestorer.new(device).restore_from_checkpoint
+  let(:device) { Y2Partitioner::DeviceGraphs.instance.current.find_by_name(device_name) }
+
+  describe "#restore_from_checkpoint" do
+    let(:device_name) { "/dev/sda1" }
+
+    context "when restoring a device used by filesystem itself" do
+      let(:filesystem) { device.direct_blk_filesystem }
+
+      before do
+        # same sequence as in Controllers::BtrfsDevices.remove_device
+        filesystem.remove_device(device)
+      end
+
+      it "does not raise an exception" do
+        expect { subject.restore_from_checkpoint }.to_not raise_error
+      end
+
+      it "does not remove the filesystem" do
+        sid = filesystem.sid
+
+        subject.restore_from_checkpoint
+
+        expect(Y2Partitioner::DeviceGraphs.instance.current.find_device(sid)).to_not be_nil
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

The BlkDeviceRestorer tries to add a device that already exists.

- https://bugzilla.suse.com/show_bug.cgi?id=1142669

## Solution

Do not try to add a device that already exists.

## Bonus

The selected devices in the dialog for LVM VGs and btrfses are sorted by name now.
