### PR TITLE
AutoYaST: CT_DMMULTIPATH handling

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 23 11:51:58 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: consider CT_DMMULTIPATH an alias of CT_DISK (related
+  to bsc#1130988).
+- 4.1.90
+
+-------------------------------------------------------------------
 Wed Oct 16 14:09:42 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - If a given device cannot be mounted by the method configured as

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.1.89
+Version:        4.1.90
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/autoinst_profile/partitioning_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partitioning_section.rb
@@ -95,11 +95,14 @@ module Y2Storage
         drives.map(&:to_hashes)
       end
 
+      DISK_DRIVE_TYPES = [:CT_DISK, :CT_DMMULTIPATH].freeze
+      private_constant :DISK_DRIVE_TYPES
+
       # Drive sections with type :CT_DISK
       #
       # @return [Array<DriveSection>]
       def disk_drives
-        drives.select { |d| d.type == :CT_DISK }
+        drives.select { |d| DISK_DRIVE_TYPES.include?(d.type) }
       end
 
       # Drive sections with type :CT_LVM

--- a/src/lib/y2storage/proposal/autoinst_devices_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_devices_planner.rb
@@ -82,7 +82,7 @@ module Y2Storage
       # @return [Array<Planned::Device>, nil] nil if the device cannot be planned
       def planned_for_drive(drive, disk_name)
         case drive.type
-        when :CT_DISK
+        when :CT_DISK, :CT_DMMULTIPATH
           planned_for_disk_device(drive, disk_name)
         when :CT_LVM
           planned_for_vg(drive)

--- a/src/lib/y2storage/proposal/autoinst_drives_map.rb
+++ b/src/lib/y2storage/proposal/autoinst_drives_map.rb
@@ -211,7 +211,7 @@ module Y2Storage
       # @see Y2Storage::Devicegraph#find_by_any_name
       #
       # @param devicegraph [Devicegraph]
-      # @param device_name [String, nil] e.g., "/dev/sda"
+      # @param device_name [String] e.g., "/dev/sda"
       #
       # @return [Disk, nil] Usable disk or nil if none is found
       def find_disk(devicegraph, device_name)

--- a/test/y2storage/autoinst_profile/partitioning_section_test.rb
+++ b/test/y2storage/autoinst_profile/partitioning_section_test.rb
@@ -185,6 +185,7 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
     let(:drive7) { double("DriveSection", type: :CT_DISK) }
     let(:drive8) { double("DriveSection", type: :CT_BCACHE) }
     let(:drive9) { double("DriveSection", type: :CT_NFS) }
+    let(:drive10) { double("DriveSection", type: :CT_DMMULTIPATH) }
     let(:wrongdrv1) { double("DriveSection", device: "/dev/md", type: :CT_DISK) }
     let(:wrongdrv2) { double("DriveSection", device: "/dev/sdc", type: :CT_MD) }
     let(:wrongdrv3) { double("DriveSection", device: "/dev/sdd", type: :CT_WRONG) }
@@ -193,14 +194,14 @@ describe Y2Storage::AutoinstProfile::PartitioningSection do
 
     before do
       section.drives = [
-        drive1, drive2, drive3, drive4, drive5, drive6, drive7, drive8, drive9,
+        drive1, drive2, drive3, drive4, drive5, drive6, drive7, drive8, drive9, drive10,
         wrongdrv1, wrongdrv2, wrongdrv3, wrongdrv4, wrongdrv5
       ]
     end
 
     describe "#disk_drives" do
-      it "returns drives which type is :CT_DISK, even if they look invalid" do
-        expect(section.disk_drives).to contain_exactly(drive1, drive2, drive7, wrongdrv1)
+      it "returns drives which type is :CT_DISK or :CT_DMMULTIPATH, even if they look invalid" do
+        expect(section.disk_drives).to contain_exactly(drive1, drive2, drive7, drive10, wrongdrv1)
       end
     end
 

--- a/test/y2storage/proposal/autoinst_devices_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_devices_planner_test.rb
@@ -55,6 +55,32 @@ describe Y2Storage::Proposal::AutoinstDevicesPlanner do
   end
 
   describe "#planned_devices" do
+    context "using CT_DISK as type" do
+      let(:partitioning_array) do
+        [{
+          "type" => :CT_DISK, "partitions" => [{ "mount" => "/" }]
+        }]
+      end
+
+      it "plans a disk device" do
+        devices = planner.planned_devices(drives_map)
+        expect(devices.disks).to_not be_empty
+      end
+    end
+
+    context "using CT_DMMULTIPATH as type" do
+      let(:partitioning_array) do
+        [{
+          "type" => :CT_DMMULTIPATH, "partitions" => [{ "mount" => "/" }]
+        }]
+      end
+
+      it "plans a disk device" do
+        devices = planner.planned_devices(drives_map)
+        expect(devices.disks).to_not be_empty
+      end
+    end
+
     context "using NFS with the old format" do
       let(:partitioning_array) do
         [{


### PR DESCRIPTION
Treat CT_DMMULTIPATH as an alias to CT_DISK.

* https://trello.com/c/wd3xE1Wq/1349-3-compatibility-and-documentation-for-autoyastmultipath