### PR TITLE
Pervasive encryption

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 23 11:08:38 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Partitioner: allows encrypting volumes using pervasive
+  encryption (jsc#SLE-7376).
+- 4.2.41
+
+-------------------------------------------------------------------
 Thu Sep 19 07:57:35 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Partitioner: allow creating encrypted swap with random

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.40
+Version:        4.2.41
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/encryption.rb
+++ b/src/lib/y2partitioner/actions/controllers/encryption.rb
@@ -100,9 +100,12 @@ module Y2Partitioner
         #
         # @return [Array<Y2Storage::EncryptionMethod>]
         def methods
-          encrypt_methods = [Y2Storage::EncryptionMethod::LUKS1]
-          encrypt_methods << Y2Storage::EncryptionMethod::RANDOM_SWAP if swap?
-          encrypt_methods
+          @methods ||=
+            if swap?
+              Y2Storage::EncryptionMethod.available
+            else
+              Y2Storage::EncryptionMethod.available.reject(&:only_for_swap?)
+            end
         end
 
         # Applies last changes to the block device at the end of the wizard, which

--- a/src/lib/y2partitioner/dialogs/encryption.rb
+++ b/src/lib/y2partitioner/dialogs/encryption.rb
@@ -70,7 +70,7 @@ module Y2Partitioner
         # @macro seeItemsSelection
         def items
           keep_label =
-            format(_("Preserve existing encryption (%s)"), encryption_method.to_human_string)
+            format(_("Preserve existing encryption (%s)"), encryption_system.to_human_string)
 
           [
             [:keep, keep_label],
@@ -114,9 +114,12 @@ module Y2Partitioner
 
         # Encryption method currently used by the device
         #
-        # @return [Y2Storage::EncryptionMethod]
-        def encryption_method
-          @controller.encryption.method
+        # If the method couldn't be determined, it returns the encryption type
+        # instead
+        #
+        # @return [Y2Storage::EncryptionMethod, Y2Storage::EncryptionType]
+        def encryption_system
+          @controller.encryption.method || @controller.encryption.type
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/encrypt.rb
+++ b/src/lib/y2partitioner/widgets/encrypt.rb
@@ -175,7 +175,14 @@ module Y2Partitioner
       # @return [String]
       def help_for_pervasive_luks2(encrypt_method)
         format(
-          _("<p><b>%{label}</b>: TODO</p>"),
+          # TRANSLATORS: Pervasive encryption terminology. For the English version see
+          # https://www.ibm.com/support/knowledgecenter/linuxonibm/liaaf/lnz_r_crypt.html
+          _("<p><b>%{label}</b>: allows to encrypt the device using LUKS2 with a master secure key " \
+            "processed by a Crypto Express cryptographic coprocessor configured in CCA mode.</p>" \
+           "<p>If the cryptographic system already contains a secure key associated to this " \
+           "volume, that key will be used. Otherwise, a new secure key will be generated and " \
+           "registered in the system. You need to provide an encryption password that will be " \
+           "used to protect the access to that master key.</p>"),
           label: encrypt_method.to_human_string
         )
       end

--- a/src/lib/y2partitioner/widgets/encrypt.rb
+++ b/src/lib/y2partitioner/widgets/encrypt.rb
@@ -169,6 +169,16 @@ module Y2Partitioner
           label: encrypt_method.to_human_string
         )
       end
+
+      # Help text for the  encryption method
+      #
+      # @return [String]
+      def help_for_pervasive_luks2(encrypt_method)
+        format(
+          _("<p><b>%{label}</b>: TODO</p>"),
+          label: encrypt_method.to_human_string
+        )
+      end
     end
   end
 end

--- a/src/lib/y2partitioner/widgets/encrypt_method_options.rb
+++ b/src/lib/y2partitioner/widgets/encrypt_method_options.rb
@@ -54,10 +54,11 @@ module Y2Partitioner
       # @return [CWM::CustomWidget] a widget containing the options for the
       # given encryption method
       def options_for(encrypt_method)
-        if encrypt_method.is?(:random_swap)
+        case encrypt_method.to_sym
+        when :random_swap
           RandomOptions.new(controller)
-        elsif encrypt_method.is?(:luks1)
-          Luks1Options.new(controller)
+        when :luks1, :pervasive_luks2
+          LuksOptions.new(controller)
         end
       end
     end
@@ -88,8 +89,8 @@ module Y2Partitioner
       end
     end
 
-    # Internal widget to display the Luks1 encryption options
-    class Luks1Options < CWM::CustomWidget
+    # Internal widget to display the Luks encryption options
+    class LuksOptions < CWM::CustomWidget
       # Constructor
       #
       # @param controller [Actions::Controllers::Encryption]

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -300,7 +300,7 @@ module Y2Storage
     def encrypt(method: EncryptionMethod::LUKS1, dm_name: nil, password: nil)
       method = EncryptionMethod.find(method) if method.is_a?(Symbol)
       enc = method.create_device(self, dm_name)
-      enc.auto_dm_name = !dm_name
+      enc.auto_dm_name = enc.dm_table_name.empty?
       enc.password = password if password
 
       Encryption.update_dm_names(devicegraph)

--- a/src/lib/y2storage/device.rb
+++ b/src/lib/y2storage/device.rb
@@ -197,6 +197,11 @@ module Y2Storage
     #       sorted list (less than)
     storage_class_forward :compare_by_name
 
+    # @!method self.all(devicegraph)
+    #   @param devicegraph [Devicegraph]
+    #   @return [Array<Device>] all the devices in the given devicegraph
+    storage_class_forward :all, as: "Device"
+
     # Check whether the device exists in the probed devicegraph
     #
     # @note This is slightly different from Storage::Device#exists_in_probed?, which

--- a/src/lib/y2storage/devicegraph.rb
+++ b/src/lib/y2storage/devicegraph.rb
@@ -155,6 +155,13 @@ module Y2Storage
       Actiongraph.new(graph)
     end
 
+    # All the devices in the devicegraph, in no particular order
+    #
+    # @return [Array<Device>]
+    def devices
+      Device.all(self)
+    end
+
     # All the DASDs in the devicegraph, sorted by name
     #
     # @note Based on the libstorage classes hierarchy, DASDs are not considered to be disks.
@@ -508,6 +515,16 @@ module Y2Storage
       DumpManager.dump(self, file_base_name)
     end
 
+    # Executes the pre_commit method in all the devices
+    def pre_commit
+      devices_action(:pre_commit)
+    end
+
+    # Executes the post_commit method in all the devices
+    def post_commit
+      devices_action(:post_commit)
+    end
+
     private
 
     # Copy of a device tree where hashes have been substituted by sorted
@@ -558,6 +575,13 @@ module Y2Storage
 
         dev.remove_descendants
         remove_device(dev)
+      end
+    end
+
+    # See {#pre_commit} and {#post_commit}
+    def devices_action(method)
+      devices.each do |device|
+        device.send(method) if device.respond_to?(method)
       end
     end
   end

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -185,6 +185,10 @@ module Y2Storage
 
     # Saves the given encryption process
     #
+    # @note Keeping the state of this object is important, so see {#encryption_process}
+    #   and {#save_encryption_process} for some considerations about how it is
+    #   persisted into the devicegraph and how the current state is held.
+    #
     # @param value [Encryption::Processes]
     def encryption_process=(value)
       save_userdata(:encryption_process, value)
@@ -219,12 +223,20 @@ module Y2Storage
 
     # Returns the process used to perform the encryption
     #
+    # @note The EncryptionProcess object is persisted using the userdata mechanism,
+    #   but it's also cached in an instance variable because, otherwise, every call
+    #   to #encryption_process would be accessing the object that was stored in the
+    #   devicegraph, with its former state. Thus, all the modifications would be lost.
+    #   See {#encryption_process=} and {#save_encryption_process}.
+    #
     # @return [EncryptionProcess::Base, nil]
     def encryption_process
       @encryption_process ||= userdata_value(:encryption_process)
     end
 
     # Updates the userdata with an up-to-date version of the encryption process
+    #
+    # @see #encryption_process
     def save_encryption_process
       self.encryption_process = encryption_process
     end

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -188,6 +188,22 @@ module Y2Storage
     # @param value [Encryption::Processes]
     def encryption_process=(value)
       save_userdata(:encryption_process, value)
+      @encryption_process = value
+    end
+
+    # Executes the actions that must be performed right before the devicegraph is
+    # committed to the system
+    def pre_commit
+      return unless encryption_process
+
+      encryption_process.pre_commit(self)
+      save_encryption_process
+    end
+
+    # Executes the actions that must be performed after the devicegraph has been
+    # committed to the system
+    def post_commit
+      encryption_process&.post_commit(self)
     end
 
     protected
@@ -205,7 +221,12 @@ module Y2Storage
     #
     # @return [EncryptionProcess::Base, nil]
     def encryption_process
-      userdata_value(:encryption_process)
+      @encryption_process ||= userdata_value(:encryption_process)
+    end
+
+    # Updates the userdata with an up-to-date version of the encryption process
+    def save_encryption_process
+      self.encryption_process = encryption_process
     end
 
     class << self

--- a/src/lib/y2storage/encryption_method.rb
+++ b/src/lib/y2storage/encryption_method.rb
@@ -151,6 +151,16 @@ module Y2Storage
       process_class.available?
     end
 
+    # Whether the encryption method is useful only for swap
+    #
+    # Some encryption methods are mainly useful for encrypting swap disks since they produdce a new key
+    # on every boot cycle.
+    #
+    # @return [Boolean]
+    def only_for_swap?
+      process_class.only_for_swap?
+    end
+
     # Creates an encryption device for the given block device
     #
     # @param blk_device [Y2Storage::BlkDevice]

--- a/src/lib/y2storage/encryption_method.rb
+++ b/src/lib/y2storage/encryption_method.rb
@@ -34,6 +34,7 @@ module Y2Storage
   # @example
   #
   #   method = EncryptionMethod.all.first
+  #   method = EncryptionMethod.available.first
   #   method = EncryptionMethod.find(:luks1)
   #   method = EncryptionMethod.find(:random_swap)
   #   method = EncryptionMethod.new #=> error, private method
@@ -75,6 +76,13 @@ module Y2Storage
       # @return [Array<Y2Storage::EncryptionMethod>]
       def all
         ALL.dup
+      end
+
+      # Sorted list of all encryption methods that can be used in this system
+      #
+      # @return [Array<Y2Storage::EncryptionMethod>]
+      def available
+        all.select(&:available?)
       end
 
       # Looks for the encryption method used for the given encryption device
@@ -130,6 +138,13 @@ module Y2Storage
     # @return [Boolean]
     def used_for?(encryption)
       process_class.used_for?(encryption)
+    end
+
+    # Whether the encryption method can be used in this system
+    #
+    # @return [Boolean]
+    def available?
+      process_class.available?
     end
 
     # Creates an encryption device for the given block device

--- a/src/lib/y2storage/encryption_method.rb
+++ b/src/lib/y2storage/encryption_method.rb
@@ -153,7 +153,7 @@ module Y2Storage
 
     # Whether the encryption method is useful only for swap
     #
-    # Some encryption methods are mainly useful for encrypting swap disks since they produdce a new key
+    # Some encryption methods are mainly useful for encrypting swap disks since they produce a new key
     # on every boot cycle.
     #
     # @return [Boolean]

--- a/src/lib/y2storage/encryption_method.rb
+++ b/src/lib/y2storage/encryption_method.rb
@@ -19,6 +19,7 @@
 
 require "y2storage/encryption_processes/luks1"
 require "y2storage/encryption_processes/swap"
+require "y2storage/encryption_processes/pervasive"
 
 module Y2Storage
   # YaST provides different Encryption Methods to encrypt a block device. Not to be confused with the
@@ -59,11 +60,14 @@ module Y2Storage
     LUKS1 = new(
       :luks1, N_("Regular LUKS1"), EncryptionProcesses::Luks1
     )
+    PERVASIVE_LUKS2 = new(
+      :pervasive_luks2, N_("Pervasive Volume Encryption"), EncryptionProcesses::Pervasive
+    )
     RANDOM_SWAP = new(
       :random_swap, N_("Random Swap"), EncryptionProcesses::Swap
     )
 
-    ALL = [LUKS1, RANDOM_SWAP].freeze
+    ALL = [LUKS1, PERVASIVE_LUKS2, RANDOM_SWAP].freeze
     private_constant :ALL
 
     class << self

--- a/src/lib/y2storage/encryption_processes/base.rb
+++ b/src/lib/y2storage/encryption_processes/base.rb
@@ -74,6 +74,18 @@ module Y2Storage
       #
       # @return [Y2Storage::EncryptionType]
       abstract_method :encryption_type
+
+      # Executes the actions that must be performed right before the devicegraph is
+      # committed to the system
+      #
+      # @param device [Encryption]
+      def pre_commit(_device); end
+
+      # Executes the actions that must be performed after the devicegraph has
+      # been committed to the system
+      #
+      # @param device [Encryption]
+      def post_commit(_device); end
     end
   end
 end

--- a/src/lib/y2storage/encryption_processes/base.rb
+++ b/src/lib/y2storage/encryption_processes/base.rb
@@ -48,6 +48,15 @@ module Y2Storage
         true
       end
 
+      # Whether the process is mainly useful for swap disks
+      #
+      # @see EncryptionMethod#only_for_swap?
+      #
+      # @return [Boolean]
+      def self.only_for_swap?
+        false
+      end
+
       # Constructor
       #
       # @param method [Y2Storage::EncryptionMethod]

--- a/src/lib/y2storage/encryption_processes/base.rb
+++ b/src/lib/y2storage/encryption_processes/base.rb
@@ -78,13 +78,13 @@ module Y2Storage
       # Executes the actions that must be performed right before the devicegraph is
       # committed to the system
       #
-      # @param device [Encryption]
+      # @param _device [Encryption]
       def pre_commit(_device); end
 
       # Executes the actions that must be performed after the devicegraph has
       # been committed to the system
       #
-      # @param device [Encryption]
+      # @param _device [Encryption]
       def post_commit(_device); end
     end
   end

--- a/src/lib/y2storage/encryption_processes/base.rb
+++ b/src/lib/y2storage/encryption_processes/base.rb
@@ -39,6 +39,15 @@ module Y2Storage
         false
       end
 
+      # Whether the process can be executed in the current system
+      #
+      # @see EncryptionMethod#available?
+      #
+      # @return [Boolean]
+      def self.available?
+        true
+      end
+
       # Constructor
       #
       # @param method [Y2Storage::EncryptionMethod]

--- a/src/lib/y2storage/encryption_processes/luks1.rb
+++ b/src/lib/y2storage/encryption_processes/luks1.rb
@@ -22,7 +22,7 @@ require "y2storage/encryption_processes/base"
 
 module Y2Storage
   module EncryptionProcesses
-    # The enryption process that allows to create and identify an encryped
+    # The encryption process that allows to create and identify an encrypted
     # device using LUKS1
     class Luks1 < Base
       # Whether the process was used for the given encryption device

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -61,6 +61,12 @@ module Y2Storage
 
       # @see Base#pre_commit
       #
+      # If there is no secure key to be used for this device, a new key is
+      # generated. In addition to that, the "zkey cryptsetup" command is
+      # executed to know the sequence of commands that must be used to set the
+      # pervasive encryption and the LUKS format options are adjusted
+      # accordingly.
+      #
       # @param device [Encryption] encryption that will be created in the system
       def pre_commit(device)
         # For the time being, we will always generate a new key for each device
@@ -75,6 +81,9 @@ module Y2Storage
       end
 
       # @see Base#post_commit
+      #
+      # Executes the extra commands reported by the former call to
+      # "zkey cryptsetup".
       #
       # @param device [Encryption] encryption that has just been created in the system
       def post_commit(device)
@@ -94,6 +103,8 @@ module Y2Storage
       end
 
       # Custom Cheetah recorder to prevent leaking the password to the logs
+      #
+      # @return [Recorder]
       def cheetah_recorder
         @cheetah_recorder ||= Recorder.new(Yast::Y2Logger.instance)
       end

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -1,0 +1,157 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/encryption_type"
+require "y2storage/encryption_processes/base"
+require "y2storage/encryption_processes/secure_key"
+require "yast2/execute"
+
+module Y2Storage
+  module EncryptionProcesses
+    # Encryption process that allows to create and identify a volume encrypted
+    # with Pervasive Encryption.
+    #
+    # For more information, see
+    # https://www.ibm.com/support/knowledgecenter/linuxonibm/liaaf/lnz_r_dccnt.html
+    class Pervasive < Base
+      # Location of the zkey command
+      ZKEY = "/usr/bin/zkey".freeze
+      private_constant :ZKEY
+
+      # @see Base.used_for?
+      def self.used_for?(encryption)
+        # TODO: it should be possible to detect a preexisting pervasive encryption
+        # after extending a bit the libstorage-ng probing capabilities.
+        super
+      end
+
+      # @see Base.available?
+      def self.available?
+        SecureKey.available?
+      end
+
+      # @see Base#create_device
+      def create_device(blk_device, dm_name)
+        @secure_key = SecureKey.for_device(blk_device)
+        if @secure_key
+          # Should we discard the key if it's not a LUKS2 one?
+          # Or maybe we should modify the secure key in that case?
+          name_from_key = @secure_key.dm_name(blk_device)
+          dm_name = name_from_key if name_from_key
+        end
+
+        super(blk_device, dm_name)
+      end
+
+      # @see Base#pre_commit
+      #
+      # @param device [Encryption] encryption that will be created in the system
+      def pre_commit(device)
+        # For the time being, we will always generate a new key for each device
+        # if there was not a preexisting one. In the future we can extend the
+        # API to allow sharing a new key among several volumes.
+        @secure_key ||= generate_secure_key(device)
+
+        @zkey_cryptsetup_output = execute_zkey_cryptsetup(device)
+        return if @zkey_cryptsetup_output.empty?
+
+        device.format_options = luksformat_options_string + " --pbkdf pbkdf2"
+      end
+
+      # @see Base#post_commit
+      #
+      # @param device [Encryption] encryption that has just been created in the system
+      def post_commit(device)
+        commands = zkey_cryptsetup_output[1..-1]
+        return if commands.nil?
+
+        commands.each do |command|
+          args = command.split(" ")
+
+          if args.any? { |arg| "setvp".casecmp(arg) == 0 }
+            args += ["--key-file", "-"]
+            Yast::Execute.locally(*args, stdin: device.password, recorder: cheetah_recorder)
+          else
+            Yast::Execute.locally(*args)
+          end
+        end
+      end
+
+      # Custom Cheetah recorder to prevent leaking the password to the logs
+      def cheetah_recorder
+        @cheetah_recorder ||= Recorder.new(Yast::Y2Logger.instance)
+      end
+
+      # Class to prevent Yast::Execute from leaking to the logs the password
+      # provided via stdin
+      class Recorder < Cheetah::DefaultRecorder
+        # To prevent leaking stdin, just do nothing
+        def record_stdin(_stdin); end
+      end
+
+      private
+
+      # @return [SecureKey] master key used to encrypt the device
+      attr_reader :secure_key
+
+      # @return [Array<String>] lines of the output of the "zkey cryptsetup"
+      #   command executed during the pre-commit phase
+      attr_reader :zkey_cryptsetup_output
+
+      # @see Base#encryption_type
+      def encryption_type
+        EncryptionType::LUKS2
+      end
+
+      # Generates a new secure key for the given encryption device and registers
+      # it into the keys database of the system
+      #
+      # @param device [Encryption]
+      # @return [SecureKey]
+      def generate_secure_key(device)
+        key_name = "YaST_#{device.dm_table_name}"
+        key = SecureKey.generate(key_name, volumes: [device])
+        log.info "Generated secure key #{key.name}"
+
+        key
+      end
+
+      # Executes the "zkey cryptsetup" used to get the list of commands that
+      # must be executed during the pervasive encryption process
+      #
+      # @return [Array<String>]
+      def execute_zkey_cryptsetup(device)
+        name = secure_key.plain_name(device)
+        command = [ZKEY, "cryptsetup", "--volumes", name]
+        Yast::Execute.locally(*command, stdout: :capture)&.lines&.map(&:strip) || []
+      end
+
+      # Options to be passed to the "cryptsetup luksFormat" during the commit
+      # phase
+      #
+      # @see Luks#format_options
+      #
+      # @return [String]
+      def luksformat_options_string
+        luksformat_command = zkey_cryptsetup_output.first
+        luksformat_command.split("luksFormat ").last.gsub(/ \/dev[^\s]*/, "")
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/encryption_processes/secure_key.rb
+++ b/src/lib/y2storage/encryption_processes/secure_key.rb
@@ -1,0 +1,233 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast2/execute"
+require "y2storage/encryption_processes/secure_key_volume"
+
+module Y2Storage
+  module EncryptionProcesses
+    # Class representing the secure AES keys managed by the Crypto Express CCA
+    # coprocessors found in the system.
+    #
+    # For more information, see
+    # https://www.ibm.com/support/knowledgecenter/linuxonibm/com.ibm.linux.z.lxdc/lxdc_zkey_reference.html
+    class SecureKey
+      # Location of the zkey command
+      ZKEY = "/usr/bin/zkey".freeze
+      # Location of the lszcrypt command
+      LSZCRYPT = "/sbin/lszcrypt".freeze
+      private_constant :ZKEY, :LSZCRYPT
+
+      # @return [String] name of the secure key
+      attr_reader :name
+
+      # Constructor
+      #
+      # @note: creating a SecureKey object does not generate a new record for it
+      # in the keys database. See {#generate}.
+      #
+      # @param name [String] see {#name}
+      def initialize(name)
+        @name = name
+        @volume_entries = []
+      end
+
+      # Whether the key contains an entry in its list of volumes referencing the
+      # given device
+      #
+      # @param device [BlkDevice, Encryption] it can be the plain device being
+      #   encrypted or the resulting encryption device
+      # @return [Boolean]
+      def for_device?(device)
+        !!volume_entry(device)
+      end
+
+      # DeviceMapper name registered in this key for the given device
+      #
+      # @param device [BlkDevice, Encryption] it can be the plain device being
+      #   encrypted or the resulting encryption device
+      # @return [String, nil] nil if the current key contain no information
+      #   about the device or whether it does not specify a DeviceMapper name
+      #   for it
+      def dm_name(device)
+        volume_entry(device)&.dm_name
+      end
+
+      # For the given device, name with which the plain device is registered
+      # in this key
+      #
+      # @param device [BlkDevice, Encryption] it can be the plain device being
+      #   encrypted or the resulting encryption device
+      # @return [String, nil] nil if the current key contain no information
+      #   about the device
+      def plain_name(device)
+        volume_entry(device)&.plain_name
+      end
+
+      # Adds the given device to the list of volumes registered for this key
+      #
+      # @note This only modifies the current object in memory, it does not imply
+      #   saving the volume entry in the keys database.
+      #
+      # @param device [Encryption]
+      def add_device(device)
+        @volume_entries << SecureKeyVolume.new_from_encryption(device)
+      end
+
+      # Registers the key in the keys database by invoking "zkey generate"
+      #
+      # The generated key will have the name and the list of volumes from this
+      # object. The rest of attributes will be set at the convenient values for
+      # pervasive LUKS2 encryption.
+      def generate
+        args = [
+          "--name", name,
+          "--xts",
+          "--keybits", "256",
+          "--volume-type", "LUKS2",
+          "--sector-size", "4096"
+        ]
+        args += ["--volumes", volume_entries.map(&:to_s).join(",")] if volume_entries.any?
+
+        Yast::Execute.locally(ZKEY, "generate", *args)
+      end
+
+      # Parses the representation of a secure key, in the format used by
+      # "zkey list", and adds the corresponding volume entries to the list of
+      # volumes registered for this key
+      #
+      # @note This only modifies the current object in memory, it does not imply
+      #   saving the volume entries in the keys database.
+      #
+      # @param string [String] portion of the output of "zkey list" that
+      #   represents a concrete secure key
+      def add_zkey_volumes(string)
+        # TODO: likely this method could be better implemented with
+        # StringScanner
+
+        vol_pattern = "\s+\/[^\s]*\s*\n"
+        match_data = /\s* Volumes\s+:((#{vol_pattern})+)/.match(string)
+        return [] unless match_data
+
+        volumes_str = match_data[1]
+        volumes = volumes_str.split("\n").map(&:strip)
+
+        @volume_entries += volumes.map { |str| SecureKeyVolume.new_from_str(str) }
+      end
+
+      private
+
+      # @return [Array<SecureKeyVolume>] entries in the "volumes" section of
+      #   this key
+      attr_accessor :volume_entries
+
+      # Volume entry associated to the given device
+      #
+      # @param device [BlkDevice, Encryption] it can be the plain device being
+      #   encrypted or the resulting encryption device
+      # @return [SecureKeyVolume, nil] nil if this key is not associated to the
+      #   device
+      def volume_entry(device)
+        volume_entries.find { |vol| vol.match_device?(device) }
+      end
+
+      class << self
+        # Whether it's possible to use secure AES keys in this system
+        #
+        # @return [Boolean]
+        def available?
+          device_list = Yast::Execute.locally!(LSZCRYPT, "--verbose", stdout: :capture)
+          device_list&.match?(/\sonline\s/) || false
+        rescue StandardError
+          false
+        end
+
+        # Registers a new secure key in the system's key database
+        #
+        # The name of the resulting key may be different (a numbered suffix is
+        # added) if the given name is already taken.
+        #
+        # @param name [String] temptative name for the new key
+        # @param volumes [Array<Encryption>] encryption devices to register in
+        #   the "volumes" section of the new key
+        # @return [SecureKey] an object representing the new key
+        def generate(name, volumes: [])
+          name = exclusive_name(name)
+          key = new(name)
+          volumes.each { |vol| key.add_device(vol) }
+          key.generate
+          key
+        end
+
+        # Finds an existing secure key that references the given device in
+        # one of its "volumes" entries
+        #
+        # @return [SecureKey, nil] nil if no key is found for the device
+        def for_device(device)
+          all.find { |key| key.for_device?(device) }
+        end
+
+        private
+
+        # All secure keys registered in the system
+        #
+        # @return [Array<SecureKey>]
+        def all
+          output = Yast::Execute.locally(ZKEY, "list", stdout: :capture)
+          return [] if output&.empty?
+
+          entries = output&.split("\n\n") || []
+          entries.map { |entry| new_from_zkey(entry) }
+        end
+
+        # Parses the representation of a secure key, in the format used by
+        # "zkey list", and returns a SecureKey object representing it
+        #
+        # @param string [String] portion of the output of "zkey list" that
+        #   represents a concrete secure key
+        def new_from_zkey(string)
+          lines = string.lines
+          name = lines.first.strip.split(/\s/).last
+          key = new(name)
+          key.add_zkey_volumes(string)
+          key
+        end
+
+        # Returns the name that is available for a new key taking original_name
+        # as a base. If the name is already taken by an existing key in the
+        # system, the returned name will have a number appended.
+        #
+        # @param original_name [String]
+        # @return [String]
+        def exclusive_name(original_name)
+          existing_names = all.map(&:name)
+          return original_name unless existing_names.include?(original_name)
+
+          suffix = 0
+          name = "#{original_name}_#{suffix}"
+          while existing_names.include?(name)
+            suffix += 1
+            name = "#{original_name}_#{suffix}"
+          end
+          name
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/encryption_processes/secure_key_volume.rb
+++ b/src/lib/y2storage/encryption_processes/secure_key_volume.rb
@@ -42,6 +42,9 @@ module Y2Storage
       # Creates a new object based on the portion of the output of
       # "zkey list" that represents a concrete volume entry
       #
+      # The input string can be something like "/dev/sda1" or
+      # "/dev/sda1:cr_sda1".
+      #
       # @param string [String] name of the plain device and, optionally, also
       #   DeviceMapper of the encrypted device
       # @return [SecureKeyVolume]

--- a/src/lib/y2storage/encryption_processes/secure_key_volume.rb
+++ b/src/lib/y2storage/encryption_processes/secure_key_volume.rb
@@ -1,0 +1,91 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Storage
+  module EncryptionProcesses
+    # Each instance of this class represents one of the entries in the "volumes"
+    # section of a secure AES key
+    #
+    # @see SecureKey
+    class SecureKeyVolume
+      # @return [String] name of the plain device
+      attr_reader :plain_name
+
+      # @return [String] DeviceMapper name of the encrypted device
+      attr_reader :dm_name
+
+      # Constructor
+      #
+      # @param plain_name [String] see #plain_name
+      # @param dm_name [String] see #dm_name
+      def initialize(plain_name, dm_name)
+        @plain_name = plain_name
+        @dm_name = dm_name
+      end
+
+      # Creates a new object based on the portion of the output of
+      # "zkey list" that represents a concrete volume entry
+      #
+      # @param string [String] name of the plain device and, optionally, also
+      #   DeviceMapper of the encrypted device
+      # @return [SecureKeyVolume]
+      def self.new_from_str(string)
+        plain, dm = string.split(":")
+        new(plain, dm)
+      end
+
+      # Creates a new object referencing the given encryption device
+      #
+      # @param device [Encryption]
+      # @return [SecureKeyVolume]
+      def self.new_from_encryption(device)
+        plain_name = device.blk_device.udev_full_ids.first || device.blk_device.name
+        new(plain_name, device.dm_table_name)
+      end
+
+      # String representation of the volume entry, using the same format than
+      # "zkey list"
+      #
+      # @return [String]
+      def to_s
+        dm_name ? "#{plain_name}:#{dm_name}" : plain_name
+      end
+
+      # Whether the volume entry references the given device
+      #
+      # @param device [BlkDevice, Encryption] it can be the plain device being
+      #   encrypted or the resulting encryption device
+      # @return [Boolean]
+      def match_device?(device)
+        if device.is?(:encryption)
+          device.dm_table_name == dm_name
+        else
+          blk_device_names(device).include?(plain_name)
+        end
+      end
+
+      private
+
+      # @see #match_device?
+      def blk_device_names(device)
+        [device.name] + device.udev_full_ids + device.udev_full_paths
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/encryption_processes/swap.rb
+++ b/src/lib/y2storage/encryption_processes/swap.rb
@@ -39,6 +39,11 @@ module Y2Storage
         encryption.crypt_options.any? { |opt| opt.downcase == SWAP }
       end
 
+      # @see EncryptionProcesses::Base#only_for_swap?
+      def self.only_for_swap?
+        true
+      end
+
       # @see EncryptionProcesses::Base#create_device
       def create_device(blk_device, dm_name)
         enc = super

--- a/src/lib/y2storage/luks.rb
+++ b/src/lib/y2storage/luks.rb
@@ -36,6 +36,18 @@ module Y2Storage
     #   @return [String] UUID of the LUKS device
     storage_forward :uuid
 
+    # @!attribute format_options
+    #
+    # Extra options for luks format call. The options are injected as-is to the
+    # command so must be properly quoted.
+    #
+    # Options that modify the size of the resulting blk device (e.g. --integrity)
+    # are not allowed.
+    #
+    # @return [String]
+    storage_forward :format_options
+    storage_forward :format_options=
+
     # Whether the LUKS encryption device matches with a given crypttab spec
     #
     # @see Encryption#match_crypttab_spec?

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -315,6 +315,9 @@ module Y2Storage
       # Tell FsSnapshot whether Snapper should be configured later
       Yast2::FsSnapshot.configure_on_install = configure_snapper?
       callbacks = Callbacks::Commit.new
+
+      staging.pre_commit
+
       storage.calculate_actiongraph
       commit_options = ::Storage::CommitOptions.new(force_rw)
 
@@ -323,6 +326,8 @@ module Y2Storage
       DumpManager.dump(staging, "committed")
 
       storage.commit(commit_options, callbacks)
+      staging.post_commit
+
       @committed = true
     rescue Storage::Exception
       false

--- a/test/data/lszcrypt/no_devs.txt
+++ b/test/data/lszcrypt/no_devs.txt
@@ -1,0 +1,2 @@
+CARD.DOMAIN TYPE  MODE        STATUS  REQUESTS  PENDING HWTYPE QDEPTH FUNCTIONS  DRIVER     
+--------------------------------------------------------------------------------------------

--- a/test/data/lszcrypt/ok.txt
+++ b/test/data/lszcrypt/ok.txt
@@ -1,0 +1,4 @@
+CARD.DOMAIN TYPE  MODE        STATUS  REQUESTS  PENDING HWTYPE QDEPTH FUNCTIONS  DRIVER     
+--------------------------------------------------------------------------------------------
+01          CEX5C CCA-Coproc  online        80        0     11     08 S--D--N--  cex4card   
+01.0001     CEX5C CCA-Coproc  online        80        0     11     08 S--D--N--  cex4queue  

--- a/test/data/zkey/list-dasdc1.txt
+++ b/test/data/zkey/list-dasdc1.txt
@@ -1,0 +1,52 @@
+Key                          : secure_xtskey1                                        
+-------------------------------------------------------------------------------------
+        Description          : 
+        Secure key size      : 128 bytes
+        Clear key size       : 512 bits
+        XTS type key         : Yes
+        Volumes              : /dev/dasdb1:cr-dasdb1
+                               /dev/dasda2:cr_7
+        APQNs                : (none)
+        Key file name        : /etc/zkey/repository/secure_xtskey1.skey
+        Sector size          : 4096 bytes
+        Volume type          : LUKS2
+        Verification pattern : 876b32220444cdf4e90f8da385703f54
+                               1f408c0c1e3bf149b98f1f3ec70313ee
+        Created              : 2019-09-06 04:54:36
+        Changed              : 2019-09-16 13:13:46
+        Re-enciphered        : (never) 
+
+Key                          : secure_xtskey2                                        
+-------------------------------------------------------------------------------------
+        Description          : 
+        Secure key size      : 128 bytes
+        Clear key size       : 512 bits
+        XTS type key         : Yes
+        Volumes              : /dev/dasdc1:cr_7
+        APQNs                : (none)
+        Key file name        : /etc/zkey/repository/secure_xtskey2.skey
+        Sector size          : 4096 bytes
+        Volume type          : LUKS2
+        Verification pattern : 66af33e3d568cb6be88c1d08e0bf7999
+                               14d9a7d7727418e2b84cba93e49bf047
+        Created              : 2019-09-16 13:11:13
+        Changed              : (never)
+        Re-enciphered        : (never) 
+
+Key                          : secure_xtskey3                                        
+-------------------------------------------------------------------------------------
+        Description          : 
+        Secure key size      : 128 bytes
+        Clear key size       : 512 bits
+        XTS type key         : Yes
+        Volumes              : (none)
+        APQNs                : (none)
+        Key file name        : /etc/zkey/repository/secure_xtskey3.skey
+        Sector size          : 4096 bytes
+        Volume type          : LUKS2
+        Verification pattern : 8368630907a910a0988b7f83aa60b407
+                               3adced5fccef9b8c596706cfd292b7ec
+        Created              : 2019-09-17 04:44:57
+        Changed              : (never)
+        Re-enciphered        : (never) 
+

--- a/test/data/zkey/list-no-dasdc1.txt
+++ b/test/data/zkey/list-no-dasdc1.txt
@@ -1,0 +1,35 @@
+Key                          : YaST_cr_dasdc1                                        
+-------------------------------------------------------------------------------------
+        Description          : 
+        Secure key size      : 128 bytes
+        Clear key size       : 512 bits
+        XTS type key         : Yes
+        Volumes              : /dev/dasdb1:cr-dasdb1
+                               /dev/dasda2:cr_7
+        APQNs                : (none)
+        Key file name        : /etc/zkey/repository/secure_xtskey1.skey
+        Sector size          : 4096 bytes
+        Volume type          : LUKS2
+        Verification pattern : 876b32220444cdf4e90f8da385703f54
+                               1f408c0c1e3bf149b98f1f3ec70313ee
+        Created              : 2019-09-06 04:54:36
+        Changed              : 2019-09-16 13:13:46
+        Re-enciphered        : (never) 
+
+Key                          : YaST_cr_dasdc1_0                                        
+-------------------------------------------------------------------------------------
+        Description          : 
+        Secure key size      : 128 bytes
+        Clear key size       : 512 bits
+        XTS type key         : Yes
+        Volumes              : (none)
+        APQNs                : (none)
+        Key file name        : /etc/zkey/repository/secure_xtskey3.skey
+        Sector size          : 4096 bytes
+        Volume type          : LUKS2
+        Verification pattern : 8368630907a910a0988b7f83aa60b407
+                               3adced5fccef9b8c596706cfd292b7ec
+        Created              : 2019-09-17 04:44:57
+        Changed              : (never)
+        Re-enciphered        : (never) 
+

--- a/test/y2partitioner/actions/controllers/encryption_test.rb
+++ b/test/y2partitioner/actions/controllers/encryption_test.rb
@@ -120,6 +120,9 @@ describe Y2Partitioner::Actions::Controllers::Encryption do
     end
 
     let(:swap) { true }
+    let(:method_only_for_swap) { double(Y2Storage::EncryptionMethod, only_for_swap?: true) }
+    let(:another_method) { double(Y2Storage::EncryptionMethod, only_for_swap?: false) }
+    let(:encryption_methods) { [method_only_for_swap, another_method] }
 
     it "returns a collection of encryption methods" do
       expect(subject.methods).to be_a Array
@@ -127,16 +130,24 @@ describe Y2Partitioner::Actions::Controllers::Encryption do
     end
 
     context "when working with a swap filesystem" do
-      it "includes the RANDOM_SWAP method" do
-        expect(subject.methods).to include(Y2Storage::EncryptionMethod::RANDOM_SWAP)
+      before do
+        allow(Y2Storage::EncryptionMethod).to receive(:available).and_return(encryption_methods)
+      end
+
+      it "includes the encryption methods intented to be used only with swap" do
+        expect(subject.methods).to include(method_only_for_swap)
       end
     end
 
     context "when not working with a swap filesystem" do
       let(:swap) { false }
 
-      it "does not include the RANDOM_SWAP method" do
-        expect(subject.methods).to_not include(Y2Storage::EncryptionMethod::RANDOM_SWAP)
+      before do
+        allow(Y2Storage::EncryptionMethod).to receive(:available).and_return(encryption_methods)
+      end
+
+      it "does not includes the encryption methods intented to be used only with swap" do
+        expect(subject.methods).to_not include(method_only_for_swap)
       end
     end
   end

--- a/test/y2partitioner/widgets/encrypt_method_options_test.rb
+++ b/test/y2partitioner/widgets/encrypt_method_options_test.rb
@@ -49,14 +49,14 @@ describe Y2Partitioner::Widgets::EncryptMethodOptions do
 
     before do
       allow(Y2Partitioner::Widgets::RandomOptions).to receive(:new).and_return(fake_random_swap_options)
-      allow(Y2Partitioner::Widgets::Luks1Options).to receive(:new).and_return(fake_luks1_options)
+      allow(Y2Partitioner::Widgets::LuksOptions).to receive(:new).and_return(fake_luks1_options)
     end
 
     it "generates the new content based on the selected method" do
       expect(Y2Partitioner::Widgets::RandomOptions).to receive(:new)
       subject.refresh(random_swap)
 
-      expect(Y2Partitioner::Widgets::Luks1Options).to receive(:new)
+      expect(Y2Partitioner::Widgets::LuksOptions).to receive(:new)
       subject.refresh(luks1)
     end
 
@@ -83,7 +83,7 @@ describe Y2Partitioner::Widgets::EncryptMethodOptions do
     end
   end
 
-  describe Y2Partitioner::Widgets::Luks1Options do
+  describe Y2Partitioner::Widgets::LuksOptions do
     subject { described_class.new(controller) }
 
     include_examples "CWM::CustomWidget"

--- a/test/y2storage/encryption_method_test.rb
+++ b/test/y2storage/encryption_method_test.rb
@@ -33,6 +33,12 @@ describe Y2Storage::EncryptionMethod do
     end
   end
 
+  describe ".available" do
+    it "returns a method for Luks1 and another for random swap" do
+      expect(described_class.available.map(&:to_sym)).to contain_exactly(:luks1, :random_swap)
+    end
+  end
+
   describe ".find" do
     context "when looking for a known method" do
       it "returns the encryption method" do

--- a/test/y2storage/encryption_processes/luks1_test.rb
+++ b/test/y2storage/encryption_processes/luks1_test.rb
@@ -45,6 +45,12 @@ describe Y2Storage::EncryptionProcesses::Luks1 do
     end
   end
 
+  describe ".only_for_swap?" do
+    it "returns false" do
+      expect(described_class.only_for_swap?).to eq(false)
+    end
+  end
+
   describe "#create_device" do
     let(:devicegraph) { Y2Partitioner::DeviceGraphs.instance.current }
     let(:blk_device) { Y2Storage::BlkDevice.find_by_name(devicegraph, "/dev/sda") }

--- a/test/y2storage/encryption_processes/swap_test.rb
+++ b/test/y2storage/encryption_processes/swap_test.rb
@@ -45,6 +45,12 @@ describe Y2Storage::EncryptionProcesses::Swap do
     end
   end
 
+  describe ".only_for_swap?" do
+    it "returns true" do
+      expect(described_class.only_for_swap?).to eq(true)
+    end
+  end
+
   describe "#create_device" do
     let(:devicegraph) { Y2Partitioner::DeviceGraphs.instance.current }
     let(:blk_device) { Y2Storage::BlkDevice.find_by_name(devicegraph, "/dev/sda") }

--- a/test/y2storage/pervasive_encryption_test.rb
+++ b/test/y2storage/pervasive_encryption_test.rb
@@ -1,0 +1,166 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+require "y2storage/encryption_processes/secure_key"
+require "yast2/execute"
+
+describe "pervasive encryption" do
+  def zkey_output(file)
+    File.read(File.join(DATA_PATH, "zkey", "#{file}.txt"))
+  end
+
+  before do
+    fake_scenario("several-dasds")
+
+    allow(Yast::Execute).to receive(:locally)
+    allow(Yast::Execute).to receive(:locally).with(/zkey/, "list", any_args)
+      .and_return zkey_list
+  end
+
+  let(:manager) { Y2Storage::StorageManager.instance }
+  let(:blk_device) { manager.staging.find_by_name("/dev/dasdc1") }
+  let(:pervasive) { Y2Storage::EncryptionMethod::PERVASIVE_LUKS2 }
+  let(:zkey_list) { zkey_output("list-dasdc1") }
+
+  describe "Y2Storage::BlkDevice#encrypt" do
+    it "creates an encryption device with type LUKS2 and method PERVASIVE_LUKS2" do
+      enc = blk_device.encrypt(method: pervasive)
+      expect(enc.type).to eq Y2Storage::EncryptionType::LUKS2
+      expect(enc.method).to eq Y2Storage::EncryptionMethod::PERVASIVE_LUKS2
+    end
+
+    context "if there is a preexisting secure key for the device" do
+      let(:zkey_list) { zkey_output("list-dasdc1") }
+
+      it "enforces the DeviceMapper name specified in the registry of keys" do
+        enc = blk_device.encrypt(method: pervasive)
+        expect(enc.dm_table_name).to eq "cr_7"
+        expect(enc.auto_dm_name?).to eq false
+      end
+    end
+
+    context "if there is no preexisting secure key for the device" do
+      let(:zkey_list) { zkey_output("list-no-dasdc1") }
+
+      it "suggests the standard YaST DeviceMapper name" do
+        enc = blk_device.encrypt(method: pervasive)
+        expect(enc.dm_table_name).to eq "cr_#{blk_device.basename}"
+        expect(enc.auto_dm_name?).to eq true
+      end
+    end
+
+    context "if the check for existing keys fails" do
+      let(:zkey_list) { nil }
+
+      it "suggests the standard YaST DeviceMapper name" do
+        enc = blk_device.encrypt(method: pervasive)
+        expect(enc.dm_table_name).to eq "cr_#{blk_device.basename}"
+        expect(enc.auto_dm_name?).to eq true
+      end
+    end
+  end
+
+  describe "Y2Storage::StorageManager#commit" do
+    before do
+      allow(manager.storage).to receive(:calculate_actiongraph)
+      allow(manager.storage).to receive(:commit)
+
+      allow(Yast::Mode).to receive(:installation).and_return false
+      allow(Yast::Stage).to receive(:initial).and_return false
+    end
+
+    RSpec.shared_examples "zkey cryptsetup actions" do
+      before do
+        allow(Yast::Execute).to receive(:locally)
+          .with(/zkey/, "cryptsetup", "--volumes", anything, stdout: :capture)
+          .and_return zkey_cryptsetup
+      end
+      # I'm not sure why this default value is needed
+      let(:zkey_cryptsetup) { "" }
+
+      context "if the 'zkey cryptsetup' command fails" do
+        let(:zkey_cryptsetup) { nil }
+
+        it "does not modify the options for 'cryptsetup luksFormat'" do
+          enc = blk_device.encrypt(method: pervasive)
+          manager.commit
+
+          expect(enc.format_options).to be_empty
+        end
+      end
+
+      context "if 'zkey cryptsetup' returns several commands" do
+        let(:zkey_cryptsetup) do
+          "cryptsetup luksFormat --one two --three /dev/whatever\n" \
+            "zkey-cryptsetup setvp --volumes /dev/whatever\n" \
+            "third command"
+        end
+
+        it "generates arguments for 'cryptsetup luksFormat'" do
+          enc = blk_device.encrypt(method: pervasive)
+          manager.commit
+
+          expect(enc.format_options).to eq "--one two --three --pbkdf pbkdf2"
+        end
+
+        it "executes the post-commit commands providing the password when needed" do
+          expect(Yast::Execute).to receive(:locally)
+            .with("zkey-cryptsetup", "setvp", any_args, stdin: "12345678", recorder: anything)
+          expect(Yast::Execute).to receive(:locally).with("third", "command")
+
+          blk_device.encrypt(method: pervasive, password: "12345678")
+          manager.commit
+        end
+      end
+    end
+
+    context "if there is a preexisting secure key for the device" do
+      let(:zkey_list) { zkey_output("list-dasdc1") }
+
+      it "does not generate a new secure key" do
+        expect(Yast::Execute).to_not receive(:locally)
+          .with(/zkey/, "generate", any_args)
+
+        blk_device.encrypt(method: pervasive)
+        manager.commit
+      end
+
+      include_examples "zkey cryptsetup actions"
+    end
+
+    context "if there is no secure key for the device" do
+      let(:zkey_list) { zkey_output("list-no-dasdc1") }
+
+      it "tries to generate a new secure key with the appropriate name and arguments" do
+        expect(Yast::Execute).to receive(:locally).with(
+          /zkey/, "generate", "--name", "YaST_cr_dasdc1_1", "--xts", "--keybits", "256",
+          "--volume-type", "LUKS2", "--sector-size", "4096", "--volumes", "/dev/dasdc1:cr_dasdc1"
+        )
+
+        blk_device.encrypt(method: pervasive)
+        manager.commit
+      end
+
+      include_examples "zkey cryptsetup actions"
+    end
+  end
+end

--- a/test/y2storage/pervasive_encryption_test.rb
+++ b/test/y2storage/pervasive_encryption_test.rb
@@ -44,8 +44,8 @@ describe "pervasive encryption" do
   describe "Y2Storage::BlkDevice#encrypt" do
     it "creates an encryption device with type LUKS2 and method PERVASIVE_LUKS2" do
       enc = blk_device.encrypt(method: pervasive)
-      expect(enc.type).to eq Y2Storage::EncryptionType::LUKS2
-      expect(enc.method).to eq Y2Storage::EncryptionMethod::PERVASIVE_LUKS2
+      expect(enc.type.is?(:luks2)).to eq(true)
+      expect(enc.method).to eq pervasive
     end
 
     context "if there is a preexisting secure key for the device" do

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -614,6 +614,8 @@ describe Y2Storage::StorageManager do
 
       before do
         allow(manager).to receive(:staging).and_return staging
+        allow(staging).to receive(:pre_commit)
+        allow(staging).to receive(:post_commit)
       end
 
       context "if the root filesystem does not respond to #configure_snapper" do


### PR DESCRIPTION
## Goal

Allow to encrypt volumes using pervasive encryption via the Partitioner.

- https://www.ibm.com/support/knowledgecenter/linuxonibm/liaaf/lnz_r_dccnt.html
- https://jira.suse.com/browse/SLE-7376
- https://trello.com/c/HKaDMPL6/1297-5-pervasive-encryption-partitioner

## Solution

Implemented a new PERVASIVE_LUKS2 encryption method.

That method is exposed in the Partitioner when the system has at least one online Crypto Express cryptographic coprocessor configured in CCA mode and the needed tools installed.

Otherwise (most users on earth) nothing changes.

This is how it looks in the partitioner, including the help.

![pervasive1](https://user-images.githubusercontent.com/3638289/65342093-4cd2a880-dbd2-11e9-9c50-714bb9761a18.png)

and

![pervasive2](https://user-images.githubusercontent.com/3638289/65342110-54924d00-dbd2-11e9-9d8a-4053c35bb884.png)

It works and it generates secure keys like the ones showed here.

![pervasive3](https://user-images.githubusercontent.com/3638289/65342147-65db5980-dbd2-11e9-830f-4a7de36d7e7f.png)

As you can see, the devices are registered by id if possible.

If a key already exists for the volume, then it's reused instead of generating a new one. In that case, the DeviceMapper name specified in the volume entry (if any) is used for the encrypted device.

## Testing

Unit tests included.

Tested manually in an installed system. See screenshots.

Pending: test a full installation process.