### PR TITLE
Speed up initial proposal on systems with many disks

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 23 13:35:49 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Proposal: in the initial attempt, consider only up to ten disks
+  (bsc#1154070).
+- 4.0.222
+
+-------------------------------------------------------------------
 Wed Jul 10 11:31:18 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Add execute permissions to test files (bsc#1141006).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.221
+Version:        4.0.222
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/guided_proposal.rb
+++ b/src/lib/y2storage/guided_proposal.rb
@@ -213,7 +213,11 @@ module Y2Storage
       return @populated_settings if @populated_settings
 
       populated = settings.dup
-      populated.candidate_devices ||= disk_analyzer.candidate_disks.map(&:name)
+      # In the initial attempt, before the user has had any opportunity to
+      # select the candidate devices, consider only the first 10 disks.
+      # Otherwise, the process to find the optimal layout can be very slow
+      # specially if LVM is enabled by default for the product. See bsc#1154070
+      populated.candidate_devices ||= disk_analyzer.candidate_disks.map(&:name)[0, 10]
 
       @populated_settings = populated
     end


### PR DESCRIPTION
## Problem

As reported in [bug#1154070](https://bugzilla.suse.com/show_bug.cgi?id=1154070), the initial storage proposal, before the user has had any chance to select the disks, is very slow in SLE 15 for SAP in systems with many disks (40 in the case of the report). That's a consequence of SLE for SAP using LVM by default, which is much slower than the partition-based proposal.

## Solution

This limits that initial attempt to the first 10 disks on the system in all cases, not only SLE for SAP. To be honest, in any system with so many disks it's kind of expected the user will run the Guided Setup or the Expert Partitioner anyways (the possibilities for the automatic initial proposal to match user expectations with so many disks is almost zero).

## Testing

Tested manually. With 10 disks the calculation is much, much faster.
