### PR TITLE
bind-mount /run from inst-sys to target system during install (bsc#1136463)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug 30 09:25:52 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- bind-mount /run from inst-sys to target system during install (bsc#1136463)
+- 4.2.37
+
+-------------------------------------------------------------------
 Wed Aug 28 15:13:44 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Partitioner: display encryption type (related to jsc#SLE-7376).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.36
+Version:        4.2.37
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -68,6 +68,7 @@ module Y2Storage
         mount_in_target("/proc", "proc", "-t proc")
         mount_in_target("/sys", "sysfs", "-t sysfs")
         mount_in_target(EFIVARS_PATH, "efivarfs", "-t efivarfs") if File.exist?(EFIVARS_PATH)
+        mount_in_target("/run", "/run", "--bind")
 
         true
       end
@@ -78,6 +79,9 @@ module Y2Storage
         if !Yast::FileUtils.Exists(target_path)
           raise ".target.mkdir failed" if !SCR.Execute(path(".target.mkdir"), target_path)
         end
+
+        log.info "Cmd: mount #{options} #{device} #{target_path}"
+
         if !SCR.Execute(path(".target.mount"), [device, target_path], options)
           raise ".target.mount failed"
         end


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1136463

Files in `/run` are needed also in the target system during installation.

That's basically [bnc#717321](https://bugzilla.suse.com/show_bug.cgi?id=1136463) but again for storage-ng.

## Solution

Bind-mount `/run` into target system.

## See also

https://bugzilla.suse.com/show_bug.cgi?id=717321

Same issue in SLE12, fixed in old storage stack.

https://github.com/yast/yast-storage/blob/SLE-12-SP5/src/clients/inst_prepdisk.rb#L143-L166

## Testing

Tested manually.