### PR TITLE
Enhance behavior of fallback_max_size_lvm (bsc#1075990)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec 20 16:20:29 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed an error when applying fallback_max_size_lvm in some corner
+  cases (bsc#1075990).
+- 4.2.66
+
+-------------------------------------------------------------------
 Thu Dec 19 14:22:49 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: use the multipath device when the 'device' element

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.65
+Version:        4.2.66
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/test/y2storage/proposal/devices_planner_strategies/ng_test.rb
+++ b/test/y2storage/proposal/devices_planner_strategies/ng_test.rb
@@ -312,17 +312,28 @@ describe Y2Storage::Proposal::DevicesPlannerStrategies::Ng do
               context "and it is proposing a LVM-based setup" do
                 let(:lvm) { true }
 
-                let(:max_size_lvm) { 10.GiB }
+                context "with the max size of the volume being based on max_size_lvm" do
+                  let(:max_size_lvm) { 10.GiB }
 
-                it "sets max_size including max_size_lvm fallback values" do
-                  expect(planned_device.max_size).to eq(max_size_lvm + home_max_size_lvm)
+                  it "sets max_size including max_size_lvm fallback values" do
+                    expect(planned_device.max_size).to eq(max_size_lvm + home_max_size_lvm)
+                  end
+                end
+
+                context "with the max size being based on max_size (no value for max_size_lvm)" do
+                  let(:max_size_lvm) { nil }
+                  let(:max_size) { 23.GiB }
+
+                  it "sets max_size including max_size_lvm fallback values" do
+                    expect(planned_device.max_size).to eq(max_size + home_max_size_lvm)
+                  end
                 end
               end
             end
           end
         end
 
-        context "when it is adjunsting the min_size" do
+        context "when it is adjusting the min_size" do
           context "and it is calculating desired sizes" do
             let(:target) { :desired }
 


### PR DESCRIPTION
## Problem

As described in [bug#1075990](https://bugzilla.suse.com/show_bug.cgi?id=1075990), there is a corner-case in which the max size for a volume is not properly calculated. Check the bug report for details.

## Solution

Make sure `max_size` is always used when `max_size_lvm` is not there, even if the value must be increased by sizes coming from other volumes via `fallback_max_size_lvm`.

This includes a preliminary commit to organize the code a little bit better, so it's MUCH easier to review commit by commit.

## Testing

Added a new unit test with the situation described in the bug.
