### PR TITLE
Set passno to 2 for the ESP (bsc#1135523)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 27 13:53:57 UTC 2019 - Christopher Hofmann <cwh@suse.com>
+
+- Set passno to 2 for the ESP (bsc#1135523)
+- 4.2.59
+
+-------------------------------------------------------------------
 Mon Nov 25 12:21:07 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Detect root mount point probed as inactive (e.g., as result of a

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.58
+Version:        4.2.59
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -33,6 +33,9 @@ module Y2Storage
     # @return [Pathname] Object that represents the root path
     ROOT_PATH = Pathname.new("/").freeze
 
+    # @return [Pathname] Object that represents the ESP path
+    ESP_PATH = Pathname.new("/boot/efi").freeze
+
     # @return [Pathname] Object that represents the swap path
     SWAP_PATH = Pathname.new("swap").freeze
 
@@ -241,6 +244,13 @@ module Y2Storage
       path == ROOT_PATH.to_s
     end
 
+    # Whether the mount point is the ESP
+    #
+    # @return [Boolean]
+    def esp?
+      path == ESP_PATH.to_s
+    end
+
     # @see Device#in_etc?
     # @see #in_etc_fstab
     def in_etc?
@@ -360,7 +370,7 @@ module Y2Storage
     def passno_must_be_set?
       return false unless mountable&.is?(:filesystem)
 
-      filesystem.type.is?(*TYPES_WITH_PASSNO)
+      filesystem.type.is?(*TYPES_WITH_PASSNO) || esp?
     end
 
     # Executes the given block on a mount point that has been adapted to honor

--- a/test/y2storage/mount_point_test.rb
+++ b/test/y2storage/mount_point_test.rb
@@ -135,7 +135,7 @@ describe Y2Storage::MountPoint do
       end
     end
 
-    context "for a NFS share" do
+    context "for an NFS share" do
       let(:blk_device) { nil }
       subject(:filesystem) { fake_devicegraph.nfs_mounts.first }
 
@@ -412,6 +412,48 @@ describe Y2Storage::MountPoint do
 
         it "is set to 0" do
           expect(mount_point.passno).to eq 0
+        end
+      end
+    end
+
+    context "for a VFAT filesystem" do
+      let(:fs_type) { Y2Storage::Filesystems::Type::VFAT }
+
+      context "mounted at /" do
+        let(:path) { "/" }
+
+        it "is set to 0" do
+          expect(mount_point.passno).to eq 0
+        end
+
+        context "and later reassigned to another path" do
+          it "is set to 0" do
+            mount_point.path = "/var"
+            expect(mount_point.passno).to eq 0
+          end
+        end
+
+        context "and later reassigned to /boot/efi" do
+          it "is set to 2" do
+            mount_point.path = "/boot/efi"
+            expect(mount_point.passno).to eq 2
+          end
+        end
+      end
+
+      context "mounted at a non-root location" do
+        let(:path) { "/home" }
+
+        it "is set to 0" do
+          expect(mount_point.passno).to eq 0
+        end
+      end
+
+      context "mounted at /boot/efi" do
+        let(:path) { "/boot/efi" }
+
+        it "is set to 2" do
+          expect(mount_point.passno).to eq 2
         end
       end
     end


### PR DESCRIPTION
## Problem

The ESP - the boot partition used for booting an EFI system - has been configured to not being fscked on boot. That leads to error messages on boot in case the filesystem has not been unmounted properly.

https://bugzilla.suse.com/show_bug.cgi?id=1135523

## Solution

In `etc/fstab` **passno** now is set to `2` for something that is mounted as `/boot/efi`
I did no extra check if the filesystem really is VFAT for that partition since this is a requirement of the EFI standard anyway and should be - and surely is - checked elsewhere.

## Testing

- *Added a new unit test*
- *Tested manually*
