### PR TITLE
Improve callback for LUKS activation

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 11 15:19:00 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Show device name when activating a LUKS device (related to
+  bsc#1125774).
+- 4.2.62
+
+-------------------------------------------------------------------
 Tue Dec 10 15:32:05 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Generate encryption names according to the mount point of the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# Storage::MountPoint#default_mount_options
-BuildRequires:	libstorage-ng-ruby >= 4.2.27
+# Storage::LuksInfo
+BuildRequires:	libstorage-ng-ruby >= 4.2.39
 BuildRequires:  update-desktop-files
 # CWM::Dialog#next_handler (4.1 branch) and improved CWM::Dialog
 BuildRequires:  yast2 >= 4.1.11
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# Storage::MountPoint#default_mount_options
-Requires:       libstorage-ng-ruby >= 4.2.27
+# Storage::LuksInfo
+Requires:       libstorage-ng-ruby >= 4.2.39
 # CWM::Dialog#next_handler (4.1 branch) and improved CWM::Dialog
 Requires:       yast2 >= 4.1.11
 # Y2Packager::Repository

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.61
+Version:        4.2.62
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/dialogs/callbacks/activate_luks.rb
+++ b/src/lib/y2storage/dialogs/callbacks/activate_luks.rb
@@ -1,8 +1,4 @@
-#!/usr/bin/env ruby
-#
-# encoding: utf-8
-
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -36,9 +32,13 @@ module Y2Storage
 
         secret_attr :encryption_password
 
-        def initialize(uuid, attempt)
+        # Constructor
+        #
+        # @param info [Storage::LuksInfo]
+        # @param attempt [Numeric]
+        def initialize(info, attempt)
           textdomain "storage"
-          @uuid = uuid
+          @info = info
           @attempt = attempt
         end
 
@@ -78,7 +78,7 @@ module Y2Storage
 
         protected
 
-        attr_reader :uuid, :attempt
+        attr_reader :info, :attempt
 
         def create_dialog
           super
@@ -103,7 +103,10 @@ module Y2Storage
               )
             ),
             VSpacing(0.2),
-            Left(Label("UUID: #{uuid}")),
+            # TRANSLATORS: %{name} is replaced by a device name (e.g., /dev/sda1)
+            Left(Label(format(_("Device Name: %{name}"), name: info.device_name))),
+            # TRANSLATORS: %{uuid} is replaced by a device UUID (e.g., 111-2222-33333)
+            Left(Label(format(_("LUKS UUID: %{uuid}"), uuid: info.uuid))),
             VSpacing(0.2),
             Left(
               Label(

--- a/test/support/devices_planner_context.rb
+++ b/test/support/devices_planner_context.rb
@@ -40,6 +40,8 @@ RSpec.shared_context "devices planner" do
   let(:control_file_content) { nil }
 
   before do
+    Y2Storage::StorageManager.create_test_instance
+
     Yast::ProductFeatures.Import("partitioning" => control_file_content)
 
     allow(Y2Storage::BootRequirementsChecker).to receive(:new).and_return boot_checker

--- a/test/y2storage/callbacks/activate_test.rb
+++ b/test/y2storage/callbacks/activate_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017] SUSE LLC
+
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -39,25 +40,30 @@ describe Y2Storage::Callbacks::Activate do
       allow(Y2Storage::Dialogs::Callbacks::ActivateLuks).to receive(:new).and_return dialog
     end
 
+    let(:info) { instance_double(Storage::LuksInfo, device_name: device_name, uuid: uuid, label: label) }
+
+    let(:device_name) { "/dev/sda1" }
     let(:uuid) { "11111111-1111-1111-1111-11111111" }
+    let(:label) { "" }
+
     let(:attempts) { 1 }
     let(:action) { nil }
     let(:encryption_password) { "123456" }
 
     it "opens a dialog to request the password" do
       expect(dialog).to receive(:run).once
-      subject.luks(uuid, attempts)
+      subject.luks(info, attempts)
     end
 
     it "returns an object of the expected type" do
-      expect(subject.luks(uuid, attempts)).to be_a(Storage::PairBoolString)
+      expect(subject.luks(info, attempts)).to be_a(Storage::PairBoolString)
     end
 
     context "when the dialog is accepted" do
       let(:action) { :accept }
 
       it "returns the pair (true, password)" do
-        result = subject.luks(uuid, attempts)
+        result = subject.luks(info, attempts)
         expect(result.first).to eq(true)
         expect(result.second).to eq(encryption_password)
       end
@@ -67,7 +73,7 @@ describe Y2Storage::Callbacks::Activate do
       let(:action) { :cancel }
 
       it "returns the pair (false, \"\")" do
-        result = subject.luks(uuid, attempts)
+        result = subject.luks(info, attempts)
         expect(result.first).to eq(false)
         expect(result.second).to eq("")
       end

--- a/test/y2storage/dialogs/callbacks/activate_luks_test.rb
+++ b/test/y2storage/dialogs/callbacks/activate_luks_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017] SUSE LLC
+
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -32,9 +33,14 @@ describe Y2Storage::Dialogs::Callbacks::ActivateLuks do
       .and_return(password)
   end
 
-  subject { described_class.new(uuid, attempts) }
+  subject { described_class.new(info, attempts) }
 
+  let(:info) { instance_double(Storage::LuksInfo, device_name: device_name, uuid: uuid, label: label) }
+
+  let(:device_name) { "/dev/sda1" }
   let(:uuid) { "11111111-1111-1111-1111-11111111" }
+  let(:label) { "" }
+
   let(:attempts) { 1 }
   let(:action) { :cancel }
   let(:password) { nil }


### PR DESCRIPTION
NOTE FOR REVIEWERS: unit tests require https://github.com/openSUSE/libstorage-ng/pull/688 to pass.

## Problem

When a LUKS needs to be activated, the user is prompted to give the encryption password. But the popup only shows the encryption UUID, making very difficult to identify the device when the systems contains several encrypted devices. 

* Part of https://trello.com/c/MR24HhqL/1486-2-research-p4-1125774-sles-15-sp1-beta3-improve-naming-of-crypt-devices-in-the-passphrase-prompt

* Related to https://bugzilla.suse.com/show_bug.cgi?id=1125774

* Requires https://github.com/openSUSE/libstorage-ng/pull/688

## Solution

Now on, the activation popup also shows the name of the underlying device.

## Testing

- Unit tests adapted.
- Tested manually


## Screenshots

<details>

<summary>Show/Hide</summary>

![VirtualBox_openSUSE Tumbleweed_11_12_2019_15_43_29](https://user-images.githubusercontent.com/1112304/70636218-0c148980-1c2d-11ea-94ad-36d85db6a100.png)

![VirtualBox_openSUSE Tumbleweed 2_12_12_2019_17_09_29](https://user-images.githubusercontent.com/1112304/70733426-36844680-1d02-11ea-8506-ac2579d467ee.png)


</details>


