### PR TITLE
add warning if /boot is on a luks2 encrypted partition

### DIFF
--- a/doc/boot-requirements.md
+++ b/doc/boot-requirements.md
@@ -66,6 +66,14 @@
 				- **does not require any partition (PReP will be reused and Grub2 can handle this setup)**
 			- and it is not on the boot disk
 				- **requires only a new PReP partition (to allocate Grub2)**
+	- with an encrypted proposal using LUKS2
+		- if there are no suitable PReP partitions in the target disk
+			- **requires a new PReP and a new /boot partition**
+		- if there is already a suitable PReP partition in the disk
+			- and it is on the boot disk
+				- **requires a /boot partition**
+			- and it is not on the boot disk
+				- **requires a new PReP and a new /boot partition**
 - in bare metal (PowerNV)
 	- with a partitions-based proposal
 		- **does not require any booting partition (no Grub stage1, PPC firmware parses grub2.cfg)**
@@ -274,6 +282,8 @@
 				- **does not require any particular volume**
 			- in an encrypted proposal
 				- **does not require any particular volume**
+			- in an encrypted proposal using LUKS2
+				- **requires a new /boot partition to install Grub into it**
 		- with a MBR gap too small to accommodate Grub
 			- in a partitions-based proposal
 				- if the file-system selected for / can embed grub (ext2/3/4 or btrfs)

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 17 14:41:01 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- add warning if /boot is on a LUKS2 encrypted partition
+- 4.2.39
+
+-------------------------------------------------------------------
 Thu Sep  5 15:03:50 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Partitioner: better handling of existing encryptions, including

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.38
+Version:        4.2.39
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -83,7 +83,7 @@ module Y2Storage
       def warnings
         res = []
 
-        if !grub_can_read_boot?
+        if !encrypted_for_grub?
           error_message =
             _(
               "The boot loader cannot access the file system mounted at /boot. " \
@@ -147,7 +147,7 @@ module Y2Storage
       end
 
       def boot_partition_needed?
-        !grub_can_read_boot?
+        !encrypted_for_grub?
       end
 
       def too_small_boot?
@@ -211,17 +211,6 @@ module Y2Storage
         # TRANSLATORS: error message
         error_message = _("Boot requirements cannot be determined because there is no '/' mount point")
         SetupError.new(message: error_message)
-      end
-
-      # Whether the filesystem containing /boot is readable by grub
-      #
-      # We might need to check if the filesystem is actually supported by grub
-      # but currently all storage-ng supported filesystems are.
-      #
-      # @return [Boolean] true if the filesystem where /boot resides is going to
-      #   be readable by grub
-      def grub_can_read_boot?
-        encrypted_for_grub?
       end
 
       # Whether the boot device is encrypted and grub can decrypt it

--- a/src/lib/y2storage/boot_requirements_strategies/legacy.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/legacy.rb
@@ -154,7 +154,7 @@ module Y2Storage
       #
       # @return [Boolean] true if a separate boot partition is needed, else false
       def boot_partition_needed?
-        boot_ptable_type?(:msdos) && !mbr_gap_for_grub? && !root_can_embed_grub?
+        super || (boot_ptable_type?(:msdos) && !mbr_gap_for_grub? && !root_can_embed_grub?)
       end
 
       # @return [VolumeSpecification]

--- a/src/lib/y2storage/boot_requirements_strategies/prep.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/prep.rb
@@ -98,7 +98,7 @@ module Y2Storage
 
         # We cannot ensure the mentioned firmware can handle technologies like
         # LVM, MD or LUKS, so propose a separate /boot partition for those cases
-        root_in_lvm? || root_in_software_raid? || encrypted_root?
+        super || (root_in_lvm? || root_in_software_raid? || encrypted_root?)
       end
 
       def prep_partition_needed?

--- a/test/support/boot_requirements_context.rb
+++ b/test/support/boot_requirements_context.rb
@@ -64,7 +64,7 @@ RSpec.shared_context "boot requirements" do
       esp_in_software_raid?:   false,
       esp_in_software_raid1?:  false,
       encrypted_esp?:          false,
-      boot_encryption_type:    Y2Storage::EncryptionType::NONE
+      boot_encryption_type:    boot_enc_type
     )
   end
 
@@ -79,6 +79,7 @@ RSpec.shared_context "boot requirements" do
     use_btrfs ? Y2Storage::Filesystems::Type::BTRFS : Y2Storage::Filesystems::Type::EXT4
   end
   let(:boot_ptable_type) { :msdos }
+  let(:boot_enc_type) { Y2Storage::EncryptionType::NONE }
 
   # Mocks for Raspberry Pi detection
   let(:raspi_system) { false }

--- a/test/support/boot_requirements_context.rb
+++ b/test/support/boot_requirements_context.rb
@@ -63,7 +63,8 @@ RSpec.shared_context "boot requirements" do
       esp_in_lvm?:             false,
       esp_in_software_raid?:   false,
       esp_in_software_raid1?:  false,
-      encrypted_esp?:          false
+      encrypted_esp?:          false,
+      boot_encryption_type:    Y2Storage::EncryptionType::NONE
     )
   end
 

--- a/test/y2storage/boot_requirements_checker_x86_test.rb
+++ b/test/y2storage/boot_requirements_checker_x86_test.rb
@@ -159,6 +159,14 @@ describe Y2Storage::BootRequirementsChecker do
 
             include_examples("needs no volume")
           end
+
+          context "in an encrypted proposal using LUKS2" do
+            let(:use_lvm) { false }
+            let(:use_encryption) { true }
+            let(:boot_enc_type) { Y2Storage::EncryptionType::LUKS2 }
+
+            include_examples("needs /boot partition")
+          end
         end
 
         context "with a MBR gap too small to accommodate Grub" do


### PR DESCRIPTION
## Task

Add warning if `/boot` is luks2 encrypted as grub does only support luks1.

## Solution

Warning added. 

This also implies that the proposal will go for a separate `/boot` partition if `/` is on luks2.

## Testing

- manual integration testing
- unit tests

Note:

> I've added only two tests for LUKS2 in the proposal (to see if it results in a  `/boot` partition). It's my impression the boot requirements document would quite blow up otherwise.

## Screenshots

![bar](https://user-images.githubusercontent.com/927244/65038735-ed199a80-d950-11e9-8875-1c25beff52aa.jpg)