### PR TITLE
Fix wrong check about installed packages (bsc#1151148)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 21 16:10:22 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed a wrong check that was preventing the installation of some
+  needed packages (bsc#1151148).
+- 4.2.57
+
+-------------------------------------------------------------------
 Thu Nov 14 16:23:39 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Propagate the noauto, nofail and _netdev options from fstab

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.56
+Version:        4.2.57
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/package_handler.rb
+++ b/src/lib/y2storage/package_handler.rb
@@ -108,7 +108,7 @@ module Y2Storage
     # them immediately.
     #
     def commit
-      if Yast::Mode.installation
+      if installation?
         set_proposal_packages
       else
         install
@@ -157,7 +157,8 @@ module Y2Storage
     #
     def compact
       @pkg_list.uniq!
-      @pkg_list = @pkg_list.delete_if { |pkg| Yast::Package.Installed(pkg) }
+      @pkg_list.reject! { |pkg| Yast::Package.Installed(pkg) } unless installation?
+      @pkg_list
     end
 
     private
@@ -178,6 +179,16 @@ module Y2Storage
       pkg_list = @pkg_list.join(", ")
       # TRANSLATORS: error popup. %s is the list of affected packages.
       Yast::Report.Error(_("Adding the following packages failed: %s") % pkg_list)
+    end
+
+    # Whether the operating system is being installed
+    #
+    # If that's the case, we don't want to query and manage the packages in the
+    # current system, but to prepare the proposal for the target one.
+    #
+    # @return [Boolean]
+    def installation?
+      Yast::Mode.installation
     end
   end
 end


### PR DESCRIPTION
## Problem

During installation, YaST was not always marking for installation all the packages needed by the storage stack.

It happened because YaST was checking which packages were already installed and skipping them. That makes sense when yast2-storage-ng is running in an already installed system, but makes no sense during installation. The packages where not being added to the software proposal of the target system if they where available in the inst-sys.

- https://bugzilla.suse.com/show_bug.cgi?id=1151148
- https://openqa.opensuse.org/tests/1091600/modules/await_install/steps/136
- https://trello.com/c/LxzOqypU/1352-ostumbleweed-p2-1151148-live-installation-fails-because-yast-does-not-install-storage-feature-packages

## Solution

Skip the check for already installed packages when running during the installation.

## Testing

- Added a new unit test (and reorganized a bit the existing ones)
- Tested manually
