### PR TITLE
AutoYaST: extended fixes related to UUID (bsc#1148477)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct  4 11:07:07 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- AutoYaST: do not include the uuid field in the <partition>
+  sections when cloning a system (bsc#1148477, bsc#1152535).
+- 4.2.46
+
+-------------------------------------------------------------------
 Thu Oct  3 16:58:02 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - AutoYaST: do not fail if the uuid is specified for a new

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Oct  3 16:58:02 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- AutoYaST: do not fail if the uuid is specified for a new
+  filesystem (bsc#1148477, bsc#1152535).
+- AutoYaST: partitions and logical volumes to be reused can now be
+  found by uuid (bsc#1148477, bsc#1152535).
+
+-------------------------------------------------------------------
 Wed Oct  2 13:35:42 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Partitioner: fix the type column value for Ext3/4 filesystems

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.45
+Version:        4.2.46
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -113,7 +113,8 @@ module Y2Storage
       #   @return [String] label of the filesystem
 
       # @!attribute uuid
-      #   @return [String] UUID of the partition
+      #   @return [String] UUID of the partition, only useful for reusing
+      #     existing filesystems
 
       # @!attribute lv_name
       #   @return [String] name of the LVM logical volume
@@ -189,7 +190,6 @@ module Y2Storage
       # @return [PartitionSection]
       def self.new_from_storage(device)
         result = new
-        # So far, only real partitions are supported
         result.init_from_device(device)
         result
       end

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -380,7 +380,6 @@ module Y2Storage
       # @param filesystem [Filesystems::BlkFilesystem]
       def init_blk_filesystem_fields(filesystem)
         @filesystem = filesystem.type.to_sym
-        @uuid = filesystem.uuid
         @label = filesystem.label unless filesystem.label.empty?
         @mkfs_options = filesystem.mkfs_options unless filesystem.mkfs_options.empty?
         init_subvolumes(filesystem)

--- a/src/lib/y2storage/proposal/autoinst_btrfs_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_btrfs_planner.rb
@@ -123,13 +123,14 @@ module Y2Storage
       # @param filesystem [Planned::Btrfs]
       # @param partition_section [AutoinstProfile::PartitionSection]
       def reuse_btrfs(filesystem, partition_section)
-        reused_btrfs = reused_btrfs(filesystem, partition_section)
+        reused_btrfs = reused_btrfs(partition_section)
 
         if !reused_btrfs
           issues_list.add(:missing_reusable_device, partition_section)
           return
         end
 
+        filesystem.uuid = reused_btrfs.uuid
         filesystem.reuse_sid = reused_btrfs.sid
       end
 
@@ -137,14 +138,13 @@ module Y2Storage
       #
       # @note The filesystem UUID must be given in the AutoYaST profile (partition section).
       #
-      # @param filesystem [Planned::Btrfs]
       # @param partition_section [AutoinstProfile::PartitionSection]
       #
       # @return [Filesystems::Btrfs, nil] nil if no filesystem found
-      def reused_btrfs(filesystem, partition_section)
+      def reused_btrfs(partition_section)
         return nil unless partition_section.uuid
 
-        devicegraph.btrfs_filesystems.detect { |f| f.uuid == filesystem.uuid }
+        devicegraph.btrfs_filesystems.detect { |f| f.uuid == partition_section.uuid }
       end
     end
   end

--- a/src/lib/y2storage/proposal/autoinst_drive_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_drive_planner.rb
@@ -97,7 +97,6 @@ module Y2Storage
       def add_filesystem_attrs(device, partition_section)
         device.mount_point = partition_section.mount
         device.label = partition_section.label
-        device.uuid = partition_section.uuid
         device.filesystem_type = filesystem_for(partition_section)
         device.mount_by = partition_section.type_for_mountby
         device.mkfs_options = partition_section.mkfs_options
@@ -193,6 +192,7 @@ module Y2Storage
       # @param device         [Y2Storage::Device] Device to reuse
       # @param section        [AutoinstProfile::PartitionSection] AutoYaST specification
       def add_device_reuse(planned_device, device, section)
+        planned_device.uuid = section.uuid
         planned_device.reuse_name = device.is_a?(LvmVg) ? device.volume_group_name : device.name
         planned_device.reformat = !!section.format
         planned_device.resize = !!section.resize if planned_device.respond_to?(:resize=)
@@ -254,6 +254,8 @@ module Y2Storage
         device =
           if part_section.partition_nr
             disk.partitions.find { |i| i.number == part_section.partition_nr }
+          elsif part_section.uuid
+            disk.partitions.find { |i| i.filesystem_uuid == part_section.uuid }
           elsif part_section.label
             disk.partitions.find { |i| i.filesystem_label == part_section.label }
           else

--- a/src/lib/y2storage/proposal/autoinst_vg_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_vg_planner.rb
@@ -151,6 +151,8 @@ module Y2Storage
       def find_lv_in_vg(vg, part_section)
         if part_section.lv_name
           vg.lvm_lvs.find { |v| v.lv_name == part_section.lv_name }
+        elsif part_section.uuid
+          vg.lvm_lvs.find { |v| v.filesystem_uuid == part_section.uuid }
         elsif part_section.label
           vg.lvm_lvs.find { |v| v.filesystem_label == part_section.label }
         else

--- a/test/data/devicegraphs/autoyast_drive_examples.yml
+++ b/test/data/devicegraphs/autoyast_drive_examples.yml
@@ -81,6 +81,7 @@
         name:         /dev/sdc3
         file_system:  ext4
         mount_point:  /
+        uuid:         root-uuid
         label:        root
         mount_by:     uuid
         mkfs_options: -b 2048

--- a/test/data/devicegraphs/lvm-two-vgs.yml
+++ b/test/data/devicegraphs/lvm-two-vgs.yml
@@ -73,6 +73,7 @@
             lv_name:      lv2
             file_system:  ext4
             label:        rootfs
+            uuid:         lv2-uuid
 
 - lvm_vg:
     vg_name: vg1

--- a/test/data/devicegraphs/windows-linux-free-pc.yml
+++ b/test/data/devicegraphs/windows-linux-free-pc.yml
@@ -17,15 +17,14 @@
         name:         /dev/sda2
         id:           swap
         file_system:  swap
-        mount_point:  swap
         label:        swap
 
     - partition:
         size:         20 GiB
         name:         /dev/sda3
         file_system:  ext4
-        mount_point:  /
         label:        root
+        uuid:         sda3-uuid
 
 - disk:
     name: /dev/sdb

--- a/test/y2storage/autoinst_issues/shrinked_planned_devices_test.rb
+++ b/test/y2storage/autoinst_issues/shrinked_planned_devices_test.rb
@@ -39,7 +39,10 @@ describe Y2Storage::AutoinstIssues::ShrinkedPlannedDevices do
     ]
   end
 
-  before { fake_scenario("windows-linux-free-pc") }
+  before do
+    fake_scenario("windows-linux-free-pc")
+    real_root.filesystem.mount_path = "/"
+  end
 
   describe "#message" do
     it "returns a description of the issue" do

--- a/test/y2storage/autoinst_profile/drive_section_test.rb
+++ b/test/y2storage/autoinst_profile/drive_section_test.rb
@@ -622,8 +622,7 @@ describe Y2Storage::AutoinstProfile::DriveSection do
           an_object_having_attributes(
             filesystem: :btrfs,
             mount:      "/test",
-            mountby:    :device,
-            uuid:       "b7b96325-feb5-4e7e-a7f4-014ce2402e71"
+            mountby:    :device
           )
         )
       end

--- a/test/y2storage/autoinst_profile/partition_section_test.rb
+++ b/test/y2storage/autoinst_profile/partition_section_test.rb
@@ -383,8 +383,9 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
         expect(section.filesystem).to eq(filesystem.type.to_sym)
       end
 
-      it "initializes uuid with the filesystem uuid" do
-        expect(section.uuid).to eq(filesystem.uuid)
+      # See bug#1148477
+      it "does not initialize the uuid" do
+        expect(section.uuid).to be_nil
       end
 
       context "when the filesystem has a label" do

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -223,6 +223,22 @@ describe Y2Storage::AutoinstProposal do
         end
       end
 
+      context "when an existing uuid is specified" do
+        let(:root) do
+          { "mount" => "/", "uuid" => "sda3-uuid", "create" => false }
+        end
+
+        it "reuses the partition with the given uuid" do
+          proposal.propose
+          devicegraph = proposal.devices
+          reused_part = devicegraph.partitions.find { |p| p.filesystem_uuid == "sda3-uuid" }
+          expect(reused_part).to have_attributes(
+            filesystem_type:       Y2Storage::Filesystems::Type::EXT4,
+            filesystem_mountpoint: "/"
+          )
+        end
+      end
+
       context "when partition is marked to be formatted" do
         let(:root) do
           { "mount" => "/", "partition_nr" => 3, "create" => false,
@@ -481,13 +497,6 @@ describe Y2Storage::AutoinstProposal do
 
       let(:lvm_group) { "vg0" }
 
-      let(:root) do
-        {
-          "create" => false, "mount" => "/", "filesystem" => "ext4", "lv_name" => "lv1",
-          "size" => "20G"
-        }
-      end
-
       let(:partitioning) do
         [
           { "device" => "/dev/sda", "use" => "all", "partitions" => [pv] }, vg
@@ -502,21 +511,57 @@ describe Y2Storage::AutoinstProposal do
         { "create" => false, "lvm_group" => lvm_group, "size" => "max", "type" => :CT_LVM }
       end
 
-      it "reuses the volume group" do
-        proposal.propose
-        devicegraph = proposal.devices
-        expect(devicegraph.partitions).to contain_exactly(
-          an_object_having_attributes("name" => "/dev/sda1"), # new pv
-          an_object_having_attributes("name" => "/dev/sda3"),
-          an_object_having_attributes("name" => "/dev/sda5")
-        )
+      RSpec.shared_examples "autoinst LVM reuse" do
+        it "reuses the volume group" do
+          proposal.propose
+          devicegraph = proposal.devices
+          expect(devicegraph.partitions).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/sda1"), # new pv
+            an_object_having_attributes("name" => "/dev/sda3"),
+            an_object_having_attributes("name" => "/dev/sda5")
+          )
 
-        vg = devicegraph.lvm_vgs.first
-        expect(vg.vg_name).to eq(lvm_group)
-        expect(vg.lvm_pvs.map(&:blk_device)).to contain_exactly(
-          an_object_having_attributes("name" => "/dev/sda1"), # new pv
-          an_object_having_attributes("name" => "/dev/sda5")
-        )
+          vg = devicegraph.lvm_vgs.first
+          expect(vg.vg_name).to eq(lvm_group)
+          expect(vg.lvm_pvs.map(&:blk_device)).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/sda1"), # new pv
+            an_object_having_attributes("name" => "/dev/sda5")
+          )
+        end
+
+        it "reuses the indicated logical volumes" do
+          lv2 = fake_devicegraph.find_by_name("/dev/vg0/lv2")
+
+          proposal.propose
+          devicegraph = proposal.devices
+
+          root_lv = devicegraph.lvm_lvs.find { |lv| lv.filesystem_mountpoint == "/" }
+          expect(root_lv.sid).to eq lv2.sid
+        end
+      end
+
+      context "by lv_name" do
+        let(:root) do
+          { "create" => false, "mount" => "/", "filesystem" => "ext4", "lv_name" => "lv2" }
+        end
+
+        include_examples "autoinst LVM reuse"
+      end
+
+      context "by label" do
+        let(:root) do
+          { "create" => false, "mount" => "/", "filesystem" => "ext4", "label" => "rootfs" }
+        end
+
+        include_examples "autoinst LVM reuse"
+      end
+
+      context "by label" do
+        let(:root) do
+          { "create" => false, "mount" => "/", "filesystem" => "ext4", "uuid" => "lv2-uuid" }
+        end
+
+        include_examples "autoinst LVM reuse"
       end
     end
 

--- a/test/y2storage/partition_test.rb
+++ b/test/y2storage/partition_test.rb
@@ -460,6 +460,8 @@ describe Y2Storage::Partition do
       volume.partition_id = volume_partition_id
       volume.fs_types = volume_fs_types
       volume.min_size = volume_min_size
+
+      partition.filesystem.mount_path = "swap"
     end
 
     context "when the partition has the same values than the volume" do

--- a/test/y2storage/planned/can_be_formatted_test.rb
+++ b/test/y2storage/planned/can_be_formatted_test.rb
@@ -130,6 +130,8 @@ describe Y2Storage::Planned::CanBeFormatted do
         planned.mount_point = "/old"
         planned.mount_by = mount_by
         allow(planned).to receive(:final_device!).and_return(blk_device)
+
+        blk_device.filesystem.mount_path = "/"
       end
 
       context "and a mount point has been set" do

--- a/test/y2storage/proposal/autoinst_btrfs_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_btrfs_planner_test.rb
@@ -102,8 +102,8 @@ describe Y2Storage::Proposal::AutoinstBtrfsPlanner do
     context "when the partition section specifies the uuid" do
       let(:partition_spec) { { "uuid" => "111-2222-33333" } }
 
-      it "sets the uuid" do
-        expect(planned_btrfs.uuid).to eq("111-2222-33333")
+      it "does not set the uuid" do
+        expect(planned_btrfs.uuid).to be_nil
       end
     end
 

--- a/test/y2storage/proposal/autoinst_devices_creator_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_creator_test.rb
@@ -388,14 +388,16 @@ describe Y2Storage::Proposal::AutoinstDevicesCreator do
         end
 
         let(:root) do
-          planned_partition(disk: "/dev/bcache0", mount_point: "/", min_size: 250.GiB)
+          planned_partition(
+            disk: "/dev/bcache0", mount_point: "/", min_size: 250.GiB, filesystem_type: filesystem_type
+          )
         end
 
         it "shrinks the partition to make it fit into the bcache" do
           result = creator.populated_devicegraph(planned_devices, ["/dev/sda", "/dev/sdb"])
           devicegraph = result.devicegraph
           root = devicegraph.partitions.find { |p| p.filesystem_mountpoint == "/" }
-          expect(root.size).to eq(20.GiB)
+          expect(root.size).to be < 20.GiB
         end
 
         it "registers which devices were shrinked" do

--- a/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
@@ -82,6 +82,25 @@ describe Y2Storage::Proposal::AutoinstDiskDevicePlanner do
       end
     end
 
+    context "specifying the uuid" do
+      let(:scenario) { "autoyast_drive_examples" }
+
+      let(:disk_spec) do
+        { "device" => "/dev/sdc", "partitions" => [root_spec] }
+      end
+
+      let(:root_spec) do
+        { "mount" => "/", "filesystem" => "btrfs", "uuid" => "root-uuid" }
+      end
+
+      it "ignores it" do
+        disk = planner.planned_devices(drive).first
+        root = disk.partitions.find { |d| d.mount_point == "/" }
+
+        expect(root.uuid).to be_nil
+      end
+    end
+
     context "specifying size" do
       using Y2Storage::Refinements::SizeCasts
 
@@ -360,6 +379,25 @@ describe Y2Storage::Proposal::AutoinstDiskDevicePlanner do
           disk = planner.planned_devices(drive).first
           root = disk.partitions.find { |d| d.mount_point == "/" }
           expect(root.reuse_name).to eq("/dev/sda3")
+        end
+      end
+
+      context "when an uuid is specified" do
+        let(:scenario) { "autoyast_drive_examples" }
+
+        let(:disk_spec) do
+          { "device" => "/dev/sdc", "partitions" => [root_spec] }
+        end
+
+        let(:root_spec) do
+          { "create" => false, "uuid" => "root-uuid" }
+        end
+
+        it "reuses the partition with that uuid" do
+          disk = planner.planned_devices(drive).first
+          root = disk.partitions.find { |d| d.uuid == "root-uuid" }
+
+          expect(root.reuse_name).to eq("/dev/sdc3")
         end
       end
 


### PR DESCRIPTION
## Problem

Follow-up of #976, this time for master. For details, see [comment#9 at bsc#1148477](https://bugzilla.suse.com/show_bug.cgi?id=1148477#c9).

This is about the problems affecting master (15.2 and TW):

- It was failing to reuse partitions and LVs finding them by their UUID. There was simply no code for that.
- It failed if the UUID was specified in the profile for a new file system. Setting such UUID was never intended to work, but AutoYaST should not fail.
- It was exporting the UUID when cloning a system, which triggered the mentioned failure.

See also https://trello.com/c/XibWb5sb/1335-2-ostumbleweed-p5-1148477-build-20190824-installation-fails-on-setting-uuid-of-btrfs

## Solution

Use the `uuid` property to find devices to be reused, do not export the `uuid` property when cloning to a profile and ignore it if it's there.

This includes a merge from SLE-15-SP1. Most commits come from there, only the latest four are new.

See also https://github.com/SUSE/doc-sle/pull/483 and the original pull request for SLE-15-SP1 #976 

## Testing

- Added a new unit test
