### PR TITLE
Error message for inactive root

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Nov 25 12:21:07 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Detect root mount point probed as inactive (e.g., as result of a
+  snapshot rollback without rebooting the system).
+- Related to bsc#1124581.
+- 4.2.58
+
+-------------------------------------------------------------------
 Thu Nov 21 16:10:22 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Fixed a wrong check that was preventing the installation of some

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.57
+Version:        4.2.58
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/devicegraph_sanitizer.rb
+++ b/src/lib/y2storage/devicegraph_sanitizer.rb
@@ -23,6 +23,8 @@ require "y2storage/devicegraph"
 require "y2storage/bcache"
 require "y2storage/bcache_cset"
 
+require "abstract_method"
+
 Yast.import "Mode"
 
 module Y2Storage
@@ -35,8 +37,6 @@ module Y2Storage
   #   sanitizer = DevicegraphSanitizer.new(devicegraph)
   #   new_devicegraph = sanitizer.sanitized_devicegraph
   class DevicegraphSanitizer
-    include Yast::I18n
-
     # @return [Devicegraph]
     attr_reader :devicegraph
 
@@ -44,15 +44,12 @@ module Y2Storage
     #
     # @param devicegraph [Devicegraph] devicegraph to sanitize
     def initialize(devicegraph)
-      textdomain "storage"
-
       @devicegraph = devicegraph
     end
 
     # Errors that need to be fixed in order to obtain a sanitized devicegraph
     #
-    # @return [Array<DevicegraphSanitizer::Error>] empty if the devicegraph is
-    #   already sanitized.
+    # @return [Array<DevicegraphSanitizer::Error>] empty if the devicegraph is already sanitized.
     def errors
       @errors ||= errors_for(devicegraph)
     end
@@ -66,6 +63,68 @@ module Y2Storage
 
     private
 
+    # Errors in the given devicegraph
+    #
+    # @param devicegraph [Y2Storage::Devicegraph]
+    # @return [Array<DevicegraphSanitizer::Error>]
+    def errors_for(devicegraph)
+      lvm_vgs_errors(devicegraph) +
+        bcaches_errors(devicegraph) +
+        filesystems_errors(devicegraph)
+    end
+
+    # Errors related to LVM VGs in the given devicegraph
+    #
+    # @param devicegraph [Y2Storage::Devicegraph]
+    # @return [Array<DevicegraphSanitizer::Error>]
+    def lvm_vgs_errors(devicegraph)
+      devicegraph.lvm_vgs.flat_map { |v| lvm_vg_errors(v) }.compact
+    end
+
+    # Errors for an LVM VG
+    #
+    # @param vg [Y2Storage::LvmVg]
+    # @return [Array<DevicegraphSanitizer::Error>]
+    def lvm_vg_errors(vg)
+      errors = []
+
+      errors << MissingLvmPvError.new(vg) if MissingLvmPvError.check(vg)
+
+      errors
+    end
+
+    # Errors related to Bcache in the given devicegraph
+    #
+    # @param devicegraph [Y2Storage::Devicegraph]
+    # @return [Array<DevicegraphSanitizer::Error>]
+    def bcaches_errors(devicegraph)
+      errors = []
+
+      errors << UnsupportedBcacheError.new if UnsupportedBcacheError.check(devicegraph)
+
+      errors
+    end
+
+    # Errors related to filesystems in the given devicegraph
+    #
+    # @param devicegraph [Y2Storage::Devicegraph]
+    # @return [Array<DevicegraphSanitizer::Error>]
+    def filesystems_errors(devicegraph)
+      devicegraph.filesystems.flat_map { |f| filesystem_errors(f) }.compact
+    end
+
+    # Errors for a filesystem
+    #
+    # @param filesystem [Y2Storage::Filesystems::Base]
+    # @return [Array<DevicegraphSanitizer::Error>]
+    def filesystem_errors(filesystem)
+      errors = []
+
+      errors << InactiveRootError.new(filesystem) if InactiveRootError.check(filesystem)
+
+      errors
+    end
+
     # Sanitizes a given devicegraph
     #
     # @note The given devicegraph is modified.
@@ -73,153 +132,173 @@ module Y2Storage
     # @param devicegraph [Y2Storage::Devicegraph]
     # @return [Y2Storage::Devicegraph]
     def sanitize(devicegraph)
-      errors_for(devicegraph).each { |e| fix_error(devicegraph, e) }
-      devicegraph
-    end
+      errors_for(devicegraph).each { |e| e.fix(devicegraph) }
 
-    # Fixes an specific error in the given devicegraph
-    #
-    # @note The given devicegraph is modified.
-    #
-    # @param devicegraph [Y2Storage::Devicegraph]
-    # @param error [Y2Storage::DevicegraphSanitizer::Error] error to fix
-    # @return [Y2Storage::Devicegraph]
-    def fix_error(devicegraph, error)
-      device = error.device
-
-      fix_error_for_lvm_vg(devicegraph, device) if device.is?(:lvm_vg)
-      fix_error_for_bcache(devicegraph, device) if device.is?(:bcache) || device.is?(:bcache_cset)
-      devicegraph
-    end
-
-    # Fixes an error with an LVM VG in a given devicegraph
-    #
-    # @note The given devicegraph is modified.
-    #
-    # @param devicegraph [Y2Storage::Devicegraph]
-    # @param vg [Y2Storage::LvmVg] vg with the error
-    # @return [Y2Storage::Devicegraph]
-    def fix_error_for_lvm_vg(devicegraph, vg)
-      devicegraph.remove_lvm_vg(vg)
-      devicegraph
-    end
-
-    # Errors in the given devicegraph
-    #
-    # @param devicegraph [Y2Storage::Devicegraph]
-    # @return [Array<DevicegraphSanitizer::Error>]
-    def errors_for(devicegraph)
-      errors = errors_for_lvm_vgs(devicegraph)
-      errors.concat(errors_for_bcache(devicegraph))
-    end
-
-    # Errors related to LVM VGs in the given devicegraph
-    #
-    # @param devicegraph [Y2Storage::Devicegraph]
-    # @return [Array<DevicegraphSanitizer::Error>]
-    def errors_for_lvm_vgs(devicegraph)
-      devicegraph.lvm_vgs.map { |v| error_for_lvm_vg(v) }.compact
-    end
-
-    # Error with an LVM VGs
-    #
-    # @param vg [Y2Storage::LvmVg] vg to check
-    # @return [DevicegraphSanitizer::Error, nil] nil if the LVM VG is correct
-    def error_for_lvm_vg(vg)
-      return nil unless missing_pvs?(vg)
-
-      Error.new(vg, error_message_for_lvm_vg(vg))
-    end
-
-    # Error message for an incomplete LVM VG (missing PVs)
-    #
-    # @param vg [Y2Storage::LvmVg]
-    # @return [String]
-    def error_message_for_lvm_vg(vg)
-      if Yast::Mode.installation
-        # TRANSLATORS: %{name} is the name of an LVM Volume Group (e.g., /dev/vg1)
-        format(
-          _("The volume group %{name} is incomplete because some physical volumes are missing.\n" \
-            "If you continue, the volume group will be deleted later as part of the installation\n" \
-            "process. Moreover, incomplete volume groups are ignored by the partitioning proposal\n" \
-            "and are not visible in the Expert Partitioner."),
-          name: vg.name
-        )
-      else
-        # TRANSLATORS: %{name} is the name of an LVM Volume Group (e.g., /dev/vg1)
-        format(
-          _("The volume group %{name} is incomplete because some physical volumes are missing.\n" \
-            "Incomplete volume groups are not visible in the Partitioner and will be deleted at the\n" \
-            "final step, when all the changes are performed in the system."),
-          name: vg.name
-        )
-      end
-    end
-
-    # Checks whether an LVM VG has missing PVs
-    #
-    # @param vg [Y2Storage::LvmVg]
-    # @return [Boolean]
-    def missing_pvs?(vg)
-      vg.lvm_pvs.any? { |p| p.blk_device.nil? }
-    end
-
-    # Errors related to bcache in the given devicegraph
-    #
-    # @param devicegraph [Y2Storage::Devicegraph]
-    # @return [Array<DevicegraphSanitizer::Error>]
-    def errors_for_bcache(devicegraph)
-      return [] if Bcache.supported?
-
-      bcache_dev = first_bcache_device(devicegraph)
-      return [] if bcache_dev.nil?
-
-      [Error.new(bcache_dev, msg_no_bcache_support)]
-    end
-
-    # Find the first bcache of BcacheCset device in the devicegraph
-    # or nil if there is none.
-    #
-    # @return [Y2Storage::Device, nil]
-    def first_bcache_device(devicegraph)
-      Bcache.all(devicegraph).first || BcacheCset.all(devicegraph).first
-    end
-
-    # Error message for missing bcache support on this platform
-    #
-    # @return [String]
-    def msg_no_bcache_support
-      msg = _("Bcache detected, but bcache is not supported on this platform!")
-      msg += "\n\n"
-      msg + _("This may or may not work. Use at your own risk.\n" \
-               "The safe way is to remove this bcache manually\n" \
-               "with command line tools and then restart YaST.")
-    end
-
-    # Fix an error for a Bcache or BcacheCset in a devicegraph.
-    #
-    # @param devicegraph [Y2Storage::Devicegraph]
-    # @param _device [Y2Storage::Device] not used
-    # @return [Y2Storage::Devicegraph]
-    def fix_error_for_bcache(devicegraph, _device)
       devicegraph
     end
 
     # Class to represent an error in a devicegraph
     class Error
+      include Yast::I18n
+
       # @return [Y2Storage::Device]
       attr_reader :device
-
-      # @return [String]
-      attr_reader :message
 
       # Constructor
       #
       # @param device [Y2Storage::Device]
-      # @param message [String]
-      def initialize(device, message)
+      def initialize(device)
+        textdomain "storage"
+
         @device = device
-        @message = message
+      end
+
+      # @!method message
+      #   Error message
+      #
+      #   @return [String]
+      abstract_method :message
+
+      # @!method fix(devicegraph)
+      #   Fixes the error in the given devicegraph
+      #
+      #   @param devicegraph [Y2Storage::Devicegraph]
+      #   @return [Y2Storage::Devicegraph]
+      abstract_method :fix
+    end
+
+    # Error when a LVM VG has missing PVs
+    class MissingLvmPvError < Error
+      # Checks whether the given LVM VG has missing PVs
+      #
+      # @param vg [Y2Storage::LvmVg]
+      # @return [Boolean]
+      def self.check(vg)
+        vg.lvm_pvs.any? { |p| p.blk_device.nil? }
+      end
+
+      # @see Error#initialize
+      def initialize(device)
+        super
+
+        @fixed = false
+      end
+
+      # Error message for an incomplete LVM VG (missing PVs)
+      #
+      # @return [String]
+      def message
+        if Yast::Mode.installation
+          # TRANSLATORS: %{name} is the name of an LVM Volume Group (e.g., /dev/vg1)
+          format(
+            _("The volume group %{name} is incomplete because some physical volumes are missing.\n" \
+              "If you continue, the volume group will be deleted later as part of the installation\n" \
+              "process. Moreover, incomplete volume groups are ignored by the partitioning proposal\n" \
+              "and are not visible in the Expert Partitioner."),
+            name: device.name
+          )
+        else
+          # TRANSLATORS: %{name} is the name of an LVM Volume Group (e.g., /dev/vg1)
+          format(
+            _("The volume group %{name} is incomplete because some physical volumes are missing.\n" \
+            "Incomplete volume groups are not visible in the Partitioner and will be deleted at the\n" \
+            "final step, when all the changes are performed in the system."),
+            name: device.name
+          )
+        end
+      end
+
+      # Fixes the error by removing the LVM VG
+      #
+      # @note The given devicegraph is modified.
+      #
+      # @param devicegraph [Y2Storage::Devicegraph]
+      # @return [Y2Storage::Devicegraph]
+      def fix(devicegraph)
+        return devicegraph if @fixed
+
+        devicegraph.remove_lvm_vg(device)
+
+        @fixed = true
+
+        devicegraph
+      end
+    end
+
+    # Error when Bcache is not supported and there are Bcache devices
+    class UnsupportedBcacheError < Error
+      # Checks whether Bcache is not supported and the given devicegraph contains any Bcache device
+      #
+      # @param devicegraph [Y2Storage::Devicegraph]
+      # @return [Boolean]
+      def self.check(devicegraph)
+        return false if Bcache.supported?
+
+        device = Bcache.all(devicegraph).first || BcacheCset.all(devicegraph).first
+
+        !device.nil?
+      end
+
+      def initialize
+        super(nil)
+      end
+
+      # Error message for missing Bcache support on the current platform
+      #
+      # @return [String]
+      def message
+        msg = _("Bcache detected, but bcache is not supported on this platform!")
+        msg += "\n\n"
+        msg + _("This may or may not work. Use at your own risk.\n" \
+                "The safe way is to remove this bcache manually\n" \
+                "with command line tools and then restart YaST.")
+      end
+
+      # The error cannot be fixed
+      #
+      # @param devicegraph [Y2Storage::Devicegraph]
+      # @return [Y2Storage::Devicegraph]
+      def fix(devicegraph)
+        devicegraph
+      end
+    end
+
+    # Error when the root filesystem is not currently mounted
+    class InactiveRootError < Error
+      # Checks whether the given filesystem is root but its mount point is inactive (not mounted)
+      #
+      # A root filesystem might be probed with an inactive mount point when a snapshot rollback is
+      # performed but the system has not been rebooted yet. In that scenario, /etc/fstab contains an
+      # entry for root, but /proc/mounts would contain none entry for the new default subvolume.
+      #
+      # @param filesystem [Y2Storage::Filesystems::Base]
+      # @return [Boolean]
+      def self.check(filesystem)
+        filesystem.root? && !filesystem.mount_point.active?
+      end
+
+      # Error message
+      #
+      # @return [String]
+      def message
+        msg = _("The root filesystem looks like not currently mounted!")
+
+        if device.is?(:btrfs)
+          msg += _(
+            "\n\n" \
+            "If you have executed a snapshot rollback, please reboot your system before continuing."
+          )
+        end
+
+        msg
+      end
+
+      # The error cannot be fixed
+      #
+      # @param devicegraph [Y2Storage::Devicegraph]
+      # @return [Y2Storage::Devicegraph]
+      def fix(devicegraph)
+        devicegraph
       end
     end
   end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -108,7 +108,7 @@ RSpec.configure do |c|
     # This should be properly unmocked in the tests where real Bcache checking needs
     # to be performed (e.g., DevicegraphSanitizer tests).
     allow_any_instance_of(Y2Storage::DevicegraphSanitizer)
-      .to receive(:errors_for_bcache).and_return([])
+      .to receive(:bcaches_errors).and_return([])
   end
 
   # Some tests use ProposalSettings#new_for_current_product to initialize

--- a/test/y2storage/devicegraph_sanitizer_test.rb
+++ b/test/y2storage/devicegraph_sanitizer_test.rb
@@ -32,12 +32,34 @@ describe Y2Storage::DevicegraphSanitizer do
     context "when the devicegraph contains errors" do
       let(:devicegraph) { devicegraph_from("lvm-errors1-devicegraph.xml") }
 
-      before do
-        Y2Storage::LvmVg.create(devicegraph, "test3")
+      it "returns a list of errors" do
+        errors = subject.errors
+
+        expect(errors).to be_a(Array)
+        expect(errors).to all(be_a(Y2Storage::DevicegraphSanitizer::Error))
       end
 
-      it "returns a list of errors" do
-        expect(subject.errors).to be_a(Array)
+      it "does not generate new errors in sequential calls" do
+        errors = subject.errors
+
+        expect(subject.errors).to eq(errors)
+        expect(subject.errors.object_id).to eq(errors.object_id)
+      end
+    end
+
+    context "when the devicegraph does not contain errors" do
+      let(:devicegraph) { devicegraph_from("lvm-two-vgs") }
+
+      it "returns an empty list" do
+        expect(subject.errors).to be_empty
+      end
+    end
+
+    context "when there are LVM VGs in the devicegraph" do
+      let(:devicegraph) { devicegraph_from("lvm-errors1-devicegraph.xml") }
+
+      before do
+        Y2Storage::LvmVg.create(devicegraph, "test3")
       end
 
       it "contains an error for each LVM VG with missing PVs" do
@@ -52,30 +74,15 @@ describe Y2Storage::DevicegraphSanitizer do
 
         expect(subject.errors.map(&:device)).to_not include(vg3)
       end
-
-      it "does not generate new errors in sequential calls" do
-        errors = subject.errors
-        expect(subject.errors).to eq(errors)
-        expect(subject.errors.object_id).to eq(errors.object_id)
-      end
     end
 
-    context "when the devicegraph does not contain errors" do
-      let(:devicegraph) { devicegraph_from("lvm-two-vgs") }
-
-      it "returns an empty list" do
-        expect(subject.errors).to be_empty
-      end
-    end
-
-    context "with a bcache device in the devicegraph" do
+    context "when there is a bcache device in the devicegraph" do
       let(:devicegraph) { devicegraph_from("bcache2.xml") }
-      let(:bcache_name) { "/dev/bcache0" }
 
       before do
-        # Unmocking errors for Bcache
+        # Unmocking errors for Bcache (see spec_helper.rb)
         allow_any_instance_of(Y2Storage::DevicegraphSanitizer)
-          .to receive(:errors_for_bcache).and_call_original
+          .to receive(:bcaches_errors).and_call_original
       end
 
       context "on an architecture that supports bcache (x86_64)" do
@@ -93,10 +100,23 @@ describe Y2Storage::DevicegraphSanitizer do
           errors = subject.errors
           expect(errors).not_to be_empty
 
-          err_devices = errors.map(&:device)
-          bcache = devicegraph.find_by_name(bcache_name)
-          expect(err_devices).to include(bcache)
+          expect(errors).to include(be_a(Y2Storage::DevicegraphSanitizer::UnsupportedBcacheError))
         end
+      end
+    end
+
+    context "when the mount point for the root filesystem is not active" do
+      let(:devicegraph) { devicegraph_from("mixed_disks") }
+
+      before do
+        allow_any_instance_of(Y2Storage::MountPoint).to receive(:active?).and_return(false)
+      end
+
+      it "contains an error for inactive root" do
+        errors = subject.errors
+        expect(errors).not_to be_empty
+
+        expect(errors).to include(be_a(Y2Storage::DevicegraphSanitizer::InactiveRootError))
       end
     end
   end
@@ -116,6 +136,7 @@ describe Y2Storage::DevicegraphSanitizer do
 
       it "does not create a new devicegraph in sequential calls" do
         sanitized = subject.sanitized_devicegraph
+
         expect(subject.sanitized_devicegraph).to equal(sanitized)
       end
     end
@@ -123,17 +144,49 @@ describe Y2Storage::DevicegraphSanitizer do
     context "when the devicegraph contains errors" do
       let(:devicegraph) { devicegraph_from("lvm-errors1-devicegraph.xml") }
 
-      before do
-        Y2Storage::LvmVg.create(devicegraph, "test3")
-      end
-
       include_examples "sanitized devicegraph"
 
-      it "returns a devicegraph without the LVM VGs with missing PVs" do
-        vg3 = devicegraph.find_by_name("/dev/test3")
+      context "when there are LVM VGS with missing PVs" do
+        let(:devicegraph) { devicegraph_from("lvm-errors1-devicegraph.xml") }
 
-        expect(devicegraph.lvm_vgs.size).to eq(3)
-        expect(subject.sanitized_devicegraph.lvm_vgs).to contain_exactly(vg3)
+        before do
+          Y2Storage::LvmVg.create(devicegraph, "test3")
+        end
+
+        it "returns a devicegraph without the LVM VGs with missing PVs" do
+          vg3 = devicegraph.find_by_name("/dev/test3")
+
+          expect(devicegraph.lvm_vgs.size).to eq(3)
+          expect(subject.sanitized_devicegraph.lvm_vgs).to contain_exactly(vg3)
+        end
+      end
+
+      context "when there is a Bcache device in a not supported architecture" do
+        let(:devicegraph) { devicegraph_from("bcache2.xml") }
+
+        before do
+          # Unmocking errors for Bcache (see spec_helper.rb)
+          allow_any_instance_of(Y2Storage::DevicegraphSanitizer)
+            .to receive(:bcaches_errors).and_call_original
+        end
+
+        let(:architecture) { :ppc }
+
+        it "returns a devicegraph equal to the initial one" do
+          expect(subject.sanitized_devicegraph).to eq(devicegraph)
+        end
+      end
+
+      context "when there is an inactive root" do
+        let(:devicegraph) { devicegraph_from("mixed_disks") }
+
+        before do
+          allow_any_instance_of(Y2Storage::MountPoint).to receive(:active?).and_return(false)
+        end
+
+        it "returns a devicegraph equal to the initial one" do
+          expect(subject.sanitized_devicegraph).to eq(devicegraph)
+        end
       end
     end
 
@@ -148,6 +201,198 @@ describe Y2Storage::DevicegraphSanitizer do
 
       it "returns a devicegraph equal to the initial one" do
         expect(subject.sanitized_devicegraph).to eq(devicegraph)
+      end
+    end
+  end
+
+  describe Y2Storage::DevicegraphSanitizer::MissingLvmPvError do
+    let(:devicegraph) { devicegraph_from(scenario) }
+
+    describe ".check" do
+      let(:scenario) { "lvm-errors1-devicegraph.xml" }
+
+      let(:device) { devicegraph.find_by_name(device_name) }
+
+      context "when the given device is a LVM VG with missing PVs" do
+        let(:device_name) { "/dev/test1" }
+
+        it "returns true" do
+          expect(described_class.check(device)).to eq(true)
+        end
+      end
+
+      context "when the given device is a LVM VG without missing PVs" do
+        before do
+          Y2Storage::LvmVg.create(devicegraph, "test3")
+        end
+
+        let(:device_name) { "/dev/test3" }
+
+        it "returns false" do
+          expect(described_class.check(device)).to eq(false)
+        end
+      end
+    end
+
+    describe "#message" do
+      subject { described_class.new(device) }
+
+      let(:scenario) { "lvm-errors1-devicegraph.xml" }
+
+      let(:device) { devicegraph.find_by_name("/dev/test1") }
+
+      it "returns a message for incomplete LVM VG" do
+        expect(subject.message).to match("volume group /dev/test1 is incomplete")
+      end
+    end
+
+    describe "#fix" do
+      subject { described_class.new(device) }
+
+      let(:scenario) { "lvm-errors1-devicegraph.xml" }
+
+      let(:device) { devicegraph.find_by_name("/dev/test1") }
+
+      it "removes the LVM VGs with missing PVs" do
+        expect(devicegraph.find_by_name("/dev/test1")).to_not be_nil
+
+        subject.fix(devicegraph)
+
+        expect(devicegraph.find_by_name("/dev/test1")).to be_nil
+      end
+    end
+  end
+
+  describe Y2Storage::DevicegraphSanitizer::UnsupportedBcacheError do
+    let(:devicegraph) { devicegraph_from(scenario) }
+
+    describe ".check" do
+      context "when Bcache is not supported by the current architecture" do
+        let(:architecture) { :ppc }
+
+        context "and there are Bcache devices" do
+          let(:scenario) { "bcache2.xml" }
+
+          it "returns true" do
+            expect(described_class.check(devicegraph)).to eq(true)
+          end
+        end
+
+        context "and there are no Bcache devices" do
+          let(:scenario) { "mixed_disks" }
+
+          it "returns false" do
+            expect(described_class.check(devicegraph)).to eq(false)
+          end
+        end
+      end
+
+      context "when Bcache is supported by the current architecture" do
+        let(:architecture) { :x86_64 }
+
+        let(:scenario) { "bcache2.xml" }
+
+        it "returns false" do
+          expect(described_class.check(devicegraph)).to eq(false)
+        end
+      end
+    end
+
+    describe "#message" do
+      subject { described_class.new }
+
+      let(:scenario) { "bcache2.xml" }
+
+      it "returns a message for unsupported Bcache device" do
+        expect(subject.message).to match("bcache is not supported")
+      end
+    end
+
+    describe "#fix" do
+      subject { described_class.new }
+
+      let(:scenario) { "bcache2.xml" }
+
+      it "does not modify the given devicegraph" do
+        init_devicegraph = devicegraph.dup
+
+        subject.fix(devicegraph)
+
+        expect(devicegraph).to eq(init_devicegraph)
+      end
+    end
+  end
+
+  describe Y2Storage::DevicegraphSanitizer::InactiveRootError do
+    let(:devicegraph) { devicegraph_from(scenario) }
+
+    let(:scenario) { "mixed_disks" }
+
+    let(:device) { devicegraph.find_by_name(device_name) }
+
+    let(:filesystem) { device.filesystem }
+
+    describe ".check" do
+      context "when the given filesystem is not root" do
+        let(:device_name) { "/dev/sdb5" }
+
+        it "returns false" do
+          expect(described_class.check(filesystem)).to eq(false)
+        end
+      end
+
+      context "when the given filesystem is root" do
+        let(:device_name) { "/dev/sdb2" }
+
+        before do
+          device.mount_point.active = active
+        end
+
+        context "and its mount point is active" do
+          let(:active) { true }
+
+          it "returns false" do
+            expect(described_class.check(filesystem)).to eq(false)
+          end
+        end
+
+        context "and its mount point is not active" do
+          let(:active) { false }
+
+          it "returns true" do
+            expect(described_class.check(filesystem)).to eq(true)
+          end
+        end
+      end
+    end
+
+    describe "#message" do
+      subject { described_class.new(filesystem) }
+
+      let(:device_name) { "/dev/sdb2" }
+
+      it "returns a message for inactive root" do
+        expect(subject.message).to match("root filesystem looks like not currently mounted")
+      end
+
+      context "and the filesystem is Btrfs" do
+        it "includes rollback tip" do
+          expect(subject.message).to match("executed a snapshot rollback")
+        end
+      end
+    end
+
+    describe "#fix" do
+      subject { described_class.new(filesystem) }
+
+      let(:device_name) { "/dev/sdb2" }
+
+      it "does not modify the given devicegraph" do
+        init_devicegraph = devicegraph.dup
+
+        subject.fix(devicegraph)
+
+        expect(devicegraph).to eq(init_devicegraph)
       end
     end
   end


### PR DESCRIPTION
## Problem

Under certain scenarios, the root mount point could be probed as inactive (which does not make sense). One situation where this happens is when the user executes a snapshot rollback and the system has not been rebooted yet. In that case, */etc/fstab* and */proc/mounts* files would contain something like the following:

~~~
$ cat /etc/fstab

/dev/sda1  /  btrfs  defaults  0  0

$ cat /proc/mounts

dev/sda1 / btrfs rw,relatime,space_cache,subvolid=268,subvol=/@/.snapshots/1/snapshot 0 0
~~~

Note that subvolid 268 in */proc/mounts* entry is the Id of the default subvolume before the rollback process. The new default subvolume would have a different Id, and for that reason, the root mount point is probed as inactive (there is no entry in */proc/mounts* for root with the new default subvolume Id).

- Related to [bsc#1124581](https://bugzilla.suse.com/show_bug.cgi?id=1124581)
- See also https://github.com/openSUSE/libstorage-ng/pull/678
- https://trello.com/c/5lTMnxHm/688-3-tw-p2-1124581-problem-with-mount-bind-and-or-docker-and-or-rollback


## Solution

A new check has been added to the Devicegraph sanitizer process. Now, when an inactive root mount point is detected, the user is alerted about that. In case Btrfs is used, a tip about rollback without rebooting is reported as possible reason. 


## Testing

- Added new unit tests
- Tested manually after a rollback


## Screenshots

<details>

<summary>Show/hide</summary>

<h3>Error about inactive root</h3>

![VirtualBox_openSUSE Tumbleweed 2_25_11_2019_12_09_35](https://user-images.githubusercontent.com/1112304/69539934-6cdd6a00-0f7d-11ea-8151-cb19fe9f4662.png)

<h3>Mount point probed as inactive (asterisk in path)</h3> 

![VirtualBox_openSUSE Tumbleweed 2_25_11_2019_12_10_35](https://user-images.githubusercontent.com/1112304/69539943-72d34b00-0f7d-11ea-9033-ec4a12c8e599.png)

<h3>Help already explains what asterisk means</h3>

![VirtualBox_openSUSE Tumbleweed 2_25_11_2019_12_11_03](https://user-images.githubusercontent.com/1112304/69539949-7535a500-0f7d-11ea-8efc-7f9a2766e812.png)


</details>


