### PR TITLE
Wrapping error

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Tue Dec 17 12:48:40 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
-- Wrap long details message when error happen (bsc#1085468)
+- Wrap long details message when error happens (bsc#1085468)
 - 4.2.64
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Dec 17 12:48:40 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- Wrap long details message when error happen (bsc#1085468)
+- 4.2.64
+
+-------------------------------------------------------------------
 Fri Dec 13 16:37:32 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Improved support for Raspberry Pi in the Guided Proposal: now it

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.63
+Version:        4.2.64
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/callbacks/libstorage_callback.rb
+++ b/src/lib/y2storage/callbacks/libstorage_callback.rb
@@ -20,6 +20,7 @@
 require "yast"
 require "storage"
 require "y2storage/storage_env"
+require "ui/text_helpers"
 
 Yast.import "Report"
 Yast.import "Popup"
@@ -33,6 +34,7 @@ module Y2Storage
     module LibstorageCallback
       include Yast::Logger
       include Yast::I18n
+      include UI::TextHelpers
 
       # Callback for libstorage-ng to show a message to the user.
       #
@@ -87,7 +89,7 @@ module Y2Storage
         focus = default_answer_to_error ? :yes : :no
 
         result = Yast::Report.yesno_popup(
-          msg, details: what, focus: focus, buttons: buttons
+          msg, details: wrap_text(what), focus: focus, buttons: buttons
         )
 
         log.info "User answer: #{result}"

--- a/test/y2storage/callbacks/callbacks_examples.rb
+++ b/test/y2storage/callbacks/callbacks_examples.rb
@@ -53,7 +53,7 @@ RSpec.shared_examples "general #error examples" do
   end
 
   # see https://bugzilla.suse.com/show_bug.cgi?id=1085468
-  context "with an long error" do
+  context "with long error" do
     let(:what) do
       "command '/usr/sbin/parted --script '/dev/sda' mklabel gpt' failed:\n\n\n" \
       "stderr:\n"\


### PR DESCRIPTION
## Problem

stderr of some programs can be so long that it does not fit on the screen and so it is useless for users.

- https://bugzilla.suse.com/show_bug.cgi?id=1085468


## Solution

Use shared functionality to [wrap text](https://github.com/yast/yast-yast2/blob/6bc7bd9f1ef03f783ed269cd59174fe9e8a25c78/library/general/src/lib/ui/text_helpers.rb#L34).


## Testing

- Unit tests included.


## Screenshots

before:
![Snímek obrazovky_2019-12-17_14-07-15](https://user-images.githubusercontent.com/478871/70998105-cf3a0e00-20d6-11ea-8943-8ffc49f4dfc2.png)

after:
![Snímek obrazovky_2019-12-17_14-09-06](https://user-images.githubusercontent.com/478871/70998103-cf3a0e00-20d6-11ea-9201-a10ec27a9735.png)