### PR TITLE
Speed up even more initial proposal on systems with many disks

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec  5 12:47:25 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Proposal: in the initial attempt, consider only up to five disks
+  (bsc#1154070).
+- 4.0.223
+
+-------------------------------------------------------------------
 Wed Oct 23 13:35:49 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Proposal: in the initial attempt, consider only up to ten disks

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.0.222
+Version:        4.0.223
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/guided_proposal.rb
+++ b/src/lib/y2storage/guided_proposal.rb
@@ -214,10 +214,10 @@ module Y2Storage
 
       populated = settings.dup
       # In the initial attempt, before the user has had any opportunity to
-      # select the candidate devices, consider only the first 10 disks.
+      # select the candidate devices, consider only the first 5 disks.
       # Otherwise, the process to find the optimal layout can be very slow
       # specially if LVM is enabled by default for the product. See bsc#1154070
-      populated.candidate_devices ||= disk_analyzer.candidate_disks.map(&:name)[0, 10]
+      populated.candidate_devices ||= disk_analyzer.candidate_disks.map(&:name)[0, 5]
 
       @populated_settings = populated
     end


### PR DESCRIPTION
## Problem

As reported in [bug#1154070](https://bugzilla.suse.com/show_bug.cgi?id=1154070), the initial storage proposal, before the user has had any chance to select the disks, is very slow in SLE 15 for SAP in systems with many disks.

In #988 a limit of 10 disks was introduced for that first attempt in order to speed up the calculation. But some reports indicate that limit could not be enough to keep the proposal under a reasonable time threshold in some specially complex situations.

## Solution

Lower the limit to only 5 disks. After all, users with more than 5 disks will very likely dismiss the initial proposal and use the Guided Setup or the Expert Partitioner. So trying so hard to find a good proposal is often just wasting time.