### PR TITLE
Doc: document impact of Btrfs quotas in the Partitioner

### DIFF
--- a/doc/btrfs_in_partitioner.md
+++ b/doc/btrfs_in_partitioner.md
@@ -70,6 +70,35 @@ and `/var/cache`. If a separate partition is then formatted and mounted in
 `/var`, two of the subvolumes will become irrelevant because they cannot be
 accessed.
 
+### Group quotas
+
+In the past, it was common to use separate partitions with their own filesystems
+for `/var`, `/tmp` and `/home` (among other directories) as a way to ensure the
+root filesystem couldn't be 100% filled due to the growth of one of the mentioned
+directories.
+
+With Btrfs the usual approach is to have a single filesystem with the relevant
+subdirectories as subvolumes. The mechanism to limit the space a given subvolume
+can consume is the usage of Btrfs quota groups. If such optional Btrfs feature
+is enabled, each subvolume (including the snapshots) is by default associated to
+a quota group, short qgroup. It is possible to set limits on those qgroups,
+which effectively limits the space used by the corresponding subvolumes.
+
+But quota groups go far beyond limiting the space of each subvolume. The user
+can define more qgroups organized in hierarchical levels for different purposes.
+Detailing all the possible organizations of qgroups and its association to the
+subvolumes is out of the scope of this document, but it's definitely something
+to take into account when thinking about representing the quotas in the
+Partitioner user interface.
+
+As a side note, activating support for quota groups for a Btrfs filesystem makes
+it possible to know how much space will be freed by deleting a particular
+snapshot, something that is not easy to predict without the usage of qgroups.
+
+Last but not least, it's worth mentioning that currently Btrfs quota groups are
+known to be rather buggy and to cause a noticeable performance penalty,
+specially when used in a filesystem with many snapshots.
+
 ## Traditional Partitioner UI
 
 Before coming with a solution to support the new features in the upcoming
@@ -183,6 +212,13 @@ The snapshoting feature of Btrfs is heavily based on subvolumes. But that
 connection is not visible at all in the Partitioner. If during installation the
 "Enable Snapshots" is checked, a `.snapshots` subvolume will be created in the
 root filesystem. But that subvolume is not visible in the corresponding list.
+
+It has also been requested to offer an understandable mechanism in the
+Partitioner to limit the space used by each subvolume. As explained above, that
+implies representing somehow the quota groups that exist or that are going to be
+created in the filesystem. For each subvolume (that is, for each associated
+qgroup) it would be necessary to display the usage of _referenced_ and
+_exclusive_ space and the limit for both, allowing to modify those limits.
 
 Last but not least, the management of shadowed subvolumes is not exactly
 intuituve, with many things happening behind user's back. If a subvolume


### PR DESCRIPTION
Adding the group quotas to the list of Btrfs features we need to take into account when rethinking the UI for managing Btrfs subvolumes.

For more details, see the discussion at https://jira.suse.com/browse/SLE-7742