### PR TITLE
Improve behavior when editing encrypted devices

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep  5 15:03:50 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Partitioner: better handling of existing encryptions, including
+  the possibility of reusing them (related to jsc#SLE-7376).
+
+-------------------------------------------------------------------
 Wed Sep 04 14:46:12 CEST 2019 - aschnell@suse.com
 
 - added translation for new EncryptionType::PLAIN (bsc#1088641)

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -441,15 +441,25 @@ module Y2Partitioner
         private
 
         def delete_filesystem
-          blk_device.remove_descendants
+          filesystem_parent.remove_descendants
           # Shadowing control of btrfs subvolumes might be needed if the deleted
           # filesystem had mount point
           Y2Storage::Filesystems::Btrfs.refresh_subvolumes_shadowing(working_graph)
         end
 
         def create_filesystem(type, label: nil)
-          blk_device.create_blk_filesystem(type)
+          filesystem_parent.create_blk_filesystem(type)
           filesystem.label = label unless label.nil?
+        end
+
+        # Device containing the filesystem
+        #
+        # Unlike {#blk_device}, that always returns the plain device, this
+        # method will return the encryption device for encrypted filesystems
+        #
+        # @return [Y2Storage::BlkDevice]
+        def filesystem_parent
+          blk_device.encrypted? ? blk_device.encryption : blk_device
         end
 
         def restore_filesystem

--- a/src/lib/y2partitioner/actions/filesystem_steps.rb
+++ b/src/lib/y2partitioner/actions/filesystem_steps.rb
@@ -71,7 +71,7 @@ module Y2Partitioner
       def encrypt_password
         @encrypt_controller = Controllers::Encryption.new(fs_controller)
 
-        return :next unless encrypt_controller.to_be_encrypted?
+        return :next unless encrypt_controller.show_dialog?
 
         Dialogs::Encryption.run(encrypt_controller)
       end

--- a/src/lib/y2partitioner/dialogs/encryption.rb
+++ b/src/lib/y2partitioner/dialogs/encryption.rb
@@ -20,10 +20,12 @@
 require "yast"
 require "y2partitioner/dialogs/base"
 require "y2partitioner/widgets/encrypt_password"
+require "y2partitioner/widgets/controller_radio_buttons"
 
 module Y2Partitioner
   module Dialogs
-    # Ask for a password to assign to an encrypted device.
+    # Ask for the concrete action to perform when the goal is to obtain an
+    # encrypted device, including details like the password.
     # Part of {Actions::AddPartition} and {Actions::EditBlkDevice}.
     # Formerly MiniWorkflowStepPassword
     class Encryption < Base
@@ -34,14 +36,87 @@ module Y2Partitioner
         @controller = controller
       end
 
+      # @macro seeDialog
       def title
-        _("Encryption password for %s") % @controller.blk_device_name
+        @controller.wizard_title
       end
 
+      # @macro seeDialog
       def contents
-        HVSquash(
-          Widgets::EncryptPassword.new(@controller)
-        )
+        main_widget =
+          if @controller.actions.include?(:keep)
+            ActionWidget.new(@controller)
+          else
+            Widgets::EncryptPassword.new(@controller)
+          end
+
+        HVSquash(main_widget)
+      end
+
+      # Internal widget used when both :keep and :encrypt options are possible
+      class ActionWidget < Widgets::ControllerRadioButtons
+        # @param controller [Actions::Controllers::Encryption]
+        #   a controller collecting data for managing the encryption of a device
+        def initialize(controller)
+          textdomain "storage"
+          @controller = controller
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Choose an Action")
+        end
+
+        # @macro seeItemsSelection
+        def items
+          keep_label =
+            format(_("Preserve existing encryption (%s)"), encryption_type.to_human_string)
+
+          [
+            [:keep, keep_label],
+            [:encrypt, _("Encrypt the device (replaces current encryption)")]
+          ]
+        end
+
+        # @see Widgets::ControllerRadioButtons
+        def widgets
+          @widgets ||= [
+            CWM::Empty.new("empty"),
+            Widgets::EncryptPassword.new(@controller)
+          ]
+        end
+
+        # @macro seeAbstractWidget
+        def init
+          self.value = @controller.action
+          # trigger disabling the other subwidgets
+          handle("ID" => value)
+        end
+
+        # @macro seeAbstractWidget
+        def store
+          current_widget.store if current_widget.respond_to?(:store)
+          @controller.action = value
+        end
+
+        # @macro seeAbstractWidget
+        def help
+          # helptext
+          _(
+            "<p>Choose the encryption layer.</p>\n" \
+            "<p>The device is already encrypted in the system, it's possible to re-encrypt it" \
+            "with new settings or to use the existing encryption layer.</p>"
+          )
+        end
+
+        private
+
+        # Type of the encryption currently used by the device
+        #
+        # @return [Y2Storage::EncryptionType]
+        def encryption_type
+          @controller.encryption.type
+        end
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/encrypt_password.rb
+++ b/src/lib/y2partitioner/widgets/encrypt_password.rb
@@ -31,7 +31,7 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def validate
-        msg = checker.error_msg(pw1, pw2)
+        msg = checker.error_msg(pw1, pw2) if enabled?
         return true unless msg
 
         Yast::Report.Error(msg)
@@ -41,7 +41,7 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def store
-        @controller.encrypt_password = pw1
+        @controller.password = pw1
       end
 
       # @macro seeAbstractWidget
@@ -51,30 +51,19 @@ module Y2Partitioner
 
       # @macro seeCustomWidget
       def contents
-        Frame(
-          _("Encryption Password"),
-          MarginBox(
-            1.45,
-            0.5,
-            VBox(
-              Password(
-                Id(:pw1),
-                Opt(:hstretch),
-                # Label: get password for user root
-                # Please use newline if label is longer than 40 characters
-                _("&Enter a Password for your File System:"),
-                ""
-              ),
-              Password(
-                Id(:pw2),
-                Opt(:hstretch),
-                # Label: get same password again for verification
-                # Please use newline if label is longer than 40 characters
-                _("Reenter the Password for &Verification:"),
-                ""
-              ),
-              VSpacing(0.5)
-            )
+        VBox(
+          Id(widget_id),
+          Password(
+            Id(:pw1),
+            Opt(:hstretch),
+            _("&Enter an Encryption Password:"),
+            @controller.password
+          ),
+          Password(
+            Id(:pw2),
+            Opt(:hstretch),
+            _("Reenter the Password for &Verification:"),
+            @controller.password
           )
         )
       end

--- a/test/y2partitioner/dialogs/encryption_test.rb
+++ b/test/y2partitioner/dialogs/encryption_test.rb
@@ -25,9 +25,76 @@ require "cwm/rspec"
 require "y2partitioner/dialogs/encryption"
 
 describe Y2Partitioner::Dialogs::Encryption do
-  let(:controller) { double("FilesystemController", blk_device_name: "/dev/sda1") }
+  let(:controller) { double("FilesystemController", wizard_title: "Title", actions: actions) }
 
-  subject { described_class.new(controller) }
+  subject(:dialog) { described_class.new(controller) }
 
-  include_examples "CWM::Dialog"
+  context "when :encrypt is the only possible action" do
+    let(:actions) { [:encrypt] }
+
+    include_examples "CWM::Dialog"
+
+    describe "#contents" do
+      it "delegates everything to an EncryptPassword widget " do
+        content = dialog.contents.params
+        expect(content.size).to eq 1
+        expect(content.first).to be_a Y2Partitioner::Widgets::EncryptPassword
+      end
+    end
+  end
+
+  context "when :keep and :encrypt are both possible actions" do
+    let(:actions) { [:keep, :encrypt] }
+
+    include_examples "CWM::Dialog"
+
+    describe "#contents" do
+      it "delegates everything to an Encryption::Action widget " do
+        content = dialog.contents.params
+        expect(content.size).to eq 1
+        expect(content.first).to be_a Y2Partitioner::Dialogs::Encryption::ActionWidget
+      end
+    end
+  end
+end
+
+describe Y2Partitioner::Dialogs::Encryption::ActionWidget do
+  let(:controller) do
+    double("FilesystemController", actions: [:keep, :encrypt], encryption: encryption)
+  end
+
+  let(:encryption) { double("Encryption", type: Y2Storage::EncryptionType::LUKS) }
+
+  subject(:widget) { described_class.new(controller) }
+
+  include_examples "CWM::CustomWidget"
+
+  describe "#help" do
+    it "returns a string" do
+      expect(widget.help).to be_a(String)
+    end
+  end
+
+  describe "#store" do
+    before do
+      allow(widget).to receive(:value).and_return :the_value
+      allow(widget).to receive(:current_widget)
+    end
+
+    it "sets #action in the controller" do
+      expect(controller).to receive(:action=).with(:the_value)
+      widget.store
+    end
+  end
+
+  describe "#init" do
+    before do
+      allow(controller).to receive(:action).and_return :the_value
+    end
+
+    it "sets #value to the action given by the controller" do
+      expect(widget).to receive(:value=).with(:the_value)
+      widget.init
+    end
+  end
 end

--- a/test/y2partitioner/keep_original_filesystems_test.rb
+++ b/test/y2partitioner/keep_original_filesystems_test.rb
@@ -109,6 +109,8 @@ describe "Creating and deleting filesystems in a block device" do
   def format_partition
     fs_controller.new_filesystem(new_fs_type)
     fs_controller.encrypt = false
+    Y2Partitioner::Actions::Controllers::Encryption.new(fs_controller).finish
+
     expect(partition.filesystem.type).to eq new_fs_type
     expect(partition.encrypted?).to eq false
   end


### PR DESCRIPTION
## Problem

Editing a block device that already contains an encryption layer has some problems, described at
https://trello.com/c/qeSZSCxQ/1244-5-partitioner-fix-behavior-when-selecting-deselecting-encryption-checkbox

This PR specifically targets the following problems:

- If the password was already provided, editing again looses it and asks for a new password. That will become a bigger problem soon, since we plan to add more types of encryption (random, pervasive, maybe LUKS2) each of them with their own arguments. Having to re-enter the type and all the arguments would be even a better PITA than it's today.
- If there is already a existing encryption in the system (e.g. a LUKS2 one created with other tool), it cannot be reused. This will also become a bigger problem soon with pervasive encryption, in which likely the user doesn't want to re-encrypt the device, but simply use the existing one and (re)format the resulting device.

## Solution

When encrypting for the first time a device that was not originally encrypted in the system (or encrypting a new device just created using the Partitioner), nothing changes apart from minor adjustments in the labels. The user simply sees a form with an empty "password" field.

![enc_new_3](https://user-images.githubusercontent.com/3638289/64270191-74bbde00-cf3b-11e9-9ab0-84fcaf0fbdbd.png)

When editing for a second time a device that was already marked for encryption during the current execution of the Partitioner, the form is already prefilled with the password entered before. In the past, the previous encryption layered was ditched (so it's password and other arguments were forgotten) and the user had to define the encryption again from scratch. That will become even more relevant soon, when the form for encryption becomes more than just a "password" field. See #960.

![enc_modify_3](https://user-images.githubusercontent.com/3638289/64270214-7b4a5580-cf3b-11e9-835b-622086aac7f8.png)

Last but not least, when editing a device that is already encrypted in the system (that is, it contains an active encryption layer that was there already when the Partitioner was executed), an option is offered to just use the existing encryption layer instead of replacing it with a (likely more limited) encryption created by the Partitioner.

![enc_keep_3](https://user-images.githubusercontent.com/3638289/64270235-8309fa00-cf3b-11e9-96f9-6e214dd6550c.png)

Note the option is only possible if the preexisting encryption device is active (e.g. the user already entered its passphrase during boot or during the initial hardware probing performed by the Partitioner).

## Testing

- Unit test coverage extended
- Tested manually with the `partitioner_testing` client
- Not done yet: manually test a full installation with reused encryption