### PR TITLE
improved sorting of devices by device size

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 19 17:51:09 CET 2019 - aschnell@suse.com
+
+- Improved sorting of devices by device size (bonus to bsc#1140018)
+- 4.2.66
+
+-------------------------------------------------------------------
 Thu Dec 19 14:22:49 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: use the multipath device when the 'device' element

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.65
+Version:        4.2.66
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only
@@ -25,11 +25,11 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# Storage::LuksInfo
-BuildRequires:	libstorage-ng-ruby >= 4.2.39
+# Device::get_name_sort_key
+BuildRequires:	libstorage-ng-ruby >= 4.2.43
 BuildRequires:  update-desktop-files
-# CWM::Dialog#next_handler (4.1 branch) and improved CWM::Dialog
-BuildRequires:  yast2 >= 4.1.11
+# for CWM sort_key helper
+BuildRequires:  yast2 >= 4.2.48
 BuildRequires:  yast2-devtools >= 4.2.2
 # for AbortException and handle direct abort
 BuildRequires:  yast2-ruby-bindings >= 4.0.6
@@ -47,14 +47,16 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# Storage::LuksInfo
-Requires:       libstorage-ng-ruby >= 4.2.39
-# CWM::Dialog#next_handler (4.1 branch) and improved CWM::Dialog
-Requires:       yast2 >= 4.1.11
+# Device::get_name_sort_key
+Requires:       libstorage-ng-ruby >= 4.2.43
+# for CWM sort_key helper
+Requires:       yast2 >= 4.2.48
 # Y2Packager::Repository
 Requires:       yast2-packager >= 3.3.7
 # for AbortException and handle direct abort
 Requires:       yast2-ruby-bindings >= 4.0.6
+# for sortKey
+Requires:	yast2-ycp-ui-bindings >= 4.2.7
 # communicate with udisks
 Requires:       rubygem(%{rb_default_ruby_abi}:ruby-dbus)
 Requires(post): %fillup_prereq

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -164,7 +164,7 @@ module Y2Partitioner
         # such devices without a direct and straightforward #size method.
         return "" unless device.respond_to?(:size)
 
-        device.size.to_human_string
+        cell(device.size.to_human_string, sort_key(device.size.to_i.to_s))
       end
 
       def format_value(device)

--- a/src/lib/y2storage/device.rb
+++ b/src/lib/y2storage/device.rb
@@ -197,6 +197,12 @@ module Y2Storage
     #       sorted list (less than)
     storage_class_forward :compare_by_name
 
+    # @!method name_sort_key
+    #   Return a sort key based of the device name.
+    #
+    #   @return [string] a sort key for the device name or empty string
+    storage_forward :name_sort_key
+
     # @!method self.all(devicegraph)
     #   @param devicegraph [Devicegraph]
     #   @return [Array<Device>] all the devices in the given devicegraph

--- a/src/lib/y2storage/device.rb
+++ b/src/lib/y2storage/device.rb
@@ -197,12 +197,6 @@ module Y2Storage
     #       sorted list (less than)
     storage_class_forward :compare_by_name
 
-    # @!method name_sort_key
-    #   Return a sort key based of the device name.
-    #
-    #   @return [string] a sort key for the device name or empty string
-    storage_forward :name_sort_key
-
     # @!method self.all(devicegraph)
     #   @param devicegraph [Devicegraph]
     #   @return [Array<Device>] all the devices in the given devicegraph


### PR DESCRIPTION
So far devices in tables were sorted alphabetical when the user selected sorting by size. That does not give good results. Now the sorting is done numerical.

Note: There is already some code included to also better sort by name. The missing code is easy but adapting the testsuite needs a lot more work.

![size](https://user-images.githubusercontent.com/908062/71192917-78286a80-2289-11ea-8a93-caa0c0b85577.png)

Also see https://github.com/libyui/libyui/pull/156.
