### PR TITLE
AutoYaST: specify a multipath device through one of its wires

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 19 14:22:49 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: use the multipath device when the 'device' element
+  points to one of its wires (bsc#1159081).
+- 4.2.65
+
+-------------------------------------------------------------------
 Tue Dec 17 12:48:40 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Wrap long details message when error happens (bsc#1085468)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.64
+Version:        4.2.65
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/proposal/autoinst_drives_map.rb
+++ b/src/lib/y2storage/proposal/autoinst_drives_map.rb
@@ -227,6 +227,7 @@ module Y2Storage
 
         mp_device = device.multipath
         return mp_device if mp_device
+
         ([device] + device.ancestors).find { |d| d.is?(:disk_device, :stray_blk_device) }
       end
 

--- a/src/lib/y2storage/proposal/autoinst_drives_map.rb
+++ b/src/lib/y2storage/proposal/autoinst_drives_map.rb
@@ -225,6 +225,8 @@ module Y2Storage
         device = devicegraph.find_by_any_name(device_name)
         return nil unless device
 
+        mp_device = device.multipath
+        return mp_device if mp_device
         ([device] + device.ancestors).find { |d| d.is?(:disk_device, :stray_blk_device) }
       end
 

--- a/test/y2storage/proposal/autoinst_drives_map_test.rb
+++ b/test/y2storage/proposal/autoinst_drives_map_test.rb
@@ -160,6 +160,23 @@ describe Y2Storage::Proposal::AutoinstDrivesMap do
         expect(drives_map.disk_names).to include("root_fs")
       end
     end
+
+    context "when a multipath member is used" do
+      let(:scenario) { "multipath-formatted.xml" }
+
+      let(:partitioning_array) do
+        [
+          {
+            "device" => "/dev/sda", "use" => "all"
+          }
+        ]
+      end
+
+      it "uses the multipath device" do
+        expect(drives_map.disk_names)
+          .to eq(["/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"])
+      end
+    end
   end
 
   describe "#each" do

--- a/test/y2storage/proposal/autoinst_drives_map_test.rb
+++ b/test/y2storage/proposal/autoinst_drives_map_test.rb
@@ -137,8 +137,6 @@ describe Y2Storage::Proposal::AutoinstDrivesMap do
       end
 
       it "uses the device name" do
-        described_class.new(fake_devicegraph, partitioning, issues_list)
-
         expect(drives_map.disk_names).to include("/dev/nfs")
       end
     end


### PR DESCRIPTION
## Problem

If you want to use multipath through AutoYaST, you need to specify the multipath device name in the `device` element. Sometimes, it might be more convenient to use one of its wires. For instance, let's say that you use a multipath device that is accessible through `/dev/sda` and `/dev/sdb`. Instead of using `/dev/mapper/WHATEVER-MP-NAME`, you might want to just use `/dev/sda` (or `/dev/sdb`).

See [bsc#1159081](https://bugzilla.suse.com/show_bug.cgi?id=1159081) for further details.

## Solution

This PR adds support to use the wire instead of the full multipath device name. Basically, it checks whether the specified device is part of a multipath one. In that case, it will consider the multipath device. Otherwise, it will apply the default logic (searching for the disk device where it belongs).

## Testing

- Added a new unit test
- Tested manually
