### PR TITLE
NFS Client: update the UI after discarding a created but not reachable entry

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,3 +1,10 @@
+------------------------------------------------------------------
+Wed Jan  8 23:55:39 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- NFS Client: updates the UI after discarding a not reachable NFS
+  entry (bsc#1156446).
+- 4.1.91
+
 -------------------------------------------------------------------
 Wed Oct 23 11:51:58 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -32,6 +32,8 @@ Requires:	libstorage-ng-ruby >= 4.1.89
 Requires:	rubygem(ruby-dbus)
 # Y2Packager::Repository
 Requires:	yast2-packager >= 3.3.7
+# NfsClient4partClient RefreshUI action
+Requires:	yast2-nfs-client >= 4.1.6
 # findutils for xargs
 Requires:	findutils
 

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.1.90
+Version:        4.1.91
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2partitioner/yast_nfs_client.rb
+++ b/src/lib/y2partitioner/yast_nfs_client.rb
@@ -213,6 +213,9 @@ module Y2Partitioner
 
     # Handler for the 'add' button
     #
+    # Note that UI will reflect the added entry immediately, even before test if it is reachable.
+    # Hence, an UI refresh is needed when the user decides to not keep a failed NFS entry.
+    #
     # @see #process_result
     def newbut_handler(legacy)
       log.info "Adding NFS to current graph: #{legacy.inspect}"
@@ -230,6 +233,7 @@ module Y2Partitioner
       log.info "Test mount failed, so removing NFS from current graph: #{nfs.inspect}"
       current_graph.remove_nfs(nfs)
       set_client_list
+      call_client("RefreshUI")
     end
 
     # Handler for the 'edit' button


### PR DESCRIPTION
####  :warning: Closed after [move the "RefreshUI" action to the NfsClient4partClient](https://github.com/yast/yast-nfs-client/pull/87/commits/ec9bb889bf73c0c91024f6b696ab3de208f40d62) itself. Motivation in [comments](https://github.com/yast/yast-storage-ng/pull/1018#discussion_r364660436)

---

## Problem

Partitioner ends with a crash when the user edits a _phantom_ NFS entry.

For more information, see the description of https://github.com/yast/yast-nfs-client/pull/87, which is ~~a required part of~~ the solution.

  * Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1156446
  * Trello: https://trello.com/c/WGmxRkxu


## Solution

~~To update the UI after discarding a not reachable NFS entry, calling to the _RefreshUI_ action added in [yast2-nfs-client 4.1.6](https://github.com/yast/yast-nfs-client/pull/87). As nfs entries are previously sync via _FromStorage_ action, the useless entry will be removed from the UI.~~

## Testing

- Tested manually

