### PR TITLE
AutoYaST: fix Bcache creation

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Aug  8 10:37:33 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- AutoYaST: allow to create a Bcache without a caching device.
+- AutoYaST: allow to create a Bcache over a LVM Logical Volume.
+- bsc#1139783
+- 4.2.32
+
+-------------------------------------------------------------------
 Wed Aug  7 09:29:06 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
 
 - fix NilClass issue when calculating proposal on RAID (bsc#1139808)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.31
+Version:        4.2.32
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/planned/lvm_lv.rb
+++ b/src/lib/y2storage/planned/lvm_lv.rb
@@ -34,6 +34,7 @@ module Y2Storage
       include Planned::CanBeResized
       include Planned::CanBeMounted
       include Planned::CanBeEncrypted
+      include Planned::CanBeBcacheMember
       include Planned::CanBeBtrfsMember
       include MatchVolumeSpec
 
@@ -84,6 +85,7 @@ module Y2Storage
         initialize_can_be_formatted
         initialize_can_be_mounted
         initialize_can_be_encrypted
+        initialize_can_be_bcache_member
         initialize_can_be_btrfs_member
 
         @mount_point = mount_point

--- a/src/lib/y2storage/proposal/autoinst_devices_creator.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_creator.rb
@@ -161,8 +161,8 @@ module Y2Storage
         # Process planned disk like devices (Xen virtual partitions and full disks)
         process_disk_like_devs
         process_mds
-        process_bcaches
         process_vgs
+        process_bcaches
         process_btrfs_filesystems
         process_nfs_filesystems
 
@@ -223,6 +223,7 @@ module Y2Storage
         reuse_vgs(vgs_to_reuse)
 
         add_devices_to_create(planned_vgs)
+        add_devices_to_reuse(vgs_to_reuse.flat_map(&:lvs))
         self.creator_result = set_up_lvm(planned_vgs, devices_to_reuse)
       end
 
@@ -289,8 +290,7 @@ module Y2Storage
       # Creates MD RAID devices
       #
       # @param mds [Array<Planned::Md>] List of planned MD arrays to create
-      # @param devs_to_reuse [Array<Planned::Partition, Planned::StrayBlkDevice>] List of devices
-      #   to reuse
+      # @param devs_to_reuse [Array<Planned::Device>] List of devices to reuse as MD device
       #
       # @return [Proposal::CreatorResult] Result containing the specified MD RAIDs
       def create_mds(mds, devs_to_reuse)
@@ -315,8 +315,8 @@ module Y2Storage
       # Creates bcaches
       #
       # @param bcaches [Array<Planned::Bcache>] List of planned Bcache devices to create
-      # @param devs_to_reuse [Array<Planned::Partition, Planned::StrayBlkDevice>] List of devices to
-      #   reuse
+      # @param devs_to_reuse [Array<Planned::Device>] List of devices to reuse as backing or caching
+      #   device
       #
       # @return [Proposal::CreatorResult] Result containing the specified Bcache devices
       def create_bcaches(bcaches, devs_to_reuse)
@@ -331,8 +331,7 @@ module Y2Storage
       # Creates volume groups
       #
       # @param vgs [Array<Planned::LvmVg>] List of planned volume groups to add
-      # @param devs_to_reuse [Array<Planned::Partition, Planned::StrayBlkDevice>] List of devices
-      #   to reuse as Physical Volumes
+      # @param devs_to_reuse [Array<Planned::Device>] List of devices to reuse as Physical Volumes
       #
       # @return [Proposal::CreatorResult] Result containing the specified volume groups
       def set_up_lvm(vgs, devs_to_reuse)
@@ -343,7 +342,9 @@ module Y2Storage
 
         vgs.reduce(creator_result) do |result, vg|
           pvs = creator_result.created_names { |d| d.pv_for?(vg.volume_group_name) }
-          pvs += devs_to_reuse.select { |d| d.pv_for?(vg.volume_group_name) }.map(&:reuse_name)
+          devs = devs_to_reuse.select { |d| d.respond_to?(:pv_for?) && d.pv_for?(vg.volume_group_name) }
+          pvs += devs.map(&:reuse_name)
+
           result.merge(create_logical_volumes(result.devicegraph, vg, pvs))
         end
       end
@@ -351,8 +352,7 @@ module Y2Storage
       # Creates Btrfs filesystems
       #
       # @param filesystems_to_create [Array<Planned::Btrfs>]
-      # @param reusable_devices [Array<Planned::Disk, Planned::StrayBlkDevice>, Planned::Partition]
-      #   devices that can be reused for the new Btrfs filesystems.
+      # @param reusable_devices [Array<Planned::Device>] devices that can be reused for the new Btrfs
       #
       # @return [Proposal::CreatorResult] Result containing the specified Btrfs filesystems
       def create_btrfs_filesystems(filesystems_to_create, reusable_devices)
@@ -378,7 +378,7 @@ module Y2Storage
       # Name of devices that can be reused for a specific planned Btrfs
       #
       # @param planned_filesystem [Planned::Btrfs]
-      # @param reusable_devices [Array<Planned::Disk, Planned::StrayBlkDevice>, Planned::Partition]
+      # @param reusable_devices [Array<Planned::Device>]
       #
       # @return [Array<String>] devices names
       def reused_devices_for_btrfs(planned_filesystem, reusable_devices)

--- a/src/lib/y2storage/proposal/autoinst_vg_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_vg_planner.rb
@@ -65,6 +65,8 @@ module Y2Storage
         planned_lv.btrfs_name = section.btrfs_name
         add_stripes(planned_lv, section)
         device_config(planned_lv, section, drive)
+        add_bcache_attrs(planned_lv, section)
+
         return if section.used_pool && !add_to_thin_pool(planned_lv, planned_vg, section)
 
         add_lv_reuse(planned_lv, planned_vg, section) if section.create == false

--- a/test/y2storage/proposal/autoinst_bcache_creator_test.rb
+++ b/test/y2storage/proposal/autoinst_bcache_creator_test.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env rspec
+
 # Copyright (c) [2019] SUSE LLC
 #
 # All Rights Reserved.
@@ -74,6 +75,19 @@ describe Y2Storage::Proposal::AutoinstBcacheCreator do
       bcache = devicegraph.find_by_name("/dev/bcache0")
       caching_device = devicegraph.find_by_name(caching_devname)
       expect(caching_device.descendants).to include(bcache)
+    end
+
+    # Regression test for bsc#1139783
+    context "when no caching device is specified" do
+      let(:caching_devname) { nil }
+
+      it "does not add a caching device" do
+        result = creator.create_bcache(planned_bcache0, backing_devname, caching_devname)
+
+        bcache = result.devicegraph.find_by_name("/dev/bcache0")
+
+        expect(bcache.bcache_cset).to be_nil
+      end
     end
 
     context "when no partitions are specified" do

--- a/test/y2storage/proposal/autoinst_devices_creator_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_creator_test.rb
@@ -1,6 +1,4 @@
 #!/usr/bin/env rspec
-#
-# encoding: utf-8
 
 # Copyright (c) [2017-2019] SUSE LLC
 #
@@ -331,6 +329,15 @@ describe Y2Storage::Proposal::AutoinstDevicesCreator do
         caching_device = bcache.bcache_cset.blk_devices.first
         expect(caching_device.disk.name).to eq("/dev/sdb")
         expect(bcache).to be_a(Y2Storage::Bcache)
+      end
+
+      context "when no backing device is found" do
+        let(:partitions) { [caching_part] }
+
+        it "raises an exception" do
+          expect { creator.populated_devicegraph(planned_devices, ["/dev/sda", "/dev/sdb"]) }
+            .to raise_error(Y2Storage::DeviceNotFoundError)
+        end
       end
 
       context "reusing a Bcache" do


### PR DESCRIPTION
## Problem

AutoYaST does no support to create a Bcache without a caching device. And a Bcache over a LVM LV is not supported either.

* https://bugzilla.suse.com/show_bug.cgi?id=1139783

* https://trello.com/c/jcmHbDNT/1190-3-osdistribution-p5-1139783-lvm-lv-cannot-be-used-as-bcache-cache-device-and-possibly-backing-device


## Solution

* Added AutoYaST support for creating a Bcache without a caching device.
* Added AutoYaST support for creating a Bache over a LVM PV (for both: caching and backing).
* Error message when the AutoYaST profile does not specify a valid backing device for a Bcache.

NOTE: setting the cache mode fails when the backing device is a LVM LV, see https://bugzilla.suse.com/show_bug.cgi?id=1139948 


## Testing

* Added unit tests
* Tested manually


## Screenshots

<details>
<summary>
Show/hide screenshots
</summary>

Bcache over LVM

![bcache_over_lvm](https://user-images.githubusercontent.com/1112304/62697672-1ef32500-b9d3-11e9-9faa-f769d50eca94.png)

Bcache without caching device

![bcache_without_caching](https://user-images.githubusercontent.com/1112304/62697671-1ef32500-b9d3-11e9-830c-2da54ec3ebf1.png)

Bcache error when setting cache mode

![bcache_lvm_error](https://user-images.githubusercontent.com/1112304/62697670-1ef32500-b9d3-11e9-93fa-866945ed3c2a.png)

Bcache error details

![bcache_lvm_error_details](https://user-images.githubusercontent.com/1112304/62697669-1e5a8e80-b9d3-11e9-9cd2-a56e58f88ee2.png)

Profile error when no backing device

![bcache_backing_error](https://user-images.githubusercontent.com/1112304/62697667-1e5a8e80-b9d3-11e9-95e0-878588d819ee.png)


</details>