### PR TITLE
added warning before resizing block devices which were probed empty

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 21 12:11:46 CET 2020 - aschnell@suse.com
+
+- added warning before resizing block devices which were probed
+  empty (related to bsc#1159318)
+- 4.2.76
+
+-------------------------------------------------------------------
 Tue Jan 21 11:34:31 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Guided Setup: enforced a consistent width for both password

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.75
+Version:        4.2.76
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/test/y2partitioner/actions/resize_blk_device_test.rb
+++ b/test/y2partitioner/actions/resize_blk_device_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -272,6 +272,17 @@ describe Y2Partitioner::Actions::ResizeBlkDevice do
         include_examples "partition_holds_lvm"
 
         include_examples "partition_holds_md"
+      end
+    end
+
+    context "when executed on an 'empty' partition" do
+      let(:scenario) { "mixed_disks.yml" }
+
+      let(:device_name) { "/dev/sdb7" }
+
+      it "shows a warning popup" do
+        expect(Yast2::Popup).to receive(:show)
+        action.run
       end
     end
 


### PR DESCRIPTION
## Problem

We had a bug report where a user shrunk a partition with BitLocker on it (which caused data loss since BitLocker was not detected).

## Solution

The data loss is now prevented by two changes:

- BitLocker is detected (other PRs)
- A warning is presented to the user when trying to resize a device which seems to be empty (this PR).

## Testing

- Added a new unit test.
- Tested manually.

## See also

- https://bugzilla.suse.com/show_bug.cgi?id=1159318
- https://trello.com/c/CEJP4jFv/1575-1-warn-when-resizing-empty-partitions-2nd-part-of-bug1159318-expert-partitioner-let-me-resize-bitlocker-partition-cause-data-loss
- https://trello.com/c/urYYuPsW/1562-3-detecting-bitlocker-part-of-bug1159318-expert-partitioner-let-me-resize-bitlocker-partition-cause-data-lost
