### PR TITLE
Improve encryption names

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 10 15:32:05 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Generate encryption names according to the mount point of the
+  encryption device (bsc#1125774).
+- 4.2.61
+
+-------------------------------------------------------------------
 Wed Dec  4 12:17:37 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Improve detection of Windows systems (related to bsc#1135341).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.60
+Version:        4.2.61
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -19,6 +19,7 @@
 
 require "y2storage/storage_class_wrapper"
 require "y2storage/device"
+require "y2storage/encryption"
 require "y2storage/encryption_type"
 require "y2storage/filesystems/mount_by_type"
 require "pathname"
@@ -81,6 +82,8 @@ module Y2Storage
         else
           0
         end
+
+      Y2Storage::Encryption.update_dm_names(devicegraph)
     end
 
     # @!method mount_by

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc-sep-home.yml
@@ -16,7 +16,7 @@
         mount_point:  "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda2"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
     - partition:
         size:         2 GiB
@@ -26,7 +26,7 @@
         mount_point:  swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda3"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'
     - partition:
         size:         unlimited
@@ -35,7 +35,7 @@
         mount_point:  "/home"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda4"
+          name: "/dev/mapper/cr_home"
           password: '12345678'
     - free:
         size: 16.5 KiB

--- a/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc.yml
+++ b/test/data/devicegraphs/output/empty_hard_disk_gpt_50GiB-enc.yml
@@ -16,7 +16,7 @@
         mount_point:  "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda2"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
     - partition:
         size:         2 GiB
@@ -26,5 +26,5 @@
         mount_point:  swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda3"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'

--- a/test/data/devicegraphs/output/multi-linux-pc-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-enc-sep-home.yml
@@ -51,7 +51,7 @@
         mount_point: "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda6"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
 
     - partition:
@@ -63,7 +63,7 @@
         mount_point: swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda7"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'
 
     - partition:
@@ -75,5 +75,5 @@
         mount_point: "/home"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda8"
+          name: "/dev/mapper/cr_home"
           password: '12345678'

--- a/test/data/devicegraphs/output/multi-linux-pc-enc.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-enc.yml
@@ -47,7 +47,7 @@
         mount_point: "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda6"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
     - partition:
         size: 2 GiB
@@ -58,5 +58,5 @@
         mount_point: swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda7"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'

--- a/test/data/devicegraphs/output/multi-linux-pc-gpt-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-gpt-enc-sep-home.yml
@@ -43,7 +43,7 @@
         mount_point:  "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda6"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
 
     - partition:
@@ -54,7 +54,7 @@
         mount_point:  swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda7"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'
 
     - partition:
@@ -65,7 +65,7 @@
         mount_point:  "/home"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda8"
+          name: "/dev/mapper/cr_home"
           password: '12345678'
 
     # The last 16.5 KiB of a GPT disk are not usable

--- a/test/data/devicegraphs/output/multi-linux-pc-gpt-enc.yml
+++ b/test/data/devicegraphs/output/multi-linux-pc-gpt-enc.yml
@@ -43,7 +43,7 @@
         mount_point:  "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda6"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
 
     - partition:
@@ -54,7 +54,7 @@
         mount_point:    swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda7"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'
 
     - free:

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-enc-sep-home.yml
@@ -27,7 +27,7 @@
         mount_point: "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda3"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
     - partition:
         size: unlimited
@@ -43,7 +43,7 @@
         mount_point: swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda5"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'
     - partition:
         size: 210941 MiB (206.00 GiB)
@@ -54,5 +54,5 @@
         mount_point: "/home"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda6"
+          name: "/dev/mapper/cr_home"
           password: '12345678'

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-enc.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-enc.yml
@@ -27,7 +27,7 @@
         mount_point: "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda3"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
     - partition:
         size: 2 GiB
@@ -38,5 +38,5 @@
         mount_point: swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda4"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-enc-sep-home.yml
@@ -30,7 +30,7 @@
         mount_point: "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda4"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
     - partition:
         size: 2 GiB
@@ -41,7 +41,7 @@
         mount_point: swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda5"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'
     - partition:
         size: unlimited
@@ -51,7 +51,7 @@
         mount_point: "/home"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda6"
+          name: "/dev/mapper/cr_home"
           password: '12345678'
     - free:
         size: 16.5 KiB

--- a/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-enc.yml
+++ b/test/data/devicegraphs/output/windows-linux-multiboot-pc-gpt-enc.yml
@@ -29,7 +29,7 @@
         mount_point: "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda4"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
     - partition:
         size: 2 GiB
@@ -40,5 +40,5 @@
         mount_point: swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda5"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'

--- a/test/data/devicegraphs/output/windows-pc-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-enc-sep-home.yml
@@ -21,7 +21,7 @@
         mount_point: "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda3"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
 
     - partition:
@@ -39,7 +39,7 @@
         mount_point: swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda5"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'
 
     - partition:
@@ -51,7 +51,7 @@
         mount_point: "/home"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda6"
+          name: "/dev/mapper/cr_home"
           password: '12345678'
 
     - partition:

--- a/test/data/devicegraphs/output/windows-pc-enc.yml
+++ b/test/data/devicegraphs/output/windows-pc-enc.yml
@@ -21,7 +21,7 @@
         mount_point: "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda3"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
 
     - partition:
@@ -32,7 +32,7 @@
         mount_point: swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda4"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'
 
     - partition:

--- a/test/data/devicegraphs/output/windows-pc-gpt-enc-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-enc-sep-home.yml
@@ -25,7 +25,7 @@
         mount_point: "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda4"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
 
     - partition:
@@ -36,7 +36,7 @@
         mount_point: swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda5"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'
 
     - partition:
@@ -47,7 +47,7 @@
         mount_point: "/home"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda6"
+          name: "/dev/mapper/cr_home"
           password: '12345678'
 
     - partition:

--- a/test/data/devicegraphs/output/windows-pc-gpt-enc.yml
+++ b/test/data/devicegraphs/output/windows-pc-gpt-enc.yml
@@ -25,7 +25,7 @@
         mount_point: "/"
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda4"
+          name: "/dev/mapper/cr_root"
           password: '12345678'
 
     - partition:
@@ -36,7 +36,7 @@
         mount_point: swap
         encryption:
           type: luks
-          name: "/dev/mapper/cr_sda5"
+          name: "/dev/mapper/cr_swap"
           password: '12345678'
 
     - partition:

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -1138,9 +1138,12 @@ describe Y2Storage::BlkDevice do
     end
 
     RSpec.shared_examples "auto-generated encryption name" do
-      it "creates an encryption device with an auto-generated name and #auto_dm_name?" do
-        expect(Y2Storage::Encryption).to receive(:dm_name_for).with(device).and_return "cr_auto"
+      before do
+        allow_any_instance_of(Y2Storage::Encryption)
+          .to receive(:auto_dm_table_name).and_return("cr_auto")
+      end
 
+      it "creates an encryption device with an auto-generated name and #auto_dm_name?" do
         expect(enc).to be_a Y2Storage::Encryption
         expect(enc.blk_device).to eq device
         expect(enc.dm_table_name).to eq "cr_auto"
@@ -1272,12 +1275,15 @@ describe Y2Storage::BlkDevice do
 
         before do
           # Ensure the first option for the name is already taken
-          enc_name = Y2Storage::Encryption.dm_name_for(sda2)
-          sda3.encryption.dm_table_name = enc_name
+          sda2.encrypt
+          sda3.encryption.dm_table_name = sda2.dm_table_name
+
+          sda2.remove_encryption
         end
 
         it "does not generate redundant DeviceMapper names" do
           sda2.encrypt
+
           expect_no_dm_duplicates
         end
       end

--- a/test/y2storage/fake_device_factory_test.rb
+++ b/test/y2storage/fake_device_factory_test.rb
@@ -426,7 +426,7 @@ describe Y2Storage::FakeDeviceFactory do
         disk = Storage.to_disk(Storage::BlkDevice.find_by_name(staging, "/dev/sdb"))
 
         expect(disk.has_encryption).to be true
-        expect(disk.encryption.name).to eq "/dev/mapper/cr_sdb"
+        expect(disk.encryption.name).to eq "/dev/mapper/cr_data"
       end
     end
 
@@ -441,7 +441,7 @@ describe Y2Storage::FakeDeviceFactory do
               label: "backup"
               encryption:
                   type: "luks"
-                  name: "/dev/mapper/cr_data"
+                  name: "/dev/mapper/cr_custom_name"
         )
       end
 
@@ -451,7 +451,7 @@ describe Y2Storage::FakeDeviceFactory do
         disk = Storage.to_disk(Storage::BlkDevice.find_by_name(staging, "/dev/sdb"))
 
         expect(disk.has_encryption).to be true
-        expect(disk.encryption.name).to eq "/dev/mapper/cr_data"
+        expect(disk.encryption.name).to eq "/dev/mapper/cr_custom_name"
       end
     end
 
@@ -466,7 +466,7 @@ describe Y2Storage::FakeDeviceFactory do
               label: "backup"
               encryption:
                   type: "luks"
-                  name: "cr_data"
+                  name: "cr_dm_name"
         )
       end
 
@@ -476,7 +476,7 @@ describe Y2Storage::FakeDeviceFactory do
         disk = Storage.to_disk(Storage::BlkDevice.find_by_name(staging, "/dev/sdb"))
 
         expect(disk.has_encryption).to be true
-        expect(disk.encryption.name).to eq "/dev/mapper/cr_data"
+        expect(disk.encryption.name).to eq "/dev/mapper/cr_dm_name"
       end
     end
 


### PR DESCRIPTION
## Problem

When an encryption device is created in YaST (by means of either the storage proposal or manually with the Expert Partitioner), the device mapper name for the new device is generated from the udev id of the underlying device (e.g., "cr_ccw-0XAF5E-part2"). When booting, a message is prompted like this:

~~~
"Please enter passphrase for disk cr_ccw-0XAF5E-part2!"
~~~

But it is difficult to know what device this refers when there are several encrypted devices in the system. More user-friendly names should be used for encryption devices. 

* https://bugzilla.suse.com/show_bug.cgi?id=1125774

* https://trello.com/c/MR24HhqL/1486-2-research-p4-1125774-sles-15-sp1-beta3-improve-naming-of-crypt-devices-in-the-passphrase-prompt


## Solution

Now on (and similar to what the old storage stack did), the mount point of the encryption device is considered for generating the device mapper name. So, the encryption names would be something like:

~~~
cr_root => if mounted at /

cr_home => if mounted at /home

cr_foo_bar => if mounted at /foo/bar

cr_foo_bar_2 => if mounted at /foo/bar and a cr_foo_bar already exists
~~~

Note that name collisions are prevented. Device mapper names based on udev ids can still be used if the encryption device is not mounted.


## Testing

- Added a new unit test
- Tested manually
