### PR TITLE
bind-mount /run from inst-sys to target system during install (bsc#1136463)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 18 09:31:41 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- bind-mount /run from inst-sys to target system during install
+  (bsc#1136463)
+- 4.1.87
+
+-------------------------------------------------------------------
 Wed Aug  7 13:36:03 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
 
 - fix NilClass issue when calculating proposal on RAID (bsc#1139808)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.1.86
+Version:        4.1.87
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -68,6 +68,7 @@ module Y2Storage
         mount_in_target("/proc", "proc", "-t proc")
         mount_in_target("/sys", "sysfs", "-t sysfs")
         mount_in_target(EFIVARS_PATH, "efivarfs", "-t efivarfs") if File.exist?(EFIVARS_PATH)
+        mount_in_target("/run", "/run", "--bind")
 
         true
       end
@@ -80,6 +81,9 @@ module Y2Storage
             raise ".target.mkdir failed"
           end
         end
+
+        log.info "Cmd: mount #{options} #{device} #{target_path}"
+
         if !SCR.Execute(path(".target.mount"), [device, target_path], options)
           raise ".target.mount failed"
         end


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1136463

Files in `/run` are needed also in the target system during installation.

That's basically [bnc#717321](https://bugzilla.suse.com/show_bug.cgi?id=1136463) but again for storage-ng.

## Solution

Bind-mount `/run` into target system.

## See also

Fix in `master`: https://github.com/yast/yast-storage-ng/pull/958.

## Important!

This fix must be submitted together with https://github.com/yast/yast-installation/pull/814.

## Testing

- tested manually