### PR TITLE
Add _netdev option to fstab and crypttab when needed (jsc#SLE-7687)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Nov 14 16:23:39 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Propagate the noauto, nofail and _netdev options from fstab
+  to crypttab (needed for jsc#SLE-7687).
+- Add the _netdev option to fstab for mount points on top of a
+  network-based device like iSCSI or FCoE (jsc#SLE-7687).
+- 4.2.56
+
+-------------------------------------------------------------------
 Tue Nov 12 11:27:38 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: allow to inject settings for the guided proposal

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.55
+Version:        4.2.56
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# RB_PASSWORD_REQUIRED
-BuildRequires:	libstorage-ng-ruby >= 4.2.15
+# Storage::MountPoint#default_mount_options
+BuildRequires:	libstorage-ng-ruby >= 4.2.27
 BuildRequires:  update-desktop-files
 # CWM::Dialog#next_handler (4.1 branch) and improved CWM::Dialog
 BuildRequires:  yast2 >= 4.1.11
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# RB_PASSWORD_REQUIRED
-Requires:       libstorage-ng-ruby >= 4.2.15
+# Storage::MountPoint#default_mount_options
+Requires:       libstorage-ng-ruby >= 4.2.27
 # CWM::Dialog#next_handler (4.1 branch) and improved CWM::Dialog
 Requires:       yast2 >= 4.1.11
 # Y2Packager::Repository

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -268,10 +268,9 @@ module Y2Partitioner
           # The mount point is not created if there is already a mount point
           return unless mount_point.nil?
 
-          options[:mount_options] ||= filesystem.type.default_mount_options(path)
-
           before_change_mount_point
-          filesystem.create_mount_point(path)
+          mp = filesystem.create_mount_point(path)
+          options[:mount_options] ||= mp.default_mount_options
           apply_mount_point_options(options)
           after_change_mount_point
         end
@@ -285,7 +284,8 @@ module Y2Partitioner
 
           before_change_mount_point
           mount_point.path = path
-          apply_mount_point_options({})
+          options = { mount_options: mount_point.default_mount_options }
+          apply_mount_point_options(options)
           after_change_mount_point
         end
 

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -279,14 +279,13 @@ module Y2Partitioner
         # Updates the current filesystem mount point
         #
         # @param path [String]
-        # @param options [Hash] options for the mount point (e.g., { mount_by: :uuid })
-        def update_mount_point(path, options = {})
+        def update_mount_point(path)
           return if mount_point.nil?
-          return if mount_point.path == path && (options.nil? || options.empty?)
+          return if mount_point.path == path
 
           before_change_mount_point
           mount_point.path = path
-          apply_mount_point_options(options)
+          apply_mount_point_options({})
           after_change_mount_point
         end
 
@@ -294,14 +293,13 @@ module Y2Partitioner
         # mount point is updated.
         #
         # @param path [String]
-        # @param options [Hash] options for the mount point (e.g., { mount_by: :uuid })
-        def create_or_update_mount_point(path, options = {})
+        def create_or_update_mount_point(path)
           return if filesystem.nil?
 
           if mount_point.nil?
-            create_mount_point(path, options)
+            create_mount_point(path, {})
           else
-            update_mount_point(path, options)
+            update_mount_point(path)
           end
         end
 

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -623,6 +623,13 @@ module Y2Storage
       end
     end
 
+    # Whether this is a network device
+    #
+    # @return [Boolean] true if this is a network-based disk or depends on one
+    def in_network?
+      false
+    end
+
     protected
 
     # Values for volume specification matching

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -312,6 +312,7 @@ module Y2Storage
       enc.password = password if password
       enc.ensure_suitable_mount_by
       enc.mount_point&.ensure_suitable_mount_by
+      enc.adjust_crypt_options
 
       Encryption.update_dm_names(devicegraph)
 

--- a/src/lib/y2storage/disk_device.rb
+++ b/src/lib/y2storage/disk_device.rb
@@ -33,13 +33,6 @@ module Y2Storage
       false
     end
 
-    # Checks whether it's in network
-    #
-    # @return [Boolean]
-    def in_network?
-      false
-    end
-
     # Checks whether the device is a multipath wire
     #
     # @return [Boolean]

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -68,6 +68,12 @@ module Y2Storage
     storage_forward :cipher=
 
     # @!attribute crypt_options
+    #   Options in the fourth field of /etc/crypttab
+    #
+    #   @note This returns an array based on the underlying SWIG vector,
+    #   modifying the returned object will have no effect in the Encryption
+    #   object. Use #crypt_options= to actually change the value.
+    #
     #   @return [Array<String>] options for the encryption
     storage_forward :crypt_options
 
@@ -283,6 +289,26 @@ module Y2Storage
       blk_device.in_network?
     end
 
+    # Options that must be propagated from the fstab entries of the mount points
+    # to the crypttab entries of the corresponding device
+    OPTIONS_TO_PROPAGATE = ["_netdev", "noauto", "nofail"]
+    private_constant :OPTIONS_TO_PROPAGATE
+
+    # Synchronizes {#crypt_options} with the {MountPoint#mount_options} of the
+    # mount points associated to this encryption device
+    #
+    # This must be called after creating a new encryption device and after
+    # modifying the options of any of the mount points associated to it.
+    def adjust_crypt_options
+      # Let's ignore mount points of subvolumes, since they usually only contain 'subvol=$path'.
+      # Moreover, libstorage-ng currently enforces that behavior.
+      mount_points = descendants.select { |d| d.is?(:filesystem) }.map(&:mount_point).compact
+
+      OPTIONS_TO_PROPAGATE.each do |opt|
+        propagate_mount_option(opt, mount_points)
+      end
+    end
+
     protected
 
     # @see Device#is?
@@ -340,6 +366,22 @@ module Y2Storage
     # @return [Array<Filesystems::MountByType>]
     def suitable_mount_bys
       Filesystems::MountByType.all.select { |type| suitable_mount_by?(type) }
+    end
+
+    # @see #adjust_crypt_options
+    #
+    # @param option [String] option from fstab and crypttab
+    # @param mount_points [Array<MountPoint>] relevant mount points associated
+    #   to the encryption device
+    def propagate_mount_option(option, mount_points)
+      in_mount_points = mount_points.all? { |mp| mp.mount_options.include?(option) }
+      in_encryption = crypt_options.include?(option)
+
+      if in_mount_points && !in_encryption
+        self.crypt_options = crypt_options + [option]
+      elsif !in_mount_points && in_encryption
+        self.crypt_options = crypt_options - [option]
+      end
     end
 
     class << self

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -278,6 +278,11 @@ module Y2Storage
       self.mount_by = Filesystems::MountByType.best_for(blk_device, suitable_mount_bys)
     end
 
+    # @see BlkDevice#in_network?
+    def in_network?
+      blk_device.in_network?
+    end
+
     protected
 
     # @see Device#is?

--- a/src/lib/y2storage/filesystems/base.rb
+++ b/src/lib/y2storage/filesystems/base.rb
@@ -77,6 +77,17 @@ module Y2Storage
         false
       end
 
+      # @see Mountable#extra_default_mount_options
+      #
+      # @return [Array<String>]
+      def extra_default_mount_options
+        if mount_point
+          (super + type.default_fstab_options(mount_path)).uniq
+        else
+          super
+        end
+      end
+
       # Whether the kernel name used to reference the filesystem (that is, the
       # one used when mounting via {Filesystems::MountByType::Device) is stable
       # and remains equal across system reboots

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -167,8 +167,7 @@ module Y2Storage
 
       # @return [Boolean]
       def in_network?
-        disks = ancestors.find_all { |d| d.is?(:disk) }
-        disks.any?(&:in_network?)
+        blk_devices.any?(&:in_network?)
       end
 
       # @see Base#stable_name?

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -170,6 +170,27 @@ module Y2Storage
         blk_devices.any?(&:in_network?)
       end
 
+      # Option used in the fstab file for devices that require network
+      NETWORK_OPTION = "_netdev".freeze
+      private_constant :NETWORK_OPTION
+
+      # @see Mountable#extra_default_mount_options
+      #
+      # @return [Array<String>]
+      def extra_default_mount_options
+        # Adding _netdev is implemented in BlkFilesystem so far.
+        #  - Fully network-based filesystems like NFS do not need it because systemd
+        #    always detect those right, without the need of _netdev.
+        #  - We don't specify extra options for Btrfs subvolumes because the current
+        #    libstorage-ng implementation would ignore them (BtrfsSubvolume#mount_options
+        #    is bypassed to only return subvol=$path).
+        if in_network?
+          (super + [NETWORK_OPTION]).uniq
+        else
+          super
+        end
+      end
+
       # @see Base#stable_name?
       def stable_name?
         blk_devices.all?(&:stable_name?)

--- a/src/lib/y2storage/lvm_lv.rb
+++ b/src/lib/y2storage/lvm_lv.rb
@@ -152,6 +152,13 @@ module Y2Storage
       log.info "Size of #{name} set to #{size}"
     end
 
+    # @see BlkDevice#in_network?
+    #
+    # @return [Boolean]
+    def in_network?
+      lvm_vg.lvm_pvs.map(&:blk_device).any?(&:in_network?)
+    end
+
     protected
 
     def types_for_is

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -149,6 +149,7 @@ module Y2Storage
     def mount_options=(options)
       to_storage_value.mount_options.clear
       options&.each { |o| to_storage_value.mount_options << o }
+      mountable.adjust_crypt_options
       mount_options
     end
 

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -61,6 +61,9 @@ module Y2Storage
     storage_forward :storage_path=, to: :path=
     private :storage_path=
 
+    storage_forward :storage_default_mount_options, to: :default_mount_options
+    private :storage_default_mount_options
+
     # Sets the value for {#path} and ensures {#passno} has a value consistent
     # with the new path
     #
@@ -163,11 +166,6 @@ module Y2Storage
     #
     #   @return [Array<Filesystems::MountByType>]
     storage_forward :possible_mount_bys, as: "Filesystems::MountByType"
-
-    # @!method set_default_mount_options
-    #   Sets the mount options to the default mount options. So far the
-    #   default mount options only contain the subvol for btrfs subvolumes.
-    storage_forward :set_default_mount_options, to: :default_mount_options=
 
     # @!attribute mount_type
     #   Filesystem type used to mount the device, as specified in fstab and/or
@@ -324,6 +322,29 @@ module Y2Storage
     # @param value [Boolean]
     def manual_mount_by=(value)
       save_userdata(:manual_mount_by, value)
+    end
+
+    # Mount options that YaST would propose as the default ones for this mount
+    # point, having into account the mount path, the type of filesystem, the
+    # underlying device and similar criteria
+    #
+    # @note This extends the corresponding Storage::MountPoint#default_mount_options
+    #   provided by libstorage-ng. This adds YaST-specific options on top of the
+    #   ones provided by the method in the library (which so far only returns the
+    #   'subvol=' option when needed).
+    #
+    # @return [Array<String>]
+    def default_mount_options
+      storage_default_mount_options + mountable.extra_default_mount_options
+    end
+
+    # Set {#mount_options} to the default value
+    #
+    # This overrides the Storage::MountsPoint#set_default_mount_options method
+    # provided by libstorage-ng. The original one only sets the default values
+    # calculated by the library, while this relies on {#default_mount_options}.
+    def set_default_mount_options
+      self.mount_options = default_mount_options
     end
 
     protected

--- a/src/lib/y2storage/mountable.rb
+++ b/src/lib/y2storage/mountable.rb
@@ -145,5 +145,21 @@ module Y2Storage
     def adjust_crypt_options
       ancestors.select { |d| d.is?(:encryption) }.each(&:adjust_crypt_options)
     end
+
+    # Mount options proposed by YaST for mount points associated to this device,
+    # in addition to the ones returned by libstorage-ng
+    #
+    # @see MountPoint#default_mount_options
+    #
+    # @note This method contains the 'extra' prefix in the name for two reasons.
+    #   To make clear these options are added to the one provided by the library
+    #   and to avoid possible conflicts in the future if the corresponding
+    #   library methods become public (so far, they are internal but also called
+    #   #default_mount_options).
+    #
+    # @return [Array<String>]
+    def extra_default_mount_options
+      []
+    end
   end
 end

--- a/src/lib/y2storage/mountable.rb
+++ b/src/lib/y2storage/mountable.rb
@@ -116,6 +116,8 @@ module Y2Storage
       mp.path = path
       # Recalculate etc status for the parent devices
       update_etc_status
+      # Recalculate the crypt_options for parent encryption devices
+      adjust_crypt_options
       # Ensure the mount_by makes sense
       mp.ensure_suitable_mount_by
       mp
@@ -126,6 +128,7 @@ module Y2Storage
     # @raise [Storage::Exception] if the mountable has no mount point
     def remove_mount_point
       storage_remove_mount_point
+      adjust_crypt_options
       update_etc_status
     end
 
@@ -134,6 +137,13 @@ module Y2Storage
     # @return [Boolean]
     def active_mount_point?
       !mount_point.nil? && mount_point.active?
+    end
+
+    # Updates the crypttab options for all the associated encryption devices
+    #
+    # @see Encryption#adjust_crypt_options
+    def adjust_crypt_options
+      ancestors.select { |d| d.is?(:encryption) }.each(&:adjust_crypt_options)
     end
   end
 end

--- a/src/lib/y2storage/partition.rb
+++ b/src/lib/y2storage/partition.rb
@@ -281,6 +281,11 @@ module Y2Storage
       id.is?(:esp) && formatted_as?(:vfat)
     end
 
+    # @see BlkDevice#in_network?
+    def in_network?
+      partitionable.in_network?
+    end
+
     protected
 
     # Values for volume specification matching

--- a/src/lib/y2storage/planned/can_be_formatted.rb
+++ b/src/lib/y2storage/planned/can_be_formatted.rb
@@ -203,7 +203,7 @@ module Y2Storage
           if fstab_options
             fstab_options
           elsif filesystem_type
-            filesystem_type.default_fstab_options(mount_point.path)
+            mount_point.default_mount_options
           else
             []
           end

--- a/test/data/devicegraphs/btrfs-multidevice-over-partitions.xml
+++ b/test/data/devicegraphs/btrfs-multidevice-over-partitions.xml
@@ -59,7 +59,7 @@
       </region>
       <range>256</range>
       <rotational>true</rotational>
-      <transport>ATA</transport>
+      <transport>iSCSI</transport>
     </Disk>
     <Gpt>
       <sid>143</sid>

--- a/test/data/devicegraphs/encrypted_partition.xml
+++ b/test/data/devicegraphs/encrypted_partition.xml
@@ -48,7 +48,7 @@
       </region>
       <dm-table-name>cr_sda1</dm-table-name>
       <mount-by>uuid</mount-by>
-      <in-etc-crypttab>true</in-etc-crypttab>
+      <in-etc-crypttab>false</in-etc-crypttab>
       <uuid>ccd40fe6-48df-491e-b862-02e5941e5d13</uuid>
     </Luks>
     <Partition>

--- a/test/data/devicegraphs/mixed_disks_btrfs.yml
+++ b/test/data/devicegraphs/mixed_disks_btrfs.yml
@@ -16,7 +16,7 @@
         size:         2 GiB
 
     - partition:
-        size:         unlimited
+        size:         80 GiB
         name:         /dev/sda2
         mount_point:  /
         label:        root
@@ -58,6 +58,12 @@
             - subvolume:
                 path: "@/var/lib/pgsql"
                 nocow: true
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda3
+        mount_point:  /mnt
+        file_system:  ext3
 
 - disk:
     name: /dev/sdb
@@ -115,7 +121,8 @@
         size:         500 GiB
         name:         /dev/sdb6
         type:         logical
-        file_system:  xfs
+        file_system:  ext3
+        mount_point:  /mnt/data
         label:        data
 
     - partition:

--- a/test/y2partitioner/actions/controllers/filesystem_test.rb
+++ b/test/y2partitioner/actions/controllers/filesystem_test.rb
@@ -957,7 +957,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
     end
 
     context "when the currently editing device has filesystem" do
-      let(:dev_name) { "/dev/sdd1" }
+      let(:dev_name) { "/dev/sdb6" }
 
       context "and the filesystem has no mount point" do
         before do
@@ -991,6 +991,13 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
 
             expect(filesystem.mount_point.sid).to eq(mount_point_sid)
             expect(filesystem.mount_point.path).to eq(mount_path)
+          end
+
+          it "creates a mount point with default mount options" do
+            subject.update_mount_point(mount_path)
+
+            expect(filesystem.mount_point.mount_options).to_not be_empty
+            expect(filesystem.mount_point.mount_options).to eq(filesystem.type.default_mount_options)
           end
 
           context "and the filesystem is btrfs" do

--- a/test/y2partitioner/actions/controllers/filesystem_test.rb
+++ b/test/y2partitioner/actions/controllers/filesystem_test.rb
@@ -665,6 +665,16 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
     let(:filesystem) { subject.filesystem }
   end
 
+  # Auxiliar method needed because not all methods to be tested receive an
+  # options hash
+  def send_testing_method(controller)
+    if mount_point_options
+      controller.public_send(testing_method, mount_path, mount_point_options)
+    else
+      controller.public_send(testing_method, mount_path)
+    end
+  end
+
   RSpec.shared_examples "btrfs subvolumes check" do
     let(:filesystem) { subject.filesystem }
 
@@ -675,26 +685,27 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
 
     it "does not delete the probed subvolumes" do
       subvolumes = filesystem.btrfs_subvolumes
-      subject.public_send(testing_method, mount_path, mount_point_options)
+      send_testing_method(subject)
 
       expect(filesystem.btrfs_subvolumes).to include(*subvolumes)
     end
 
     it "updates the subvolumes mount points" do
-      subject.public_send(testing_method, mount_path, mount_point_options)
+
+      send_testing_method(subject)
       mount_points = filesystem.btrfs_subvolumes.map(&:mount_path).compact
       expect(mount_points).to all(start_with(mount_path))
     end
 
     it "does not change the mount point for special subvolumes" do
-      subject.public_send(testing_method, mount_path, mount_point_options)
+      send_testing_method(subject)
       expect(filesystem.top_level_btrfs_subvolume.mount_path.to_s).to be_empty
       expect(filesystem.default_btrfs_subvolume.mount_path.to_s).to be_empty
     end
 
     it "refreshes btrfs subvolumes shadowing" do
       expect(Y2Storage::Filesystems::Btrfs).to receive(:refresh_subvolumes_shadowing)
-      subject.public_send(testing_method, mount_path, mount_point_options)
+      send_testing_method(subject)
     end
 
     context "and there is spec with specific default btrfs subvolume for the mount point" do
@@ -706,7 +717,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
         end
 
         it "creates a new default subvolume" do
-          subject.public_send(testing_method, mount_path, mount_point_options)
+          send_testing_method(subject)
 
           expect(filesystem.top_level_btrfs_subvolume).to_not eq(filesystem.default_btrfs_subvolume)
           expect(filesystem.default_btrfs_subvolume.path).to eq("@")
@@ -720,7 +731,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
           it "does not change the default subvolume" do
             initial_default_subvolume = filesystem.default_btrfs_subvolume
 
-            subject.public_send(testing_method, mount_path, mount_point_options)
+            send_testing_method(subject)
 
             expect(filesystem.default_btrfs_subvolume.sid).to eq(initial_default_subvolume.sid)
             expect(filesystem.default_btrfs_subvolume.path).to eq("@")
@@ -731,13 +742,13 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
           let(:default_subvolume) { "@@" }
 
           it "does not remove the previous default subvolume" do
-            subject.public_send(testing_method, mount_path, mount_point_options)
+            send_testing_method(subject)
 
             expect(filesystem.btrfs_subvolumes).to include(an_object_having_attributes(path: "@"))
           end
 
           it "creates a new default subvolume" do
-            subject.public_send(testing_method, mount_path, mount_point_options)
+            send_testing_method(subject)
 
             expect(filesystem.default_btrfs_subvolume.path).to eq("@@")
           end
@@ -751,14 +762,14 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
 
         it "removes the previous default subvolume" do
           default_subvolume_sid = filesystem.default_btrfs_subvolume.sid
-          subject.public_send(testing_method, mount_path, mount_point_options)
+          send_testing_method(subject)
 
           expect(filesystem.btrfs_subvolumes)
             .to_not include(an_object_having_attributes(sid: default_subvolume_sid))
         end
 
         it "creates a new default subvolume" do
-          subject.public_send(testing_method, mount_path, mount_point_options)
+          send_testing_method(subject)
 
           expect(filesystem.default_btrfs_subvolume.path).to eq("@")
         end
@@ -776,7 +787,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
         it "does not change the default subvolume" do
           initial_default_subvolume = filesystem.default_btrfs_subvolume
 
-          subject.public_send(testing_method, mount_path, mount_point_options)
+          send_testing_method(subject)
 
           expect(filesystem.default_btrfs_subvolume.sid).to eq(initial_default_subvolume.sid)
           expect(filesystem.default_btrfs_subvolume.path).to eq("")
@@ -786,7 +797,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
       context "and the current default subvolume is probed" do
         it "does not change the default subvolume" do
           default_subvolume = filesystem.default_btrfs_subvolume
-          subject.public_send(testing_method, mount_path, mount_point_options)
+          send_testing_method(subject)
 
           expect(filesystem.default_btrfs_subvolume.sid).to eq(default_subvolume.sid)
         end
@@ -800,13 +811,13 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
         it "removes the previous not probed default subvolume" do
           expect(filesystem.default_btrfs_subvolume.path).to eq("@@")
 
-          subject.public_send(testing_method, mount_path, mount_point_options)
+          send_testing_method(subject)
 
           expect(filesystem.btrfs_subvolumes).to_not include(an_object_having_attributes(path: "@@"))
         end
 
         it "sets the top level subvolume as default subvolume" do
-          subject.public_send(testing_method, mount_path, mount_point_options)
+          send_testing_method(subject)
           expect(filesystem.top_level_btrfs_subvolume).to eq(filesystem.default_btrfs_subvolume)
         end
       end
@@ -820,7 +831,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
       end
 
       it "deletes the not probed subvolumes" do
-        subject.public_send(testing_method, mount_path, mount_point_options)
+        send_testing_method(subject)
         expect(filesystem.find_btrfs_subvolume_by_path(path)).to be_nil
       end
     end
@@ -839,7 +850,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
       end
 
       it "adds the proposed subvolumes that do not exist" do
-        subject.public_send(testing_method, mount_path, mount_point_options)
+        send_testing_method(subject)
 
         arch_specs = Y2Storage::SubvolSpecification.for_current_arch(subvolumes)
         paths = arch_specs.map { |s| filesystem.btrfs_subvolume_path(s.path) }
@@ -853,7 +864,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
 
       it "does not add any subvolume" do
         paths = filesystem.btrfs_subvolumes.map(&:path)
-        subject.public_send(testing_method, mount_path, mount_point_options)
+        send_testing_method(subject)
 
         expect(filesystem.btrfs_subvolumes.map(&:path) - paths).to be_empty
       end
@@ -863,7 +874,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
   RSpec.shared_examples "does nothing" do
     it "does nothing" do
       devicegraph = Y2Partitioner::DeviceGraphs.instance.current.dup
-      subject.public_send(testing_method, mount_path, mount_point_options)
+      send_testing_method(subject)
 
       expect(devicegraph).to eq(Y2Partitioner::DeviceGraphs.instance.current)
     end
@@ -937,6 +948,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
     include_context "mount point actions"
 
     let(:testing_method) { :update_mount_point }
+    let(:mount_point_options) { nil }
 
     context "when the currently editing device has no filesystem" do
       let(:dev_name) { "/dev/sdb7" }
@@ -965,38 +977,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
 
           let(:mount_path) { "/bar" }
 
-          context "and no mount point options are given" do
-            let(:mount_point_options) { nil }
-
-            include_examples "does nothing"
-          end
-
-          context "and mount point options are given" do
-            before do
-              device.remove_descendants
-              device.create_filesystem(fs_type)
-              device.filesystem.mount_path = fs_mount_path
-            end
-
-            let(:fs_type) { Y2Storage::Filesystems::Type::EXT4 }
-
-            it "updates the filesystem mount point options" do
-              mount_point_sid = filesystem.mount_point.sid
-
-              subject.update_mount_point(mount_path, mount_point_options)
-
-              expect(filesystem.mount_point.sid).to eq(mount_point_sid)
-              expect(filesystem.mount_point.mount_by).to eq(mount_by_id)
-              expect(filesystem.mount_point.mount_options).to eq(mount_options)
-            end
-
-            it "does not change the mount path" do
-              path = filesystem.mount_point.path
-              subject.update_mount_point(mount_path, mount_point_options)
-
-              expect(filesystem.mount_point.path).to eq(path)
-            end
-          end
+          include_examples "does nothing"
         end
 
         context "and the filesystem mount point path is not equal to the given path" do
@@ -1006,7 +987,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
 
           it "updates the filesystem mount point path" do
             mount_point_sid = filesystem.mount_point.sid
-            subject.update_mount_point(mount_path, mount_point_options)
+            subject.update_mount_point(mount_path)
 
             expect(filesystem.mount_point.sid).to eq(mount_point_sid)
             expect(filesystem.mount_point.path).to eq(mount_path)
@@ -1026,6 +1007,7 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
     include_context "mount point actions"
 
     let(:testing_method) { :create_or_update_mount_point }
+    let(:mount_point_options) { nil }
 
     context "when the currently editing device has no filesystem" do
       let(:dev_name) { "/dev/sdb7" }
@@ -1042,8 +1024,8 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
 
       context "and the filesystem has no mount point" do
         it "creates a new mount point" do
-          expect(subject).to receive(:create_mount_point).with(mount_path, mount_point_options)
-          subject.create_or_update_mount_point(mount_path, mount_point_options)
+          expect(subject).to receive(:create_mount_point).with(mount_path, {})
+          subject.create_or_update_mount_point(mount_path)
         end
       end
 
@@ -1053,8 +1035,8 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
         end
 
         it "updates the filesystem mount point" do
-          expect(subject).to receive(:update_mount_point).with(mount_path, mount_point_options)
-          subject.create_or_update_mount_point(mount_path, mount_point_options)
+          expect(subject).to receive(:update_mount_point).with(mount_path)
+          subject.create_or_update_mount_point(mount_path)
         end
       end
     end

--- a/test/y2storage/filesystems/blk_filesystem_test.rb
+++ b/test/y2storage/filesystems/blk_filesystem_test.rb
@@ -284,8 +284,7 @@ describe Y2Storage::Filesystems::BlkFilesystem do
     context "for a single disk in network" do
       let(:dev_name) { "/dev/sda1" }
       before do
-        allow(filesystem).to receive(:ancestors).and_return([disk])
-        allow(disk).to receive(:in_network?).and_return(true)
+        allow(disk.transport).to receive(:network?).and_return(true)
       end
 
       it "returns true" do
@@ -295,8 +294,7 @@ describe Y2Storage::Filesystems::BlkFilesystem do
 
     context "for a single local disk" do
       before do
-        allow(filesystem).to receive(:ancestors).and_return([disk])
-        allow(disk).to receive(:in_network?).and_return(false)
+        allow(disk.transport).to receive(:network?).and_return(false)
       end
       let(:dev_name) { "/dev/sda1" }
 
@@ -320,13 +318,8 @@ describe Y2Storage::Filesystems::BlkFilesystem do
     end
 
     context "when filesystem has multiple ancestors and at least one disk is in network" do
-      before do
-        allow(filesystem).to receive(:ancestors).and_return([disk, second_disk])
-        allow(disk).to receive(:in_network?).and_return(false)
-        allow(second_disk).to receive(:in_network?).and_return(true)
-      end
-      let(:second_disk) { Y2Storage::BlkDevice.find_by_name(fake_devicegraph, "/dev/sdb") }
-      let(:dev_name) { "/dev/sda1" }
+      let(:scenario) { "btrfs-multidevice-over-partitions.xml" }
+      let(:dev_name) { "/dev/sda2" }
 
       it "returns true" do
         expect(filesystem.in_network?).to eq true


### PR DESCRIPTION
## Problem

Systemd should be able to distinguish when an encrypted device is based on a network-based storage device and, thus, can only be initialized after the network is up. In some cases that detection fails (for example network block device based mounts, such as iSCSI), and systemd gets stuck before initializing the network waiting for the device to be available.

Recently, SLE and openSUSE Leap has incorporated support for specifying the option `_netdev` in the crypttab file. With such option, systemd will recognize the encrypted device as network-based and will only try to activate it after setting up the network. That's analogous to the corresponding `_netdev` option in fstab that has been already there for quite some time and that can be used to defer when a device is mounted.

For it to work properly, the `_netdev` option must be present in all the relevant entries of both crypttab and fstab.

- Current Jira entry: https://jira.suse.com/browse/SLE-7687
- Original bug report (that was then moved to another, and then to Fate, before ending up in the Jira mentioned above): https://bugzilla.suse.com/show_bug.cgi?id=1047099
- Submit request introducing support for `_netdev` in crypttab https://build.suse.de/request/show/201960

## Solution

Add the `_netdev` option to fstab when encrypting a device that depends (directly or indirectly) on the network. **For that to work, this pull request depends on https://github.com/openSUSE/libstorage-ng/pull/677**

In addition, propagate the `_netdev` option (and also `noauto` and `nofail`) to the corresponding crypttab entries if such option is present in fstab.

Review commit by commit, it makes way more sense (some commits are more about polishing that about changing behavior).

## Testing

- Unit tests included in the pull request.
- Manually tested during installation.
