### PR TITLE
AutoYaST: avoid repeating filesystem elements for Btrfs multidevice filesystems

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Nov  6 11:49:35 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: do not repeat filesystem related information when
+  cloning multidevice Btrfs filesystems (bsc#1148578).
+- AutoYaST: do not export the enable_snapshots element for drive
+  which do not contain the root filesystem.
+- 4.2.54
+
+-------------------------------------------------------------------
 Wed Oct 30 09:55:48 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: add support to set the encryption method (related to

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -3,7 +3,7 @@ Wed Nov  6 11:49:35 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: do not repeat filesystem related information when
   cloning multidevice Btrfs filesystems (bsc#1148578).
-- AutoYaST: do not export the enable_snapshots element for drive
+- AutoYaST: do not export the enable_snapshots element for drives
   which do not contain the root filesystem.
 - 4.2.54
 

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.53
+Version:        4.2.54
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -623,7 +623,7 @@ module Y2Storage
         end
       end
 
-      # Determined whether the section is describine a multi-device Btrfs filesystem
+      # Determines whether the section is describing a multi-device Btrfs filesystem
       #
       # @return [Boolean]
       def btrfs_drive_section?

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -283,7 +283,7 @@ module Y2Storage
         return unless device.is?(:blk_device)
 
         init_encryption_fields(device)
-        init_filesystem_fields(device)
+        init_filesystem_fields(device) unless device.filesystem&.multidevice?
 
         # NOTE: The old AutoYaST exporter does not report the real size here.
         # It intentionally reports one cylinder less. Cylinders is an obsolete

--- a/test/data/devicegraphs/root_md_raid.yml
+++ b/test/data/devicegraphs/root_md_raid.yml
@@ -1,0 +1,86 @@
+---
+- disk:
+    name: "/dev/sda"
+    size: 50 GiB
+    block_size: 0.5 KiB
+    io_size: 0 B
+    min_grain: 1 MiB
+    align_ofs: 0 B
+    partition_table: gpt
+    partitions:
+    - free:
+        size: 1 MiB
+        start: 0 B
+    - partition:
+        size: 10 GiB
+        start: 1 MiB
+        name: "/dev/sda1"
+        type: primary
+        id: raid
+    - partition:
+        size: 10 GiB
+        start: 10241 MiB (10.00 GiB)
+        name: "/dev/sda2"
+        type: primary
+        id: raid
+    - partition:
+        size: 31456239.5 KiB (30.00 GiB)
+        start: 20481 MiB (20.00 GiB)
+        name: "/dev/sda3"
+        type: primary
+        id: linux
+    - free:
+        size: 16.5 KiB
+        start: 52428783.5 KiB (50.00 GiB)
+- md:
+    name: "/dev/md/md0"
+    md_level: raid0
+    md_parity: default
+    chunk_size: 32 KiB
+    md_devices:
+    - md_device:
+        blk_device: "/dev/sda1"
+    - md_device:
+        blk_device: "/dev/sda2"
+    file_system: btrfs
+    mount_point: "/"
+    btrfs:
+        default_subvolume: "@"
+        subvolumes:
+        - subvolume:
+            path: "@/home"
+            nocow: false
+        - subvolume:
+            path: "@/srv"
+            nocow: false
+        - subvolume:
+            path: "@/tmp"
+            nocow: false
+        - subvolume:
+            path: "@/usr/local"
+            nocow: false
+        - subvolume:
+            path: "@/var/cache"
+            nocow: false
+        - subvolume:
+            path: "@/var/crash"
+            nocow: false
+        - subvolume:
+            path: "@/log"
+            nocow: false
+        - subvolume:
+            path: "@/opt"
+            nocow: false
+        - subvolume:
+            path: "@/var/lib/mariadb"
+            nocow: true
+        - subvolume:
+            path: "@/var/lib/mysql"
+            nocow: true
+        - subvolume:
+            path: "@/var/lib/pgsql"
+            nocow: true
+        - subvolume:
+            path: "@/.snapshots"
+        - subvolume:
+            path: "@/.snapshots/1/snapshot"

--- a/test/data/devicegraphs/root_partitioned_md_raid.yml
+++ b/test/data/devicegraphs/root_partitioned_md_raid.yml
@@ -1,0 +1,115 @@
+# 2019-11-06 10:06:31 +0000
+---
+- disk:
+    name: "/dev/vda"
+    size: 20 GiB
+    block_size: 0.5 KiB
+    io_size: 0 B
+    min_grain: 1 MiB
+    align_ofs: 0 B
+    partition_table: gpt
+    partitions:
+    - free:
+        size: 1 MiB
+        start: 0 B
+    - partition:
+        size: 8 MiB
+        start: 1 MiB
+        name: "/dev/vda1"
+        type: primary
+        id: bios_boot
+    - partition:
+        size: 20962287.5 KiB (19.99 GiB)
+        start: 9 MiB
+        name: "/dev/vda2"
+        type: primary
+        id: raid
+    - free:
+        size: 16.5 KiB
+        start: 20971503.5 KiB (20.00 GiB)
+- disk:
+    name: "/dev/vdb"
+    size: 20 GiB
+    block_size: 0.5 KiB
+    io_size: 0 B
+    min_grain: 1 MiB
+    align_ofs: 0 B
+    partition_table: gpt
+    partitions:
+    - free:
+        size: 1 MiB
+        start: 0 B
+    - partition:
+        size: 20970479.5 KiB (20.00 GiB)
+        start: 1 MiB
+        name: "/dev/vdb1"
+        type: primary
+        id: raid
+    - free:
+        size: 16.5 KiB
+        start: 20971503.5 KiB (20.00 GiB)
+- md:
+    name: "/dev/md0"
+    md_level: raid0
+    md_parity: default
+    chunk_size: 64 KiB
+    md_uuid: ''
+    in_etc_mdadm: true
+    metadata: ''
+    partition_table: gpt
+    partitions:
+    - free:
+        size: 1 MiB
+        start: 0 B
+    - partition:
+        size: 39 GiB
+        start: 1 MiB
+        name: "/dev/md0p1"
+        type: primary
+        id: linux
+        file_system: btrfs
+        mount_point: "/"
+        btrfs:
+          default_subvolume: "@"
+          subvolumes:
+          - subvolume:
+              path: "@"
+          - subvolume:
+              path: "@/boot/grub2/i386-pc"
+          - subvolume:
+              path: "@/var"
+              nocow: true
+          - subvolume:
+              path: "@/root"
+          - subvolume:
+              path: "@/usr/local"
+          - subvolume:
+              path: "@/opt"
+          - subvolume:
+              path: "@/boot/grub2/x86_64-efi"
+          - subvolume:
+              path: "@/home"
+          - subvolume:
+              path: "@/tmp"
+          - subvolume:
+              path: "@/srv"
+          - subvolume:
+              path: "@/.snapshots"
+          - subvolume:
+              path: "@/.snapshots/1/snapshot"
+    - partition:
+        size: 775023.5 KiB (0.74 GiB)
+        start: 39937 MiB (39.00 GiB)
+        name: "/dev/md0p2"
+        type: primary
+        id: swap
+        file_system: swap
+        mount_point: swap
+    - free:
+        size: 16.5 KiB
+        start: 41670511.5 KiB (39.74 GiB)
+    md_devices:
+    - md_device:
+        blk_device: "/dev/vda2"
+    - md_device:
+        blk_device: "/dev/vdb1"

--- a/test/y2storage/autoinst_profile/partition_section_test.rb
+++ b/test/y2storage/autoinst_profile/partition_section_test.rb
@@ -544,6 +544,21 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
       end
     end
 
+    context "given a partition which is part of a Btrfs multidevice" do
+      let(:scenario) { "btrfs2-devicegraph.xml" }
+
+      it "includes the Btrfs name" do
+        expect(section_for("sdd1").btrfs_name).to eq("btrfs_63")
+      end
+
+      it "does not include filesystem attributes" do
+        section = section_for("sdd1")
+        expect(section.filesystem).to be_nil
+        expect(section.mkfs_options).to be_nil
+        expect(section.fstab_options).to be_nil
+      end
+    end
+
     context "if the device is formatted" do
       it "initializes #format to true for most partition ids" do
         expect(section_for("nvme0n1p1").format).to eq true


### PR DESCRIPTION
When exporting a Btrfs multidevice filesystem, the filesystem related information will be repeated for each component. For instance, the list of subvolumes will appear in all `<partition>` elements which are part of the Btrfs filesystem. See [bsc#1148578](https://bugzilla.suse.com/show_bug.cgi?id=1148578).

Additionally, this PR prevents exporting the `enable_snapshots` element when the `drive` section does not contain the root filesystem. The reason for this change is that snapshots will be applied [only to the root filesystem](https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2storage/proposal/autoinst_drive_planner.rb#L163), so it does not make sense in any other drive.