### PR TITLE
Set encryption sector size from the underlying device

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 16 11:40:56 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Set sector size to 4k for encrypted devices which underlying
+  device is, at least, 4k too (jsc#SLE-7376).
+- 4.2.48
+
+-------------------------------------------------------------------
 Fri Oct 11 14:26:23 CEST 2019 - aschnell@suse.com
 
 - Added translation for new enum value RB_PASSWORD_REQUIRED

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.47
+Version:        4.2.48
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/crypttab.rb
+++ b/src/lib/y2storage/crypttab.rb
@@ -98,7 +98,7 @@ module Y2Storage
       end
     end
 
-    # Whether the encrytion layer should be created for a swap device according to the given crypttab
+    # Whether the encryption layer should be created for a swap device according to the given crypttab
     # entry
     #
     # @param device [BlkDevice]

--- a/src/lib/y2storage/encryption_method/protected_swap.rb
+++ b/src/lib/y2storage/encryption_method/protected_swap.rb
@@ -32,9 +32,6 @@ module Y2Storage
       KEY_SIZE = "1280".freeze
       private_constant :KEY_SIZE
 
-      SECTOR_SIZE = "4096".freeze
-      private_constant :SECTOR_SIZE
-
       def initialize
         textdomain "storage"
         super(:protected_swap, _("Volatile Encryption with Protected Key"))

--- a/src/lib/y2storage/encryption_method/secure_swap.rb
+++ b/src/lib/y2storage/encryption_method/secure_swap.rb
@@ -32,9 +32,6 @@ module Y2Storage
       KEY_SIZE = "1024".freeze
       private_constant :KEY_SIZE
 
-      SECTOR_SIZE = "4096".freeze
-      private_constant :SECTOR_SIZE
-
       # Encryption swap process (see {Swap}) for z Systems to encrypt a device by using secure keys
       def initialize
         textdomain "storage"

--- a/src/lib/y2storage/encryption_method/swap.rb
+++ b/src/lib/y2storage/encryption_method/swap.rb
@@ -77,7 +77,7 @@ module Y2Storage
 
       SWAP_OPTION = "swap".freeze
 
-      # Checks whether the process was used according to the given key file and encrytion options
+      # Checks whether the process was used according to the given key file and encryption options
       #
       # @param key_file [String]
       # @param crypt_options [Array<String>]

--- a/src/lib/y2storage/encryption_method/swap.rb
+++ b/src/lib/y2storage/encryption_method/swap.rb
@@ -73,13 +73,6 @@ module Y2Storage
         self.class.const_get(:KEY_SIZE) if self.class.const_defined?(:KEY_SIZE)
       end
 
-      # Sector size for the encryption
-      #
-      # @return [String, nil] nil if no specific sector size
-      def sector_size
-        self.class.const_get(:SECTOR_SIZE) if self.class.const_defined?(:SECTOR_SIZE)
-      end
-
       private
 
       SWAP_OPTION = "swap".freeze
@@ -111,7 +104,7 @@ module Y2Storage
       # @see Base#encryption_process
       def encryption_process
         EncryptionProcesses::Volatile.new(
-          self, key_file: key_file, cipher: cipher, key_size: key_size, sector_size: sector_size
+          self, key_file: key_file, cipher: cipher, key_size: key_size
         )
       end
     end

--- a/src/lib/y2storage/encryption_processes/base.rb
+++ b/src/lib/y2storage/encryption_processes/base.rb
@@ -100,6 +100,41 @@ module Y2Storage
       def open_command_options(blk_device)
         open_options(blk_device).join(" ")
       end
+
+      # Sector size option for the encryption
+      #
+      # @param blk_device [BlkDevice] Block device to encrypt
+      # @return [String, nil] nil if no specific sector size
+      def sector_size_option(blk_device)
+        sector_size = sector_size_for(blk_device)
+        return nil unless sector_size
+
+        "sector-size=#{sector_size}"
+      end
+
+      # Sector size option to open the encryption device
+      #
+      # @param blk_device [BlkDevice] Block device to encrypt
+      # @return [String, nil] nil if no specific sector size
+      def sector_size_open_option(blk_device)
+        sector_size = sector_size_for(blk_device)
+        return nil unless sector_size
+
+        "--sector-size '#{sector_size}'"
+      end
+
+      IDEAL_SECTOR_SIZE = 4096
+
+      # Sector size for a given device
+      #
+      # For performance reasons, it tries to use 4k when possible. Otherwise, it returns
+      # nil so the default is used.
+      #
+      # @param blk_device [BlkDevice] Block device to encrypt
+      # @return [Integer,nil]
+      def sector_size_for(blk_device)
+        return IDEAL_SECTOR_SIZE if blk_device.region.block_size.to_i >= IDEAL_SECTOR_SIZE
+      end
     end
   end
 end

--- a/src/lib/y2storage/encryption_processes/base.rb
+++ b/src/lib/y2storage/encryption_processes/base.rb
@@ -101,28 +101,6 @@ module Y2Storage
         open_options(blk_device).join(" ")
       end
 
-      # Sector size option for the encryption
-      #
-      # @param blk_device [BlkDevice] Block device to encrypt
-      # @return [String, nil] nil if no specific sector size
-      def sector_size_option(blk_device)
-        sector_size = sector_size_for(blk_device)
-        return nil unless sector_size
-
-        "sector-size=#{sector_size}"
-      end
-
-      # Sector size option to open the encryption device
-      #
-      # @param blk_device [BlkDevice] Block device to encrypt
-      # @return [String, nil] nil if no specific sector size
-      def sector_size_open_option(blk_device)
-        sector_size = sector_size_for(blk_device)
-        return nil unless sector_size
-
-        "--sector-size '#{sector_size}'"
-      end
-
       IDEAL_SECTOR_SIZE = 4096
 
       # Sector size for a given device

--- a/src/lib/y2storage/encryption_processes/base.rb
+++ b/src/lib/y2storage/encryption_processes/base.rb
@@ -46,7 +46,8 @@ module Y2Storage
       # @param dm_name [String]
       def create_device(blk_device, dm_name)
         enc = blk_device.create_encryption(dm_name || "", encryption_type)
-        enc.open_options = open_command_options
+        enc.open_options = open_command_options(blk_device)
+        enc.crypt_options = crypt_options(blk_device) + enc.crypt_options
         enc.encryption_process = self
         enc
       end
@@ -76,8 +77,17 @@ module Y2Storage
 
       # Open options for the encryption device
       #
+      # @param _blk_device [BlkDevice] Block device to encrypt
       # @return [Array<String>]
-      def open_options
+      def open_options(_blk_device)
+        []
+      end
+
+      # Crypt options for the encryption device
+      #
+      # @param _blk_device [BlkDevice] Block device to encrypt
+      # @return [Array<String>]
+      def crypt_options(_blk_device)
         []
       end
 
@@ -85,9 +95,10 @@ module Y2Storage
 
       # Open options with the format expected by the underlying tools (cryptsetup)
       #
+      # @param blk_device [BlkDevice] Block device to encrypt
       # @return [String]
-      def open_command_options
-        open_options.join(" ")
+      def open_command_options(blk_device)
+        open_options(blk_device).join(" ")
       end
     end
   end

--- a/src/lib/y2storage/encryption_processes/luks1.rb
+++ b/src/lib/y2storage/encryption_processes/luks1.rb
@@ -24,11 +24,6 @@ module Y2Storage
   module EncryptionProcesses
     # The encryption process that allows to create and identify an encrypted
     # device using LUKS1
-    #
-    # ## Encryption and open options
-    #
-    # In this case, the luksOpen command does not receive any additional argument (see
-    # {Base#open_options}) and no options are written to `/etc/crypttab` (see {Base#crypt_options}).
     class Luks1 < Base
       private
 

--- a/src/lib/y2storage/encryption_processes/luks1.rb
+++ b/src/lib/y2storage/encryption_processes/luks1.rb
@@ -24,6 +24,11 @@ module Y2Storage
   module EncryptionProcesses
     # The encryption process that allows to create and identify an encrypted
     # device using LUKS1
+    #
+    # ## Encryption and open options
+    #
+    # In this case, the luksOpen command does not receive any additional argument (see
+    # {Base#open_options}) and no options are written to `/etc/crypttab` (see {Base#crypt_options}).
     class Luks1 < Base
       private
 

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -142,7 +142,11 @@ module Y2Storage
       # @return [SecureKey]
       def generate_secure_key(device)
         key_name = "YaST_#{device.dm_table_name}"
-        key = SecureKey.generate(key_name, volumes: [device], sector_size: sector_size_for(device.blk_device))
+        key = SecureKey.generate(
+          key_name,
+          volumes:     [device],
+          sector_size: sector_size_for(device.blk_device)
+        )
         log.info "Generated secure key #{key.name}"
 
         key

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -30,11 +30,6 @@ module Y2Storage
     #
     # For more information, see
     # https://www.ibm.com/support/knowledgecenter/linuxonibm/liaaf/lnz_r_dccnt.html
-    #
-    # ## Encryption and open options
-    #
-    # When using pervasive, only the sector size is written to `/etc/crypttab` (see {#crypt_options}).
-    # No additional arguments are given to the luksOpen command (see {Base#open_options}).
     class Pervasive < Base
       # Location of the zkey command
       ZKEY = "/usr/bin/zkey".freeze
@@ -94,14 +89,6 @@ module Y2Storage
             Yast::Execute.locally(*args)
           end
         end
-      end
-
-      # Encryption options to add to the encryption device (crypttab options)
-      #
-      # @param blk_device [BlkDevice] Block device to encrypt
-      # @return [Array<String>]
-      def crypt_options(blk_device)
-        [sector_size_option(blk_device)].compact
       end
 
       # @see Base#finish_installation

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -91,6 +91,22 @@ module Y2Storage
         end
       end
 
+      # Encryption options to add to the encryption device (crypttab options)
+      #
+      # @param blk_device [BlkDevice] Block device to encrypt
+      # @return [Array<String>]
+      def crypt_options(blk_device)
+        [sector_size_option(blk_device)].compact
+      end
+
+      # Encryption options to open the encryption device
+      #
+      # @param blk_device [BlkDevice] Block device to encrypt
+      # @return [Array<String>]
+      def open_options(blk_device)
+        [sector_size_open_option(blk_device)].compact
+      end
+
       # @see Base#finish_installation
       #
       # Copies the keys from the zkey repository of the inst-sys to the
@@ -134,7 +150,7 @@ module Y2Storage
       # @return [SecureKey]
       def generate_secure_key(device)
         key_name = "YaST_#{device.dm_table_name}"
-        key = SecureKey.generate(key_name, volumes: [device])
+        key = SecureKey.generate(key_name, volumes: [device], sector_size: sector_size_for(device.blk_device))
         log.info "Generated secure key #{key.name}"
 
         key

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -30,6 +30,11 @@ module Y2Storage
     #
     # For more information, see
     # https://www.ibm.com/support/knowledgecenter/linuxonibm/liaaf/lnz_r_dccnt.html
+    #
+    # ## Encryption and open options
+    #
+    # When using pervasive, only the sector size is written to `/etc/crypttab` (see {#crypt_options}).
+    # No additional arguments are given to the luksOpen command (see {Base#open_options}).
     class Pervasive < Base
       # Location of the zkey command
       ZKEY = "/usr/bin/zkey".freeze

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -99,14 +99,6 @@ module Y2Storage
         [sector_size_option(blk_device)].compact
       end
 
-      # Encryption options to open the encryption device
-      #
-      # @param blk_device [BlkDevice] Block device to encrypt
-      # @return [Array<String>]
-      def open_options(blk_device)
-        [sector_size_open_option(blk_device)].compact
-      end
-
       # @see Base#finish_installation
       #
       # Copies the keys from the zkey repository of the inst-sys to the

--- a/src/lib/y2storage/encryption_processes/secure_key.rb
+++ b/src/lib/y2storage/encryption_processes/secure_key.rb
@@ -45,15 +45,20 @@ module Y2Storage
       # @return [String] name of the secure key
       attr_reader :name
 
+      # @return [Integer, nil] sector size in bytes
+      attr_reader :sector_size
+
       # Constructor
       #
       # @note: creating a SecureKey object does not generate a new record for it
       # in the keys database. See {#generate}.
       #
       # @param name [String] see {#name}
-      def initialize(name)
+      # @param sector_size [Integer, nil] see {#sector_size}
+      def initialize(name, sector_size: nil)
         @name = name
         @volume_entries = []
+        @sector_size = sector_size
       end
 
       # Whether the key contains an entry in its list of volumes referencing the
@@ -108,9 +113,9 @@ module Y2Storage
           "--name", name,
           "--xts",
           "--keybits", "256",
-          "--volume-type", "LUKS2",
-          "--sector-size", "4096"
+          "--volume-type", "LUKS2"
         ]
+        args += ["--sector-size", sector_size.to_s] if sector_size
         args += ["--volumes", volume_entries.map(&:to_s).join(",")] if volume_entries.any?
 
         Yast::Execute.locally(ZKEY, "generate", *args)
@@ -209,9 +214,9 @@ module Y2Storage
         # @param volumes [Array<Encryption>] encryption devices to register in
         #   the "volumes" section of the new key
         # @return [SecureKey] an object representing the new key
-        def generate(name, volumes: [])
+        def generate(name, sector_size: nil, volumes: [])
           name = exclusive_name(name)
-          key = new(name)
+          key = new(name, sector_size: sector_size)
           volumes.each { |vol| key.add_device(vol) }
           key.generate
           key
@@ -220,9 +225,28 @@ module Y2Storage
         # Finds an existing secure key that references the given device in
         # one of its "volumes" entries
         #
+        # @param device [BlkDevice] Block device to search the secure key for
         # @return [SecureKey, nil] nil if no key is found for the device
         def for_device(device)
           all.find { |key| key.for_device?(device) }
+        end
+
+        # Parses the representation of a secure key, in the format used by
+        # "zkey list", and returns a SecureKey object representing it
+        #
+        # @param string [String] portion of the output of "zkey list" that
+        #   represents a concrete secure key
+        def new_from_zkey(string)
+          lines = string.lines
+          attrs = lines.map { |l| l.split(":", 2) }.each_with_object({}) do |parts, all|
+            next if parts.size != 2
+
+            all[parts[0].strip] = parts[1].strip
+          end
+          sector_size = attrs["Sector size"].start_with?(/\d/) ? attrs["Sector size"].to_i : nil
+          key = new(attrs["Key"], sector_size: sector_size)
+          key.add_zkey_volumes(string)
+          key
         end
 
         private
@@ -236,19 +260,6 @@ module Y2Storage
 
           entries = output&.split("\n\n") || []
           entries.map { |entry| new_from_zkey(entry) }
-        end
-
-        # Parses the representation of a secure key, in the format used by
-        # "zkey list", and returns a SecureKey object representing it
-        #
-        # @param string [String] portion of the output of "zkey list" that
-        #   represents a concrete secure key
-        def new_from_zkey(string)
-          lines = string.lines
-          name = lines.first.strip.split(/\s/).last
-          key = new(name)
-          key.add_zkey_volumes(string)
-          key
         end
 
         # Returns the name that is available for a new key taking original_name

--- a/src/lib/y2storage/encryption_processes/secure_key.rb
+++ b/src/lib/y2storage/encryption_processes/secure_key.rb
@@ -213,6 +213,8 @@ module Y2Storage
         # @param name [String] temptative name for the new key
         # @param volumes [Array<Encryption>] encryption devices to register in
         #   the "volumes" section of the new key
+        # @param sector_size [Integer,nil] sector size to set in the register.
+        #   Use the nil to use the system's default.
         # @return [SecureKey] an object representing the new key
         def generate(name, sector_size: nil, volumes: [])
           name = exclusive_name(name)

--- a/src/lib/y2storage/encryption_processes/volatile.rb
+++ b/src/lib/y2storage/encryption_processes/volatile.rb
@@ -28,15 +28,6 @@ module Y2Storage
     # password generated at boot time. Generally, the new password is generated based on
     # /dev/urandom data (see {EncryptionMethod::RandomSwap}), but IBM offers other mechanisms for z
     # Systems (see {EncryptionMethod::ProtectedSwap} and {EncryptionMethod::SecureSwap} processes).
-    #
-    # ## Encryption and open options
-    #
-    # When using volatile encryption, there are a few options that should be present in the
-    # `/etc/crypttab`: the cipher method, the key size and the sector size. Additionally, the `swap`
-    # option should be present too. See {#crypt_options}.
-    #
-    # In a similar way, it is expected to specify these options (except `swap`) when running the
-    # luksOpen command (see {#open_options}).
     class Volatile < Base
       SWAP_OPTION = "swap".freeze
       private_constant :SWAP_OPTION
@@ -141,6 +132,28 @@ module Y2Storage
         return nil unless key_size?
 
         "--key-size '#{key_size}'"
+      end
+
+      # Sector size option for the encryption
+      #
+      # @param blk_device [BlkDevice] Block device to encrypt
+      # @return [String, nil] nil if no specific sector size
+      def sector_size_option(blk_device)
+        sector_size = sector_size_for(blk_device)
+        return nil unless sector_size
+
+        "sector-size=#{sector_size}"
+      end
+
+      # Sector size option to open the encryption device
+      #
+      # @param blk_device [BlkDevice] Block device to encrypt
+      # @return [String, nil] nil if no specific sector size
+      def sector_size_open_option(blk_device)
+        sector_size = sector_size_for(blk_device)
+        return nil unless sector_size
+
+        "--sector-size '#{sector_size}'"
       end
     end
   end

--- a/src/lib/y2storage/encryption_processes/volatile.rb
+++ b/src/lib/y2storage/encryption_processes/volatile.rb
@@ -35,27 +35,23 @@ module Y2Storage
       attr_reader :key_file
       attr_reader :cipher
       attr_reader :key_size
-      attr_reader :sector_size
 
       # Constructor
       #
       # @param key_file [String]         Path to the key file
       # @param cipher   [String,nil]     Cipher type
       # @param key_size [Integer,nil]    Key size
-      # @param sector_size [Integer,nil] Sector size
-      def initialize(method, key_file: nil, cipher: nil, key_size: nil, sector_size: nil)
+      def initialize(method, key_file: nil, cipher: nil, key_size: nil)
         super(method)
         @key_file = key_file
         @cipher = cipher
         @key_size = key_size
-        @sector_size = sector_size
       end
 
       # @see Base#create_device
       def create_device(blk_device, dm_name)
         enc = super
         enc.key_file = key_file if key_file
-        enc.crypt_options = crypt_options + enc.crypt_options
         enc
       end
 
@@ -65,16 +61,18 @@ module Y2Storage
 
       # Encryption options to add to the encryption device (crypttab options)
       #
+      # @param blk_device [BlkDevice] Block device to encrypt
       # @return [Array<String>]
-      def crypt_options
-        [swap_option, cipher_option, key_size_option, sector_size_option].compact
+      def crypt_options(blk_device)
+        [swap_option, cipher_option, key_size_option, sector_size_option(blk_device)].compact
       end
 
       # Encryption options to open the encryption device
       #
+      # @param blk_device [BlkDevice] Block device to encrypt
       # @return [Array<String>]
-      def open_options
-        [cipher_open_option, key_size_open_option, sector_size_open_option].compact
+      def open_options(blk_device)
+        [cipher_open_option, key_size_open_option, sector_size_open_option(blk_device)].compact
       end
 
       # Wheter a specific cipher is used
@@ -92,8 +90,11 @@ module Y2Storage
       end
 
       # Whether a specific sector size is used
-      def sector_size?
-        !sector_size.nil?
+      #
+      # @param blk_device [BlkDevice] Block device to encrypt
+      # @return [Boolean]
+      def sector_size?(blk_device)
+        !sector_size(blk_device).nil?
       end
 
       private
@@ -125,11 +126,12 @@ module Y2Storage
 
       # Sector size option for the encryption
       #
+      # @param blk_device [BlkDevice] Block device to encrypt
       # @return [String, nil] nil if no specific sector size
-      def sector_size_option
-        return nil unless sector_size?
+      def sector_size_option(blk_device)
+        return nil unless sector_size?(blk_device)
 
-        "sector-size=#{sector_size}"
+        "sector-size=#{sector_size(blk_device)}"
       end
 
       # Cipher option to open the encryption device
@@ -152,11 +154,25 @@ module Y2Storage
 
       # Sector size option to open the encryption device
       #
+      # @param blk_device [BlkDevice] Block device to encrypt
       # @return [String, nil] nil if no specific sector size
-      def sector_size_open_option
-        return nil unless sector_size?
+      def sector_size_open_option(blk_device)
+        return nil unless sector_size?(blk_device)
 
-        "--sector-size '#{sector_size}'"
+        "--sector-size '#{sector_size(blk_device)}'"
+      end
+
+      IDEAL_SECTOR_SIZE = 4096
+
+      # Sector size for a given device
+      #
+      # For performance reasons, it tries to use 4k when possible. Otherwise, it returns
+      # nil so the default is used.
+      #
+      # @param blk_device [BlkDevice] Block device to encrypt
+      # @return [Integer,nil]
+      def sector_size(blk_device)
+        return IDEAL_SECTOR_SIZE if blk_device.region.block_size >= IDEAL_SECTOR_SIZE
       end
     end
   end

--- a/src/lib/y2storage/encryption_processes/volatile.rb
+++ b/src/lib/y2storage/encryption_processes/volatile.rb
@@ -28,6 +28,15 @@ module Y2Storage
     # password generated at boot time. Generally, the new password is generated based on
     # /dev/urandom data (see {EncryptionMethod::RandomSwap}), but IBM offers other mechanisms for z
     # Systems (see {EncryptionMethod::ProtectedSwap} and {EncryptionMethod::SecureSwap} processes).
+    #
+    # ## Encryption and open options
+    #
+    # When using volatile encryption, there are a few options that should be present in the
+    # `/etc/crypttab`: the cipher method, the key size and the sector size. Additionally, the `swap`
+    # option should be present too. See {#crypt_options}.
+    #
+    # In a similar way, it is expected to specify these options (except `swap`) when running the
+    # luksOpen command (see {#open_options}).
     class Volatile < Base
       SWAP_OPTION = "swap".freeze
       private_constant :SWAP_OPTION

--- a/src/lib/y2storage/encryption_processes/volatile.rb
+++ b/src/lib/y2storage/encryption_processes/volatile.rb
@@ -89,14 +89,6 @@ module Y2Storage
         !key_size.nil?
       end
 
-      # Whether a specific sector size is used
-      #
-      # @param blk_device [BlkDevice] Block device to encrypt
-      # @return [Boolean]
-      def sector_size?(blk_device)
-        !sector_size(blk_device).nil?
-      end
-
       private
 
       # Swap option for the crypttab file
@@ -124,16 +116,6 @@ module Y2Storage
         "size=#{key_size}"
       end
 
-      # Sector size option for the encryption
-      #
-      # @param blk_device [BlkDevice] Block device to encrypt
-      # @return [String, nil] nil if no specific sector size
-      def sector_size_option(blk_device)
-        return nil unless sector_size?(blk_device)
-
-        "sector-size=#{sector_size(blk_device)}"
-      end
-
       # Cipher option to open the encryption device
       #
       # @return [String, nil] nil if no specific cipher
@@ -150,29 +132,6 @@ module Y2Storage
         return nil unless key_size?
 
         "--key-size '#{key_size}'"
-      end
-
-      # Sector size option to open the encryption device
-      #
-      # @param blk_device [BlkDevice] Block device to encrypt
-      # @return [String, nil] nil if no specific sector size
-      def sector_size_open_option(blk_device)
-        return nil unless sector_size?(blk_device)
-
-        "--sector-size '#{sector_size(blk_device)}'"
-      end
-
-      IDEAL_SECTOR_SIZE = 4096
-
-      # Sector size for a given device
-      #
-      # For performance reasons, it tries to use 4k when possible. Otherwise, it returns
-      # nil so the default is used.
-      #
-      # @param blk_device [BlkDevice] Block device to encrypt
-      # @return [Integer,nil]
-      def sector_size(blk_device)
-        return IDEAL_SECTOR_SIZE if blk_device.region.block_size >= IDEAL_SECTOR_SIZE
       end
     end
   end

--- a/test/data/zkey/list-no-sector-size.txt
+++ b/test/data/zkey/list-no-sector-size.txt
@@ -1,0 +1,16 @@
+Key                          : YaST_cr_ccw-0X0150-part4                              
+-------------------------------------------------------------------------------------
+        Description          : 
+        Secure key size      : 128 bytes
+        Clear key size       : 512 bits
+        XTS type key         : Yes
+        Volumes              : (none)
+        APQNs                : (none)
+        Key file name        : /etc/zkey/repository/test.skey
+        Sector size          : (system default)
+        Volume type          : LUKS2
+        Verification pattern : df3f05854fb735a6f9ce4d9e1b79429a
+                               23a7ff44cf2bded878aee481fa1e31c7
+        Created              : 2019-10-11 09:19:30
+        Changed              : (never)
+        Re-enciphered        : (never) 

--- a/test/y2storage/crypttab_test.rb
+++ b/test/y2storage/crypttab_test.rb
@@ -88,7 +88,7 @@ describe Y2Storage::Crypttab do
         expect(device.encryption.method.to_sym).to eq(encryption_method)
       end
 
-      it "uses the crypttab name for the new encrytion device" do
+      it "uses the crypttab name for the new encryption device" do
         subject.save_encryption_names(devicegraph)
 
         expect(device.encryption.basename).to eq("luks1")

--- a/test/y2storage/encryption_processes/pervasive_test.rb
+++ b/test/y2storage/encryption_processes/pervasive_test.rb
@@ -72,32 +72,9 @@ describe Y2Storage::EncryptionProcesses::Pervasive do
       end
     end
 
-    context "when the block size of the underlying device is greater than 4k" do
-      let(:block_size) { Y2Storage::DiskSize.new(8192) }
-
-      it "sets the sector-size encryption option to 4096" do
-        encryption = subject.create_device(blk_device, dm_name)
-        expect(encryption.crypt_options).to include("sector-size=4096")
-      end
-    end
-
-    context "when the block size of the underlying device is 4k" do
-      let(:block_size) { Y2Storage::DiskSize.new(4096) }
-
-      it "sets the sector-size encryption option to 4096" do
-        encryption = subject.create_device(blk_device, dm_name)
-        expect(encryption.crypt_options).to include("sector-size=4096")
-      end
-
-    end
-
-    context "when the block size of the underlying less than 4k" do
-      let(:block_size) { Y2Storage::DiskSize.new(2048) }
-
-      it "does not set the sector-size option" do
-        encryption = subject.create_device(blk_device, dm_name)
-        expect(encryption.crypt_options).to_not include("sector-size=2048")
-      end
+    it "does not set any option for secure key" do
+      encryption = subject.create_device(blk_device, dm_name)
+      expect(encryption.crypt_options).to be_empty
     end
 
     it "does not set any open option for secure key" do

--- a/test/y2storage/encryption_processes/pervasive_test.rb
+++ b/test/y2storage/encryption_processes/pervasive_test.rb
@@ -29,20 +29,44 @@ describe Y2Storage::EncryptionProcesses::Pervasive do
   let(:devicegraph) { Y2Partitioner::DeviceGraphs.instance.current }
   let(:blk_device) { Y2Storage::BlkDevice.find_by_name(devicegraph, "/dev/sda") }
   let(:dm_name) { "cr_sda" }
+  let(:zkey_cryptsetup) do
+    "cryptsetup luksFormat --foo bar --dummy /dev/dasdc1\n" \
+      "zkey-cryptsetup setvp --volumes /dev/dasdc1\n" \
+      "third-command"
+  end
+
+  let(:secure_key) { nil }
 
   before do
     devicegraph_stub("empty_hard_disk_50GiB.yml")
+    allow(Yast::Execute).to receive(:locally)
+      .with(/zkey/, "cryptsetup", "--volumes", "/dev/dasdc1", anything)
+      .and_return(zkey_cryptsetup)
+    allow(Y2Storage::EncryptionProcesses::SecureKey).to receive(:for_device)
+      .and_return(secure_key)
   end
 
   describe "#create_device" do
     it "returns an encryption device" do
       encryption = process.create_device(blk_device, dm_name)
       expect(encryption.is?(:encryption)).to eq(true)
+      expect(encryption.dm_table_name).to eq("cr_sda")
     end
 
     it "creates an luks2 encryption device for given block device" do
       encryption = process.create_device(blk_device, dm_name)
       expect(encryption.type).to eq(Y2Storage::EncryptionType::LUKS2)
+    end
+
+    context "when a secure key for the device was found" do
+      let(:secure_key) do
+        instance_double(Y2Storage::EncryptionProcesses::SecureKey, dm_name: "cr_custom")
+      end
+
+      it "uses the dm name from the key" do
+        encryption = process.create_device(blk_device, dm_name)
+        expect(encryption.dm_table_name).to eq("cr_custom")
+      end
     end
 
     it "does not set any specific encryption option" do
@@ -53,6 +77,68 @@ describe Y2Storage::EncryptionProcesses::Pervasive do
     it "does not set any specific open option" do
       encryption = subject.create_device(blk_device, dm_name)
       expect(encryption.open_options).to be_empty
+    end
+  end
+
+  describe "#pre_commit" do
+    let(:encryption) { subject.create_device(blk_device, dm_name) }
+
+    let(:secure_key) { nil }
+
+    let(:generated_key) do
+      instance_double(Y2Storage::EncryptionProcesses::SecureKey,
+        plain_name: "/dev/dasdc1", dm_name: "cr_1", name: "secure_xtskey1")
+    end
+
+    before do
+      allow(Y2Storage::EncryptionProcesses::SecureKey).to receive(:generate)
+        .and_return(generated_key)
+    end
+
+    it "generates a new secure key for the device" do
+      expect(Y2Storage::EncryptionProcesses::SecureKey).to receive(:generate)
+        .with("YaST_cr_sda", volumes: [encryption]).and_return(generated_key)
+      subject.pre_commit(encryption)
+    end
+
+    context "when a secure key for the device was found" do
+      let(:secure_key) { generated_key }
+
+      it "does not generate a new secure key" do
+        expect(Y2Storage::EncryptionProcesses::SecureKey).to_not receive(:generate)
+        subject.pre_commit(encryption)
+      end
+    end
+
+    it "sets LUKS format options" do
+      subject.pre_commit(encryption)
+      expect(encryption.format_options).to include("--foo bar --dummy --pbkdf pbkdf2")
+    end
+  end
+
+  describe "#post_commit" do
+    let(:encryption) { subject.create_device(blk_device, dm_name) }
+
+    let(:secure_key) do
+      instance_double(Y2Storage::EncryptionProcesses::SecureKey,
+        plain_name: "/dev/dasdc1", dm_name: "cr_1", name: "secure_xtskey1")
+    end
+
+    before do
+      subject.pre_commit(encryption)
+    end
+
+    it "executes commands reported by zkey cryptsetup skipping the first one" do
+      expect(Yast::Execute).to receive(:locally).with(/zkey-cryptsetup/, any_args)
+      expect(Yast::Execute).to receive(:locally).with("third-command")
+      subject.post_commit(encryption)
+    end
+
+    it "adds the --key-file option to the setvp command" do
+      allow(Yast::Execute).to receive(:locally)
+      expect(Yast::Execute).to receive(:locally)
+        .with(/zkey-cryptsetup/, "setvp", "--volumes", "/dev/dasdc1", "--key-file", "-", any_args)
+      subject.post_commit(encryption)
     end
   end
 end

--- a/test/y2storage/encryption_processes/pervasive_test.rb
+++ b/test/y2storage/encryption_processes/pervasive_test.rb
@@ -79,11 +79,6 @@ describe Y2Storage::EncryptionProcesses::Pervasive do
         encryption = subject.create_device(blk_device, dm_name)
         expect(encryption.crypt_options).to include("sector-size=4096")
       end
-
-      it "sets the sector-size open option for secure key" do
-        encryption = subject.create_device(blk_device, dm_name)
-        expect(encryption.open_options).to include("--sector-size '4096'")
-      end
     end
 
     context "when the block size of the underlying device is 4k" do
@@ -94,10 +89,6 @@ describe Y2Storage::EncryptionProcesses::Pervasive do
         expect(encryption.crypt_options).to include("sector-size=4096")
       end
 
-      it "sets the sector-size open option for secure key" do
-        encryption = subject.create_device(blk_device, dm_name)
-        expect(encryption.open_options).to include("--sector-size '4096'")
-      end
     end
 
     context "when the block size of the underlying less than 4k" do
@@ -107,11 +98,11 @@ describe Y2Storage::EncryptionProcesses::Pervasive do
         encryption = subject.create_device(blk_device, dm_name)
         expect(encryption.crypt_options).to_not include("sector-size=2048")
       end
+    end
 
-      it "sets the sector-size open option for secure key" do
-        encryption = subject.create_device(blk_device, dm_name)
-        expect(encryption.open_options).to_not include("--sector-size '2048'")
-      end
+    it "does not set any open option for secure key" do
+      encryption = subject.create_device(blk_device, dm_name)
+      expect(encryption.open_options).to be_empty
     end
   end
 

--- a/test/y2storage/encryption_processes/secure_key_test.rb
+++ b/test/y2storage/encryption_processes/secure_key_test.rb
@@ -1,0 +1,86 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::EncryptionProcesses::SecureKey do
+  def zkey_output(file)
+    File.read(File.join(DATA_PATH, "zkey", "#{file}.txt"))
+  end
+
+  subject(:key) { described_class.new("cr", sector_size: 2048) }
+
+  describe ".for_device" do
+    before do
+      fake_scenario("several-dasds")
+
+      allow(Yast::Execute).to receive(:locally).with(/zkey/, "list", any_args)
+        .and_return(zkey_list)
+    end
+
+    let(:manager) { Y2Storage::StorageManager.instance }
+    let(:zkey_list) { zkey_output("list-no-dasdc1") }
+    let(:blk_device) { manager.staging.find_by_name("/dev/dasdb1") }
+
+    it "returns the secure key for the given device" do
+      key = described_class.for_device(blk_device)
+      expect(key).to be_for_device(blk_device)
+      expect(key.sector_size).to eq(4096)
+    end
+  end
+
+  describe ".new_from_zkey" do
+    let(:zkey_list) { zkey_output("list-no-dasdc1") }
+
+    it "returns a secure key using the values from the string" do
+      key = described_class.new_from_zkey(zkey_list)
+      expect(key.sector_size).to eq(4096)
+    end
+
+    context "when the sector size is not defined" do
+      let(:zkey_list) { zkey_output("list-no-sector-size") }
+      it "sets the sector size to nil" do
+        key = described_class.new_from_zkey(zkey_list)
+        expect(key.sector_size).to be_nil
+      end
+    end
+  end
+
+  describe "#generate" do
+    it "runs zkey to create the a LUKS2 key with the given name and sector size" do
+      expect(Yast::Execute).to receive(:locally).with(
+        "/usr/bin/zkey", "generate", "--name", key.name, "--xts", "--keybits", "256",
+        "--volume-type", "LUKS2", "--sector-size", key.sector_size.to_s
+      )
+      key.generate
+    end
+
+    context "when sector size is not set" do
+      subject(:key) { described_class.new("cr") }
+
+      it "does not specify any sector size value" do
+        expect(Yast::Execute).to receive(:locally) do |*args|
+          expect(args).to_not include("--sector-size")
+        end
+
+        key.generate
+      end
+    end
+  end
+end

--- a/test/y2storage/encryption_processes/volatile_test.rb
+++ b/test/y2storage/encryption_processes/volatile_test.rb
@@ -26,9 +26,9 @@ describe Y2Storage::EncryptionProcesses::Volatile do
   subject do
     described_class.new(
       method,
-      key_file:    key_file,
-      cipher:      cipher,
-      key_size:    key_size
+      key_file: key_file,
+      cipher:   cipher,
+      key_size: key_size
     )
   end
 
@@ -50,7 +50,7 @@ describe Y2Storage::EncryptionProcesses::Volatile do
 
     let(:dm_name) { "cr_sda" }
 
-    let(:block_size) { 4096 }
+    let(:block_size) { Y2Storage::DiskSize.new(4096) }
 
     let(:region) { instance_double(Y2Storage::Region, block_size: block_size) }
 
@@ -130,8 +130,8 @@ describe Y2Storage::EncryptionProcesses::Volatile do
       end
     end
 
-    context "when the block size of ther underlying device is greater than 4k" do
-      let(:block_size) { 8192 }
+    context "when the block size of the underlying device is greater than 4k" do
+      let(:block_size) { Y2Storage::DiskSize.new(8192) }
 
       it "sets the sector-size encryption option to 4096" do
         encryption = subject.create_device(device, dm_name)
@@ -144,8 +144,8 @@ describe Y2Storage::EncryptionProcesses::Volatile do
       end
     end
 
-    context "when the block size of ther underlying device is 4k" do
-      let(:block_size) { 4096 }
+    context "when the block size of the underlying device is 4k" do
+      let(:block_size) { Y2Storage::DiskSize.new(4096) }
 
       it "sets the sector-size encryption option to 4096" do
         encryption = subject.create_device(device, dm_name)
@@ -158,15 +158,15 @@ describe Y2Storage::EncryptionProcesses::Volatile do
       end
     end
 
-    context "when the block size of ther underlying less than 4k" do
-      let(:block_size) { 2048 }
+    context "when the block size of the underlying less than 4k" do
+      let(:block_size) { Y2Storage::DiskSize.new(2048) }
 
       it "does not set the sector-size option" do
         encryption = subject.create_device(device, dm_name)
         expect(encryption.crypt_options).to_not include("sector-size=2048")
       end
 
-      it "sets the sector-size open option for secure key" do
+      it "does not set the sector-size open option for secure key" do
         encryption = subject.create_device(device, dm_name)
         expect(encryption.open_options).to_not include("--sector-size '2048'")
       end

--- a/test/y2storage/encryption_processes/volatile_test.rb
+++ b/test/y2storage/encryption_processes/volatile_test.rb
@@ -28,8 +28,7 @@ describe Y2Storage::EncryptionProcesses::Volatile do
       method,
       key_file:    key_file,
       cipher:      cipher,
-      key_size:    key_size,
-      sector_size: sector_size
+      key_size:    key_size
     )
   end
 
@@ -38,11 +37,11 @@ describe Y2Storage::EncryptionProcesses::Volatile do
   let(:key_file) { "/sys/some-key" }
   let(:cipher) { "paes-xts-plain64" }
   let(:key_size) { 1024 }
-  let(:sector_size) { 4096 }
 
   describe "#create_device" do
     before do
       fake_scenario("empty_hard_disk_50GiB")
+      allow(device).to receive(:region).and_return(region)
     end
 
     let(:devicegraph) { Y2Storage::StorageManager.instance.staging }
@@ -50,6 +49,10 @@ describe Y2Storage::EncryptionProcesses::Volatile do
     let(:device) { devicegraph.find_by_name("/dev/sda") }
 
     let(:dm_name) { "cr_sda" }
+
+    let(:block_size) { 4096 }
+
+    let(:region) { instance_double(Y2Storage::Region, block_size: block_size) }
 
     it "returns an encryption device" do
       result = subject.create_device(device, dm_name)
@@ -127,27 +130,45 @@ describe Y2Storage::EncryptionProcesses::Volatile do
       end
     end
 
-    it "sets the sector-size encyption option" do
-      encryption = subject.create_device(device, dm_name)
-      expect(encryption.crypt_options).to include("sector-size=4096")
-    end
+    context "when the block size of ther underlying device is greater than 4k" do
+      let(:block_size) { 8192 }
 
-    it "sets the sector-size open option for secure key" do
-      encryption = subject.create_device(device, dm_name)
-      expect(encryption.open_options).to include("--sector-size '4096'")
-    end
-
-    context "when the sector size is not defined" do
-      let(:sector_size) { nil }
-
-      it "does not set the sector-size encyption option" do
+      it "sets the sector-size encryption option to 4096" do
         encryption = subject.create_device(device, dm_name)
-        expect(encryption.crypt_options).to_not include("sector-size=4096")
+        expect(encryption.crypt_options).to include("sector-size=4096")
       end
 
       it "sets the sector-size open option for secure key" do
         encryption = subject.create_device(device, dm_name)
-        expect(encryption.open_options).to_not include("--sector-size '4096'")
+        expect(encryption.open_options).to include("--sector-size '4096'")
+      end
+    end
+
+    context "when the block size of ther underlying device is 4k" do
+      let(:block_size) { 4096 }
+
+      it "sets the sector-size encryption option to 4096" do
+        encryption = subject.create_device(device, dm_name)
+        expect(encryption.crypt_options).to include("sector-size=4096")
+      end
+
+      it "sets the sector-size open option for secure key" do
+        encryption = subject.create_device(device, dm_name)
+        expect(encryption.open_options).to include("--sector-size '4096'")
+      end
+    end
+
+    context "when the block size of ther underlying less than 4k" do
+      let(:block_size) { 2048 }
+
+      it "does not set the sector-size option" do
+        encryption = subject.create_device(device, dm_name)
+        expect(encryption.crypt_options).to_not include("sector-size=2048")
+      end
+
+      it "sets the sector-size open option for secure key" do
+        encryption = subject.create_device(device, dm_name)
+        expect(encryption.open_options).to_not include("--sector-size '2048'")
       end
     end
   end


### PR DESCRIPTION
Set the encryption sector size according to the underlying device.

* If it is 4k or bigger, set the sector-size to 4k for performance reasons.
* If it is smaller than 4k, just do the default (do not set any sector size).
