### PR TITLE
extended checks for XFS format options

### DIFF
--- a/doc/boot-requirements.md
+++ b/doc/boot-requirements.md
@@ -187,7 +187,7 @@
 - when proposing a /boot/zipl partition
 	- **requires /boot/zipl to be on the boot disk**
 	- **requires /boot/zipl to be a non-encrypted partition**
-	- **requires /boot/zipl to be formated as ext2**
+	- **requires /boot/zipl to be formatted as ext2**
 	- **requires /boot/zipl to be at most 300 MiB (anything bigger would mean wasting space)**
 	- when aiming for the recommended size (first proposal attempt)
 		- **requires /boot/zipl to be at least 200 MiB (Grub2, one kernel+initrd and extra space)**

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 14 09:54:08 CET 2020 - aschnell@suse.com
+
+- do not allow block sizes bigger than the system page size when
+  creating xfs (bsc#1111668)
+- 4.2.70
+
+-------------------------------------------------------------------
 Thu Jan 09 12:45:00 CET 2020 - aschnell@suse.com
 
 - disallow to mount BitLocker (related to bsc#1159318)

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -3,6 +3,7 @@ Tue Jan 14 09:54:08 CET 2020 - aschnell@suse.com
 
 - do not allow block sizes bigger than the system page size when
   creating xfs (bsc#1111668)
+- check inode size depending on block size when creating xfs
 - 4.2.70
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-storage-ng
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2020 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.69
+Version:        4.2.70
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/dialogs/mkfs_options.rb
+++ b/src/lib/y2partitioner/dialogs/mkfs_options.rb
@@ -24,7 +24,7 @@ require "y2partitioner/widgets/mkfs_options"
 
 module Y2Partitioner
   module Dialogs
-    # CWM Dialog to set specific mkfs options for the blk_device being formated
+    # CWM Dialog to set specific mkfs options for the blk_device being formatted
     class MkfsOptions < Popup
       # @param controller [Actions::Controllers::Filesystem]
       def initialize(controller)

--- a/src/lib/y2partitioner/widgets/mkfs_options.rb
+++ b/src/lib/y2partitioner/widgets/mkfs_options.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -21,6 +21,7 @@ require "yast"
 require "cwm"
 require "y2storage"
 require "y2partitioner/widgets/mkfs_optiondata"
+require "y2partitioner/widgets/mkfs_optionvalidator"
 
 module Y2Partitioner
   # Partitioner widgets
@@ -78,6 +79,14 @@ module Y2Partitioner
           true
         end
       end
+
+      # An optional id for the option.
+      #
+      # @return [Symbol]
+      #
+      def option_id
+        @option.option_id
+      end
     end
 
     # Class for selecting mkfs and tune2fs options for {Y2Storage::Filesystems}.
@@ -122,6 +131,29 @@ module Y2Partitioner
             Left(Widgets.const_get(w.widget).new(@controller, w))
           end
         )
+      end
+
+      # All validators for the widget.
+      #
+      # @return [Arrar<MkfsOptionvalidator>]
+      #
+      def validators
+        MkfsOptionvalidator.validators_for(@controller.filesystem)
+      end
+
+      # @macro seeAbstractWidget
+      def validate
+        return true if !@contents
+
+        widgets = Yast::CWM.widgets_in_contents(@contents)
+        validators.each do |validator|
+          if !validator.validate?(widgets)
+            Yast::Popup.Error(format(validator.error))
+            return false
+          end
+        end
+
+        true
       end
     end
 

--- a/src/lib/y2partitioner/widgets/mkfs_optionvalidator.rb
+++ b/src/lib/y2partitioner/widgets/mkfs_optionvalidator.rb
@@ -148,7 +148,9 @@ module Y2Partitioner
           ALL_VALIDATORS
         end
 
-        # TODO
+        # Get the value of an option using the option_id.
+        #
+        # @return [Any]
         #
         def option_value(widgets, option_id)
           widgets.find { |widget| widget.option_id == option_id }.value

--- a/src/lib/y2partitioner/widgets/mkfs_optionvalidator.rb
+++ b/src/lib/y2partitioner/widgets/mkfs_optionvalidator.rb
@@ -1,0 +1,159 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+module Y2Partitioner
+  module Widgets
+    # Class to validate cross option constraints of filesystem
+    # formatting (mkfs and tune2fs, atm) options.
+    #
+    class MkfsOptionvalidator
+      include Yast::Logger
+      include Yast::I18n
+      extend Yast::I18n
+
+      # TODO
+      #
+      ALL_VALIDATORS = [
+        {
+          fs:       [:xfs],
+          validate: lambda do |widgets|
+            block_size = option_value(widgets, :block_size)
+            block_size = (block_size == "auto") ? 4096 : block_size.to_i
+
+            inode_size = option_value(widgets, :inode_size)
+            inode_size = (inode_size == "auto") ? 512 : inode_size.to_i
+
+            inode_size <= block_size / 2
+          end,
+          error:    N_(
+            "The inode size is too big for the block size. " \
+            "The inode size must not exceed one half of the block size."
+          )
+        }
+      ]
+
+      # Remember validator data.
+      #
+      # @param validator [Hash]
+      #
+      def initialize(validator)
+        @value = validator
+        textdomain "storage"
+      end
+
+      # Validate option value.
+      #
+      # This calls the validation function if there is one defined _and_ an
+      # error message exists. Else it just returns true.
+      #
+      # @param val [Array<Widgets>]
+      #
+      # @return [Boolean]
+      #
+      def validate?(val)
+        return true if val.nil? || !validate || !@value[:error]
+
+        validate[val]
+      end
+
+      private
+
+      # Allowed keys in {ALL_VALIDATORS}.
+      #
+      # @param foo [Symbol]
+      #
+      # @return [Boolean]
+      #
+      def good_key?(foo)
+        [
+          :fs, :validate, :error
+        ].include?(foo)
+      end
+
+      # Make validator hash entries readable via methods.
+      #
+      # Note this intentionally returns nil if there's neither a method nor
+      # a hash key.
+      #
+      # @param foo [Symbol]
+      #
+      # @return [Object]
+      #
+      def method_missing(foo)
+        if good_key?(foo)
+          @value[foo]
+        else
+          super
+        end
+      end
+
+      # Make class interface consistent. Rubocop insists on this function.
+      #
+      # @param foo [Symbol]
+      # @param _all [Boolean]
+      #
+      # @return [Boolean]
+      #
+      def respond_to_missing?(foo, _all)
+        good_key?(foo)
+      end
+
+      class << self
+        # Get list of option validators for a specific file system.
+        #
+        # The returned list can be empty.
+        #
+        # @param filesystem [Y2Storage::Filesystems]
+        #
+        # @return [Array<MkfsOptionvalidator>]
+        #
+        def validators_for(filesystem)
+          fs = filesystem.type.to_sym
+          all_validators.find_all { |x| x[:fs].include?(fs) }.map { |x| MkfsOptionvalidator.new(x) }
+        end
+
+        # Get list of all validators.
+        #
+        # @return [Array<MkfsOptionvalidator>]
+        #
+        def all
+          all_validators.map { |x| MkfsOptionvalidator.new(x) }
+        end
+
+        private
+
+        # Get list of all validators.
+        #
+        # @return [Array<Hash>]
+        #
+        def all_validators
+          ALL_VALIDATORS
+        end
+
+        # TODO
+        #
+        def option_value(widgets, option_id)
+          widgets.find { |widget| widget.option_id == option_id }.value
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/arch.rb
+++ b/src/lib/y2storage/arch.rb
@@ -48,6 +48,10 @@ module Y2Storage
     #   @return [Boolean] whether it is a Power NV system
     storage_forward :ppc_power_nv?
 
+    # @!method page_size
+    #   @return [Integer] the system page size
+    storage_forward :page_size
+
     # Whether to resume from swap is supported by the current architecture
     #
     # @return [Boolean]

--- a/test/support/proposed_partitions_examples.rb
+++ b/test/support/proposed_partitions_examples.rb
@@ -226,7 +226,7 @@ RSpec.shared_examples "proposed /boot/zipl partition" do
     expect(zipl_part.encrypt?).to eq false
   end
 
-  it "requires /boot/zipl to be formated as ext2" do
+  it "requires /boot/zipl to be formatted as ext2" do
     expect(zipl_part.filesystem_type.is?(:ext2)).to eq true
   end
 

--- a/test/y2partitioner/actions/controllers/lvm_vg_test.rb
+++ b/test/y2partitioner/actions/controllers/lvm_vg_test.rb
@@ -322,7 +322,7 @@ describe Y2Partitioner::Actions::Controllers::LvmVg do
 
     # A device is unused when fulfill the previous tested conditions:
     # - has no partitions
-    # - formated but not mounted
+    # - formatted but not mounted
     # - not used as PV
     it "includes unused disks" do
       expect(controller.available_devices.map(&:name)).to include("/dev/sdb")

--- a/test/y2partitioner/widgets/mkfs_optiondata_test.rb
+++ b/test/y2partitioner/widgets/mkfs_optiondata_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -37,10 +37,10 @@ describe Y2Partitioner::Widgets do
       end
     end
 
-    it "'fs' is a list of symbols" do
+    it "'fs' is a list of allowed filesystem symbols" do
       subject.each do |x|
         expect(x.fs).to be_a(Array)
-        expect(x.fs.find { |fs| fs.class != Symbol }).to be nil
+        expect(x.fs.find { |fs| ![:ext2, :ext3, :ext4, :btrfs, :xfs, :vfat].include? fs }).to be nil
       end
     end
 

--- a/test/y2partitioner/widgets/mkfs_optionvalidator_test.rb
+++ b/test/y2partitioner/widgets/mkfs_optionvalidator_test.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/mkfs_optionvalidator"
+
+describe Y2Partitioner::Widgets do
+  let(:all_validators) { Y2Partitioner::Widgets::MkfsOptionvalidator.all }
+
+  describe Y2Partitioner::Widgets::MkfsOptionvalidator do
+    subject { all_validators }
+
+    it "'fs' is a list of allowed filesystem symbols" do
+      subject.each do |x|
+        expect(x.fs).to be_a(Array)
+        expect(x.fs.find { |fs| ![:ext2, :ext3, :ext4, :btrfs, :xfs, :vfat].include? fs }).to be nil
+      end
+    end
+
+    it "'validate' references a proc" do
+      subject.each do |x|
+        expect(x.validate).to be_a(Proc).or be_a(NilClass)
+      end
+    end
+
+    it "if it can validate there must be an error message" do
+      subject.each do |x|
+        expect(x.validate ? !x.error.empty? : true).to be true
+      end
+    end
+  end
+end

--- a/test/y2storage/disk_test.rb
+++ b/test/y2storage/disk_test.rb
@@ -52,7 +52,7 @@ describe Y2Storage::Disk do
       end
     end
 
-    context "in a directly formated disk (filesystem but no partition table)" do
+    context "in a directly formatted disk (filesystem but no partition table)" do
       let(:disk_name) { "/dev/sdf" }
 
       it "returns an empty array" do

--- a/test/y2storage/proposal_scenarios_s390_test.rb
+++ b/test/y2storage/proposal_scenarios_s390_test.rb
@@ -110,7 +110,7 @@ describe Y2Storage::GuidedProposal do
       let(:scenario) { "empty_dasd_50GiB" }
       let(:expected_scenario) { "s390_dasd_zipl" }
 
-      context "formated as LDL" do
+      context "formatted as LDL" do
         let(:format) { Y2Storage::DasdFormat::LDL }
 
         it "fails to make a proposal" do
@@ -118,7 +118,7 @@ describe Y2Storage::GuidedProposal do
         end
       end
 
-      context "formated as CDL" do
+      context "formatted as CDL" do
         let(:format) { Y2Storage::DasdFormat::CDL }
 
         context "not using LVM" do


### PR DESCRIPTION
## Problem

The dialog with format options for XFS allowed invalid options:

- Invalid block size (bsc#1111668)
- Invalid inode size

## Solution

- Extended checks for block and inode size.

## Testing

- Unit tests
- Tested manually

## Also see

- https://trello.com/c/tUOAy26G/1568-2-sles15-sp1-1111668-build-662-installation-fails-to-mount-partition-when-define-16384-as-block-size-for-xfs
- https://bugzilla.suse.com/show_bug.cgi?id=1111668
