### PR TITLE
Unify partition id names

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan  7 09:10:11 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Use partition id names defined by libstorage-ng.
+- 4.2.68
+
+-------------------------------------------------------------------
 Mon Dec 23 08:29:03 CET 2019 - aschnell@suse.com
 
 - Improved sorting by device name and size in tables (bsc#1140018)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# Device::get_name_sort_key
-BuildRequires:	libstorage-ng-ruby >= 4.2.43
+# Storage.partition_id_name
+BuildRequires:	libstorage-ng-ruby >= 4.2.45
 BuildRequires:  update-desktop-files
 # for CWM sort_key helper
 BuildRequires:  yast2 >= 4.2.48
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# Device::get_name_sort_key
-Requires:       libstorage-ng-ruby >= 4.2.39
+# Storage.partition_id_name
+Requires:       libstorage-ng-ruby >= 4.2.45
 # for CWM sort_key helper
 Requires:       yast2 >= 4.2.48
 # Y2Packager::Repository

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.67
+Version:        4.2.68
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/partition_id.rb
+++ b/src/lib/y2storage/partition_id.rb
@@ -17,6 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast"
 require "y2storage/storage_enum_wrapper"
 
 module Y2Storage
@@ -24,35 +25,138 @@ module Y2Storage
   #
   # This is a wrapper for the Storage::ID enum
   class PartitionId
-    include Yast::I18n
-    extend Yast::I18n
     include StorageEnumWrapper
-    include Yast::Logger
-
     wrap_enum "ID"
 
-    NOT_ALLOW_FORMAT = [LVM, RAID, ESP, PREP, BIOS_BOOT, UNKNOWN].freeze
-    private_constant :NOT_ALLOW_FORMAT
+    include Yast::Logger
 
-    # Do not include 'Partition' in the name.
-    TRANSLATIONS = {
-      BIOS_BOOT.to_i          => N_("BIOS Boot"),
-      DIAG.to_i               => N_("Diagnostics"),
-      DOS12.to_i              => N_("DOS12"),
-      DOS16.to_i              => N_("DOS16"),
-      DOS32.to_i              => N_("DOS32"),
-      ESP.to_i                => N_("EFI System"),
-      EXTENDED.to_i           => N_("Extended"),
-      IRST.to_i               => N_("Intel Rapid Start"),
-      LINUX.to_i              => N_("Linux Native"),
-      LVM.to_i                => N_("Linux LVM"),
-      MICROSOFT_RESERVED.to_i => N_("Microsoft Reserved"),
-      NTFS.to_i               => N_("NTFS"),
-      PREP.to_i               => N_("PReP Boot"),
-      RAID.to_i               => N_("Linux RAID"),
-      SWAP.to_i               => N_("Linux Swap"),
-      UNKNOWN.to_i            => N_("Unknown"),
-      WINDOWS_BASIC_DATA.to_i => N_("Windows Data")
+    class << self
+      # Partition id that was represented by the given numeric fsid in the old
+      # libstorage.
+      #
+      # @param number [Integer] fsid used in the old libstorage
+      # @return [PartitionId] corresponding id. UNKNOWN if there is no equivalent
+      def new_from_legacy(number)
+        return LEGACY_TO_CURRENT[number] if LEGACY_TO_CURRENT.key?(number)
+        return new(number) if LEGACY_KEPT.map(&:to_i).include?(number)
+
+        UNKNOWN
+      end
+
+      # Set of ids for partitions that are typically part of a Linux system.
+      # This may be a normal Linux partition (type 0x83), a Linux swap partition
+      # (type 0x82), an LVM partition, or a RAID partition.
+      #
+      # @return [Array<PartitionId>]
+      def linux_system_ids
+        LINUX_SYSTEM_IDS.dup
+      end
+
+      # Set of ids for partitions that could potentially host a MS Windows system.
+      #
+      # Take into account that checking the partition id is not enough to ensure a
+      # partition is suitable to host a MS Windows installation (for example,
+      # Windows can only be installed in primary partitions).
+      #
+      # @return [Array<PartitionId>]
+      def windows_system_ids
+        WINDOWS_SYSTEM_IDS.dup
+      end
+    end
+
+    def formattable?
+      !NOT_ALLOW_FORMAT.include?(to_sym)
+    end
+
+    def to_human_string
+      id_name = Storage.partition_id_name(to_i)
+
+      if id_name.empty?
+        log.warn "Unhandled Partition ID '#{inspect}'"
+        id_name = "0x#{to_i.to_s(16)}"
+      end
+
+      id_name
+    end
+
+    # Numeric fsid used in the old libstorage to represent this partition id.
+    #
+    # @return [Integer]
+    def to_i_legacy
+      return CURRENT_TO_LEGACY[to_i] if CURRENT_TO_LEGACY.key?(to_i)
+
+      to_i
+    end
+
+    # Get the sort order of this partition ID.
+    # @return [Integer]
+    def sort_order
+      SORT_ORDER.find_index(self) || SORT_ORDER.size
+    end
+
+    # Comparison operator for sorting.
+    # @return [Integer] -1, 0, 1
+    def <=>(other)
+      return -1 unless other.respond_to?(:sort_order)
+
+      sort_order <=> other.sort_order
+    end
+
+    # @see StorageEnumWrapper#is?
+    #
+    # In addition to checking by name, it also supports :linux_system and
+    # :windows_system
+    #
+    # @see .linux_system_ids
+    # @see .windows_system_ids
+    def is?(*names)
+      names.any? do |name|
+        case name.to_sym
+        when :linux_system
+          LINUX_SYSTEM_IDS.include?(self)
+        when :windows_system
+          WINDOWS_SYSTEM_IDS.include?(self)
+        else
+          name.to_sym == to_sym
+        end
+      end
+    end
+
+    LINUX_SYSTEM_IDS = [LINUX, SWAP, LVM, RAID].freeze
+
+    WINDOWS_SYSTEM_IDS = [NTFS, DOS32, DOS16, DOS12, WINDOWS_BASIC_DATA, MICROSOFT_RESERVED].freeze
+
+    NOT_ALLOW_FORMAT = [LVM, RAID, ESP, PREP, BIOS_BOOT, UNKNOWN].freeze
+
+    # Partition ids for which the internal numeric id is the same than the
+    # corresponding fsid in the old libstorage.
+    # See {.new_from_legacy} and {#to_i_legacy}.
+    LEGACY_KEPT = [DOS12, DOS16, DOS32, NTFS, EXTENDED, PREP, LINUX, SWAP, LVM, RAID, DIAG, ESP].freeze
+
+    # Matching between fsids in the old libstorage and the corresponding
+    # partition id.
+    # See {.new_from_legacy} and {#to_i_legacy}.
+    LEGACY_TO_CURRENT = {
+      4   => DOS16, # Known as "FAT16 <32M"
+      5   => EXTENDED, # In the past both 5 and 15 were recognized as extended
+      11  => DOS32, # Known as "Win95 FAT32" as an alternative to 0x0c (Win95 FAT32 LBA)
+      14  => DOS16, # Known as "Win95 FAT16" as an alternative to 0x06 (FAT16)
+      257 => UNKNOWN, # 257 used to mean mac_hidden, but is BIOS_BOOT now
+      258 => UNKNOWN, # 258 used to mean mac_hfs, but is WINDOWS_BASIC_DATA now
+      259 => ESP, # 259 is MICROSOFT_RESERVED now
+      261 => MICROSOFT_RESERVED,
+      263 => BIOS_BOOT,
+      264 => PREP
+    }.freeze
+
+    # Matching between partition ids and the number that was used to represent
+    # them in the old libstorage.
+    # See {.new_from_legacy} and {#to_i_legacy}.
+    CURRENT_TO_LEGACY = {
+      BIOS_BOOT.to_i          => 263, # BIOS_BOOT.to_i is 257, that used to mean mac_hidden
+      ESP.to_i                => 259, # ESP.to_i is 239, that used to have no special meaning
+      WINDOWS_BASIC_DATA.to_i => 0, # WINDOWS_BASIC_DATA.to_i is 258, that used to mean mac_hfs
+      MICROSOFT_RESERVED.to_i => 261 # MICROSOFT_RESERVED.to_i is 261, that used to mean BIOS_BOOT
     }.freeze
 
     SORT_ORDER = [
@@ -79,135 +183,12 @@ module Y2Storage
       # Eveything not listed here is sorted after this
     ].freeze
 
-    private_constant :TRANSLATIONS, :SORT_ORDER
-
-    def to_human_string
-      textdomain "storage"
-
-      string = TRANSLATIONS[to_i]
-      if string.nil?
-        log.warn "Unhandled Partition ID '#{inspect}'"
-        string = "0x#{to_i.to_s(16)}"
-      end
-
-      _(string)
-    end
-
-    def formattable?
-      !NOT_ALLOW_FORMAT.include?(to_sym)
-    end
-
-    LINUX_SYSTEM_IDS = [LINUX, SWAP, LVM, RAID]
-
-    WINDOWS_SYSTEM_IDS = [NTFS, DOS32, DOS16, DOS12, WINDOWS_BASIC_DATA, MICROSOFT_RESERVED]
-
-    private_constant :LINUX_SYSTEM_IDS, :WINDOWS_SYSTEM_IDS
-
-    # Partition ids for which the internal numeric id is the same than the
-    # corresponding fsid in the old libstorage.
-    # See {.new_from_legacy} and {#to_i_legacy}.
-    LEGACY_KEPT = [DOS12, DOS16, DOS32, NTFS, EXTENDED, PREP, LINUX, SWAP, LVM, RAID, DIAG, ESP]
-
-    # Matching between fsids in the old libstorage and the corresponding
-    # partition id.
-    # See {.new_from_legacy} and {#to_i_legacy}.
-    LEGACY_TO_CURRENT = {
-      4   => DOS16, # Known as "FAT16 <32M"
-      5   => EXTENDED, # In the past both 5 and 15 were recognized as extended
-      11  => DOS32, # Known as "Win95 FAT32" as an alternative to 0x0c (Win95 FAT32 LBA)
-      14  => DOS16, # Known as "Win95 FAT16" as an alternative to 0x06 (FAT16)
-      257 => UNKNOWN, # 257 used to mean mac_hidden, but is BIOS_BOOT now
-      258 => UNKNOWN, # 258 used to mean mac_hfs, but is WINDOWS_BASIC_DATA now
-      259 => ESP, # 259 is MICROSOFT_RESERVED now
-      261 => MICROSOFT_RESERVED,
-      263 => BIOS_BOOT,
-      264 => PREP
-    }
-
-    # Matching between partition ids and the number that was used to represent
-    # them in the old libstorage.
-    # See {.new_from_legacy} and {#to_i_legacy}.
-    CURRENT_TO_LEGACY = {
-      BIOS_BOOT.to_i          => 263, # BIOS_BOOT.to_i is 257, that used to mean mac_hidden
-      ESP.to_i                => 259, # ESP.to_i is 239, that used to have no special meaning
-      WINDOWS_BASIC_DATA.to_i => 0, # WINDOWS_BASIC_DATA.to_i is 258, that used to mean mac_hfs
-      MICROSOFT_RESERVED.to_i => 261 # MICROSOFT_RESERVED.to_i is 261, that used to mean BIOS_BOOT
-    }
-    private_constant :LEGACY_KEPT, :LEGACY_TO_CURRENT, :CURRENT_TO_LEGACY
-
-    # Partition id that was represented by the given numeric fsid in the old
-    # libstorage.
-    #
-    # @param number [Integer] fsid used in the old libstorage
-    # @return [PartitionId] corresponding id. UNKNOWN if there is no equivalent
-    def self.new_from_legacy(number)
-      return LEGACY_TO_CURRENT[number] if LEGACY_TO_CURRENT.key?(number)
-      return new(number) if LEGACY_KEPT.map(&:to_i).include?(number)
-
-      UNKNOWN
-    end
-
-    # Numeric fsid used in the old libstorage to represent this partition id.
-    #
-    # @return [Integer]
-    def to_i_legacy
-      return CURRENT_TO_LEGACY[to_i] if CURRENT_TO_LEGACY.key?(to_i)
-
-      to_i
-    end
-
-    # Set of ids for partitions that are typically part of a Linux system.
-    # This may be a normal Linux partition (type 0x83), a Linux swap partition
-    # (type 0x82), an LVM partition, or a RAID partition.
-    #
-    # @return [Array<PartitionId>]
-    def self.linux_system_ids
-      LINUX_SYSTEM_IDS.dup
-    end
-
-    # Set of ids for partitions that could potentially host a MS Windows system.
-    #
-    # Take into account that checking the partition id is not enough to ensure a
-    # partition is suitable to host a MS Windows installation (for example,
-    # Windows can only be installed in primary partitions).
-    #
-    # @return [Array<PartitionId>]
-    def self.windows_system_ids
-      WINDOWS_SYSTEM_IDS.dup
-    end
-
-    # @see StorageEnumWrapper#is?
-    #
-    # In addition to checking by name, it also supports :linux_system and
-    # :windows_system
-    #
-    # @see .linux_system_ids
-    # @see .windows_system_ids
-    def is?(*names)
-      names.any? do |name|
-        case name.to_sym
-        when :linux_system
-          LINUX_SYSTEM_IDS.include?(self)
-        when :windows_system
-          WINDOWS_SYSTEM_IDS.include?(self)
-        else
-          name.to_sym == to_sym
-        end
-      end
-    end
-
-    # Get the sort order of this partition ID.
-    # @return [Integer]
-    def sort_order
-      SORT_ORDER.find_index(self) || SORT_ORDER.size
-    end
-
-    # Comparison operator for sorting.
-    # @return [Integer] -1, 0, 1
-    def <=>(other)
-      return -1 unless other.respond_to?(:sort_order)
-
-      sort_order <=> other.sort_order
-    end
+    private_constant :LINUX_SYSTEM_IDS,
+      :WINDOWS_SYSTEM_IDS,
+      :NOT_ALLOW_FORMAT,
+      :LEGACY_KEPT,
+      :LEGACY_TO_CURRENT,
+      :CURRENT_TO_LEGACY,
+      :SORT_ORDER
   end
 end

--- a/test/y2storage/partition_id_test.rb
+++ b/test/y2storage/partition_id_test.rb
@@ -105,20 +105,21 @@ describe Y2Storage::PartitionId do
   end
 
   describe "#to_human_string" do
-    it "returns translated string" do
-      Y2Storage::PartitionId.constants.each do |constant|
-        partition = Y2Storage::PartitionId.const_get(constant)
-        next unless partition.is_a?(Y2Storage::PartitionId)
+    context "when the partition id is known" do
+      let(:ids) { Y2Storage::PartitionId.all - [Y2Storage::PartitionId::UNKNOWN] }
 
-        expect(partition.to_human_string).to be_a(::String)
+      it "returns the partition id name" do
+        ids.each do |id|
+          expect(id.to_human_string).to eq(Storage.partition_id_name(id.to_i))
+        end
       end
     end
 
-    context "when it is an unhandled partition id" do
-      subject(:partition_id) { Y2Storage::PartitionId.new(9999) }
-
+    context "when the partition id is unknown" do
       it "returns the id formatted as an hexadecimal number" do
-        expect(partition_id.to_human_string).to eq("0x270f")
+        id = Y2Storage::PartitionId.new(9999)
+
+        expect(id.to_human_string).to eq("0x270f")
       end
     end
   end


### PR DESCRIPTION
NOTE FOR REVIEWERS: tests require https://github.com/openSUSE/libstorage-ng/pull/691.

## Problem

Partition Id names are defined for both: libstorage-ng and yast2-storage-ng. But now on, libstorage-ng provides a public method to get the name of a partition id.

* Part of https://trello.com/c/QsLIaeYN/1519-tw-leap-151-storage-ng-inconsistent-partition-type-display

* Requires https://github.com/openSUSE/libstorage-ng/pull/691


## Solution

New method `Storage.partition_id_name` is used instead of defining own names.


## Testing

- Unit tests updated.
- Tested manually


## Screenshots

<details>

<summary>Show/Hide</summary>

![VirtualBox_openSUSE Tumbleweed_20_12_2019_16_14_04](https://user-images.githubusercontent.com/1112304/71270050-8db09980-2348-11ea-9543-8b4e76507642.png)

</details>
