### PR TITLE
Guided Setup: enforce width of password fields (bsc#1161202)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 21 11:34:31 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Guided Setup: enforced a consistent width for both password
+  fields (bsc#1161202)
+- 4.2.75
+
+-------------------------------------------------------------------
 Fri Jan 17 14:54:37 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Partitioner: make it possible to directly work with devices

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.74
+Version:        4.2.75
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -130,13 +130,13 @@ module Y2Storage
             Left(
               HBox(
                 HSpacing(2),
-                Password(Id(:password), _("Password"))
+                Password(Id(:password), Opt(:hstretch), _("Password"))
               )
             ),
             Left(
               HBox(
                 HSpacing(2),
-                Password(Id(:repeat_password), _("Verify Password"))
+                Password(Id(:repeat_password), Opt(:hstretch), _("Verify Password"))
               )
             )
           )


### PR DESCRIPTION
## Problem

At some point, the Guided Setup started to look like this in ncurses:

![nostretch](https://user-images.githubusercontent.com/3638289/72801942-eeced400-3c4a-11ea-8e66-fab100bd9169.png)

Note the different width of the "Password" and "Verify Password" fields.

Reported as https://bugzilla.suse.com/show_bug.cgi?id=1161202

## Solution

Enlarge both fields to use the whole width of the form. With that, the fields look longer than before. The change affects both Qt and ncurses views (see screenshots below), but it should be more solid, regarding internationalization, than hardcoding a (minimal) size.

Fixed ncurses view:

![hstretch-ncurses](https://user-images.githubusercontent.com/3638289/72802095-466d3f80-3c4b-11ea-95ce-075a71c5d820.png)

Qt also changed:
![hstretch-qt](https://user-images.githubusercontent.com/3638289/72802117-52f19800-3c4b-11ea-8c7d-4cfd7a647e71.png)
