### PR TITLE
Add comment about possible encryption improvements

### DIFF
--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -155,6 +155,18 @@ module Y2Storage
     #
     # @return [String]
     def auto_dm_table_name
+      # TODO: Better encryption names can be generated for indirectly used encryption devices (e.g., an
+      # encrypted device used as LVM PV). But this implies to update the auto generated device mapper
+      # names at some quite points, for example, when a device is added/removed to a LVM VG, MD RAID,
+      # etc.
+      #
+      # Another option could be to update the encryption names just before the commit action, but in that
+      # case, the devicegraph would contain temporary encryption names all the time. Temporary names are
+      # a problem if they are presented to the user in the UI.
+      #
+      # Note that any change to the encryption name generation could affect to the pervasive encryption
+      # key generation, specially when probed encryption names are modified. Right now, probed names are
+      # not touched.
       name =
         if !blk_device.dm_table_name.empty?
           blk_device.dm_table_name


### PR DESCRIPTION
## Problem

Encryption names were improved here https://github.com/yast/yast-storage-ng/pull/1006 to take into account the mount point when possible, for example:

~~~
mount point: / => cr_root

mount point: /foo/bar => cr_foo_bar
~~~

But indirectly used encrypted devices (e.g., an encrypted LVM PV) could also have more user-friendly names. For example, when an encrypted LVM PV is added to the volume group "vg0", the encryption name could be `cr_vg0`. Similarly, it could be improved for encrypted devices used by a MD Raid, Bcache or Bcache caching set. 

* Related to https://bugzilla.suse.com/show_bug.cgi?id=1125774

## Solution

Adapting encryption names for indirectly used encrypted devices could be tricky and it requires to take several implications into account. Some comments are added to the code, but the feature is not implemented for the time being.
