### PR TITLE
disallow to mount BitLocker

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 09 12:45:00 CET 2020 - aschnell@suse.com
+
+- disallow to mount BitLocker (related to bsc#1159318)
+- 4.2.69
+
+-------------------------------------------------------------------
 Tue Jan  7 09:10:11 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Use partition id names defined by libstorage-ng.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.68
+Version:        4.2.69
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# Storage.partition_id_name
-BuildRequires:	libstorage-ng-ruby >= 4.2.45
+# Bitlocker
+BuildRequires:	libstorage-ng-ruby >= 4.2.47
 BuildRequires:  update-desktop-files
 # for CWM sort_key helper
 BuildRequires:  yast2 >= 4.2.48
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# Storage.partition_id_name
-Requires:       libstorage-ng-ruby >= 4.2.45
+# Bitlocker
+Requires:       libstorage-ng-ruby >= 4.2.47
 # for CWM sort_key helper
 Requires:       yast2 >= 4.2.48
 # Y2Packager::Repository

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -192,7 +192,7 @@ module Y2Partitioner
         @mount_point_widget.refresh
         @btrfs_subvolumes_widget.refresh
 
-        if filesystem
+        if filesystem&.supports_mount?
           Yast::UI.ChangeWidget(Id(:mount_device), :Enabled, true)
 
           if filesystem.mount_point.nil?

--- a/src/lib/y2storage/filesystems/base.rb
+++ b/src/lib/y2storage/filesystems/base.rb
@@ -45,6 +45,10 @@ module Y2Storage
       #   @return [Filesystems::Type]
       storage_forward :type, as: "Filesystems::Type"
 
+      # @!method supports_mount?
+      #   @return [Boolean]
+      storage_forward :supports_mount?
+
       # @!method detect_space_info
       #   Information about the free space on a device.
       #

--- a/src/lib/y2storage/filesystems/base.rb
+++ b/src/lib/y2storage/filesystems/base.rb
@@ -45,10 +45,6 @@ module Y2Storage
       #   @return [Filesystems::Type]
       storage_forward :type, as: "Filesystems::Type"
 
-      # @!method supports_mount?
-      #   @return [Boolean]
-      storage_forward :supports_mount?
-
       # @!method detect_space_info
       #   Information about the free space on a device.
       #

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -70,71 +70,74 @@ module Y2Storage
       # Not all combinations of filesystem types and properties are represented,
       # default values are used for missing information.
       PROPERTIES = {
-        btrfs:    {
+        btrfs:     {
           fstab_options: COMMON_FSTAB_OPTIONS,
           name:          "BtrFS"
         },
-        ext2:     {
+        ext2:      {
           fstab_options: COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS,
           name:          "Ext2"
         },
-        ext3:     {
+        ext3:      {
           fstab_options:         COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],
           default_fstab_options: JOURNAL_OPTIONS,
           name:                  "Ext3"
         },
-        ext4:     {
+        ext4:      {
           fstab_options:         COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],
           default_fstab_options: JOURNAL_OPTIONS,
           name:                  "Ext4"
         },
-        hfs:      {
+        hfs:       {
           name: "MacHFS"
         },
-        hfsplus:  {
+        hfsplus:   {
           name: "MacHFS+"
         },
-        jfs:      {
+        jfs:       {
           name: "JFS"
         },
-        nfs:      {
+        nfs:       {
           name: "NFS"
         },
-        nfs4:     {
+        nfs4:      {
           name: "NFS4"
         },
-        nilfs2:   {
+        nilfs2:    {
           name: "NilFS"
         },
-        ntfs:     {
+        ntfs:      {
           default_fstab_options: ["fmask=133", "dmask=022"],
           name:                  "NTFS"
         },
-        reiserfs: {
+        reiserfs:  {
           name: "ReiserFS"
         },
-        swap:     {
+        swap:      {
           fstab_options:        ["pri="],
           default_partition_id: PartitionId::SWAP,
           name:                 "Swap"
         },
-        vfat:     {
+        vfat:      {
           fstab_options:         COMMON_FSTAB_OPTIONS + ["dev", "nodev", "iocharset=", "codepage="],
           default_fstab_options: IOCHARSET_OPTIONS + CODEPAGE_OPTIONS,
           default_partition_id:  PartitionId::DOS32,
           name:                  "FAT"
         },
-        xfs:      {
+        xfs:       {
           fstab_options: COMMON_FSTAB_OPTIONS + ["usrquota", "grpquota"],
           name:          "XFS"
         },
-        iso9660:  {
+        iso9660:   {
           fstab_options: ["acl", "noacl"],
           name:          "ISO9660"
         },
-        udf:      {
+        udf:       {
           fstab_options: ["acl", "noacl"],
           name:          "UDF"
+        },
+        bitlocker: {
+          name: "BitLocker"
         }
       }
 

--- a/src/lib/y2storage/mountable.rb
+++ b/src/lib/y2storage/mountable.rb
@@ -34,6 +34,10 @@ module Y2Storage
     #   @return [Array<Mountable>] all mountable devices in the devicegraph
     storage_class_forward :all, as: "Mountable"
 
+    # @!method supports_mount?
+    #   @return [Boolean]
+    storage_forward :supports_mount?
+
     storage_forward :storage_create_mount_point, to: :create_mount_point, as: "MountPoint"
     private :storage_create_mount_point
 


### PR DESCRIPTION
## Problem

Now that libstorage-ng can represent BitLocker in the devicegraph it is possible to try to mount it in the expert partitioner.

## Solution

Disallow mounting of BitLocker in the expert partitioner using the new ```supports_mount?``` function from libstorage-ng.

## Testing

- Tested manually
