### PR TITLE
fix creation of secure key for new partitions (bsc#1154267)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct 28 14:22:24 CET 2019 - aschnell@suse.com
+
+- fix creation of secure key for new partitions (bsc#1154267)
+- 4.2.52
+
+-------------------------------------------------------------------
 Wed Oct 23 11:51:58 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: consider CT_DMMULTIPATH an alias of CT_DISK (related

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.51
+Version:        4.2.52
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -51,10 +51,7 @@ module Y2Storage
       # @see Base#pre_commit
       #
       # If there is no secure key to be used for this device, a new key is
-      # generated. In addition to that, the "zkey cryptsetup" command is
-      # executed to know the sequence of commands that must be used to set the
-      # pervasive encryption and the LUKS format options are adjusted
-      # accordingly.
+      # generated.
       #
       # @param device [Encryption] encryption that will be created in the system
       def pre_commit(device)
@@ -63,19 +60,30 @@ module Y2Storage
         # API to allow sharing a new key among several volumes.
         @secure_key ||= generate_secure_key(device)
 
-        @zkey_cryptsetup_output = execute_zkey_cryptsetup(device)
-        return if @zkey_cryptsetup_output.empty?
+        master_key_file = "/etc/zkey/repository/#{@secure_key.name}.skey"
+        sector_size = sector_size_for(device.blk_device)
 
-        device.format_options = luksformat_options_string + " --pbkdf pbkdf2"
+        device.format_options = "--master-key-file #{master_key_file.shellescape} --key-size 1024 "\
+                                "--cipher paes-xts-plain64"
+        device.format_options += " --sector-size #{sector_size}" if sector_size
+        device.format_options += " --pbkdf pbkdf2"
       end
 
       # @see Base#post_commit
       #
-      # Executes the extra commands reported by the former call to
-      # "zkey cryptsetup".
+      # Adds the device to the secure key if needed and executes the
+      # extra commands reported by a call to "zkey cryptsetup".
       #
       # @param device [Encryption] encryption that has just been created in the system
       def post_commit(device)
+        if !@secure_key.for_device?(device)
+          secure_key_volume = @secure_key.add_device(device)
+
+          Yast::Execute.locally(ZKEY, "change", "--name", secure_key.name, "--volumes",
+            "+#{secure_key_volume.plain_name.shellescape}:#{secure_key_volume.dm_name.shellescape}")
+        end
+
+        zkey_cryptsetup_output = execute_zkey_cryptsetup(device)
         commands = zkey_cryptsetup_output[1..-1]
         return if commands.nil?
 
@@ -127,8 +135,9 @@ module Y2Storage
         Recorder.new(Yast::Y2Logger.instance)
       end
 
-      # Generates a new secure key for the given encryption device and registers
-      # it into the keys database of the system
+      # Generates a new secure key for the given encryption device and
+      # registers it into the keys database of the system. The secure
+      # does not include the volume since that may not exist yet.
       #
       # @param device [Encryption]
       # @return [SecureKey]
@@ -136,7 +145,6 @@ module Y2Storage
         key_name = "YaST_#{device.dm_table_name}"
         key = SecureKey.generate(
           key_name,
-          volumes:     [device],
           sector_size: sector_size_for(device.blk_device)
         )
         log.info "Generated secure key #{key.name}"
@@ -152,17 +160,6 @@ module Y2Storage
         name = secure_key.plain_name(device)
         command = [ZKEY, "cryptsetup", "--volumes", name]
         Yast::Execute.locally(*command, stdout: :capture)&.lines&.map(&:strip) || []
-      end
-
-      # Options to be passed to the "cryptsetup luksFormat" during the commit
-      # phase
-      #
-      # @see Luks#format_options
-      #
-      # @return [String]
-      def luksformat_options_string
-        luksformat_command = zkey_cryptsetup_output.first
-        luksformat_command.split("luksFormat ").last.gsub(/ \/dev[^\s]*/, "")
       end
     end
   end

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -80,7 +80,7 @@ module Y2Storage
           secure_key_volume = @secure_key.add_device(device)
 
           Yast::Execute.locally(ZKEY, "change", "--name", secure_key.name, "--volumes",
-            "+#{secure_key_volume.plain_name.shellescape}:#{secure_key_volume.dm_name.shellescape}")
+            "+#{secure_key_volume}")
         end
 
         zkey_cryptsetup_output = execute_zkey_cryptsetup(device)

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -60,7 +60,7 @@ module Y2Storage
         # API to allow sharing a new key among several volumes.
         @secure_key ||= generate_secure_key(device)
 
-        master_key_file = "/etc/zkey/repository/#{@secure_key.name}.skey"
+        master_key_file = @secure_key.filename
         sector_size = sector_size_for(device.blk_device)
 
         device.format_options = "--master-key-file #{master_key_file.shellescape} --key-size 1024 "\

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -76,12 +76,7 @@ module Y2Storage
       #
       # @param device [Encryption] encryption that has just been created in the system
       def post_commit(device)
-        if !@secure_key.for_device?(device)
-          secure_key_volume = @secure_key.add_device(device)
-
-          Yast::Execute.locally(ZKEY, "change", "--name", secure_key.name, "--volumes",
-            "+#{secure_key_volume}")
-        end
+        @secure_key.add_device_and_write(device) unless @secure_key.for_device?(device)
 
         zkey_cryptsetup_output = execute_zkey_cryptsetup(device)
         commands = zkey_cryptsetup_output[1..-1]

--- a/src/lib/y2storage/encryption_processes/secure_key.rb
+++ b/src/lib/y2storage/encryption_processes/secure_key.rb
@@ -99,8 +99,10 @@ module Y2Storage
       #   saving the volume entry in the keys database.
       #
       # @param device [Encryption]
+      # @return [SecureKeyVolume] the newly added SecureKeyVolume
       def add_device(device)
         @volume_entries << SecureKeyVolume.new_from_encryption(device)
+        @volume_entries.last
       end
 
       # Registers the key in the keys database by invoking "zkey generate"

--- a/src/lib/y2storage/encryption_processes/secure_key.rb
+++ b/src/lib/y2storage/encryption_processes/secure_key.rb
@@ -105,6 +105,19 @@ module Y2Storage
         @volume_entries.last
       end
 
+      # Adds the given device to the list of volumes registered for this key
+      #
+      # @param device [Encryption]
+      # @return [SecureKeyVolume] the newly added SecureKeyVolume
+      def add_device_and_write(device)
+        secure_key_volume = add_device(device)
+
+        Yast::Execute.locally(ZKEY, "change", "--name", name, "--volumes",
+          "+#{secure_key_volume}")
+
+        secure_key_volume
+      end
+
       # Registers the key in the keys database by invoking "zkey generate"
       #
       # The generated key will have the name and the list of volumes from this

--- a/src/lib/y2storage/encryption_processes/secure_key.rb
+++ b/src/lib/y2storage/encryption_processes/secure_key.rb
@@ -146,6 +146,13 @@ module Y2Storage
         @volume_entries += volumes.map { |str| SecureKeyVolume.new_from_str(str) }
       end
 
+      # Full filename of the secure key file.
+      #
+      # @return [String]
+      def filename
+        File.join(repo_dir, name + ".skey")
+      end
+
       # Copies the files of this key from the current keys repository to the
       # repository of a target system
       #

--- a/test/y2storage/encryption_processes/pervasive_test.rb
+++ b/test/y2storage/encryption_processes/pervasive_test.rb
@@ -161,7 +161,7 @@ describe Y2Storage::EncryptionProcesses::Pervasive do
 
     let(:secure_key_volume) do
       instance_double(Y2Storage::EncryptionProcesses::SecureKeyVolume,
-        plain_name: "/dev/dasdc1", dm_name: "cr_1")
+        plain_name: "/dev/dasdc1", dm_name: "cr_1", to_s: "/dev/dasdc1:cr_1")
     end
 
     before do

--- a/test/y2storage/encryption_processes/pervasive_test.rb
+++ b/test/y2storage/encryption_processes/pervasive_test.rb
@@ -90,7 +90,8 @@ describe Y2Storage::EncryptionProcesses::Pervasive do
 
     let(:generated_key) do
       instance_double(Y2Storage::EncryptionProcesses::SecureKey,
-        plain_name: "/dev/dasdc1", dm_name: "cr_1", name: "secure_xtskey1")
+        plain_name: "/dev/dasdc1", dm_name: "cr_1", name: "secure_xtskey1",
+        filename: "/etc/zkey/repository/secure_xtskey1.skey")
     end
 
     before do
@@ -156,7 +157,8 @@ describe Y2Storage::EncryptionProcesses::Pervasive do
 
     let(:secure_key) do
       instance_double(Y2Storage::EncryptionProcesses::SecureKey,
-        plain_name: "/dev/dasdc1", dm_name: "cr_1", name: "secure_xtskey1")
+        plain_name: "/dev/dasdc1", dm_name: "cr_1", name: "secure_xtskey1",
+        filename: "/etc/zkey/repository/secure_xtskey1.skey")
     end
 
     let(:secure_key_volume) do

--- a/test/y2storage/encryption_processes/pervasive_test.rb
+++ b/test/y2storage/encryption_processes/pervasive_test.rb
@@ -172,12 +172,7 @@ describe Y2Storage::EncryptionProcesses::Pervasive do
 
     it "executes commands reported by zkey cryptsetup skipping the first one" do
       allow(secure_key).to receive(:for_device?).and_return(false)
-
-      expect(secure_key).to receive(:add_device).and_return(secure_key_volume)
-
-      expect(Yast::Execute).to receive(:locally).with(/zkey/, "change", "--name", "secure_xtskey1",
-        "--volumes", "+/dev/dasdc1:cr_1", any_args)
-
+      expect(secure_key).to receive(:add_device_and_write).and_return(secure_key_volume)
       expect(Yast::Execute).to receive(:locally).with(/zkey-cryptsetup/, any_args)
       expect(Yast::Execute).to receive(:locally).with("third-command")
       subject.post_commit(encryption)

--- a/test/y2storage/encryption_processes/secure_key_test.rb
+++ b/test/y2storage/encryption_processes/secure_key_test.rb
@@ -63,7 +63,7 @@ describe Y2Storage::EncryptionProcesses::SecureKey do
   end
 
   describe "#generate" do
-    it "runs zkey to create the a LUKS2 key with the given name and sector size" do
+    it "runs zkey to create the LUKS2 key with the given name and sector size" do
       expect(Yast::Execute).to receive(:locally).with(
         "/usr/bin/zkey", "generate", "--name", key.name, "--xts", "--keybits", "256",
         "--volume-type", "LUKS2", "--sector-size", key.sector_size.to_s
@@ -81,6 +81,12 @@ describe Y2Storage::EncryptionProcesses::SecureKey do
 
         key.generate
       end
+    end
+  end
+
+  describe "#filename" do
+    it "returns the correct filename" do
+      expect(key.filename).to eq("/etc/zkey/repository/cr.skey")
     end
   end
 end

--- a/test/y2storage/encryption_processes/secure_key_test.rb
+++ b/test/y2storage/encryption_processes/secure_key_test.rb
@@ -89,4 +89,21 @@ describe Y2Storage::EncryptionProcesses::SecureKey do
       expect(key.filename).to eq("/etc/zkey/repository/cr.skey")
     end
   end
+
+  describe "#add_device_and_write" do
+    let(:blk_device) do
+      instance_double(Y2Storage::BlkDevice, udev_full_ids: ["/dev/dasdc1"])
+    end
+
+    let(:device) do
+      instance_double(Y2Storage::Encryption, blk_device: blk_device, dm_table_name: "cr_1")
+    end
+
+    it "calls zkey to add the volume" do
+      expect(Yast::Execute).to receive(:locally).with(/zkey/, "change", "--name", "cr",
+        "--volumes", "+/dev/dasdc1:cr_1", any_args)
+
+      key.add_device_and_write(device)
+    end
+  end
 end

--- a/test/y2storage/pervasive_encryption_test.rb
+++ b/test/y2storage/pervasive_encryption_test.rb
@@ -100,11 +100,11 @@ describe "pervasive encryption" do
       context "if the 'zkey cryptsetup' command fails" do
         let(:zkey_cryptsetup) { nil }
 
-        it "does not modify the options for 'cryptsetup luksFormat'" do
+        it "anyway sets options for 'cryptsetup luksFormat'" do
           enc = blk_device.encrypt(method: pervasive)
           manager.commit
 
-          expect(enc.format_options).to be_empty
+          expect(enc.format_options).to include("--master-key-file")
         end
       end
 
@@ -115,11 +115,11 @@ describe "pervasive encryption" do
             "third command"
         end
 
-        it "generates arguments for 'cryptsetup luksFormat'" do
+        it "ignores arguments from 'zkey' for 'cryptsetup luksFormat'" do
           enc = blk_device.encrypt(method: pervasive)
           manager.commit
 
-          expect(enc.format_options).to eq "--one two --three --pbkdf pbkdf2"
+          expect(enc.format_options).to_not include("--one two")
         end
 
         it "executes the post-commit commands providing the password when needed" do
@@ -166,7 +166,7 @@ describe "pervasive encryption" do
       it "tries to generate a new secure key with the appropriate name and arguments" do
         expect(Yast::Execute).to receive(:locally).with(
           /zkey/, "generate", "--name", "YaST_cr_dasdc1_1", "--xts", "--keybits", "256",
-          "--volume-type", "LUKS2", "--sector-size", "4096", "--volumes", "/dev/dasdc1:cr_dasdc1"
+          "--volume-type", "LUKS2", "--sector-size", "4096"
         )
 
         blk_device.encrypt(method: pervasive)


### PR DESCRIPTION
## Problem

The secure key creation fails if the block device does not exist yet.

## Solution

The secure key is first created without the device information and later the device information is added to the secure key.

## Testing

- Updated and added unit tests.
- Tested manually.
