### PR TITLE
Improve integration of NFS client

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 16 11:48:39 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Improve integration with yast2-nfs-client.
+- Related bugs: bsc#1006815, bsc#1151426.
+- 4.1.91
+
+-------------------------------------------------------------------
 Wed Oct 23 11:51:58 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: consider CT_DMMULTIPATH an alias of CT_DISK (related

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.1.90
+Version:        4.1.91
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -26,8 +26,8 @@ Source:		%{name}-%{version}.tar.bz2
 Requires:	yast2 >= 4.1.11
 # for AbortException and handle direct abort
 Requires:	yast2-ruby-bindings >= 4.0.6
-# Bcache#remove_bcache_cset
-Requires:	libstorage-ng-ruby >= 4.1.89
+# Fix mount/unmount
+Requires:	libstorage-ng-ruby >= 4.1.107
 # communicate with udisks
 Requires:	rubygem(ruby-dbus)
 # Y2Packager::Repository
@@ -36,8 +36,8 @@ Requires:	yast2-packager >= 3.3.7
 Requires:	findutils
 
 BuildRequires:	update-desktop-files
-# Bcache#remove_bcache_cset
-BuildRequires:	libstorage-ng-ruby >= 4.1.89
+# Fix mount/unmount
+BuildRequires:	libstorage-ng-ruby >= 4.1.107
 BuildRequires:	yast2-ruby-bindings
 BuildRequires:	yast2-devtools
 # yast2-xml dependency is added by yast2 but ignored in the

--- a/src/lib/y2partitioner/widgets/help.rb
+++ b/src/lib/y2partitioner/widgets/help.rb
@@ -1,3 +1,22 @@
+# Copyright (c) [2017-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require "yast"
 
 Yast.import "Mode"
@@ -114,19 +133,34 @@ module Y2Partitioner
                              "is empty if no caching is used."),
 
         cache_mode:       N_("<b>Cache Mode</b> shows the operating mode for bcache. Currently there " \
-                             "are four supported modes: Writethrough, Writeback, Writearound and None.")
+                             "are four supported modes: Writethrough, Writeback, Writearound and None."),
+
+        nfs_server:       N_("<b>Server</b> host name or IP address of the NFS server."),
+
+        nfs_directory:    N_("<b>Remote Directory</b> the directory on the NFS server."),
+
+        nfs_mount_point:  N_("<b>Mount Point</b> shows path in the local filesystem where the \n" \
+          "directory is mounted."),
+
+        nfs_type:         N_("<b>NFS Type</b> the filesystem type; typically \"nfs\"."),
+
+        nfs_options:      N_("<b>Options</b> Mount options. See also \"man 5 nfs\".")
       }.freeze
+
+      UNMOUNTED_TEXT = N_("An asterisk (*) after the mount point\n" \
+      "indicates a file system that is currently not mounted (for example, " \
+      "because it\nhas the <tt>noauto</tt> option set in <tt>/etc/fstab</tt>).")
 
       # help texts that are appended to the common help only in Mode.normal
       NORMAL_MODE_TEXTS = {
-        mount_by:    N_("A question mark (?) indicates that\n" \
-                  "the file system is not listed in <tt>/etc/fstab</tt>. It is either mounted\n" \
-                  "manually or by some automount system. When changing settings for this volume\n" \
-                  "YaST will not update <tt>/etc/fstab</tt>.\n"),
+        mount_by:        N_("A question mark (?) indicates that\n" \
+          "the file system is not listed in <tt>/etc/fstab</tt>. It is either mounted\n" \
+          "manually or by some automount system. When changing settings for this volume\n" \
+          "YaST will not update <tt>/etc/fstab</tt>.\n"),
 
-        mount_point: N_("An asterisk (*) after the mount point\n" \
-            "indicates a file system that is currently not mounted (for example, " \
-            "because it\nhas the <tt>noauto</tt> option set in <tt>/etc/fstab</tt>).")
+        mount_point:     UNMOUNTED_TEXT,
+
+        nfs_mount_point: UNMOUNTED_TEXT
       }.freeze
 
       # return translated text for given field in table or description

--- a/src/lib/y2partitioner/widgets/pages/nfs_mounts.rb
+++ b/src/lib/y2partitioner/widgets/pages/nfs_mounts.rb
@@ -1,6 +1,4 @@
-# encoding: utf-8
-
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -21,6 +19,7 @@
 
 require "cwm/tree_pager"
 require "y2partitioner/icons"
+require "y2partitioner/widgets/help"
 require "y2partitioner/yast_nfs_client"
 
 module Y2Partitioner
@@ -32,6 +31,8 @@ module Y2Partitioner
       # @see YastNfsClient
       class NfsMounts < CWM::Page
         include Yast::I18n
+
+        include Help
 
         # Constructor
         #
@@ -66,13 +67,11 @@ module Y2Partitioner
         end
 
         def help
-          # Translators: Help text for the list of NFS mounts
-          _("<p><b>Server:</b> Host name or IP address of the NFS server.</p>" \
-            "<p><b>Remote Directory:</b> The directory on the NFS server.</p>" \
-            "<p><b>Mount Point:</b> The path in the local filesystem where " \
-            "the directory is mounted.</p>" \
-            "<p><b>NFS Type:</b> The filesystem type; typically \"nfs\".</p>" \
-            "<p><b>Options:</b> Mount options. See also \"man 5 nfs\".</p>")
+          columns = [:nfs_server, :nfs_directory, :nfs_mount_point, :nfs_type, :nfs_options]
+
+          help_text = columns.map { |c| helptext_for(c) }
+
+          help_text.join
         end
 
         # @macro seeAbstractWidget

--- a/src/lib/y2storage/filesystems/nfs.rb
+++ b/src/lib/y2storage/filesystems/nfs.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # Copyright (c) [2017] SUSE LLC
 #
 # All Rights Reserved.

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -1,6 +1,4 @@
-# encoding: utf-8
-
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -181,18 +179,24 @@ module Y2Storage
     #   @return [Boolean]
     storage_forward :in_etc_fstab?
 
-    # @!method active?
-    # 	Whether the mount point is mounted (probed devicegraph) or
-    # 	should be mounted (staging devicegraph)
+    # @!method in_etc_fstab=(value)
+    #   Whether the mount point will be present in /etc/fstab
     #
-    # 	@return [Boolean]
+    #   @param value [Boolean]
+    storage_forward :in_etc_fstab=
+
+    # @!method active?
+    #   Whether the mount point is mounted (probed devicegraph) or
+    #   should be mounted (staging devicegraph)
+    #
+    #   @return [Boolean]
     storage_forward :active?
 
     # @!method active=(value)
     #
-    # 	Sets the {#active?} flag
+    #   Sets the {#active?} flag
     #
-    # 	@param value [Boolean]
+    #   @param value [Boolean]
     storage_forward :active=
 
     # @!method immediate_deactivate

--- a/test/y2partitioner/widgets/pages/nfs_mounts_test.rb
+++ b/test/y2partitioner/widgets/pages/nfs_mounts_test.rb
@@ -434,11 +434,8 @@ describe Y2Partitioner::Widgets::Pages::NfsMounts do
         end
 
         it "edits the NFS mount in the current devicegraph" do
-          expect(nfs_object.mount_point.path).to_not eq("/foo")
-
-          nfs_page.handle(event)
-
-          expect(nfs_object.mount_point.path).to eq("/foo")
+          expect { nfs_page.handle(event) }.to change(nfs_object.mount_point, :path)
+            .from("/test1").to("/foo")
         end
 
         it "keeps the mount status" do
@@ -469,13 +466,9 @@ describe Y2Partitioner::Widgets::Pages::NfsMounts do
         end
 
         it "creates a new NFS mount in the current devicegraph" do
-          nfs = Y2Storage::Filesystems::Nfs.find_by_server_and_path(device_graph, "srv", "/home/b")
-          expect(nfs).to be_nil
-
-          nfs_page.handle(event)
-
-          nfs = Y2Storage::Filesystems::Nfs.find_by_server_and_path(device_graph, "srv", "/home/b")
-          expect(nfs).to_not be_nil
+          expect { nfs_page.handle(event) }.to change {
+            Y2Storage::Filesystems::Nfs.find_by_server_and_path(device_graph, "srv", "/home/b")
+          }.from(be_nil).to(be_a(Y2Storage::Filesystems::Nfs))
         end
 
         it "keeps the previous mount status" do

--- a/test/y2partitioner/widgets/pages/nfs_mounts_test.rb
+++ b/test/y2partitioner/widgets/pages/nfs_mounts_test.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env rspec
-# encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -373,6 +372,16 @@ describe Y2Partitioner::Widgets::Pages::NfsMounts do
     end
 
     context "when the event is triggered by the 'edit' button" do
+      before do
+        allow(Yast::WFM).to receive(:CallFunction).and_return client_result
+
+        allow_any_instance_of(Y2Storage::Filesystems::Nfs).to receive(:reachable?).and_return(true)
+      end
+
+      let(:client_result) { {} }
+
+      let(:nfs_object) { device_graph.nfs_mounts.find { |nfs| nfs.path == "/home/a" } }
+
       let(:event) do
         { "EventType" => "WidgetEvent", "EventReason" => "Activated", "ID" => :editbut }
       end
@@ -385,12 +394,9 @@ describe Y2Partitioner::Widgets::Pages::NfsMounts do
 
       context "and the legacy NFSv4 options are modified" do
         before do
-          allow(Yast::WFM).to receive(:CallFunction).and_return client_result
           # Simulate a legacy nfs4 entry
           nfs_object.mount_point.mount_type = Y2Storage::Filesystems::Type::NFS4
         end
-
-        let(:nfs_object) { device_graph.nfs_mounts.find { |nfs| nfs.path == "/home/a" } }
 
         let(:client_result) do
           {
@@ -407,6 +413,81 @@ describe Y2Partitioner::Widgets::Pages::NfsMounts do
 
           expect(nfs_object.mount_point.mount_type.to_sym).to eq :nfs
           expect(nfs_object.mount_point.mount_options).to eq ["nfsvers=4"]
+        end
+      end
+
+      context "and neither the server nor the directory are modified" do
+        let(:client_result) do
+          {
+            "device" => "srv:/home/a", "fstopt" => "", "mount" => "/foo", "vfstype" => "nfs"
+          }
+        end
+
+        it "does no re-create the NFS mount" do
+          previous_sid = nfs_object.sid
+
+          nfs_page.handle(event)
+
+          sid = Y2Storage::Filesystems::Nfs.find_by_server_and_path(device_graph, "srv", "/home/a").sid
+
+          expect(previous_sid).to eq(sid)
+        end
+
+        it "edits the NFS mount in the current devicegraph" do
+          expect(nfs_object.mount_point.path).to_not eq("/foo")
+
+          nfs_page.handle(event)
+
+          expect(nfs_object.mount_point.path).to eq("/foo")
+        end
+
+        it "keeps the mount status" do
+          active = nfs_object.mount_point.active?
+          in_etc_fstab = nfs_object.mount_point.in_etc_fstab?
+
+          nfs_page.handle(event)
+
+          expect(nfs_object.mount_point.active?).to eq(active)
+          expect(nfs_object.mount_point.in_etc_fstab?).to eq(in_etc_fstab)
+        end
+      end
+
+      context "and either the server or the directory are modified" do
+        let(:client_result) do
+          {
+            "device" => "srv:/home/b", "fstopt" => "", "mount" => "/test1", "vfstype" => "nfs",
+            "old_device" => "srv:/home/a"
+          }
+        end
+
+        it "deletes the NFS mount" do
+          nfs_page.handle(event)
+
+          nfs = Y2Storage::Filesystems::Nfs.find_by_server_and_path(device_graph, "srv", "/home/a")
+
+          expect(nfs).to be_nil
+        end
+
+        it "creates a new NFS mount in the current devicegraph" do
+          nfs = Y2Storage::Filesystems::Nfs.find_by_server_and_path(device_graph, "srv", "/home/b")
+          expect(nfs).to be_nil
+
+          nfs_page.handle(event)
+
+          nfs = Y2Storage::Filesystems::Nfs.find_by_server_and_path(device_graph, "srv", "/home/b")
+          expect(nfs).to_not be_nil
+        end
+
+        it "keeps the previous mount status" do
+          active = nfs_object.mount_point.active?
+          in_etc_fstab = nfs_object.mount_point.in_etc_fstab?
+
+          nfs_page.handle(event)
+
+          nfs = Y2Storage::Filesystems::Nfs.find_by_server_and_path(device_graph, "srv", "/home/b")
+
+          expect(nfs.mount_point.active?).to eq(active)
+          expect(nfs.mount_point.in_etc_fstab?).to eq(in_etc_fstab)
         end
       end
     end


### PR DESCRIPTION
## Problem

The NFS client (yast2-nfs-client) can be used standalone or through the Partitioner. But the behaviour is not exactly the same in both cases.

With the standalone mode:

* All nfs shares are deleted and created again.
* Current unmounted shares are mounted after saving the changes, even though the nfs entry is not edited.
* Current shares that are not included in the fstab are written to fstab after saving the changes.

With the Expert Partitioner:

* Only edited entries are modified after saving.
* Current unmounted shares are mounted only if their server or path change.
* Current shares that are not included in the fstab are written to fstab only if their server or path change.

Related bugs:

* https://bugzilla.suse.com/show_bug.cgi?id=1006815
* https://bugzilla.suse.com/show_bug.cgi?id=1151426


Part of PBI: https://trello.com/c/Z8gqtcC1/1484-3-nfs-client-and-unmounting-bug1006815-bug1151426


## Solution

This PR unifies the behavior. Now, in both cases (standalone and inside the Partitioner):

* Current unmounted shares keep unmounted after editing them, even when the server or path changes.
* Current shares that are not included in the fstab are never written to the fstab, even when the server or path changes.

These changes imply that an unmounted share cannot be mounted. For that, the user should delete the entry and create it again (from the UI, of course).

Note that libstorage-ng 4.1.107 is required to avoid some mount/unmount issues, see https://github.com/openSUSE/libstorage-ng/pull/699.

## Testing

- Added new unit tests
- Tested manually
