### PR TITLE
AutoYaST: fixes related to UUID (bsc#1148477)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Oct  3 16:58:02 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- AutoYaST: do not fail if the uuid is specified for a new
+  filesystem (bsc#1148477, bsc#1152535).
+- AutoYaST: partitions and logical volumes to be reused can now be
+  found by uuid (bsc#1148477, bsc#1152535).
+- 4.1.88
+
+-------------------------------------------------------------------
 Wed Sep 18 09:31:41 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
 
 - bind-mount /run from inst-sys to target system during install

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.1.87
+Version:        4.1.88
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -114,7 +114,8 @@ module Y2Storage
       #   @return [String] label of the filesystem
 
       # @!attribute uuid
-      #   @return [String] UUID of the partition
+      #   @return [String] UUID of the partition, only useful for reusing
+      #     existing filesystems
 
       # @!attribute lv_name
       #   @return [String] name of the LVM logical volume
@@ -186,7 +187,6 @@ module Y2Storage
       # @return [PartitionSection]
       def self.new_from_storage(device)
         result = new
-        # So far, only real partitions are supported
         result.init_from_device(device)
         result
       end

--- a/src/lib/y2storage/proposal/autoinst_drive_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_drive_planner.rb
@@ -79,7 +79,6 @@ module Y2Storage
         device.encryption_password = section.crypt_key if section.crypt_fs
         device.mount_point = section.mount
         device.label = section.label
-        device.uuid = section.uuid
         device.filesystem_type = filesystem_for(section)
         device.mount_by = section.type_for_mountby
         device.mkfs_options = section.mkfs_options
@@ -170,6 +169,7 @@ module Y2Storage
       # @param device         [Y2Storage::Device] Device to reuse
       # @param section        [AutoinstProfile::PartitionSection] AutoYaST specification
       def add_device_reuse(planned_device, device, section)
+        planned_device.uuid = section.uuid
         planned_device.reuse_name = device.is_a?(LvmVg) ? device.volume_group_name : device.name
         planned_device.reformat = !!section.format
         planned_device.resize = !!section.resize if planned_device.respond_to?(:resize=)

--- a/src/lib/y2storage/proposal/autoinst_drive_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_drive_planner.rb
@@ -230,6 +230,8 @@ module Y2Storage
         device =
           if part_section.partition_nr
             disk.partitions.find { |i| i.number == part_section.partition_nr }
+          elsif part_section.uuid
+            disk.partitions.find { |i| i.filesystem_uuid == part_section.uuid }
           elsif part_section.label
             disk.partitions.find { |i| i.filesystem_label == part_section.label }
           else

--- a/src/lib/y2storage/proposal/autoinst_vg_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_vg_planner.rb
@@ -144,6 +144,8 @@ module Y2Storage
       def find_lv_in_vg(vg, part_section)
         if part_section.lv_name
           vg.lvm_lvs.find { |v| v.lv_name == part_section.lv_name }
+        elsif part_section.uuid
+          vg.lvm_lvs.find { |v| v.filesystem_uuid == part_section.uuid }
         elsif part_section.label
           vg.lvm_lvs.find { |v| v.filesystem_label == part_section.label }
         else

--- a/test/data/devicegraphs/autoyast_drive_examples.yml
+++ b/test/data/devicegraphs/autoyast_drive_examples.yml
@@ -81,6 +81,7 @@
         name:         /dev/sdc3
         file_system:  ext4
         mount_point:  /
+        uuid:         root-uuid
         label:        root
         mount_by:     uuid
         mkfs_options: -b 2048

--- a/test/data/devicegraphs/lvm-two-vgs.yml
+++ b/test/data/devicegraphs/lvm-two-vgs.yml
@@ -73,6 +73,7 @@
             lv_name:      lv2
             file_system:  ext4
             label:        rootfs
+            uuid:         lv2-uuid
 
 - lvm_vg:
     vg_name: vg1

--- a/test/data/devicegraphs/windows-linux-free-pc.yml
+++ b/test/data/devicegraphs/windows-linux-free-pc.yml
@@ -24,6 +24,7 @@
         name:         /dev/sda3
         file_system:  ext4
         label:        root
+        uuid:         sda3-uuid
 
 - disk:
     name: /dev/sdb

--- a/test/data/devicegraphs/windows-linux-free-pc.yml
+++ b/test/data/devicegraphs/windows-linux-free-pc.yml
@@ -17,14 +17,12 @@
         name:         /dev/sda2
         id:           swap
         file_system:  swap
-        mount_point:  swap
         label:        swap
 
     - partition:
         size:         20 GiB
         name:         /dev/sda3
         file_system:  ext4
-        mount_point:  /
         label:        root
 
 - disk:

--- a/test/y2storage/autoinst_issues/shrinked_planned_devices_test.rb
+++ b/test/y2storage/autoinst_issues/shrinked_planned_devices_test.rb
@@ -41,7 +41,10 @@ describe Y2Storage::AutoinstIssues::ShrinkedPlannedDevices do
     ]
   end
 
-  before { fake_scenario("windows-linux-free-pc") }
+  before do
+    fake_scenario("windows-linux-free-pc")
+    real_root.filesystem.mount_path = "/"
+  end
 
   describe "#message" do
     it "returns a description of the issue" do

--- a/test/y2storage/partition_test.rb
+++ b/test/y2storage/partition_test.rb
@@ -462,6 +462,8 @@ describe Y2Storage::Partition do
       volume.partition_id = volume_partition_id
       volume.fs_types = volume_fs_types
       volume.min_size = volume_min_size
+
+      partition.filesystem.mount_path = "swap"
     end
 
     context "when the partition has the same values than the volume" do

--- a/test/y2storage/planned/can_be_formatted_test.rb
+++ b/test/y2storage/planned/can_be_formatted_test.rb
@@ -132,6 +132,8 @@ describe Y2Storage::Planned::CanBeFormatted do
         planned.mount_point = "/old"
         planned.mount_by = mount_by
         allow(planned).to receive(:final_device!).and_return(blk_device)
+
+        blk_device.filesystem.mount_path = "/"
       end
 
       context "and a mount point has been set" do

--- a/test/y2storage/proposal/autoinst_devices_creator_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_creator_test.rb
@@ -351,14 +351,16 @@ describe Y2Storage::Proposal::AutoinstDevicesCreator do
         end
 
         let(:root) do
-          planned_partition(disk: "/dev/bcache0", mount_point: "/", min_size: 250.GiB)
+          planned_partition(
+            disk: "/dev/bcache0", mount_point: "/", min_size: 250.GiB, filesystem_type: filesystem_type
+          )
         end
 
         it "shrinks the partition to make it fit into the bcache" do
           result = creator.populated_devicegraph(planned_devices, ["/dev/sda", "/dev/sdb"])
           devicegraph = result.devicegraph
           root = devicegraph.partitions.find { |p| p.filesystem_mountpoint == "/" }
-          expect(root.size).to eq(20.GiB)
+          expect(root.size).to be < 20.GiB
         end
 
         it "registers which devices were shrinked" do

--- a/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
@@ -365,6 +365,25 @@ describe Y2Storage::Proposal::AutoinstDiskDevicePlanner do
         end
       end
 
+      context "when an uuid is specified" do
+        let(:scenario) { "autoyast_drive_examples" }
+
+        let(:disk_spec) do
+          { "device" => "/dev/sdc", "partitions" => [root_spec] }
+        end
+
+        let(:root_spec) do
+          { "create" => false, "uuid" => "root-uuid" }
+        end
+
+        it "reuses the partition with that uuid" do
+          disk = planner.planned_devices(drive).first
+          root = disk.partitions.find { |d| d.uuid == "root-uuid" }
+
+          expect(root.reuse_name).to eq("/dev/sdc3")
+        end
+      end
+
       context "when the partition to reuse does not exist" do
         let(:root_spec) do
           { "create" => false, "mount" => "/", "filesystem" => :btrfs, "partition_nr" => 99 }

--- a/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
@@ -84,6 +84,25 @@ describe Y2Storage::Proposal::AutoinstDiskDevicePlanner do
       end
     end
 
+    context "specifying the uuid" do
+      let(:scenario) { "autoyast_drive_examples" }
+
+      let(:disk_spec) do
+        { "device" => "/dev/sdc", "partitions" => [root_spec] }
+      end
+
+      let(:root_spec) do
+        { "mount" => "/", "filesystem" => "btrfs", "uuid" => "root-uuid" }
+      end
+
+      it "ignores it" do
+        disk = planner.planned_devices(drive).first
+        root = disk.partitions.find { |d| d.mount_point == "/" }
+
+        expect(root.uuid).to be_nil
+      end
+    end
+
     context "specifying size" do
       using Y2Storage::Refinements::SizeCasts
 


### PR DESCRIPTION
## Problem

Many things were broken regarding the usage of UUID in AutoYaST. For details, see [comment#9 at bsc#1148477](https://bugzilla.suse.com/show_bug.cgi?id=1148477#c9).

In the SLE-15-SP1 case:

- It was failing to reuse partitions and LVs finding them by their UUID. There was simply no code for that.
- It failed if the UUID was specified in the profile for a new file system. Setting such UUID was never intended to work, but AutoYaST should not fail.

See also https://trello.com/c/XibWb5sb/1335-2-ostumbleweed-p5-1148477-build-20190824-installation-fails-on-setting-uuid-of-btrfs

## Solution

Use the `uuid` property to find devices to be reused and ignore the `uuid` property in any other case.

Better review commit by commit.

See also https://github.com/SUSE/doc-sle/pull/483

## Testing

- Added new unit tests
- Removed some data from the test fixtures that was masking errors