### PR TITLE
Improved sorting by device name and size in tables

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 23 08:29:03 CET 2019 - aschnell@suse.com
+
+- Improved sorting by device name and size in tables (bsc#1140018)
+- 4.2.67
+
+-------------------------------------------------------------------
 Fri Dec 20 16:20:29 UTC 2019 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Fixed an error when applying fallback_max_size_lvm in some corner

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.66
+Version:        4.2.67
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only
@@ -25,11 +25,11 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# Storage::LuksInfo
-BuildRequires:	libstorage-ng-ruby >= 4.2.39
+# Device::get_name_sort_key
+BuildRequires:	libstorage-ng-ruby >= 4.2.43
 BuildRequires:  update-desktop-files
-# CWM::Dialog#next_handler (4.1 branch) and improved CWM::Dialog
-BuildRequires:  yast2 >= 4.1.11
+# for CWM sort_key helper
+BuildRequires:  yast2 >= 4.2.48
 BuildRequires:  yast2-devtools >= 4.2.2
 # for AbortException and handle direct abort
 BuildRequires:  yast2-ruby-bindings >= 4.0.6
@@ -47,14 +47,16 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# Storage::LuksInfo
+# Device::get_name_sort_key
 Requires:       libstorage-ng-ruby >= 4.2.39
-# CWM::Dialog#next_handler (4.1 branch) and improved CWM::Dialog
-Requires:       yast2 >= 4.1.11
+# for CWM sort_key helper
+Requires:       yast2 >= 4.2.48
 # Y2Packager::Repository
 Requires:       yast2-packager >= 3.3.7
 # for AbortException and handle direct abort
 Requires:       yast2-ruby-bindings >= 4.0.6
+# for sortKey
+Requires:       yast2-ycp-ui-bindings >= 4.2.7
 # communicate with udisks
 Requires:       rubygem(%{rb_default_ruby_abi}:ruby-dbus)
 Requires(post): %fillup_prereq

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -143,7 +143,12 @@ module Y2Partitioner
       # Values
 
       def device_value(device)
-        return device.name unless device.is?(:blk_filesystem)
+        if !device.is?(:blk_filesystem)
+          name_sort_key = device.name_sort_key
+          return device.name if name_sort_key.empty?
+
+          return cell(device.name, sort_key(name_sort_key))
+        end
 
         if device.multidevice?
           format(
@@ -164,7 +169,7 @@ module Y2Partitioner
         # such devices without a direct and straightforward #size method.
         return "" unless device.respond_to?(:size)
 
-        device.size.to_human_string
+        cell(device.size.to_human_string, sort_key(device.size.to_i.to_s))
       end
 
       def format_value(device)

--- a/src/lib/y2storage/device.rb
+++ b/src/lib/y2storage/device.rb
@@ -197,6 +197,12 @@ module Y2Storage
     #       sorted list (less than)
     storage_class_forward :compare_by_name
 
+    # @!method name_sort_key
+    #   Return a sort key based of the device name.
+    #
+    #   @return [string] a sort key for the device name or empty string
+    storage_forward :name_sort_key
+
     # @!method self.all(devicegraph)
     #   @param devicegraph [Devicegraph]
     #   @return [Array<Device>] all the devices in the given devicegraph

--- a/test/y2partitioner/test_helper.rb
+++ b/test/y2partitioner/test_helper.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -19,3 +19,27 @@
 # find current contact information at www.suse.com
 
 require_relative "../spec_helper"
+
+# Removes the :sortKey term from a :cell term, possibly returning only
+# the single param of the term.
+#
+# Checking the sort-key in the testsuite would not be future-proof
+# since libstorage-ng is allowed to change the sort-key anytime.
+def remove_sort_key(term)
+  return term if term.value != :cell
+
+  term.params.delete_if { |param| param.is_a?(Yast::Term) && param.value == :sortKey }
+  return term if term.params.size > 1
+
+  term.params[0]
+end
+
+# Removes the :sortKey term from :cell terms somewhere inside (to the
+# extent needed so far) of value. Also see remove_sort_key.
+def remove_sort_keys(value)
+  return remove_sort_key(value) if value.is_a?(Yast::Term)
+
+  return value.map { |subvalue| remove_sort_keys(subvalue) } if value.is_a?(Array)
+
+  value
+end

--- a/test/y2partitioner/widgets/btrfs_devices_selector_test.rb
+++ b/test/y2partitioner/widgets/btrfs_devices_selector_test.rb
@@ -63,11 +63,11 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
   context "right after initialization" do
     describe "#contents" do
       it "displays all the unselected devices in the corresponding table" do
-        expect(rows_match?(unselected_items, *expected_unselected_items)).to eq true
+        expect(rows_match?(remove_sort_keys(unselected_items), *expected_unselected_items)).to eq true
       end
 
       it "displays all the selected devices in the corresponding table" do
-        expect(rows_match?(selected_items, *expected_selected_items)).to eq true
+        expect(rows_match?(remove_sort_keys(selected_items), *expected_selected_items)).to eq true
       end
     end
   end
@@ -91,7 +91,7 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
 
     describe "#contents" do
       it "displays all the selected devices in the corresponding table" do
-        expect(rows_match?(selected_items, *expected_selected_items)).to eq true
+        expect(rows_match?(remove_sort_keys(selected_items), *expected_selected_items)).to eq true
       end
 
       it "displays none device as unselected" do
@@ -126,11 +126,11 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
         end
 
         it "displays all the selected devices in the corresponding table" do
-          expect(rows_match?(selected_items, *expected_selected_items)).to eq true
+          expect(rows_match?(remove_sort_keys(selected_items), *expected_selected_items)).to eq true
         end
 
         it "displays all the available devices in the corresponding table" do
-          expect(rows_match?(unselected_items, *expected_unselected_items)).to eq true
+          expect(rows_match?(remove_sort_keys(unselected_items), *expected_unselected_items)).to eq true
         end
       end
     end
@@ -159,7 +159,7 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
       end
 
       it "displays all the available devices as unselected" do
-        expect(rows_match?(unselected_items, *expected_unselected_items)).to eq true
+        expect(rows_match?(remove_sort_keys(unselected_items), *expected_unselected_items)).to eq true
       end
     end
   end
@@ -190,11 +190,11 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
         end
 
         it "displays all the selected devices in the corresponding table and order" do
-          expect(rows_match?(selected_items, *expected_selected_items)).to eq true
+          expect(rows_match?(remove_sort_keys(selected_items), *expected_selected_items)).to eq true
         end
 
         it "displays all the available devices in the corresponding table and order" do
-          expect(rows_match?(unselected_items, *expected_unselected_items)).to eq true
+          expect(rows_match?(remove_sort_keys(unselected_items), *expected_unselected_items)).to eq true
         end
       end
     end
@@ -222,13 +222,13 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
         it "displays all the selected devices in the corresponding table" do
           expected_items = expected_selected_items.reject { |item| item.include?(device_name) }
 
-          expect(rows_match?(selected_items, *expected_items)).to eq true
+          expect(rows_match?(remove_sort_keys(selected_items), *expected_items)).to eq true
         end
 
         it "displays all the available devices in the corresponding" do
           expected_items = expected_unselected_items.append("#{device_name}$")
 
-          expect(rows_match?(unselected_items, *expected_items)).to eq true
+          expect(rows_match?(remove_sort_keys(unselected_items), *expected_items)).to eq true
         end
       end
     end

--- a/test/y2partitioner/widgets/lvm_vg_devices_selector_test.rb
+++ b/test/y2partitioner/widgets/lvm_vg_devices_selector_test.rb
@@ -55,13 +55,13 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
         items = unselected_table.items
         expect(items.size).to eq(4)
         names = ["^/dev/sdb$", "^/dev/sda3$", "^/dev/sda4$", "^/dev/sde3$"]
-        expect(rows_match?(items, *names)).to eq(true)
+        expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
       end
 
       it "displays all the selected devices in the corresponding table and order" do
         items = selected_table.items
         expect(items.size).to eq(2)
-        expect(rows_match?(items, "^/dev/sdc$", "^/dev/sda2$")).to eq(true)
+        expect(rows_match?(remove_sort_keys(items), "^/dev/sdc$", "^/dev/sda2$")).to eq(true)
       end
     end
   end
@@ -90,7 +90,7 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
         items = selected_table.items
         expect(items.size).to eq(6)
         names = ["/dev/sdb$", "/dev/sdc$", "/dev/sda2$", "/dev/sda3$", "/dev/sda4$", "/dev/sde3$"]
-        expect(rows_match?(items, *names)).to eq(true)
+        expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
       end
 
       it "displays no unselected devices" do
@@ -127,14 +127,14 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
           items = selected_table.items
           expect(items.size).to eq(2)
           names = ["/dev/sdc$", "/dev/sda2$"]
-          expect(rows_match?(items, *names)).to eq(true)
+          expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
         end
 
         it "displays all the available devices in the corresponding table" do
           items = unselected_table.items
           expect(items.size).to eq(4)
           names = ["/dev/sdb$", "/dev/sda3$", "/dev/sda4$", "/dev/sde3$"]
-          expect(rows_match?(items, *names)).to eq(true)
+          expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
         end
       end
     end
@@ -163,14 +163,14 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
           items = selected_table.items
           expect(items.size).to eq(3)
           names = ["/dev/sdc$", "/dev/sda2$", "/dev/sda3$"]
-          expect(rows_match?(items, *names)).to eq(true)
+          expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
         end
 
         it "displays all the available devices in the corresponding table" do
           items = unselected_table.items
           expect(items.size).to eq(3)
           names = ["/dev/sdb$", "/dev/sda4$", "/dev/sde3$"]
-          expect(rows_match?(items, *names)).to eq(true)
+          expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
         end
       end
     end
@@ -230,14 +230,14 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
         items = selected_table.items
         expect(items.size).to eq(2)
         names = ["/dev/sdd$", "/dev/sde1$"]
-        expect(rows_match?(items, *names)).to eq(true)
+        expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
       end
 
       it "displays all the available devices in the 'unselected' table" do
         items = unselected_table.items
         expect(items.size).to eq 6
         names = ["/dev/sdb$", "/dev/sdc$", "/dev/sda2$", "/dev/sda3$", "/dev/sda4$", "/dev/sde3$"]
-        expect(rows_match?(items, *names)).to eq true
+        expect(rows_match?(remove_sort_keys(items), *names)).to eq true
       end
     end
   end
@@ -269,14 +269,14 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
           items = selected_table.items
           expect(items.size).to eq(2)
           names = ["/dev/sdc$", "/dev/sda2$"]
-          expect(rows_match?(items, *names)).to eq(true)
+          expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
         end
 
         it "displays all the available devices in the corresponding table" do
           items = unselected_table.items
           expect(items.size).to eq(4)
           names = ["/dev/sdb$", "/dev/sda3$", "/dev/sda4$", "/dev/sde3$"]
-          expect(rows_match?(items, *names)).to eq(true)
+          expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
         end
       end
     end
@@ -310,14 +310,14 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
             items = selected_table.items
             expect(items.size).to eq(3)
             names = ["/dev/sdc$", "/dev/sdd$", "/dev/sde1$"]
-            expect(rows_match?(items, *names)).to eq true
+            expect(rows_match?(remove_sort_keys(items), *names)).to eq true
           end
 
           it "displays all the available devices in the corresponding table" do
             items = unselected_table.items
             expect(items.size).to eq(5)
             names = ["/dev/sdb$", "/dev/sda2$", "/dev/sda3$", "/dev/sda4$", "/dev/sde3$"]
-            expect(rows_match?(items, *names)).to eq true
+            expect(rows_match?(remove_sort_keys(items), *names)).to eq true
           end
         end
       end
@@ -351,14 +351,14 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
             items = selected_table.items
             expect(items.size).to eq(4)
             names = ["/dev/sda2$", "/dev/sdc$", "/dev/sdd$", "/dev/sde1$"]
-            expect(rows_match?(items, *names)).to eq true
+            expect(rows_match?(remove_sort_keys(items), *names)).to eq true
           end
 
           it "displays all the available devices in the corresponding table" do
             items = unselected_table.items
             expect(items.size).to eq(4)
             names = ["/dev/sdb$", "/dev/sda3$", "/dev/sda4$", "/dev/sde3$"]
-            expect(rows_match?(items, *names)).to eq true
+            expect(rows_match?(remove_sort_keys(items), *names)).to eq true
           end
         end
       end

--- a/test/y2partitioner/widgets/md_devices_selector_test.rb
+++ b/test/y2partitioner/widgets/md_devices_selector_test.rb
@@ -45,12 +45,13 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
     describe "#contents" do
       it "displays all the unselected devices in the corresponding table" do
         items = unselected_table.items
-        expect(rows_match?(items, "^/dev/sda2$", "^/dev/sda4$", "^/dev/sdb$", "^/dev/sdc$")).to eq true
+        expect(rows_match?(remove_sort_keys(items), "^/dev/sda2$", "^/dev/sda4$", "^/dev/sdb$",
+          "^/dev/sdc$")).to eq true
       end
 
       it "displays all the selected devices in the corresponding table and order" do
         items = selected_table.items
-        expect(rows_match?(items, "^/dev/sde3$", "^/dev/sda3$")).to eq true
+        expect(rows_match?(remove_sort_keys(items), "^/dev/sde3$", "^/dev/sda3$")).to eq true
       end
     end
   end
@@ -79,7 +80,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
         items = selected_table.items
         expect(items.size).to eq 6
         names = ["/dev/sde3$", "/dev/sda3$", "/dev/sda2$", "/dev/sda4$", "/dev/sdb$", "/dev/sdc$"]
-        expect(rows_match?(items, *names)).to eq true
+        expect(rows_match?(remove_sort_keys(items), *names)).to eq true
       end
 
       it "displays no unselected devices" do
@@ -113,12 +114,13 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
         it "displays all the selected devices in the corresponding table and order" do
           items = selected_table.items
-          expect(rows_match?(items, "/dev/sde3$", "/dev/sda3$")).to eq true
+          expect(rows_match?(remove_sort_keys(items), "/dev/sde3$", "/dev/sda3$")).to eq true
         end
 
         it "displays all the available devices in the corresponding table and order" do
           items = unselected_table.items
-          expect(rows_match?(items, "/dev/sda2$", "/dev/sda4$", "/dev/sdb$", "/dev/sdc$")).to eq true
+          expect(rows_match?(remove_sort_keys(items), "/dev/sda2$", "/dev/sda4$", "/dev/sdb$",
+            "/dev/sdc$")).to eq true
         end
       end
     end
@@ -146,13 +148,14 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
         it "displays all the selected devices in the corresponding table and order" do
           items = selected_table.items
           expect(items.size).to eq 3
-          expect(rows_match?(items, "/dev/sde3$", "/dev/sda3$", "/dev/sda2$")).to eq true
+          expect(rows_match?(remove_sort_keys(items), "/dev/sde3$", "/dev/sda3$",
+            "/dev/sda2$")).to eq true
         end
 
         it "displays all the available devices in the corresponding table" do
           items = unselected_table.items
           expect(items.size).to eq 3
-          expect(rows_match?(items, "/dev/sda4$", "/dev/sdb", "/dev/sdc")).to eq true
+          expect(rows_match?(remove_sort_keys(items), "/dev/sda4$", "/dev/sdb", "/dev/sdc")).to eq true
         end
       end
     end
@@ -187,7 +190,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
         items = unselected_table.items
         expect(items.size).to eq 6
         names = ["/dev/sda2$", "/dev/sda3$", "/dev/sda4$", "/dev/sdb$", "/dev/sdc$", "/dev/sde3$"]
-        expect(rows_match?(items, *names)).to eq true
+        expect(rows_match?(remove_sort_keys(items), *names)).to eq true
       end
     end
   end
@@ -216,12 +219,13 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
         it "displays all the selected devices in the corresponding table and order" do
           items = selected_table.items
-          expect(rows_match?(items, "/dev/sde3$", "/dev/sda3$")).to eq true
+          expect(rows_match?(remove_sort_keys(items), "/dev/sde3$", "/dev/sda3$")).to eq true
         end
 
         it "displays all the available devices in the corresponding table and order" do
           items = unselected_table.items
-          expect(rows_match?(items, "/dev/sda2$", "/dev/sda4$", "/dev/sdb$", "/dev/sdc$")).to eq true
+          expect(rows_match?(remove_sort_keys(items), "/dev/sda2$", "/dev/sda4$", "/dev/sdb$",
+            "/dev/sdc$")).to eq true
         end
       end
     end
@@ -248,12 +252,13 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
         it "displays all the selected devices in the corresponding table" do
           items = selected_table.items
-          expect(rows_match?(items, "/dev/sde3$")).to eq true
+          expect(rows_match?(remove_sort_keys(items), "/dev/sde3$")).to eq true
         end
 
         it "displays all the available devices in the corresponding table and order" do
           items = unselected_table.items
-          expect(rows_match?(items, "/dev/sda2$", "/dev/sda3$", "/dev/sda4$")).to eq true
+          expect(rows_match?(remove_sort_keys(items), "/dev/sda2$", "/dev/sda3$",
+            "/dev/sda4$")).to eq true
         end
       end
     end
@@ -291,7 +296,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "keeps displaying all the selected devices in the corresponding table and order" do
             names = ["/dev/sde3$", "/dev/sda3$", "/dev/sda2$", "/dev/sda4$"]
-            expect(rows_match?(selected_table.items, *names)).to eq true
+            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
           end
         end
       end
@@ -315,7 +320,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "displays all the selected devices in the corresponding table and order" do
             names = ["/dev/sda3$", "/dev/sde3$", "/dev/sda4$", "/dev/sda2$"]
-            expect(rows_match?(selected_table.items, *names)).to eq true
+            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
           end
         end
       end
@@ -343,7 +348,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "keeps displaying all the selected devices in the corresponding table and order" do
             names = ["/dev/sde3$", "/dev/sda3$", "/dev/sda2$", "/dev/sda4$"]
-            expect(rows_match?(selected_table.items, *names)).to eq true
+            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
           end
         end
       end
@@ -365,7 +370,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "displays all the selected devices in the corresponding table and order" do
             names = ["/dev/sde3$", "/dev/sda2$", "/dev/sda3$", "/dev/sda4$"]
-            expect(rows_match?(selected_table.items, *names)).to eq true
+            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
           end
         end
       end
@@ -393,7 +398,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "keeps displaying all the selected devices in the corresponding table and order" do
             names = ["/dev/sde3$", "/dev/sda3$", "/dev/sda2$", "/dev/sda4$"]
-            expect(rows_match?(selected_table.items, *names)).to eq true
+            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
           end
         end
       end
@@ -417,7 +422,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "displays all the selected devices in the corresponding table and order" do
             names = ["/dev/sda3$", "/dev/sda4$", "/dev/sde3$", "/dev/sda2$"]
-            expect(rows_match?(selected_table.items, *names)).to eq true
+            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
           end
         end
       end
@@ -445,7 +450,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "keeps displaying all the selected devices in the corresponding table and order" do
             names = ["/dev/sde3$", "/dev/sda3$", "/dev/sda2$", "/dev/sda4$"]
-            expect(rows_match?(selected_table.items, *names)).to eq true
+            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
           end
         end
       end
@@ -467,7 +472,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "displays all the selected devices in the corresponding table and order" do
             names = ["/dev/sda3$", "/dev/sda2$", "/dev/sda4$", "/dev/sde3$"]
-            expect(rows_match?(selected_table.items, *names)).to eq true
+            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
           end
         end
       end

--- a/test/y2partitioner/widgets/pages/bcaches_test.rb
+++ b/test/y2partitioner/widgets/pages/bcaches_test.rb
@@ -67,8 +67,8 @@ describe Y2Partitioner::Widgets::Pages::Bcaches do
 
         devices = table.items.map { |i| i[1] }
 
-        expect(devices).to contain_exactly("/dev/bcache0", "/dev/bcache1", "/dev/bcache2",
-          "/dev/bcache0p1", "/dev/bcache2p1")
+        expect(remove_sort_keys(devices)).to contain_exactly("/dev/bcache0", "/dev/bcache1",
+          "/dev/bcache2", "/dev/bcache0p1", "/dev/bcache2p1")
       end
     end
   end

--- a/test/y2partitioner/widgets/pages/disks_test.rb
+++ b/test/y2partitioner/widgets/pages/disks_test.rb
@@ -50,7 +50,7 @@ describe Y2Partitioner::Widgets::Pages::Disks do
       devices_name = disks_and_parts.map(&:name)
       items_name = table.items.map { |i| i[1] }
 
-      expect(items_name.sort).to eq(devices_name.sort)
+      expect(remove_sort_keys(items_name.sort)).to eq(devices_name.sort)
     end
 
     # This test is here to ensure we don't try to access the partitions within a
@@ -64,7 +64,7 @@ describe Y2Partitioner::Widgets::Pages::Disks do
         devices_name = devices.map(&:name)
         items_name = table.items.map { |i| i[1] }
 
-        expect(items_name.sort).to eq(devices_name.sort)
+        expect(remove_sort_keys(items_name.sort)).to eq(devices_name.sort)
       end
     end
   end

--- a/test/y2partitioner/widgets/pages/lvm_test.rb
+++ b/test/y2partitioner/widgets/pages/lvm_test.rb
@@ -54,7 +54,7 @@ describe Y2Partitioner::Widgets::Pages::Lvm do
     it "shows a table with the vgs devices and their lvs (including thin volumes)" do
       expect(table).to_not be_nil
 
-      expect(items).to contain_exactly(
+      expect(remove_sort_keys(items)).to contain_exactly(
         "/dev/vg0",
         "/dev/vg0/lv1",
         "/dev/vg0/lv2",

--- a/test/y2partitioner/widgets/pages/lvm_vg_test.rb
+++ b/test/y2partitioner/widgets/pages/lvm_vg_test.rb
@@ -87,7 +87,7 @@ describe Y2Partitioner::Widgets::Pages::LvmVg do
       it "shows a table with the lvs of a vg (including thin volumes)" do
         expect(table).to_not be_nil
 
-        expect(items).to contain_exactly(
+        expect(remove_sort_keys(items)).to contain_exactly(
           "/dev/vg0/lv1",
           "/dev/vg0/lv2",
           "/dev/vg0/pool1",

--- a/test/y2partitioner/widgets/pages/md_raids_test.rb
+++ b/test/y2partitioner/widgets/pages/md_raids_test.rb
@@ -64,7 +64,7 @@ describe Y2Partitioner::Widgets::Pages::MdRaids do
       devices_name = (raids + parts).map(&:name)
       items_name = table.items.map { |i| i[1] }
 
-      expect(items_name.sort).to eq(devices_name.sort)
+      expect(remove_sort_keys(items_name.sort)).to eq(devices_name.sort)
     end
 
     it "associates the table and the set of buttons" do
@@ -81,7 +81,7 @@ describe Y2Partitioner::Widgets::Pages::MdRaids do
       end
 
       it "contains all Software RAIDs" do
-        expect(items).to include(
+        expect(remove_sort_keys(items)).to include(
           "/dev/md/md0",
           "/dev/md1"
         )
@@ -92,7 +92,8 @@ describe Y2Partitioner::Widgets::Pages::MdRaids do
       let(:scenario) { "nested_md_raids" }
 
       it "contains all software RAIDs and its partitions" do
-        expect(items).to include("/dev/md0", "/dev/md0p1", "/dev/md0p2", "/dev/md1", "/dev/md2")
+        expect(remove_sort_keys(items)).to include("/dev/md0", "/dev/md0p1", "/dev/md0p2", "/dev/md1",
+          "/dev/md2")
       end
     end
 

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -92,7 +92,7 @@ describe Y2Partitioner::Widgets::Pages::System do
       let(:scenario) { "mixed_disks.yml" }
 
       it "contains all disks and their partitions" do
-        expect(items).to contain_exactly(
+        expect(remove_sort_keys(items)).to contain_exactly(
           "/dev/sda",
           "/dev/sda1",
           "/dev/sda2",
@@ -113,7 +113,7 @@ describe Y2Partitioner::Widgets::Pages::System do
       let(:scenario) { "dasd_50GiB.yml" }
 
       it "contains all DASDs and their partitions" do
-        expect(items).to contain_exactly(
+        expect(remove_sort_keys(items)).to contain_exactly(
           "/dev/dasda",
           "/dev/dasda1"
         )
@@ -124,21 +124,21 @@ describe Y2Partitioner::Widgets::Pages::System do
       let(:scenario) { "empty-dm_raids.xml" }
 
       it "contains all DM RAIDs" do
-        expect(items).to include(
+        expect(remove_sort_keys(items)).to include(
           "/dev/mapper/isw_ddgdcbibhd_test1",
           "/dev/mapper/isw_ddgdcbibhd_test2"
         )
       end
 
       it "does not contain devices belonging to DM RAIDs" do
-        expect(items).to_not include(
+        expect(remove_sort_keys(items)).to_not include(
           "/dev/sdb",
           "/dev/sdc"
         )
       end
 
       it "contains devices that does not belong to DM RAIDs" do
-        expect(items).to include(
+        expect(remove_sort_keys(items)).to include(
           "/dev/sda",
           "/dev/sda1",
           "/dev/sda2"
@@ -150,14 +150,14 @@ describe Y2Partitioner::Widgets::Pages::System do
       let(:scenario) { "md-imsm1-devicegraph.xml" }
 
       it "contains all BIOS MD RAIDs" do
-        expect(items).to include(
+        expect(remove_sort_keys(items)).to include(
           "/dev/md/a",
           "/dev/md/b"
         )
       end
 
       it "does not contain devices belonging to BIOS DM RAIDs" do
-        expect(items).to_not include(
+        expect(remove_sort_keys(items)).to_not include(
           "/dev/sdb",
           "/dev/sdc",
           "/dev/sdd"
@@ -165,7 +165,7 @@ describe Y2Partitioner::Widgets::Pages::System do
       end
 
       it "contains devices that does not belong to BIOS DM RAIDs" do
-        expect(items).to include(
+        expect(remove_sort_keys(items)).to include(
           "/dev/sda",
           "/dev/sda1",
           "/dev/sda2"
@@ -181,14 +181,14 @@ describe Y2Partitioner::Widgets::Pages::System do
       end
 
       it "contains all Software RAIDs" do
-        expect(items).to include(
+        expect(remove_sort_keys(items)).to include(
           "/dev/md/md0",
           "/dev/md1"
         )
       end
 
       it "contains devices belonging to Software RAIDs" do
-        expect(items).to include(
+        expect(remove_sort_keys(items)).to include(
           "/dev/sda"
         )
       end
@@ -203,7 +203,7 @@ describe Y2Partitioner::Widgets::Pages::System do
       end
 
       it "contains all Volume Groups and their logical volumes (including thin volumes)" do
-        expect(items).to include(
+        expect(remove_sort_keys(items)).to include(
           "/dev/vg0",
           "/dev/vg0/lv1",
           "/dev/vg0/lv2",
@@ -218,7 +218,7 @@ describe Y2Partitioner::Widgets::Pages::System do
       end
 
       it "contains devices belonging to Volume Groups" do
-        expect(items).to include(
+        expect(remove_sort_keys(items)).to include(
           "/dev/sda5",
           "/dev/sda7",
           "/dev/sda9"
@@ -238,7 +238,7 @@ describe Y2Partitioner::Widgets::Pages::System do
       let(:scenario) { "bcache1.xml" }
 
       it "contains all bcache devices" do
-        expect(items).to include("/dev/bcache0", "/dev/bcache1", "/dev/bcache2")
+        expect(remove_sort_keys(items)).to include("/dev/bcache0", "/dev/bcache1", "/dev/bcache2")
       end
     end
 
@@ -268,23 +268,23 @@ describe Y2Partitioner::Widgets::Pages::System do
       end
 
       it "caches the table content between calls" do
-        expect(rows).to eq ["/dev/sda"]
+        expect(remove_sort_keys(rows)).to eq ["/dev/sda"]
         Y2Storage::Filesystems::Nfs.create(current_graph, "new", "/device")
         # The new device is not included
-        expect(rows).to eq ["/dev/sda"]
+        expect(remove_sort_keys(rows)).to eq ["/dev/sda"]
       end
 
       it "refreshes the cached content if the NFS page was visited" do
-        expect(rows).to eq ["/dev/sda"]
+        expect(remove_sort_keys(rows)).to eq ["/dev/sda"]
         Y2Storage::Filesystems::Nfs.create(current_graph, "new", "/device")
-        expect(rows).to eq ["/dev/sda"]
+        expect(remove_sort_keys(rows)).to eq ["/dev/sda"]
         # Leave the NFS page
         nfs_page.store
         # Now the device is there
-        expect(rows).to eq ["/dev/sda", "new:/device"]
+        expect(remove_sort_keys(rows)).to eq ["/dev/sda", "new:/device"]
         Y2Storage::Filesystems::Nfs.create(current_graph, "another", "/device")
         # Still cached
-        expect(rows).to eq ["/dev/sda", "new:/device"]
+        expect(remove_sort_keys(rows)).to eq ["/dev/sda", "new:/device"]
       end
     end
   end


### PR DESCRIPTION
So far devices in tables were sorted alphabetical when the user selected sorting by name or size. That does not give good results. Now the sorting is done better, e.g. numerical for size.

![name](https://user-images.githubusercontent.com/908062/71343730-fb371280-2560-11ea-9e3a-10791f843ff7.png)

![size](https://user-images.githubusercontent.com/908062/71343736-fd996c80-2560-11ea-86ec-420ce85a3043.png)

Also see libyui/libyui#156.