### PR TITLE
treat partitions with BitLocker as Windows

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 15 22:07:30 CET 2020 - aschnell@suse.com
+
+- treat partitions with BitLocker as Windows (related to
+  bsc#1159318)
+- 4.2.72
+
+-------------------------------------------------------------------
 Tue Jan 14 20:52:30 CET 2020 - aschnell@suse.com
 
 - use udevadm in /usr/bin instead of /sbin (bsc#1160890)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.71
+Version:        4.2.72
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/filesystems/base.rb
+++ b/src/lib/y2storage/filesystems/base.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -161,6 +161,10 @@ module Y2Storage
       # @return [Boolean]
       def windows_system?
         return false unless windows_suitable?
+
+        # For BitLocker assume it is Windows without looking further
+        # at the file system (it cannot be mounted anyway).
+        return true if type.to_sym == :bitlocker
 
         !!fs_attribute(:windows)
       end

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -170,7 +170,7 @@ module Y2Storage
       # filesystems that can embed grub
       GRUB_FILESYSTEMS = [:ext2, :ext3, :ext4, :btrfs]
 
-      WINDOWS_FILESYSTEMS = [:ntfs, :vfat]
+      WINDOWS_FILESYSTEMS = [:ntfs, :vfat, :bitlocker]
 
       private_constant :PROPERTIES, :ROOT_FILESYSTEMS, :HOME_FILESYSTEMS,
         :COMMON_FSTAB_OPTIONS, :EXT_FSTAB_OPTIONS, :LEGACY_ROOT_FILESYSTEMS,

--- a/test/y2storage/filesystems/base_test.rb
+++ b/test/y2storage/filesystems/base_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -194,6 +194,19 @@ describe Y2Storage::Filesystems::Base do
         it "returns true" do
           expect(subject.windows_system?).to eq(true)
         end
+      end
+    end
+
+    context "when the filesystem is BitLocker" do
+      before do
+        allow(subject).to receive(:type).and_return(type)
+      end
+
+      let(:suitable) { true }
+      let(:type) { instance_double(Y2Storage::Filesystems::Type, to_sym: :bitlocker) }
+
+      it "returns true" do
+        expect(subject.windows_system?).to eq(true)
       end
     end
   end

--- a/test/y2storage/filesystems/base_test.rb
+++ b/test/y2storage/filesystems/base_test.rb
@@ -115,30 +115,30 @@ describe Y2Storage::Filesystems::Base do
       it "returns false" do
         expect(subject.windows_suitable?).to eq(false)
       end
+    end
 
-      context "when the type is suitable for Windows" do
-        let(:type_suitable) { true }
+    context "when the type is suitable for Windows" do
+      let(:type_suitable) { true }
 
-        before do
-          allow(subject).to receive(:blk_devices).and_return([blk_device])
+      before do
+        allow(subject).to receive(:blk_devices).and_return([blk_device])
 
-          allow(blk_device).to receive(:windows_suitable?).and_return(device_suitable)
+        allow(blk_device).to receive(:windows_suitable?).and_return(device_suitable)
+      end
+
+      context "but its device is not suitable for Windows" do
+        let(:device_suitable) { false }
+
+        it "returns false" do
+          expect(subject.windows_suitable?).to eq(false)
         end
+      end
 
-        context "but its device is not suitable for Windows" do
-          let(:device_suitable) { false }
+      context "and its device is suitable for Windows" do
+        let(:device_suitable) { true }
 
-          it "returns false" do
-            expect(subject.windows_suitable?).to eq(false)
-          end
-        end
-
-        context "and its device is suitable for Windows" do
-          let(:device_suitable) { true }
-
-          it "returns true" do
-            expect(subject.windows_suitable?).to eq(true)
-          end
+        it "returns true" do
+          expect(subject.windows_suitable?).to eq(true)
         end
       end
     end

--- a/test/y2storage/filesystems/type_test.rb
+++ b/test/y2storage/filesystems/type_test.rb
@@ -260,7 +260,7 @@ describe Y2Storage::Filesystems::Type do
       expect(described_class.windows_filesystems).to be_a(Array)
     end
 
-    it "only includes ntfs and vfat" do
+    it "only includes ntfs, vfat and bitlocker" do
       expect(described_class.windows_filesystems.map(&:to_sym)).to contain_exactly(:ntfs, :vfat,
         :bitlocker)
     end
@@ -273,6 +273,10 @@ describe Y2Storage::Filesystems::Type do
 
     it "returns true for vfat" do
       expect(described_class::VFAT.windows_ok?).to eq(true)
+    end
+
+    it "returns true for bitlocker" do
+      expect(described_class::BITLOCKER.windows_ok?).to eq(true)
     end
 
     it "returns false otherwise" do

--- a/test/y2storage/filesystems/type_test.rb
+++ b/test/y2storage/filesystems/type_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -261,7 +261,8 @@ describe Y2Storage::Filesystems::Type do
     end
 
     it "only includes ntfs and vfat" do
-      expect(described_class.windows_filesystems.map(&:to_sym)).to contain_exactly(:ntfs, :vfat)
+      expect(described_class.windows_filesystems.map(&:to_sym)).to contain_exactly(:ntfs, :vfat,
+        :bitlocker)
     end
   end
 
@@ -275,7 +276,7 @@ describe Y2Storage::Filesystems::Type do
     end
 
     it "returns false otherwise" do
-      types = described_class.all.reject { |t| t.is?(:ntfs, :vfat) }
+      types = described_class.all.reject { |t| t.is?(:ntfs, :vfat, :bitlocker) }
 
       expect(types.map(&:windows_ok?)).to all(be(false))
     end


### PR DESCRIPTION
## Problem

Partitions with BitLocker were not treated as Windows. One notable consequence of that is that BitLocker partitions could be removed by the storage proposal even when the user instructed YaST to not modify Windows.

## Solution

Treat partitions with BitLocker as Windows.

## Testing

- Added a new unit test
- Tested manually

## See also

https://trello.com/c/urYYuPsW/1562-3-detecting-bitlocker-part-of-bug1159318-expert-partitioner-let-me-resize-bitlocker-partition-cause-data-lost