### PR TITLE
Fix encrypted grub warning

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Fri Oct 18 15:20:01 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Avoid false warning about booting from LUKS2 in s390.
+- Avoid false warning about booting from LUKS2 in s390
+  (related to jsc#SLE-7376).
 
 -------------------------------------------------------------------
 Wed Oct 16 14:09:42 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Oct 18 21:01:14 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix translation of some encryption related widgets (bsc#1154364).
+- 4.2.50
+
+-------------------------------------------------------------------
 Fri Oct 18 15:20:01 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Avoid false warning about booting from LUKS2 in s390

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Oct 18 15:20:01 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Avoid false warning about booting from LUKS2 in s390.
+
+-------------------------------------------------------------------
 Wed Oct 16 14:09:42 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - If a given device cannot be mounted by the method configured as

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.49
+Version:        4.2.50
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/widgets/encrypt_method_options.rb
+++ b/src/lib/y2partitioner/widgets/encrypt_method_options.rb
@@ -91,6 +91,7 @@ module Y2Partitioner
       #
       # @param controller [Actions::Controllers::Encryption]
       def initialize(controller)
+        textdomain "storage"
         @controller = controller
       end
 
@@ -119,6 +120,7 @@ module Y2Partitioner
       # @param controller [Actions::Controllers::Encryption]
       # @param enable [Boolean] whether the widget should be enabled on init
       def initialize(controller, enable: true)
+        textdomain "storage"
         @controller = controller
         @enable_on_init = enable
       end

--- a/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
@@ -321,6 +321,40 @@ module Y2Storage
         end
       end
 
+      # Device (planned or from the devicegraph) containing the "/boot/zipl" path
+      #
+      # @see #planned_devices
+      # @see #devicegraph
+      #
+      # @return [Filesystems::Base, Planned::Device, nil] nil if there is no
+      #   filesystem or plan for anything containing "/boot/zipl"
+      def device_for_zipl
+        zipl_planned_dev || zipl_filesystem
+      end
+
+      # Planned device for a separate /boot
+      #
+      # @return [Planned::Device, nil] nil if no separate /boot is planned
+      def zipl_planned_dev
+        @zipl_planned_dev ||= planned_for_mountpoint("/boot/zipl")
+      end
+
+      # Filesystem mounted at /boot
+      #
+      # @return [Filesystems::Base, nil] nil if there is no separate filesystem for /boot
+      def zipl_filesystem
+        @zipl_filesystem ||= filesystem_for_mountpoint("/boot/zipl")
+      end
+
+      # Whether the filesystem containing /boot/zipl is going to be in an encrypted device
+      #
+      # @return [Boolean] true if the filesystem where /boot/zipl resides is going to
+      #   be in an encrypted device. False if such filesystem is unknown (not in
+      #   the planned devices or in the devicegraph) or is not encrypted.
+      def encrypted_zipl?
+        encrypted?(device_for_zipl)
+      end
+
       protected
 
       attr_reader :devicegraph

--- a/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
@@ -332,16 +332,16 @@ module Y2Storage
         zipl_planned_dev || zipl_filesystem
       end
 
-      # Planned device for a separate /boot
+      # Planned device for a separate /boot/zipl
       #
-      # @return [Planned::Device, nil] nil if no separate /boot is planned
+      # @return [Planned::Device, nil] nil if no separate /boot/zipl is planned
       def zipl_planned_dev
         @zipl_planned_dev ||= planned_for_mountpoint("/boot/zipl")
       end
 
-      # Filesystem mounted at /boot
+      # Filesystem mounted at /boot/zipl
       #
-      # @return [Filesystems::Base, nil] nil if there is no separate filesystem for /boot
+      # @return [Filesystems::Base, nil] nil if there is no separate filesystem for /boot/zipl
       def zipl_filesystem
         @zipl_filesystem ||= filesystem_for_mountpoint("/boot/zipl")
       end

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -83,7 +83,7 @@ module Y2Storage
       def warnings
         res = []
 
-        if !encrypted_for_grub?
+        if !readable_grub?
           error_message =
             _(
               "The boot loader cannot access the file system mounted at /boot. " \
@@ -147,7 +147,7 @@ module Y2Storage
       end
 
       def boot_partition_needed?
-        !encrypted_for_grub?
+        !readable_grub?
       end
 
       def too_small_boot?
@@ -213,10 +213,15 @@ module Y2Storage
         SetupError.new(message: error_message)
       end
 
-      # Whether the boot device is encrypted and grub can decrypt it
+      # Whether the boot device can be read by grub
       #
-      # @return [Boolean] true if grub can decrypt boot device (or it is unencrypted)
-      def encrypted_for_grub?
+      # The boot device can be read by grub when:
+      #
+      # * it is not encrypted (obviously),
+      # * or it is encrypted using LUKS1.
+      #
+      # @return [Boolean] true if grub can read decrypt boot device (or it is unencrypted)
+      def readable_grub?
         t = boot_encryption_type
         t.is?(:none) || t.is?(:luks1)
       end

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -83,7 +83,7 @@ module Y2Storage
       def warnings
         res = []
 
-        if !readable_grub?
+        if !boot_readable_by_grub?
           error_message =
             _(
               "The boot loader cannot access the file system mounted at /boot. " \
@@ -147,7 +147,7 @@ module Y2Storage
       end
 
       def boot_partition_needed?
-        !readable_grub?
+        !boot_readable_by_grub?
       end
 
       def too_small_boot?
@@ -220,8 +220,8 @@ module Y2Storage
       # * it is not encrypted (obviously),
       # * or it is encrypted using LUKS1.
       #
-      # @return [Boolean] true if grub can read decrypt boot device (or it is unencrypted)
-      def readable_grub?
+      # @return [Boolean] true if grub can read the boot device
+      def boot_readable_by_grub?
         t = boot_encryption_type
         t.is?(:none) || t.is?(:luks1)
       end

--- a/src/lib/y2storage/boot_requirements_strategies/zipl.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/zipl.rb
@@ -119,6 +119,7 @@ module Y2Storage
       # @see Base#readable_grub?
       def readable_grub?
         return true if super
+
         analyzer.device_for_zipl && !analyzer.encrypted_zipl?
       end
     end

--- a/src/lib/y2storage/boot_requirements_strategies/zipl.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/zipl.rb
@@ -110,6 +110,17 @@ module Y2Storage
         )
         SetupError.new(message: error_message)
       end
+
+      # Whether the grub partition is readable
+      #
+      # Even if the /boot partition is encrypted using a technology different from
+      # LUKS1, it is possible to read it if theres is an unencrypted zipl partition.
+      #
+      # @see Base#readable_grub?
+      def readable_grub?
+        return true if super
+        analyzer.device_for_zipl && !analyzer.encrypted_zipl?
+      end
     end
   end
 end

--- a/src/lib/y2storage/boot_requirements_strategies/zipl.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/zipl.rb
@@ -116,8 +116,11 @@ module Y2Storage
       # Even if the /boot partition is encrypted using a technology different from
       # LUKS1, it is possible to read it if theres is an unencrypted zipl partition.
       #
-      # @see Base#readable_grub?
-      def readable_grub?
+      # /boot/zipl contains a kernel that will take care of activating the device containing
+      # /boot, so Grub will find it accessible.
+      #
+      # @see Base#boot_readable_by_grub?
+      def boot_readable_by_grub?
         return true if super
 
         analyzer.device_for_zipl && !analyzer.encrypted_zipl?

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -658,8 +658,7 @@ module Y2Storage
     end
 
     ENCRYPTION_METHOD_ALIASES = {
-      "luks"  => "luks1",
-      "luks2" => "pervasive_luks2"
+      "luks" => "luks1"
     }.freeze
     private_constant :ENCRYPTION_METHOD_ALIASES
     # Factory method to create an encryption layer.

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -657,6 +657,11 @@ module Y2Storage
       disk_name
     end
 
+    ENCRYPTION_METHOD_ALIASES = {
+      "luks"  => "luks1",
+      "luks2" => "pervasive_luks2"
+    }.freeze
+    private_constant :ENCRYPTION_METHOD_ALIASES
     # Factory method to create an encryption layer.
     #
     # @param parent [String] parent device name ("/dev/sda1" etc.)
@@ -673,11 +678,13 @@ module Y2Storage
       name = encryption_name(args["name"], parent)
       password = args["password"]
       type_name = args["type"] || "luks"
+      type_name = ENCRYPTION_METHOD_ALIASES[type_name] if ENCRYPTION_METHOD_ALIASES.key?(type_name)
       # We only support creating LUKS so far
-      raise ArgumentError, "Unsupported encryption type #{type_name}" unless type_name == "luks"
+      method = EncryptionMethod.find(type_name)
+      raise ArgumentError, "Unsupported encryption type #{type_name}" unless method
 
       blk_parent = BlkDevice.find_by_name(@devicegraph, parent)
-      encryption = blk_parent.encrypt(dm_name: name, password: password)
+      encryption = blk_parent.encrypt(dm_name: name, password: password, method: method)
       if @file_system_data.key?(parent)
         # Notify create_file_system that this partition is encrypted
         @file_system_data[parent]["encryption"] = encryption.name

--- a/test/data/devicegraphs/s390_luks2.yml
+++ b/test/data/devicegraphs/s390_luks2.yml
@@ -1,0 +1,117 @@
+# 2019-10-02 06:31:24 -0400
+---
+- dasd:
+    name: "/dev/dasda"
+    size: 1602720 KiB (1.53 GiB)
+    block_size: 4 KiB
+    io_size: 0 B
+    min_grain: 1 MiB
+    align_ofs: 0 B
+    type: eckd
+    format: cdl
+    partition_table: dasd
+    partitions:
+    - free:
+        size: 96 KiB
+        start: 0 B
+    - partition:
+        size: 1602624 KiB (1.53 GiB)
+        start: 96 KiB
+        name: "/dev/dasda1"
+        type: primary
+        id: linux
+- dasd:
+    name: "/dev/dasdb"
+    size: 1602720 KiB (1.53 GiB)
+    block_size: 4 KiB
+    io_size: 0 B
+    min_grain: 1 MiB
+    align_ofs: 0 B
+    type: eckd
+    format: cdl
+    partition_table: dasd
+    partitions:
+    - free:
+        size: 96 KiB
+        start: 0 B
+    - partition:
+        size: 1602624 KiB (1.53 GiB)
+        start: 96 KiB
+        name: "/dev/dasdb1"
+        type: primary
+        id: linux
+        encryption:
+          type: pervasive_luks2
+          name: "/dev/mapper/cr-auto-4"
+- dasd:
+    name: "/dev/dasdc"
+    size: 7042.5 MiB (6.88 GiB)
+    block_size: 4 KiB
+    io_size: 0 B
+    min_grain: 1 MiB
+    align_ofs: 0 B
+    type: eckd
+    format: cdl
+    partition_table: dasd
+    partitions:
+    - free:
+        size: 3 MiB
+        start: 0 B
+    - partition:
+        size: 300 MiB
+        start: 3 MiB
+        name: "/dev/dasdc1"
+        type: primary
+        id: linux
+        encryption:
+          type: pervasive_luks2
+          name: "/dev/mapper/cr-auto-3"
+    - partition:
+        size: 300 MiB
+        start: 303 MiB
+        name: "/dev/dasdc2"
+        type: primary
+        id: linux
+        file_system: ext2
+        mount_point: "/boot/zipl"
+        encryption:
+          type: pervasive_luks2
+          name: "/dev/mapper/cr_zipl"
+          password: "***"
+    - partition:
+        size: 6438 MiB (6.29 GiB)
+        start: 603 MiB (0.59 GiB)
+        name: "/dev/dasdc3"
+        type: primary
+        id: linux
+        file_system: btrfs
+        mount_point: "/"
+        btrfs:
+          default_subvolume: "@"
+          subvolumes:
+          - subvolume:
+              path: "@"
+          - subvolume:
+              path: "@/home"
+          - subvolume:
+              path: "@/root"
+          - subvolume:
+              path: "@/tmp"
+          - subvolume:
+              path: "@/boot/grub2/s390x-emu"
+          - subvolume:
+              path: "@/opt"
+          - subvolume:
+              path: "@/srv"
+          - subvolume:
+              path: "@/usr/local"
+          - subvolume:
+              path: "@/var"
+              nocow: true
+        encryption:
+          type: pervasive_luks2
+          name: "/dev/mapper/cr_ccw-0X0150-part3"
+          password: "***"
+    - free:
+        size: 1.5 MiB
+        start: 7041 MiB (6.88 GiB)

--- a/test/y2storage/boot_requirements_strategies/analyzer_test.rb
+++ b/test/y2storage/boot_requirements_strategies/analyzer_test.rb
@@ -524,7 +524,9 @@ describe Y2Storage::BootRequirementsStrategies::Analyzer do
     end
 
     context "if '/boot/zipl' is a planned encrypted partition" do
-      let(:planned_zipl) { planned_partition(mount_point: "/boot/zipl", encryption_password: "12345678") }
+      let(:planned_zipl) do
+        planned_partition(mount_point: "/boot/zipl", encryption_password: "12345678")
+      end
 
       it "returns true" do
         expect(analyzer.encrypted_zipl?).to eq true

--- a/test/y2storage/boot_requirements_strategies/analyzer_test.rb
+++ b/test/y2storage/boot_requirements_strategies/analyzer_test.rb
@@ -511,6 +511,54 @@ describe Y2Storage::BootRequirementsStrategies::Analyzer do
     end
   end
 
+  describe "#encrypted_zipl?" do
+    subject(:analyzer) { described_class.new(devicegraph, planned_devs, boot_name) }
+    let(:planned_devs) { [planned_zipl] }
+
+    context "if '/boot/zipl' is a planned plain partition" do
+      let(:planned_zipl) { planned_partition(mount_point: "/boot/zipl") }
+
+      it "returns false" do
+        expect(analyzer.encrypted_zipl?).to eq false
+      end
+    end
+
+    context "if '/boot/zipl' is a planned encrypted partition" do
+      let(:planned_zipl) { planned_partition(mount_point: "/boot/zipl", encryption_password: "12345678") }
+
+      it "returns true" do
+        expect(analyzer.encrypted_zipl?).to eq true
+      end
+    end
+
+    context "if '/boot/zipl' is a plain partition from the devicegraph" do
+      let(:planned_devs) { [] }
+      let(:scenario) { "output/s390_dasd_zipl" }
+
+      it "returns false" do
+        expect(analyzer.encrypted_zipl?).to eq false
+      end
+    end
+
+    xcontext "if '/boot/zipl' is an encrypted partition from the devicegraph" do
+      let(:planned_devs) { [] }
+      let(:scenario) { "s390_luks2" }
+
+      it "returns true" do
+        expect(analyzer.encrypted_zipl?).to eq true
+      end
+    end
+
+    context "if no device or planned device is configured as '/boot/zipl'" do
+      let(:planned_devs) { [] }
+      let(:scenario) { "several-dasds" }
+
+      it "returns false" do
+        expect(analyzer.encrypted_zipl?).to eq false
+      end
+    end
+  end
+
   describe "#btrfs_root?" do
     subject(:analyzer) { described_class.new(devicegraph, planned_devs, boot_name) }
     let(:ext4) { Y2Storage::Filesystems::Type::EXT4 }

--- a/test/y2storage/boot_requirements_strategies/analyzer_test.rb
+++ b/test/y2storage/boot_requirements_strategies/analyzer_test.rb
@@ -542,7 +542,7 @@ describe Y2Storage::BootRequirementsStrategies::Analyzer do
       end
     end
 
-    xcontext "if '/boot/zipl' is an encrypted partition from the devicegraph" do
+    context "if '/boot/zipl' is an encrypted partition from the devicegraph" do
       let(:planned_devs) { [] }
       let(:scenario) { "s390_luks2" }
 

--- a/test/y2storage/boot_requirements_strategies/zipl_test.rb
+++ b/test/y2storage/boot_requirements_strategies/zipl_test.rb
@@ -1,0 +1,66 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::BootRequirementsStrategies::ZIPL do
+  subject { described_class.new(fake_devicegraph, [], "/dev/dasdc") }
+
+  before do
+    fake_scenario("s390_luks2")
+    allow(Y2Storage::BootRequirementsStrategies::Analyzer).to receive(:new).and_return(analyzer)
+    allow(analyzer).to receive(:device_for_zipl).and_return(device_for_zipl)
+    allow(analyzer).to receive(:encrypted_zipl?).and_return(encrypted_zipl?)
+  end
+
+  let(:analyzer) do
+    Y2Storage::BootRequirementsStrategies::Analyzer.new(fake_devicegraph, [], "/dev/dasdc")
+  end
+
+  let(:device_for_zipl) { double("zipl") }
+  let(:encrypted_zipl?) { false }
+
+  context "when the boot partition is encrypted using LUKS2" do
+    context "and the zipl partition is encrypted" do
+      let(:encrypted_zipl?) { true }
+
+      it "returns a warning" do
+        messages = subject.warnings.map(&:message)
+        expect(messages).to include(/The boot loader cannot access the file system/)
+      end
+    end
+
+    context "and the zipl partition is unencrypted" do
+      it "does not return any warning" do
+        messages = subject.warnings.map(&:message)
+        expect(messages).to_not include(/The boot loader cannot access the file system/)
+      end
+    end
+
+    context "and the zipl partition is not present" do
+      let(:device_for_zipl) { nil }
+
+      it "returns a warning" do
+        messages = subject.warnings.map(&:message)
+        expect(messages).to include(/The boot loader cannot access the file system/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://trello.com/c/JqMeJJbq/1353-1-avoid-false-warning-about-booting-from-luks2-in-s390.

This PR contains the version bump: https://github.com/yast/yast-storage-ng/pull/984.