### PR TITLE
use correct and absolute paths to some external programs

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 14 20:52:30 CET 2020 - aschnell@suse.com
+
+- use udevadm in /usr/bin instead of /sbin (bsc#1160890)
+- 4.2.71
+
+-------------------------------------------------------------------
 Tue Jan 14 09:54:08 CET 2020 - aschnell@suse.com
 
 - do not allow block sizes bigger than the system page size when

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -2,6 +2,7 @@
 Tue Jan 14 20:52:30 CET 2020 - aschnell@suse.com
 
 - use udevadm in /usr/bin instead of /sbin (bsc#1160890)
+- use absolute paths in mask-systemd-units
 - 4.2.71
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.70
+Version:        4.2.71
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/bin/mask-systemd-units
+++ b/src/bin/mask-systemd-units
@@ -15,7 +15,7 @@
 
 query_units()
 {
-    systemctl list-units --full --all --type mount,swap --no-legend | while read -r unit dummy ; do
+    /usr/bin/systemctl list-units --full --all --type mount,swap --no-legend | while read -r unit dummy ; do
 
 	# skip root and sysroot
 	if [[ $unit == -.mount || $unit == sysroot.mount ]] ; then
@@ -37,7 +37,7 @@ query_units()
 
 mask_units()
 {
-    query_units | xargs --verbose --no-run-if-empty --delimiter='\n' systemctl --runtime $1 --
+    query_units | /usr/bin/xargs --verbose --no-run-if-empty --delimiter='\n' /usr/bin/systemctl --runtime $1 --
 }
 
 usage()

--- a/src/lib/y2storage/inhibitors/mdadm_auto_assembly.rb
+++ b/src/lib/y2storage/inhibitors/mdadm_auto_assembly.rb
@@ -24,11 +24,14 @@ module Y2Storage
   class MdadmAutoAssembly
     include Yast::Logger
 
+    # location of udevadm program
+    UDEVADM_BIN = "/usr/bin/udevadm".freeze
+
     def inhibit
       log.info "set udev ANACONDA property"
 
       begin
-        Yast::Execute.locally!("/sbin/udevadm", "control", "--property=ANACONDA=yes")
+        Yast::Execute.locally!(UDEVADM_BIN, "control", "--property=ANACONDA=yes")
       rescue Cheetah::ExecutionFailed => e
         log.error "disabling mdadm auto assembly failed #{e.message}"
       end
@@ -38,7 +41,7 @@ module Y2Storage
       log.info "unset udev ANACONDA property"
 
       begin
-        Yast::Execute.locally!("/sbin/udevadm", "control", "--property=ANACONDA=")
+        Yast::Execute.locally!(UDEVADM_BIN, "control", "--property=ANACONDA=")
       rescue Cheetah::ExecutionFailed => e
         log.error "enabling mdadm auto assembly failed #{e.message}"
       end

--- a/test/y2partitioner/clients/main_test.rb
+++ b/test/y2partitioner/clients/main_test.rb
@@ -86,7 +86,7 @@ describe Y2Partitioner::Clients::Main do
           allow(partitioner_dialog).to receive(:run).and_return(partitioner_result)
 
           allow(Yast::Execute).to receive(:locally!)
-            .with("/sbin/udevadm", any_args)
+            .with("/usr/bin/udevadm", any_args)
           allow(Yast::Execute).to receive(:locally!)
             .with("/usr/lib/YaST2/bin/mask-systemd-units", any_args)
         end
@@ -116,13 +116,13 @@ describe Y2Partitioner::Clients::Main do
         it "runs the partitioner dialog" do
           expect(partitioner_dialog).to receive(:run)
 
-          expect(Yast::Execute).to receive(:locally!).with("/sbin/udevadm", "control",
+          expect(Yast::Execute).to receive(:locally!).with("/usr/bin/udevadm", "control",
             "--property=ANACONDA=yes").ordered
           expect(Yast::Execute).to receive(:locally!).with("/usr/lib/YaST2/bin/mask-systemd-units",
             "--mask").ordered
           expect(Yast::Execute).to receive(:locally!).with("/usr/lib/YaST2/bin/mask-systemd-units",
             "--unmask").ordered
-          expect(Yast::Execute).to receive(:locally!).with("/sbin/udevadm", "control",
+          expect(Yast::Execute).to receive(:locally!).with("/usr/bin/udevadm", "control",
             "--property=ANACONDA=").ordered
 
           subject.run


### PR DESCRIPTION
## Problem

systemd has removed some links for programs in /usr/bin to /sbin. So the paths YaST uses are gone.

Also a script did not use absolute paths. Seems as if this was not noticed during the "YaST hardening".

## Solution

Use the paths that still exist and use absolute paths.

## Testing

- Adapted unit test
- Tested manually

## See also

- https://bugzilla.suse.com/show_bug.cgi?id=1160890
- https://trello.com/c/3Y9HSV8m/3830-tw-p2-1160890-stop-using-sbin-udevadm-and-other-symlinks