### PR TITLE
AutoYaST: inject proposal settings

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 12 11:27:38 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: allow to inject settings for the guided proposal
+  (related to boo#1156539).
+- 4.2.55
+
+-------------------------------------------------------------------
 Wed Nov  6 11:49:35 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: do not repeat filesystem related information when

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.54
+Version:        4.2.55
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/autoinst_proposal.rb
+++ b/src/lib/y2storage/autoinst_proposal.rb
@@ -51,15 +51,18 @@ module Y2Storage
     # Constructor
     #
     # @param partitioning [Array<Hash>] Partitioning schema from an AutoYaST profile
+    # @param proposal_settings [Y2Storage::ProposalSettings] Guided proposal settings
     # @param devicegraph  [Devicegraph] starting point. If nil, then probed devicegraph
     #   will be used
     # @param disk_analyzer [DiskAnalyzer] by default, the method will create a new one
     #   based on the initial devicegraph or will use the one in {StorageManager} if
     #   starting from probed (i.e. 'devicegraph' argument is also missing)
     # @param issues_list [AutoinstIssues::List] List of AutoYaST issues to register them
-    def initialize(partitioning: [], devicegraph: nil, disk_analyzer: nil, issues_list: nil)
+    def initialize(partitioning: [], proposal_settings: nil, devicegraph: nil, disk_analyzer: nil,
+      issues_list: nil)
       super(devicegraph: devicegraph, disk_analyzer: disk_analyzer)
       @issues_list = issues_list || Y2Storage::AutoinstIssues::List.new
+      @proposal_settings = proposal_settings
       @partitioning = AutoinstProfile::PartitioningSection.new_from_hashes(partitioning)
     end
 
@@ -292,7 +295,7 @@ module Y2Storage
     #
     # @see Y2Storage::BlkDevice#name
     def proposal_settings_for_disks(drives)
-      settings = ProposalSettings.new_for_current_product
+      settings = @proposal_settings || ProposalSettings.new_for_current_product
       settings.use_snapshots = drives.use_snapshots?
       settings.candidate_devices = drives.disk_names
       settings

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -28,13 +28,17 @@ describe Y2Storage::AutoinstProposal do
 
   subject(:proposal) do
     described_class.new(
-      partitioning: partitioning, devicegraph: fake_devicegraph, issues_list: issues_list
+      partitioning: partitioning, proposal_settings: proposal_settings,
+      devicegraph: fake_devicegraph, issues_list: issues_list
     )
   end
 
   let(:partitioning) { [] }
   let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
   let(:vg_name) { "system" }
+  let(:proposal_settings) do
+    Y2Storage::ProposalSettings.new_for_current_product
+  end
 
   before do
     allow(Yast::Mode).to receive(:auto).and_return(true)
@@ -734,7 +738,7 @@ describe Y2Storage::AutoinstProposal do
         [{ "device" => "/dev/sda", "use" => use }]
       end
 
-      let(:settings) do
+      let(:proposal_settings) do
         Y2Storage::ProposalSettings.new_for_current_product.tap do |settings|
           settings.use_lvm = false
           settings.use_separate_home = true
@@ -757,10 +761,8 @@ describe Y2Storage::AutoinstProposal do
       let(:use) { "all" }
 
       before do
-        allow(Y2Storage::ProposalSettings).to receive(:new_for_current_product)
-          .and_return(settings)
         allow(Y2Storage::Proposal::DevicesPlanner).to receive(:new)
-          .with(settings, Y2Storage::Devicegraph)
+          .with(proposal_settings, Y2Storage::Devicegraph)
           .and_return(planner)
       end
 
@@ -790,7 +792,7 @@ describe Y2Storage::AutoinstProposal do
         end
 
         it "disables use_snapshots setting" do
-          expect(settings).to receive(:use_snapshots=).with(false)
+          expect(proposal_settings).to receive(:use_snapshots=).with(false)
           proposal.propose
         end
       end
@@ -801,7 +803,7 @@ describe Y2Storage::AutoinstProposal do
         end
 
         it "enables use_snapshots setting" do
-          expect(settings).to receive(:use_snapshots=).with(true)
+          expect(proposal_settings).to receive(:use_snapshots=).with(true)
           proposal.propose
         end
       end


### PR DESCRIPTION
`Y2Storage::AutoinstProposal` receives now the proposal settings. The idea is that, instead of using `Y2Storage::ProposalSettings.new_for_current_product`, it can receive a customized one.

Needed for https://github.com/yast/yast-autoinstallation/pull/544.