### PR TITLE
Show the dynamic buttons set in the main table of devices

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 17 14:54:37 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Partitioner: make it possible to directly work with devices
+  from the overview/system page (related to fate#318196).
+- 4.2.74
+
+-------------------------------------------------------------------
 Thu Jan 16 11:48:39 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Improve integration with yast2-nfs-client.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.73
+Version:        4.2.74
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -137,7 +137,7 @@ module Y2Partitioner
     # and selected row are cleared. See #tab=
     #
     # @param pages [Array<CWM::Page>] all the pages in the tree
-    # @return [CWM::Page, nil]
+    # @return [CWM::Page, nil] the page to be opened; the initial one when nil
     def find_tree_node(pages)
       # candidate_nodes can be empty if the user has not left the overview page yet. So, do nothing
       return nil if candidate_nodes.empty?
@@ -177,8 +177,9 @@ module Y2Partitioner
 
     protected
 
-    # A sort of breadcrumbs useful to know where to place the user within the general tree in the
-    # next redraw. It could hold both, devices id (sid, Integer) or pages labels (Sring)
+    # Useful to know where to place the user within the general tree in the next redraw
+    #
+    # It could hold both, devices id (sid, Integer) or pages labels (String).
     #
     # @see #find_tree_node
     #

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -133,19 +133,28 @@ module Y2Partitioner
 
     # Select the page to open in the general tree after a redraw
     #
+    # If the first candidate page/node (the "current" one) is not available anymore, the tab name
+    # and selected row are cleared. See #tab=
+    #
     # @param pages [Array<CWM::Page>] all the pages in the tree
     # @return [CWM::Page, nil]
     def find_tree_node(pages)
+      # candidate_nodes can be empty if the user has not left the overview page yet. So, do nothing
+      return nil if candidate_nodes.empty?
+
       candidate_nodes.each.with_index do |candidate, idx|
         result = pages.find { |page| matches?(page, candidate) }
         if result
-          # If we had to use one of the fallbacks, the tab name is not longer
-          # trustworthy
+          # If the first candidate is not available anymore (likely, it was deleted),
+          # we had to use one of the fallbacks and the tab name is not longer trustworthy
           self.tab = nil unless idx.zero?
           return result
         end
       end
+
+      # For some reason none candidate is available. Let's reset the tab name.
       self.tab = nil
+
       nil
     end
 
@@ -168,7 +177,11 @@ module Y2Partitioner
 
     protected
 
-    # Where to place the user within the general tree in next redraw
+    # A sort of breadcrumbs useful to know where to place the user within the general tree in the
+    # next redraw. It could hold both, devices id (sid, Integer) or pages labels (Sring)
+    #
+    # @see #find_tree_node
+    #
     # @return [Array<Integer, String>]
     attr_accessor :candidate_nodes
 
@@ -182,8 +195,7 @@ module Y2Partitioner
     # @see #tab
     def tab=(tab)
       @tab = tab
-      # If the user switched to a new tab, invalidate details about the inner
-      # table
+      # If the user switched to a new tab, invalidate details about the inner table
       self.row_sid = nil
     end
 

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -60,7 +60,7 @@ module Y2Partitioner
             Left(header),
             table,
             Left(device_buttons),
-            HBox(*buttons)
+            Right(HBox(*buttons))
           )
         end
 
@@ -116,7 +116,6 @@ module Y2Partitioner
         def buttons
           buttons = [rescan_devices_button]
           buttons << import_mount_points_button if Yast::Mode.installation
-          buttons << HStretch()
           buttons << Configure.new
           buttons
         end

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -24,6 +24,7 @@ require "y2partitioner/widgets/configurable_blk_devices_table"
 require "y2partitioner/widgets/rescan_devices_button"
 require "y2partitioner/widgets/import_mount_points_button"
 require "y2partitioner/widgets/configure"
+require "y2partitioner/widgets/device_buttons_set"
 
 Yast.import "Mode"
 
@@ -58,6 +59,7 @@ module Y2Partitioner
           @contents = VBox(
             Left(header),
             table,
+            Left(device_buttons),
             HBox(*buttons)
           )
         end
@@ -96,9 +98,16 @@ module Y2Partitioner
         def table
           return @table unless @table.nil?
 
-          @table = ConfigurableBlkDevicesTable.new(devices, @pager)
+          @table = ConfigurableBlkDevicesTable.new(devices, @pager, device_buttons)
           @table.remove_columns(:start, :end)
           @table
+        end
+
+        # Widget with the dynamic set of buttons for the selected row
+        #
+        # @return [DeviceButtonsSet]
+        def device_buttons
+          @device_buttons ||= DeviceButtonsSet.new(pager)
         end
 
         # Page buttons

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -77,6 +77,18 @@ describe Y2Partitioner::UIState do
       it "returns nil" do
         expect(ui_state.find_tree_node(pages)).to be_nil
       end
+
+      context "and there is a selected row" do
+        let(:device_name) { "/dev/sdb" }
+
+        before { ui_state.select_row(device) }
+
+        it "does not clear the selected row" do
+          ui_state.find_tree_node(pages)
+
+          expect(ui_state.row_sid).to eq(device.sid)
+        end
+      end
     end
 
     context "when the user has opened a partition page" do

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -61,6 +61,11 @@ describe Y2Partitioner::Widgets::Pages::System do
       expect(button).to_not be_nil
     end
 
+    it "contains a device buttons set" do
+      device_buttons = widgets.find { |w| w.is_a?(Y2Partitioner::Widgets::DeviceButtonsSet) }
+      expect(device_buttons).to_not be_nil
+    end
+
     it "contains a widget for configuring storage technologies" do
       button = widgets.find { |w| w.is_a?(Y2Partitioner::Widgets::Configure) }
       expect(button).to_not be_nil


### PR DESCRIPTION
## Problem

The [system overview page](https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2partitioner/widgets/pages/system.rb) does not include the [`DeviceButtonSet`](https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2partitioner/widgets/device_buttons_set.rb) at the bottom of the devices table. And... there is no arguable reason for it :)

* Trello: https://trello.com/c/cyWuac6k
* Fate: https://fate.suse.com/318196

## Solution

To use those dynamic (and useful) buttons also on that page.

## Side effects

To make the changes fully consistent with the rest of Partitioner _pages_, the second buttons row has been realigned to the right. Now, all pages follows the same pattern: contextual actions closest to the table and aligned to the left and general actions below but aligned to the right.

## Tests

* Added small unit tests to cover made changes
* Tested manually (it works!)

## Screenshots

<details>
<summary> Click to show/hide screenshots before realigning buttons</summary>

---

| In a running system | During Installation |
|---------------------|---------------------|
| ![in_running_system_before](https://user-images.githubusercontent.com/1691872/72544026-88c70300-387e-11ea-8d3a-58be629d5700.png) | ![partitioner_installation_mode_before](https://user-images.githubusercontent.com/1691872/72543849-3be32c80-387e-11ea-98a5-ca143ae41164.png) |
| ![ncurses_85x24_running_system_before](https://user-images.githubusercontent.com/1691872/72545898-b3ff2180-3881-11ea-8728-51a4cf92e90b.png) <p align="center">ncurses 85x24</p> | ![ncurses_85x24_installation_before](https://user-images.githubusercontent.com/1691872/72546002-e4df5680-3881-11ea-82f0-6febab18a676.png) <p align="center">ncurses 85x24</p> |

</details>

<details>
<summary> Click to show/hide screenshots after realigning buttons</summary>

---
| In a running system | During Installation |
|---------------------|---------------------|
| ![realigned_buttons_running_system](https://user-images.githubusercontent.com/1691872/72620463-41507d80-3937-11ea-9511-5d05b3945ae6.png) | ![realigned_buttons_installation](https://user-images.githubusercontent.com/1691872/72620485-49a8b880-3937-11ea-8b93-1972f57e3a16.png) |
|  ![realigned_buttons_ncurses_85x24_running_system](https://user-images.githubusercontent.com/1691872/72620524-5cbb8880-3937-11ea-9c6d-0a0ccd0fe5ec.png) <p align="center">ncurses 85x24</p> | ![realigned_buttons_ncurses_85x24_installation](https://user-images.githubusercontent.com/1691872/72620543-693fe100-3937-11ea-9e40-714e3f1aa08d.png) <p align="center">ncurses 85x24</p> |

</details>