### PR TITLE
Partitioner: remember active tab and selected row per node

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb  5 12:38:51 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Partitioner: usability improved by remembering the last active
+  tab and selected device per page (bsc#1159883).
+- 4.1.83
+
+-------------------------------------------------------------------
 Tue Feb  4 12:09:51 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Partitioner: add a new progress dialog instead of simply closing

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.82
+Version:        4.2.83
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/add_bcache.rb
+++ b/src/lib/y2partitioner/actions/add_bcache.rb
@@ -70,7 +70,7 @@ module Y2Partitioner
         return unless dialog.run == :next
 
         controller.create_bcache(dialog.backing_device, dialog.caching_device, dialog.options)
-        UIState.instance.select_row(controller.bcache)
+        UIState.instance.select_row(controller.bcache.sid)
       end
 
       # Whether there is suitable backing devices

--- a/src/lib/y2partitioner/actions/clone_partition_table.rb
+++ b/src/lib/y2partitioner/actions/clone_partition_table.rb
@@ -57,7 +57,7 @@ module Y2Partitioner
         return result if result != :ok
 
         clone_partition_table
-        UIState.instance.select_row(controller.device)
+        UIState.instance.select_row(controller.device.sid)
         :finish
       end
 

--- a/src/lib/y2partitioner/actions/controllers/add_partition.rb
+++ b/src/lib/y2partitioner/actions/controllers/add_partition.rb
@@ -125,7 +125,7 @@ module Y2Partitioner
           slot = slot_for(region)
           aligned = align(region, slot, ptable)
           @partition = ptable.create_partition(slot.name, aligned, type)
-          UIState.instance.select_row(@partition)
+          UIState.instance.select_row(@partition.sid)
         end
 
         # Removes the previously created partition from the device

--- a/src/lib/y2partitioner/actions/controllers/btrfs_devices.rb
+++ b/src/lib/y2partitioner/actions/controllers/btrfs_devices.rb
@@ -56,7 +56,7 @@ module Y2Partitioner
           @metadata_raid_level = Y2Storage::BtrfsRaidLevel::DEFAULT
           @data_raid_level = Y2Storage::BtrfsRaidLevel::DEFAULT
 
-          UIState.instance.select_row(filesystem) if filesystem
+          UIState.instance.select_row(filesystem.sid) if filesystem
         end
 
         # Metadata RAID level for the filesystem
@@ -225,7 +225,7 @@ module Y2Partitioner
           filesystem.metadata_raid_level = @metadata_raid_level
           filesystem.data_raid_level = @data_raid_level
 
-          UIState.instance.select_row(filesystem)
+          UIState.instance.select_row(filesystem.sid)
 
           @filesystem = filesystem
         end

--- a/src/lib/y2partitioner/actions/controllers/lvm_lv.rb
+++ b/src/lib/y2partitioner/actions/controllers/lvm_lv.rb
@@ -95,7 +95,7 @@ module Y2Partitioner
         # Creates the LV in the VG according to the controller attributes
         def create_lv
           @lv = lv_type.is?(:thin) ? create_thin_lv : create_normal_or_pool_lv
-          UIState.instance.select_row(@lv)
+          UIState.instance.select_row(@lv.sid)
         end
 
         # Removes the previously created logical volume

--- a/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
@@ -224,7 +224,7 @@ module Y2Partitioner
             initialize_for_resize(current_vg)
           end
 
-          UIState.instance.select_row(vg) unless vg.nil?
+          UIState.instance.select_row(vg.sid) unless vg.nil?
         end
 
         # Detects current action

--- a/src/lib/y2partitioner/actions/controllers/md.rb
+++ b/src/lib/y2partitioner/actions/controllers/md.rb
@@ -57,7 +57,7 @@ module Y2Partitioner
 
           @md_sid = md.sid
           @initial_name = md.name
-          UIState.instance.select_row(md)
+          UIState.instance.select_row(md.sid)
         end
 
         # MD RAID being modified

--- a/src/lib/y2partitioner/actions/delete_bcache.rb
+++ b/src/lib/y2partitioner/actions/delete_bcache.rb
@@ -35,7 +35,7 @@ module Y2Partitioner
         textdomain "storage"
 
         @bcache_controller = Controllers::Bcache.new(bcache)
-        UIState.instance.select_row(bcache)
+        UIState.instance.select_row(bcache.sid)
       end
 
       private

--- a/src/lib/y2partitioner/actions/delete_device.rb
+++ b/src/lib/y2partitioner/actions/delete_device.rb
@@ -72,7 +72,6 @@ module Y2Partitioner
       #
       # @see Y2Storage::Filesystems::Btrfs.refresh_subvolumes_shadowing
       def perform_action
-        UIState.instance.clear_statuses_for(device.sid)
         delete
         Y2Storage::Filesystems::Btrfs.refresh_subvolumes_shadowing(device_graph)
       end

--- a/src/lib/y2partitioner/actions/delete_device.rb
+++ b/src/lib/y2partitioner/actions/delete_device.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "yast2/popup"
+require "y2partitioner/ui_state"
 require "y2partitioner/device_graphs"
 require "y2partitioner/confirm_recursive_delete"
 require "y2partitioner/immediate_unmount"
@@ -71,6 +72,7 @@ module Y2Partitioner
       #
       # @see Y2Storage::Filesystems::Btrfs.refresh_subvolumes_shadowing
       def perform_action
+        UIState.instance.clear_statuses_for(device.sid)
         delete
         Y2Storage::Filesystems::Btrfs.refresh_subvolumes_shadowing(device_graph)
       end

--- a/src/lib/y2partitioner/actions/delete_lvm_lvs.rb
+++ b/src/lib/y2partitioner/actions/delete_lvm_lvs.rb
@@ -40,7 +40,7 @@ module Y2Partitioner
         log.info "deleting logical volumes from #{device}"
 
         device.lvm_lvs.each { |lv| device.delete_lvm_lv(lv) }
-        UIState.instance.select_row(device)
+        UIState.instance.select_row(device.sid)
       end
 
       # @see DeleteDevice#errors

--- a/src/lib/y2partitioner/actions/delete_partition.rb
+++ b/src/lib/y2partitioner/actions/delete_partition.rb
@@ -39,7 +39,7 @@ module Y2Partitioner
         log.info "deleting partition #{device}"
         parent_device = device.partitionable
         parent_device.partition_table.delete_partition(device)
-        UIState.instance.select_row(parent_device)
+        UIState.instance.select_row(parent_device.sid)
       end
 
       # @see DeleteDevice#errors

--- a/src/lib/y2partitioner/actions/delete_partitions.rb
+++ b/src/lib/y2partitioner/actions/delete_partitions.rb
@@ -40,7 +40,7 @@ module Y2Partitioner
         log.info "deleting partitions from #{device}"
 
         device.partition_table.delete_all_partitions
-        UIState.instance.select_row(device)
+        UIState.instance.select_row(device.sid)
       end
 
       # @see DeleteDevice#errors

--- a/src/lib/y2partitioner/actions/edit_bcache.rb
+++ b/src/lib/y2partitioner/actions/edit_bcache.rb
@@ -36,7 +36,7 @@ module Y2Partitioner
         textdomain "storage"
 
         @controller = Controllers::Bcache.new(bcache)
-        UIState.instance.select_row(bcache)
+        UIState.instance.select_row(bcache.sid)
       end
 
       private

--- a/src/lib/y2partitioner/actions/edit_btrfs.rb
+++ b/src/lib/y2partitioner/actions/edit_btrfs.rb
@@ -36,7 +36,7 @@ module Y2Partitioner
         textdomain "storage"
 
         @device_sid = filesystem.sid
-        UIState.instance.select_row(filesystem)
+        UIState.instance.select_row(filesystem.sid)
       end
 
       private

--- a/src/lib/y2partitioner/actions/filesystem_steps.rb
+++ b/src/lib/y2partitioner/actions/filesystem_steps.rb
@@ -78,7 +78,7 @@ module Y2Partitioner
 
       def filesystem_commit
         encrypt_controller.finish
-        UIState.instance.select_row(fs_controller.blk_device)
+        UIState.instance.select_row(fs_controller.blk_device.sid)
         :finish
       end
 

--- a/src/lib/y2partitioner/actions/go_to_device_tab.rb
+++ b/src/lib/y2partitioner/actions/go_to_device_tab.rb
@@ -46,7 +46,7 @@ module Y2Partitioner
 
         # First, pretend the user visited the device and then the tab...
         state = UIState.instance
-        state.go_to_tree_node(target_page)
+        state.select_page([device.sid])
         state.switch_to_tab(tab_label)
 
         # ...then trigger a redraw

--- a/src/lib/y2partitioner/actions/go_to_device_tab.rb
+++ b/src/lib/y2partitioner/actions/go_to_device_tab.rb
@@ -46,7 +46,7 @@ module Y2Partitioner
 
         # First, pretend the user visited the device and then the tab...
         state = UIState.instance
-        state.select_page([target_page.id])
+        state.select_page(target_page.tree_path)
         state.switch_to_tab(tab_label)
 
         # ...then trigger a redraw

--- a/src/lib/y2partitioner/actions/go_to_device_tab.rb
+++ b/src/lib/y2partitioner/actions/go_to_device_tab.rb
@@ -46,7 +46,7 @@ module Y2Partitioner
 
         # First, pretend the user visited the device and then the tab...
         state = UIState.instance
-        state.select_page([device.sid])
+        state.select_page([target_page.id])
         state.switch_to_tab(tab_label)
 
         # ...then trigger a redraw

--- a/src/lib/y2partitioner/actions/resize_blk_device.rb
+++ b/src/lib/y2partitioner/actions/resize_blk_device.rb
@@ -43,7 +43,7 @@ module Y2Partitioner
         @device = device
         @controller = Controllers::BlkDevice.new(device)
 
-        UIState.instance.select_row(device)
+        UIState.instance.select_row(device.sid)
       end
 
       # Checks whether it is possible to resize the device, and if so, the action is performed.

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -22,9 +22,9 @@ module Y2Partitioner
   # information that needs to be remembered across UI redraws to give the user a
   # sense of continuity.
   class UIState
-    # A collection holding a PageStatus for each CWM::Page visited by the user
+    # A collection holding a PageStatus for each Page visited by the user
     #
-    # The CWM::Page#widget_id is used as index
+    # The Widgets::Pages::Base#id is used as index
     # @see #status_for
     #
     # @return [Hash{String => PageStatus}]
@@ -77,9 +77,9 @@ module Y2Partitioner
       self.current_status = status_for(pages_ids)
     end
 
-    # Method to be called when the user switches to a tab within a tree node
+    # Method to be called when the user switches to a tab within a page
     #
-    # It remembers the decision so the same tab is showed when the same node will be redraw.
+    # It records the decision, so the last active tab is displayed when the page will be redraw.
     #
     # @param label [String]
     def switch_to_tab(label)
@@ -96,7 +96,7 @@ module Y2Partitioner
     # Select the page to open in the general tree after a redraw
     #
     # @param pages_ids [Array<String, Integer>] all pages ids in the tree
-    # @return [CWM::Page, nil] the page to be opened; the initial one when nil
+    # @return [page_id, nil] the page to be opened; the initial one when nil
     def find_page(pages_ids)
       return nil unless current_status
 
@@ -185,13 +185,13 @@ module Y2Partitioner
       # @return [String]
       attr_accessor :active_tab
 
-      # The path to a node, useful to correctly place the user within the tree after redrawing the
+      # The path to a page, useful to correctly place the user within the tree after redrawing the
       # UI and also to remove useless statuses after deleting a device.
       #
       # @see UIState#find_page
       # @see UIState#clear_statuses_for
       #
-      # It could hold both, a device id (sid, Integer) or a page label (String).
+      # It stores page ids, see Pages::Base#id
       #
       # @return [Array<Integer, String>]
       attr_reader :candidate_pages

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -17,23 +17,18 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2partitioner/widgets/pages/bcaches"
-require "y2partitioner/widgets/pages/btrfs_filesystems"
-require "y2partitioner/widgets/pages/lvm"
-require "y2partitioner/widgets/pages/md_raids"
-
 module Y2Partitioner
   # Singleton class to keep the position of the user in the UI and other similar
   # information that needs to be remembered across UI redraws to give the user a
   # sense of continuity.
   class UIState
-    # A collection holding the Node status for each CWM::Page visited by the user
+    # A collection holding a PageStatus for each CWM::Page visited by the user
     #
     # The CWM::Page#widget_id is used as index
-    # @see #node_for
+    # @see #status_for
     #
-    # @return [Hash{String => Node}]
-    attr_reader :nodes
+    # @return [Hash{String => PageStatus}]
+    attr_reader :statuses
 
     # A reference to the overview tree pager, which is a new instance every dialog redraw. See note
     # in {Dialogs::Main#contents}
@@ -55,8 +50,8 @@ module Y2Partitioner
     # Called through {.create_instance}, starts with a blank situation (which
     # means default for each widget will be honored).
     def initialize
-      @nodes = {}
-      @current_node = nil
+      @statuses = {}
+      @current_status = nil
       @open_items = {}
       @overview_tree_pager = nil
     end
@@ -68,81 +63,70 @@ module Y2Partitioner
     def select_row(device)
       sid = device.respond_to?(:sid) ? device.sid : device
 
-      current_node&.selected_device = sid
+      current_status&.selected_device = sid
     end
 
-    # The sid of the associated device when a row must be selected in a table with devices
-    #
-    # @return [Integer, nil]
-    def row_sid
-      current_node&.selected_device
-    end
-
-    # Method to be called when the user decides to visit a given page by
-    # clicking in one node of the general tree.
+    # Method to be called when the user decides to visit a page by clicking in one node of the
+    # general tree.
     #
     # It remembers the decision so the user is taken back to a sensible point of
     # the tree (very often the last he decided to visit) after redrawing.
     #
-    # @param [CWM::Page] page associated to the tree node
-    def go_to_tree_node(page)
-      self.current_node = node_for(page)
+    # @param pages_ids [Array<String, Integer>] a list of Page#id identifying the path to the page
+    def select_page(pages_ids)
+      self.current_status = status_for(pages_ids)
     end
 
-    # Method to be called when the user switches to a tab within a tree node.
+    # Method to be called when the user switches to a tab within a tree node
     #
     # It remembers the decision so the same tab is showed when the same node will be redraw.
     #
-    # @param [CWM::Page, String] page associated to the tab (or just its label)
-    def switch_to_tab(page)
-      current_node&.active_tab = page.respond_to?(:label) ? page.label : page
+    # @param label [String]
+    def switch_to_tab(label)
+      current_status&.active_tab = label
+    end
+
+    # Returns the sid of the last selected device in the active tab of current page
+    #
+    # @return [Integer, nil]
+    def row_sid
+      current_status&.selected_device
     end
 
     # Select the page to open in the general tree after a redraw
     #
-    # @param pages [Array<CWM::Page>] all the pages in the tree
+    # @param pages_ids [Array<String, Integer>] all pages ids in the tree
     # @return [CWM::Page, nil] the page to be opened; the initial one when nil
-    def find_tree_node(pages)
-      # candidate_nodes can be empty if the user has not left the overview page yet. So, do nothing
-      return nil unless current_node
+    def find_page(pages_ids)
+      return nil unless current_status
 
-      current_node.candidate_nodes.each do |candidate|
-        result = pages.find { |page| matches?(page, candidate) }
-        return result if result
-      end
-
-      nil
+      (current_status.candidate_pages & pages_ids).last
     end
 
-    # Select the tab to open within the node after a redraw
+    # Select the last active tab fo current PageStatus
     #
-    # @param pages [Array<CWM::Page>] pages for all the possible tabs
-    # @return [CWM::Page, nil]
-    def find_tab(pages)
-      tab = current_node&.active_tab
-
-      return nil unless tab
-
-      pages.find { |page| page.label == tab }
+    # @see PageStatus#active_tab
+    #
+    # @return [String, nil]
+    def active_tab
+      current_status&.active_tab
     end
 
     # Method to be called when the user deletes a device to properly clear dead statuses
     #
-    # Taking advantage of the path to the device provided by Node#candidate_nodes, it can discard
-    # all no longer relevant statuses after deleting a device.
+    # Taking advantage of the path to the device provided by PageStatus#candidate_pages, it can
+    # discard all no longer relevant statuses after deleting a device.
     #
     # @param sid [Integer] the sid of the deleted device
     def clear_statuses_for(sid)
       # All statuses containing the given sid as candidate must be discarded
-      nodes.reject! { |_, v| v.candidate_nodes.include?(sid) }
+      statuses.reject! { |_, v| v.candidate_pages.include?(sid) }
     end
 
     # Stores the ids of the tree items that are open
     #
-    # @note It has been decided to keep that logic here instead of moving it as part of each Node
-    # status since it complicates things more than desired: UIState only tracks the status for each
-    # visited item. Anyway, if it is being improved please bear in mind the default behavior to this
-    # regard for items without children *yet*.
+    # @note It has been decided to keep that logic here instead of moving it as part of each
+    # PageStatus because it complicates things more than desired.
     def save_open_items
       return unless overview_tree_pager
 
@@ -151,30 +135,18 @@ module Y2Partitioner
 
     protected
 
-    # A Node for the selected CWM::PageTreeItem
+    # The current status
     #
-    # @return [Node]
-    attr_accessor :current_node
+    # @return [PageStatus]
+    attr_accessor :current_status
 
-    # Returns the status representation for given page
+    # Returns the status representation for a page
     #
-    # @param page [CWM::Page]
-    # @return [Node] the current node status if it already exists; a new one when not.
-    def node_for(page)
-      nodes[page.widget_id] ||= Node.new(page)
-    end
-
-    # Whether the given page matches with the candidate tree node
-    #
-    # @param page [CWM::Page]
-    # @param candidate [Integer, String]
-    # @return boolean
-    def matches?(page, candidate)
-      if candidate.is_a?(Integer)
-        page.respond_to?(:device) && page.device.sid == candidate
-      else
-        page.label == candidate
-      end
+    # @param pages_ids [Array<String, Integer>] a list of Page#id identifying the path to the page
+    # @return [PageStatus] the current status if it already exists; a new one when not.
+    def status_for(pages_ids)
+      id = pages_ids.last
+      statuses[id] ||= PageStatus.new(id, pages_ids)
     end
 
     class << self
@@ -194,8 +166,14 @@ module Y2Partitioner
       private :new, :allocate
     end
 
-    # Represent the UI status of a CWM::PagerTreeItem and its CWM::Page
-    class Node
+    # Represent the UI status for a CWM::Page
+    #
+    # For the time being, it is able to keep
+    #
+    #   * current tab
+    #   * selected row
+    #   * candidates pages
+    class PageStatus
       # The key to reference the selected device for a table not wrapped in a tab
       FALLBACK_TAB = "root".freeze
       private_constant :FALLBACK_TAB
@@ -207,22 +185,24 @@ module Y2Partitioner
       # @return [String]
       attr_accessor :active_tab
 
-      # The path to the node, useful to correctly place the user within the tree after redrawing the
+      # The path to a node, useful to correctly place the user within the tree after redrawing the
       # UI and also to remove useless statuses after deleting a device.
       #
-      # @see UIState#find_tree_node
-      # @see UIState#clear_status_for
+      # @see UIState#find_page
+      # @see UIState#clear_statuses_for
       #
       # It could hold both, a device id (sid, Integer) or a page label (String).
       #
       # @return [Array<Integer, String>]
-      attr_reader :candidate_nodes
+      attr_reader :candidate_pages
 
       # Constructor
       #
-      # @param page [CWM:Page] the related CWM::Page
-      def initialize(page)
-        @candidate_nodes = build_candidate_nodes(page)
+      # @param page_id [String, Integer] the Page#id identifying the page
+      # @param candidate_pages_ids [Array<String, Integer>] a list of Page#id for candidate pages
+      def initialize(page_id, candidate_pages_ids)
+        @page_id = page_id
+        @candidate_pages = candidate_pages_ids
         @selected_devices = { FALLBACK_TAB => nil }
       end
 
@@ -254,54 +234,6 @@ module Y2Partitioner
       #
       # @return [Hash{String => Integer}]
       attr_reader :selected_devices
-
-      # Build the list of candidate nodes to go back after opening a device view in the tree
-      #
-      # @return [Array<Integer, String>]
-      def build_candidate_nodes(page)
-        if page.respond_to?(:device)
-          device_page_candidates(page)
-        else
-          [page.label]
-        end
-      end
-
-      # List of candidate nodes to go back after opening a device view in the tree
-      #
-      # @return [Array<Integer, String>]
-      def device_page_candidates(page)
-        device = page.device
-        [device.sid, device_page_parent(device)].compact
-      end
-
-      # @see #device_page_candidates
-      #
-      # @return [Integer, String, nil] nil if there is no parent tree entry
-      def device_page_parent(device)
-        if device.is?(:partition)
-          device.partitionable.sid
-        elsif device.is?(:lvm_lv)
-          device.lvm_vg.sid
-        else
-          device_page_section(device)
-        end
-      end
-
-      # @see #device_page_candidates
-      # @see #device_page_parent
-      #
-      # @return [Integer, String, nil] nil if there is no parent tree entry
-      def device_page_section(device)
-        if device.is?(:md)
-          Widgets::Pages::MdRaids.label
-        elsif device.is?(:lvm_vg)
-          Widgets::Pages::Lvm.label
-        elsif device.is?(:bcache)
-          Widgets::Pages::Bcaches.label
-        elsif device.is?(:btrfs)
-          Widgets::Pages::BtrfsFilesystems.label
-        end
-      end
 
       # Returns the active tab or the fallback when none
       #

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -27,7 +27,7 @@ module Y2Partitioner
     # The Widgets::Pages::Base#id is used as index
     # @see #status_for
     #
-    # @return [Hash{String => PageStatus}]
+    # @return [Array<PageStatus>]
     attr_reader :statuses
 
     # A reference to the overview tree pager, which is a new instance every dialog redraw. See note
@@ -50,7 +50,7 @@ module Y2Partitioner
     # Called through {.create_instance}, starts with a blank situation (which
     # means default for each widget will be honored).
     def initialize
-      @statuses = {}
+      @statuses = []
       @current_status = nil
       @open_items = {}
       @overview_tree_pager = nil
@@ -120,7 +120,7 @@ module Y2Partitioner
     # @param sid [Integer] the sid of the deleted device
     def clear_statuses_for(sid)
       # All statuses containing the given sid as candidate must be discarded
-      statuses.reject! { |_, v| v.candidate_pages.include?(sid) }
+      statuses.reject! { |v| v.candidate_pages.include?(sid) }
     end
 
     # Stores the ids of the tree items that are open
@@ -146,7 +146,14 @@ module Y2Partitioner
     # @return [PageStatus] the current status if it already exists; a new one when not.
     def status_for(pages_ids)
       id = pages_ids.last
-      statuses[id] ||= PageStatus.new(id, pages_ids)
+      status = statuses.find { |s| s.page_id == id }
+
+      if status.nil?
+        status = PageStatus.new(id, pages_ids)
+        statuses << status
+      end
+
+      status
     end
 
     class << self
@@ -184,6 +191,11 @@ module Y2Partitioner
       #
       # @return [String]
       attr_accessor :active_tab
+
+      # The Page#id
+      #
+      # @return [String, Integet>]
+      attr_reader :page_id
 
       # The path to a page, useful to correctly place the user within the tree after redrawing the
       # UI and also to remove useless statuses after deleting a device.

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -113,9 +113,9 @@ module Y2Partitioner
     #
     # Usually, the UI is redrawn after certain user actions like deleting a device.
     #
-    # @param pages_ids [Array<String, Integer>] pages ids of statuses to keep
-    def clear_dead_statuses(pages_ids)
-      statuses.select! { |s| pages_ids.include?(s.page_id) }
+    # @param keep [Array<String, Integer>] pages ids of statuses to keep
+    def prune(keep: [])
+      statuses.select! { |s| keep.include?(s.page_id) }
     end
 
     # Stores the ids of the tree items that are open

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -81,10 +81,10 @@ module Y2Partitioner
       current_status&.active_tab = label
     end
 
-    # Returns the sid of the last selected row in the active tab of current page
+    # Returns the id of the last selected row in the active tab of current page
     #
     # @return [Integer, nil]
-    def row_sid
+    def row_id
       current_status&.selected_row
     end
 

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -107,9 +107,6 @@ module Y2Partitioner
         else
           [page.label]
         end
-      # Landing in a new node, so invalidate previous details about position
-      # within a node, they no longer apply
-      self.tab = nil
     end
 
     # Method to be called when the user switches to a tab within a tree node.
@@ -133,27 +130,16 @@ module Y2Partitioner
 
     # Select the page to open in the general tree after a redraw
     #
-    # If the first candidate page/node (the "current" one) is not available anymore, the tab name
-    # and selected row are cleared. See #tab=
-    #
     # @param pages [Array<CWM::Page>] all the pages in the tree
     # @return [CWM::Page, nil] the page to be opened; the initial one when nil
     def find_tree_node(pages)
       # candidate_nodes can be empty if the user has not left the overview page yet. So, do nothing
       return nil if candidate_nodes.empty?
 
-      candidate_nodes.each.with_index do |candidate, idx|
+      candidate_nodes.each do |candidate|
         result = pages.find { |page| matches?(page, candidate) }
-        if result
-          # If the first candidate is not available anymore (likely, it was deleted),
-          # we had to use one of the fallbacks and the tab name is not longer trustworthy
-          self.tab = nil unless idx.zero?
-          return result
-        end
+        return result if result
       end
-
-      # For some reason none candidate is available. Let's reset the tab name.
-      self.tab = nil
 
       nil
     end

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -111,15 +111,13 @@ module Y2Partitioner
       current_status&.active_tab
     end
 
-    # Method to be called when the user deletes a device to properly clear dead statuses
+    # Method to be called when redrawing the UI to keep tracking only valid statuses
     #
-    # Taking advantage of the path to the device provided by PageStatus#candidate_pages, it can
-    # discard all no longer relevant statuses after deleting a device.
+    # Usually, the UI is redrawn after certain user actions like deleting a device.
     #
-    # @param sid [Integer] the sid of the deleted device
-    def clear_statuses_for(sid)
-      # All statuses containing the given sid as candidate must be discarded
-      statuses.reject! { |v| v.candidate_pages.include?(sid) }
+    # @param pages_ids [Array<String, Integer>] pages ids of statuses to keep
+    def clear_dead_statuses(pages_ids)
+      statuses.select! { |s| pages_ids.include?(s.page_id) }
     end
 
     # Stores the ids of the tree items that are open

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -56,11 +56,9 @@ module Y2Partitioner
     # Method to be called when the user operates in a row of a table of devices
     # or creates a new device.
     #
-    # @param device [Y2Storage::Device, Integer] a device or its sid
-    def select_row(device)
-      sid = device.respond_to?(:sid) ? device.sid : device
-
-      current_status&.selected_device = sid
+    # @param row_id [Integer] the id of selected row
+    def select_row(row_id)
+      current_status&.selected_row = row_id
     end
 
     # Method to be called when the user decides to visit a page by clicking in one node of the
@@ -83,11 +81,11 @@ module Y2Partitioner
       current_status&.active_tab = label
     end
 
-    # Returns the sid of the last selected device in the active tab of current page
+    # Returns the sid of the last selected row in the active tab of current page
     #
     # @return [Integer, nil]
     def row_sid
-      current_status&.selected_device
+      current_status&.selected_row
     end
 
     # Select the page to open in the general tree after a redraw
@@ -176,7 +174,7 @@ module Y2Partitioner
     #   * selected row
     #   * candidates pages
     class PageStatus
-      # The key to reference the selected device for a table not wrapped in a tab
+      # The key to reference the selected row for a table not wrapped in a tab
       FALLBACK_TAB = "root".freeze
       private_constant :FALLBACK_TAB
 
@@ -213,37 +211,37 @@ module Y2Partitioner
       def initialize(page_id, candidate_pages_ids)
         @page_id = page_id
         @candidate_pages = candidate_pages_ids
-        @selected_devices = { FALLBACK_TAB => nil }
+        @selected_rows = { FALLBACK_TAB => nil }
       end
 
-      # Returns the last selected device for the active tab
+      # Returns the last selected row for the active tab
       #
-      # If the node has no tabs a fallback reference will be used. See #selected_devices
+      # If the node has no tabs a fallback reference will be used. See #selected_rows
       #
       # @return [Integer, nil]
-      def selected_device
-        selected_devices[tab]
+      def selected_row
+        selected_rows[tab]
       end
 
-      # Stores selected device for the active tab
+      # Stores selected row for the active tab
       #
-      # If the node has no tabs a fallback reference will be used. See #selected_devices
+      # If the node has no tabs a fallback reference will be used. See #selected_rows
       #
       # @param sid [Integer] the device sid
-      def selected_device=(sid)
-        selected_devices[tab] = sid
+      def selected_row=(sid)
+        selected_rows[tab] = sid
       end
 
       private
 
-      # A collection to keep the selected devices per tab
+      # A collection to keep the selected rows per tab
       #
-      # The FALLBACK_TAB key will be used to reference the selected device of a CWM::Page with a
-      # devices table not wrapped within a tab (e.g, Widgets::Pages::System, Widgets:Pages::Disks,
+      # The FALLBACK_TAB key will be used to reference the selected row of a CWM::Page with a
+      # table not wrapped within a tab (e.g, Widgets::Pages::System, Widgets:Pages::Disks,
       # etc)
       #
       # @return [Hash{String => Integer}]
-      attr_reader :selected_devices
+      attr_reader :selected_rows
 
       # Returns the active tab or the fallback when none
       #

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -17,13 +17,16 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "y2partitioner/widgets/pages/bcaches"
+require "y2partitioner/widgets/pages/btrfs_filesystems"
+require "y2partitioner/widgets/pages/lvm"
+require "y2partitioner/widgets/pages/md_raids"
+
 module Y2Partitioner
   # Singleton class to keep the position of the user in the UI and other similar
   # information that needs to be remembered across UI redraws to give the user a
   # sense of continuity.
   class UIState
-    include Yast::I18n
-
     # A collection holding the Node status for each CWM::Page visited by the user
     #
     # The CWM::Page#widget_id is used as index
@@ -52,51 +55,10 @@ module Y2Partitioner
     # Called through {.create_instance}, starts with a blank situation (which
     # means default for each widget will be honored).
     def initialize
-      textdomain "storage"
-
       @nodes = {}
       @current_node = nil
       @open_items = {}
       @overview_tree_pager = nil
-    end
-
-    # Title of the section listing the MD RAIDs
-    #
-    # @note This is defined in this class as the simplest way to avoid dependency cycles in the Ruby
-    # requires. For example, CWM::Pages::Bcaches ends requiring Y2Partitioner::Actions::DeleteDevice
-    # which also requires Y2Partitioner::UIState. We might reconsider a more clean approach in the
-    # future.
-    #
-    # @return [String]
-    def md_raids_label
-      _("RAID")
-    end
-
-    # Title of the LVM section
-    #
-    # @note See note on {.md_raids_label} about why this looks misplaced.
-    #
-    # @return [String]
-    def lvm_label
-      _("Volume Management")
-    end
-
-    # Title of the bcache section
-    #
-    # @note See note on {.md_raids_label} about why this looks misplaced.
-    #
-    # @return [String]
-    def bcache_label
-      _("Bcache")
-    end
-
-    # Title of the Btrfs section
-    #
-    # @note See note on {.md_raids_label} about why this looks misplaced.
-    #
-    # @return [String]
-    def btrfs_filesystems_label
-      _("Btrfs")
     end
 
     # Method to be called when the user operates in a row of a table of devices
@@ -331,13 +293,13 @@ module Y2Partitioner
       # @return [Integer, String, nil] nil if there is no parent tree entry
       def device_page_section(device)
         if device.is?(:md)
-          UIState.instance.md_raids_label
+          Widgets::Pages::MdRaids.label
         elsif device.is?(:lvm_vg)
-          UIState.instance.lvm_label
+          Widgets::Pages::Lvm.label
         elsif device.is?(:bcache)
-          UIState.instance.bcache_label
+          Widgets::Pages::Bcaches.label
         elsif device.is?(:btrfs)
-          UIState.instance.btrfs_filesystems_label
+          Widgets::Pages::BtrfsFilesystems.label
         end
       end
 

--- a/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
@@ -52,7 +52,7 @@ module Y2Partitioner
       def init
         return if devices.empty? # do nothing if there is nothing in table
 
-        initial_sid = UIState.instance.row_sid
+        initial_sid = UIState.instance.row_id
 
         # if we do not have valid sid, then pick first available device.
         # Reason is to allow e.g. chain of delete like described in bsc#1076318

--- a/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
@@ -79,7 +79,7 @@ module Y2Partitioner
 
         return nil unless dev
 
-        UIState.instance.select_row(dev)
+        UIState.instance.select_row(dev.sid)
         buttons_set.device = dev if buttons_set
 
         nil

--- a/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
@@ -76,7 +76,12 @@ module Y2Partitioner
       # to reflect the currently selected device.
       def handle_selected
         dev = selected_device
-        buttons_set.device = dev if buttons_set && dev
+
+        return nil unless dev
+
+        UIState.instance.select_row(dev)
+        buttons_set.device = dev if buttons_set
+
         nil
       end
 

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -94,10 +94,17 @@ module Y2Partitioner
         super
       end
 
+      # Ensures that UIState prune obsolete statuses
+      def init
+        super
+
+        UIState.instance.clear_dead_statuses(@pages.map(&:id))
+      end
+
       # Ensures the tree is properly initialized according to {UIState} after
       # a redraw.
       #
-      # @see @find_initial_page
+      # @see #find_initial_page
       def initial_page
         find_initial_page || super
       end

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -90,14 +90,16 @@ module Y2Partitioner
       # Overrides default behavior of TreePager to register the new state with
       # {UIState} before jumping to the tree node
       def switch_page(page)
-        UIState.instance.go_to_tree_node(page)
+        UIState.instance.select_page(page.parents)
         super
       end
 
       # Ensures the tree is properly initialized according to {UIState} after
       # a redraw.
+      #
+      # @see @find_initial_page
       def initial_page
-        UIState.instance.find_tree_node(@pages) || super
+        find_initial_page || super
       end
 
       # Status of open/expanded items in the UI
@@ -134,6 +136,17 @@ module Y2Partitioner
       private
 
       attr_reader :tree
+
+      # Select the initial based in {UIState::PageStatus#candidate_pages}
+      #
+      # @return [Page, nil]
+      def find_initial_page
+        candidate = UIState.instance.find_page(@pages.map(&:id))
+
+        return nil unless candidate
+
+        @pages.find { |page| page.id == candidate }
+      end
 
       # Checks whether the current setup is valid, that is, it contains necessary
       # devices for booting (e.g., /boot/efi) and for the system runs properly (e.g., /).

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -56,6 +56,16 @@ module Y2Partitioner
     #
     # It has replace point where it displays more details about selected element in partitioning.
     class OverviewTreePager < CWM::TreePager
+      # Pages whose cached content should be considered outdated
+      #
+      # This is a hack introduced because the NFS page works in a completely
+      # different way in which triggering a full redraw every time something
+      # changes is not an option. This way, the NFS page can invalidate the
+      # cached contents of other pages supporting this mechanism.
+      #
+      # @return [Array<Symbol>] only :system supported so far
+      attr_accessor :invalidated_pages
+
       # Constructor
       #
       # @param [String] hostname of the system
@@ -67,15 +77,25 @@ module Y2Partitioner
         super(OverviewTree.new(items))
       end
 
-      # Pages whose cached content should be considered outdated
+      # Ensures that UIState clears obsolte statuses and is aware of current page
       #
-      # This is a hack introduced because the NFS page works in a completely
-      # different way in which triggering a full redraw every time something
-      # changes is not an option. This way, the NFS page can invalidate the
-      # cached contents of other pages supporting this mechanism.
+      # That's especially needed when initial page is a candidate of a no longer exist one
       #
-      # @return [Array<Symbol>] only :system supported so far
-      attr_accessor :invalidated_pages
+      # @see #initial_page
+      def init
+        super
+
+        UIState.instance.clear_dead_statuses(@pages.map(&:id))
+        UIState.instance.select_page(@current_page.tree_path)
+      end
+
+      # Ensures the tree is properly initialized according to {UIState} after
+      # a redraw.
+      #
+      # @see #find_initial_page
+      def initial_page
+        find_initial_page || super
+      end
 
       # @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FTree:items
       def items
@@ -92,21 +112,6 @@ module Y2Partitioner
       def switch_page(page)
         UIState.instance.select_page(page.tree_path)
         super
-      end
-
-      # Ensures that UIState prune obsolete statuses
-      def init
-        super
-
-        UIState.instance.clear_dead_statuses(@pages.map(&:id))
-      end
-
-      # Ensures the tree is properly initialized according to {UIState} after
-      # a redraw.
-      #
-      # @see #find_initial_page
-      def initial_page
-        find_initial_page || super
       end
 
       # Status of open/expanded items in the UI

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -77,15 +77,15 @@ module Y2Partitioner
         super(OverviewTree.new(items))
       end
 
-      # Ensures that UIState clears obsolte statuses and is aware of current page
+      # Ensures that UIState clears obsolete statuses and it is aware of current page
       #
-      # That's especially needed when initial page is a candidate of a no longer exist one
+      # That's especially needed when initial page is a candidate of a no longer existing one
       #
       # @see #initial_page
       def init
         super
 
-        UIState.instance.clear_dead_statuses(@pages.map(&:id))
+        UIState.instance.prune(keep: @pages.map(&:id))
         UIState.instance.select_page(@current_page.tree_path)
       end
 

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -90,7 +90,7 @@ module Y2Partitioner
       # Overrides default behavior of TreePager to register the new state with
       # {UIState} before jumping to the tree node
       def switch_page(page)
-        UIState.instance.select_page(page.parents)
+        UIState.instance.select_page(page.tree_path)
         super
       end
 
@@ -137,7 +137,7 @@ module Y2Partitioner
 
       attr_reader :tree
 
-      # Select the initial based in {UIState::PageStatus#candidate_pages}
+      # Select the initial page
       #
       # @return [Page, nil]
       def find_initial_page

--- a/src/lib/y2partitioner/widgets/pages.rb
+++ b/src/lib/y2partitioner/widgets/pages.rb
@@ -26,6 +26,7 @@ module Y2Partitioner
   end
 end
 
+require "y2partitioner/widgets/pages/base.rb"
 require "y2partitioner/widgets/pages/system.rb"
 require "y2partitioner/widgets/pages/disks.rb"
 require "y2partitioner/widgets/pages/disk.rb"

--- a/src/lib/y2partitioner/widgets/pages/base.rb
+++ b/src/lib/y2partitioner/widgets/pages/base.rb
@@ -1,0 +1,82 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "cwm/widget"
+require "cwm/pager"
+require "cwm/tree_pager"
+
+module Y2Partitioner
+  module Widgets
+    module Pages
+      # A base class for partitioner pages
+      class Base < CWM::Page
+        # Convenience method to identify a page and/or its status in {UIState}
+        #
+        # @note This has been added as a way to really avoid the dependency cycles between {UIState}
+        # and actions due to Ruby requires in some pages. As {UIState} only needs a device sid or a
+        # page label to make the work, let's pass the right one instead of the full object.
+        #
+        # @see UIState#select_page
+        #
+        # @return [String, Integer] a device sid if possible; the page label otherwise
+        def id
+          if respond_to?(:device)
+            device.sid
+          else
+            label
+          end
+        end
+
+        # The full path to reach the page within the tree
+        #
+        # Useful to know where to place the user after redrawing the UI. See
+        # {Y2Partitioner::UIState::PageStatus#candidate_pages}
+        #
+        # @return [Array<String, Integer>]
+        def parents
+          [device_page_parents, id].compact
+        end
+
+        private
+
+        # The path to the device, if any
+        #
+        # @return [String, Integer, nil]
+        def device_page_parents
+          return nil unless respond_to?(:device)
+
+          if device.is?(:partition)
+            device.partitionable.sid
+          elsif device.is?(:lvm_lv)
+            device.lvm_vg.sid
+          else
+            section
+          end
+        end
+
+        # The section which the page belongs
+        #
+        # @return [String, nil]
+        def section
+          nil
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/pages/base.rb
+++ b/src/lib/y2partitioner/widgets/pages/base.rb
@@ -57,7 +57,7 @@ module Y2Partitioner
 
         private
 
-        # The parent page i
+        # The parent page
         #
         # @return [String, Integer, nil]
         def parent

--- a/src/lib/y2partitioner/widgets/pages/base.rb
+++ b/src/lib/y2partitioner/widgets/pages/base.rb
@@ -17,8 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/widget"
-require "cwm/pager"
+require "cwm/page"
 require "cwm/tree_pager"
 
 module Y2Partitioner
@@ -43,22 +42,25 @@ module Y2Partitioner
           end
         end
 
-        # The full path to reach the page within the tree
+        # The path to reach the page within the tree
+        #
+        # When the page is related to a device, the path will contain its parent page id (which can
+        # be another device page or a section one).
         #
         # Useful to know where to place the user after redrawing the UI. See
         # {Y2Partitioner::UIState::PageStatus#candidate_pages}
         #
         # @return [Array<String, Integer>]
-        def parents
-          [device_page_parents, id].compact
+        def tree_path
+          [parent, id].compact
         end
 
         private
 
-        # The path to the device, if any
+        # The parent page i
         #
         # @return [String, Integer, nil]
-        def device_page_parents
+        def parent
           return nil unless respond_to?(:device)
 
           if device.is?(:partition)

--- a/src/lib/y2partitioner/widgets/pages/bcache.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcache.rb
@@ -60,7 +60,7 @@ module Y2Partitioner
               Left(
                 HBox(
                   Image(Icons::BCACHE, ""),
-                  # TRANSLATORS: Heading. String followed a device name like /dev/bcache0
+                  # TRANSLATORS: Heading. String followed by a device name like /dev/bcache0
                   Heading(format(_("Bcache: %s"), device.name))
                 )
               ),

--- a/src/lib/y2partitioner/widgets/pages/bcache.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcache.rb
@@ -17,8 +17,9 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/widget"
 require "y2partitioner/icons"
+require "y2partitioner/widgets/pages/base"
+require "y2partitioner/widgets/pages/bcaches"
 require "y2partitioner/widgets/bcache_description"
 require "y2partitioner/widgets/blk_device_edit_button"
 require "y2partitioner/widgets/bcache_edit_button"
@@ -30,7 +31,7 @@ module Y2Partitioner
   module Widgets
     module Pages
       # A Page for a bcache device
-      class Bcache < CWM::Page
+      class Bcache < Base
         # @return [Y2Storage::Bcache] Device this page is about
         attr_reader :bcache
         alias_method :device, :bcache
@@ -71,6 +72,13 @@ module Y2Partitioner
               )
             )
           )
+        end
+
+        private
+
+        # @return [String]
+        def section
+          Bcaches.label
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/bcache.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcache.rb
@@ -54,17 +54,21 @@ module Y2Partitioner
 
         # @macro seeCustomWidget
         def contents
-          VBox(
-            Left(
-              HBox(
-                Image(Icons::BCACHE, ""),
-                # TRANSLATORS: Heading. String followed a device name like /dev/bcache0
-                Heading(format(_("Bcache: %s"), device.name))
+          Top(
+            VBox(
+              Left(
+                HBox(
+                  Image(Icons::BCACHE, ""),
+                  # TRANSLATORS: Heading. String followed a device name like /dev/bcache0
+                  Heading(format(_("Bcache: %s"), device.name))
+                )
+              ),
+              Left(
+                Tabs.new(
+                  BcacheTab.new(device),
+                  PartitionsTab.new(device, @pager)
+                )
               )
-            ),
-            Tabs.new(
-              BcacheTab.new(device),
-              PartitionsTab.new(device, @pager)
             )
           )
         end

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -19,7 +19,6 @@
 
 require "cwm/widget"
 require "y2partitioner/icons"
-require "y2partitioner/ui_state"
 require "y2partitioner/widgets/bcache_add_button"
 require "y2partitioner/widgets/device_buttons_set"
 require "y2partitioner/widgets/configurable_blk_devices_table"
@@ -32,6 +31,19 @@ module Y2Partitioner
       # It contains two tabs: one tab with a list of bcache devices and another
       # tab with the list of caching sets.
       class Bcaches < CWM::Page
+        extend Yast::I18n
+
+        textdomain "storage"
+
+        # Label for all the instances
+        #
+        # @see #label
+        #
+        # @return [String]
+        def self.label
+          _("Bcache")
+        end
+
         # Constructor
         #
         # @param bcaches [Array<Y2Storage::Bcache>]
@@ -45,7 +57,7 @@ module Y2Partitioner
 
         # @macro seeAbstractWidget
         def label
-          UIState.instance.bcache_label
+          self.class.label
         end
 
         # @macro seeCustomWidget

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -17,8 +17,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/widget"
 require "y2partitioner/icons"
+require "y2partitioner/widgets/pages/base"
 require "y2partitioner/widgets/bcache_add_button"
 require "y2partitioner/widgets/device_buttons_set"
 require "y2partitioner/widgets/configurable_blk_devices_table"
@@ -30,7 +30,7 @@ module Y2Partitioner
       #
       # It contains two tabs: one tab with a list of bcache devices and another
       # tab with the list of caching sets.
-      class Bcaches < CWM::Page
+      class Bcaches < Base
         extend Yast::I18n
 
         textdomain "storage"

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -50,14 +50,16 @@ module Y2Partitioner
 
         # @macro seeCustomWidget
         def contents
-          @contents ||= VBox(
-            Left(
-              HBox(
-                Image(icon, ""),
-                Heading(label)
-              )
-            ),
-            tabs
+          @contents ||= Top(
+            VBox(
+              Left(
+                HBox(
+                  Image(icon, ""),
+                  Heading(label)
+                )
+              ),
+              Left(tabs)
+            )
           )
         end
 

--- a/src/lib/y2partitioner/widgets/pages/btrfs.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs.rb
@@ -59,14 +59,16 @@ module Y2Partitioner
 
         # @macro seeCustomWidget
         def contents
-          VBox(
-            Left(
-              HBox(
-                Image(icon, ""),
-                Heading(title)
-              )
-            ),
-            tabs
+          Top(
+            VBox(
+              Left(
+                HBox(
+                  Image(icon, ""),
+                  Heading(title)
+                )
+              ),
+              Left(tabs)
+            )
           )
         end
 

--- a/src/lib/y2partitioner/widgets/pages/btrfs.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs.rb
@@ -17,8 +17,9 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/widget"
 require "y2partitioner/icons"
+require "y2partitioner/widgets/pages/base"
+require "y2partitioner/widgets/pages/btrfs_filesystems"
 require "y2partitioner/widgets/used_devices_tab"
 require "y2partitioner/widgets/filesystem_description"
 require "y2partitioner/widgets/btrfs_edit_button"
@@ -32,7 +33,7 @@ module Y2Partitioner
       # Page for a BTRFS filesystem
       #
       # This page contains a {FilesystemTab} and a {UsedDevicesTab}.
-      class Btrfs < CWM::Page
+      class Btrfs < Base
         # @return [Y2Storage::Filesystems::Btrfs]
         attr_reader :filesystem
 
@@ -106,6 +107,11 @@ module Y2Partitioner
           ]
 
           Tabs.new(*tabs)
+        end
+
+        # @return [String]
+        def section
+          BtrfsFilesystems.label
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
@@ -19,7 +19,6 @@
 
 require "yast"
 require "y2partitioner/icons"
-require "y2partitioner/ui_state"
 require "y2partitioner/widgets/pages/devices_table"
 require "y2partitioner/widgets/btrfs_filesystems_table"
 require "y2partitioner/widgets/btrfs_add_button"
@@ -31,13 +30,24 @@ module Y2Partitioner
     module Pages
       # Page for BTRFS filesystems
       class BtrfsFilesystems < DevicesTable
+        extend Yast::I18n
+
+        textdomain "storage"
+
+        # Label for all the instances
+        #
+        # @see #label
+        #
+        # @return [String]
+        def self.label
+          _("Btrfs")
+        end
+
         # Constructor
         #
         # @param filesystems [Array<Y2Storage::Filesystems::Btrfs>]
         # @param pager [CWM::TreePager]
         def initialize(filesystems, pager)
-          textdomain "storage"
-
           super(pager)
 
           @filesystems = filesystems
@@ -45,7 +55,7 @@ module Y2Partitioner
 
         # @macro seeAbstractWidget
         def label
-          UIState.instance.btrfs_filesystems_label
+          self.class.label
         end
 
         private

--- a/src/lib/y2partitioner/widgets/pages/device_graph.rb
+++ b/src/lib/y2partitioner/widgets/pages/device_graph.rb
@@ -53,15 +53,17 @@ module Y2Partitioner
           return @contents if @contents
 
           @tabs = Tabs.new(current_tab, system_tab)
-          @contents = VBox(
-            Left(
-              HBox(
-                Image(Icons::GRAPH, ""),
-                # TRANSLATORS: Heading for the expert partitioner page
-                Heading(_("Device Graphs"))
-              )
-            ),
-            @tabs
+          @contents = Top(
+            VBox(
+              Left(
+                HBox(
+                  Image(Icons::GRAPH, ""),
+                  # TRANSLATORS: Heading for the expert partitioner page
+                  Heading(_("Device Graphs"))
+                )
+              ),
+              Left(@tabs)
+            )
           )
         end
 

--- a/src/lib/y2partitioner/widgets/pages/device_graph.rb
+++ b/src/lib/y2partitioner/widgets/pages/device_graph.rb
@@ -19,6 +19,7 @@
 
 require "y2partitioner/icons"
 require "y2partitioner/device_graphs"
+require "y2partitioner/widgets/pages/base"
 require "y2partitioner/widgets/device_graph_with_buttons"
 
 module Y2Partitioner
@@ -26,7 +27,7 @@ module Y2Partitioner
     module Pages
       # A page for displaying the device graphs (both current and system) in
       # interfaces supporting the Graph widget (Qt). Don't use in NCurses.
-      class DeviceGraph < CWM::Page
+      class DeviceGraph < Base
         include Yast::I18n
 
         # Constructor

--- a/src/lib/y2partitioner/widgets/pages/devices_table.rb
+++ b/src/lib/y2partitioner/widgets/pages/devices_table.rb
@@ -17,9 +17,9 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/tree_pager"
 require "y2partitioner/icons"
 require "y2partitioner/device_graphs"
+require "y2partitioner/widgets/pages/base"
 require "y2partitioner/widgets/device_buttons_set"
 
 module Y2Partitioner
@@ -29,7 +29,7 @@ module Y2Partitioner
       # Partitioner consisting on a table that display all the devices of a
       # certain kind, like the page displaying all the disks, the one with all
       # the MD devices and so on.
-      class DevicesTable < CWM::Page
+      class DevicesTable < Base
         include Yast::I18n
 
         # Constructor

--- a/src/lib/y2partitioner/widgets/pages/disk.rb
+++ b/src/lib/y2partitioner/widgets/pages/disk.rb
@@ -17,8 +17,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/widget"
 require "y2partitioner/icons"
+require "y2partitioner/widgets/pages/base"
 require "y2partitioner/widgets/disk_device_description"
 require "y2partitioner/widgets/used_devices_tab"
 require "y2partitioner/widgets/partitions_tab"
@@ -32,7 +32,7 @@ module Y2Partitioner
       #
       # This page contains a {DiskTab} and a {PartitionsTab}. In case of Multipath
       # or BIOS RAID, it also contains a {UsedDevicesTab}.
-      class Disk < CWM::Page
+      class Disk < Base
         # @return [Y2Storage::BlkDevice] Disk device this page is about
         attr_reader :disk
         alias_method :device, :disk

--- a/src/lib/y2partitioner/widgets/pages/disk.rb
+++ b/src/lib/y2partitioner/widgets/pages/disk.rb
@@ -57,15 +57,19 @@ module Y2Partitioner
 
         # @macro seeCustomWidget
         def contents
-          VBox(
-            Left(
-              HBox(
-                Image(Icons::HD, ""),
-                # TRANSLATORS: Heading. String followed by device name of hard disk
-                Heading(format(_("Hard Disk: %s"), disk.name))
+          Top(
+            VBox(
+              Left(
+                HBox(
+                  Image(Icons::HD, ""),
+                  # TRANSLATORS: Heading. String followed by device name of hard disk
+                  Heading(format(_("Hard Disk: %s"), disk.name))
+                )
+              ),
+              Left(
+                tabs
               )
-            ),
-            tabs
+            )
           )
         end
 

--- a/src/lib/y2partitioner/widgets/pages/lvm.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm.rb
@@ -18,7 +18,6 @@
 # find current contact information at www.suse.com.
 
 require "y2partitioner/icons"
-require "y2partitioner/ui_state"
 require "y2partitioner/widgets/pages/devices_table"
 require "y2partitioner/widgets/lvm_devices_table"
 require "y2partitioner/widgets/lvm_vg_add_button"
@@ -28,17 +27,27 @@ module Y2Partitioner
     module Pages
       # A Page for LVM devices
       class Lvm < DevicesTable
-        include Yast::I18n
+        extend Yast::I18n
+
+        textdomain "storage"
+
+        # Label for all the instances
+        #
+        # @see #label
+        #
+        # @return [String]
+        def self.label
+          _("Volume Management")
+        end
 
         # Constructor
         def initialize(*args)
-          textdomain "storage"
           super
         end
 
         # @macro seeAbstractWidget
         def label
-          UIState.instance.lvm_label
+          self.class.label
         end
 
         private

--- a/src/lib/y2partitioner/widgets/pages/lvm_lv.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm_lv.rb
@@ -17,9 +17,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/pager"
-
 require "y2partitioner/icons"
+require "y2partitioner/widgets/pages/base"
 require "y2partitioner/widgets/lvm_lv_description"
 require "y2partitioner/widgets/blk_device_edit_button"
 require "y2partitioner/widgets/device_resize_button"
@@ -29,7 +28,7 @@ module Y2Partitioner
   module Widgets
     module Pages
       # A Page for a LVM Logical Volume
-      class LvmLv < CWM::Page
+      class LvmLv < Base
         # @param lvm_lv [Y2Storage::LvmLv]
         def initialize(lvm_lv)
           textdomain "storage"

--- a/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
@@ -65,7 +65,7 @@ module Y2Partitioner
               Left(
                 HBox(
                   Image(Icons::LVM, ""),
-                  Heading(format(_("Volume Group: %s"), "/dev/" + @lvm_vg.vg_name))
+                  Heading(format(_("Volume Group: %s"), @lvm_vg.name))
                 )
               ),
               Left(

--- a/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
@@ -60,17 +60,21 @@ module Y2Partitioner
 
         # @macro seeCustomWidget
         def contents
-          VBox(
-            Left(
-              HBox(
-                Image(Icons::LVM, ""),
-                Heading(format(_("Volume Group: %s"), "/dev/" + @lvm_vg.vg_name))
+          Top(
+            VBox(
+              Left(
+                HBox(
+                  Image(Icons::LVM, ""),
+                  Heading(format(_("Volume Group: %s"), "/dev/" + @lvm_vg.vg_name))
+                )
+              ),
+              Left(
+                Tabs.new(
+                  LvmVgTab.new(@lvm_vg),
+                  LvmLvTab.new(@lvm_vg, @pager),
+                  LvmPvTab.new(@lvm_vg, @pager)
+                )
               )
-            ),
-            Tabs.new(
-              LvmVgTab.new(@lvm_vg),
-              LvmLvTab.new(@lvm_vg, @pager),
-              LvmPvTab.new(@lvm_vg, @pager)
             )
           )
         end

--- a/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
@@ -17,10 +17,10 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/widget"
-require "cwm/tree_pager"
 require "y2partitioner/widgets/tabs"
 require "y2partitioner/icons"
+require "y2partitioner/widgets/pages/base"
+require "y2partitioner/widgets/pages/lvm"
 require "y2partitioner/widgets/configurable_blk_devices_table"
 require "y2partitioner/widgets/lvm_devices_table"
 require "y2partitioner/widgets/lvm_vg_bar_graph"
@@ -35,7 +35,7 @@ module Y2Partitioner
   module Widgets
     module Pages
       # A Page for a LVM Volume Group. It contains several tabs.
-      class LvmVg < CWM::Page
+      class LvmVg < Base
         # Constructor
         #
         # @param lvm_vg [Y2Storage::Lvm_vg]
@@ -77,6 +77,13 @@ module Y2Partitioner
               )
             )
           )
+        end
+
+        private
+
+        # @return [String]
+        def section
+          Lvm.label
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/md_raid.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raid.rb
@@ -59,17 +59,21 @@ module Y2Partitioner
 
         # @macro seeCustomWidget
         def contents
-          VBox(
-            Left(
-              HBox(
-                Image(Icons::RAID, ""),
-                Heading(format(_("RAID: %s"), @md.name))
+          Top(
+            VBox(
+              Left(
+                HBox(
+                  Image(Icons::RAID, ""),
+                  Heading(format(_("RAID: %s"), @md.name))
+                )
+              ),
+              Left(
+                Tabs.new(
+                  MdTab.new(@md, initial: true),
+                  MdDevicesTab.new(@md, @pager),
+                  PartitionsTab.new(@md, @pager)
+                )
               )
-            ),
-            Tabs.new(
-              MdTab.new(@md, initial: true),
-              MdDevicesTab.new(@md, @pager),
-              PartitionsTab.new(@md, @pager)
             )
           )
         end

--- a/src/lib/y2partitioner/widgets/pages/md_raid.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raid.rb
@@ -17,10 +17,10 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/widget"
-require "cwm/tree_pager"
 require "y2partitioner/icons"
 require "y2partitioner/device_graphs"
+require "y2partitioner/widgets/pages/base"
+require "y2partitioner/widgets/pages/md_raids"
 require "y2partitioner/widgets/md_description"
 require "y2partitioner/widgets/configurable_blk_devices_table"
 require "y2partitioner/widgets/blk_device_edit_button"
@@ -34,7 +34,7 @@ module Y2Partitioner
   module Widgets
     module Pages
       # A Page for a md raid device: contains {MdTab}, {PartitionsTab} and {MdDevicesTab}
-      class MdRaid < CWM::Page
+      class MdRaid < Base
         # Constructor
         #
         # @param md [Y2Storage::Md]
@@ -76,6 +76,13 @@ module Y2Partitioner
               )
             )
           )
+        end
+
+        private
+
+        # @return [String]
+        def section
+          MdRaids.label
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/md_raids.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raids.rb
@@ -18,7 +18,6 @@
 # find current contact information at www.suse.com.
 
 require "y2partitioner/icons"
-require "y2partitioner/ui_state"
 require "y2partitioner/widgets/pages/devices_table"
 require "y2partitioner/widgets/md_raids_table"
 require "y2partitioner/widgets/md_add_button"
@@ -28,17 +27,27 @@ module Y2Partitioner
     module Pages
       # A Page for Software RAIDs. It contains a {MdRaidsTable}.
       class MdRaids < DevicesTable
-        include Yast::I18n
+        extend Yast::I18n
+
+        textdomain "storage"
+
+        # Label for all the instances
+        #
+        # @see #label
+        #
+        # @return [String]
+        def self.label
+          _("RAID")
+        end
 
         # Constructor
         def initialize(*args)
-          textdomain "storage"
           super
         end
 
         # @macro seeAbstractWidget
         def label
-          UIState.instance.md_raids_label
+          self.class.label
         end
 
         private

--- a/src/lib/y2partitioner/widgets/pages/nfs_mounts.rb
+++ b/src/lib/y2partitioner/widgets/pages/nfs_mounts.rb
@@ -17,8 +17,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/tree_pager"
 require "y2partitioner/icons"
+require "y2partitioner/widgets/pages/base"
 require "y2partitioner/widgets/help"
 require "y2partitioner/yast_nfs_client"
 
@@ -29,7 +29,7 @@ module Y2Partitioner
       # by yast2-nfs-client
       #
       # @see YastNfsClient
-      class NfsMounts < CWM::Page
+      class NfsMounts < Base
         include Yast::I18n
 
         include Help

--- a/src/lib/y2partitioner/widgets/pages/partition.rb
+++ b/src/lib/y2partitioner/widgets/pages/partition.rb
@@ -17,8 +17,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/pager"
 require "y2partitioner/icons"
+require "y2partitioner/widgets/pages/base"
 require "y2partitioner/widgets/blk_device_edit_button"
 require "y2partitioner/widgets/partition_move_button"
 require "y2partitioner/widgets/device_resize_button"
@@ -30,7 +30,7 @@ module Y2Partitioner
   module Widgets
     module Pages
       # A Page for a partition
-      class Partition < CWM::Page
+      class Partition < Base
         # Constructor
         #
         # @param [Y2Storage::Partition] partition

--- a/src/lib/y2partitioner/widgets/pages/settings.rb
+++ b/src/lib/y2partitioner/widgets/pages/settings.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "y2partitioner/icons"
+require "y2partitioner/widgets/pages/base"
 require "y2storage/filesystems/mount_by_type"
 require "y2storage/storage_manager"
 require "y2storage/sysconfig_storage"
@@ -27,7 +28,7 @@ module Y2Partitioner
   module Widgets
     module Pages
       # A page for displaying the Partitioner settings
-      class Settings < CWM::Page
+      class Settings < Base
         include Yast::I18n
 
         # Constructor

--- a/src/lib/y2partitioner/widgets/pages/stray_blk_device.rb
+++ b/src/lib/y2partitioner/widgets/pages/stray_blk_device.rb
@@ -17,8 +17,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cwm/pager"
 require "y2partitioner/icons"
+require "y2partitioner/widgets/pages/base"
 require "y2partitioner/widgets/blk_device_edit_button"
 require "y2partitioner/widgets/stray_blk_device_description"
 require "y2partitioner/dialogs"
@@ -27,7 +27,7 @@ module Y2Partitioner
   module Widgets
     module Pages
       # A Page for a StrayBlkDevice (basically a XEN virtual partition)
-      class StrayBlkDevice < CWM::Page
+      class StrayBlkDevice < Base
         # @return [Y2Storage::StrayBlkDevice] device the page is about
         attr_reader :device
 

--- a/src/lib/y2partitioner/widgets/pages/summary.rb
+++ b/src/lib/y2partitioner/widgets/pages/summary.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "y2partitioner/icons"
+require "y2partitioner/widgets/pages/base"
 require "y2partitioner/widgets/summary_text"
 
 Yast.import "Mode"
@@ -27,7 +28,7 @@ module Y2Partitioner
   module Widgets
     module Pages
       # A page for displaying the Installation Summary
-      class Summary < CWM::Page
+      class Summary < Base
         include Yast::I18n
 
         # Constructor

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -47,11 +47,6 @@ module Y2Partitioner
           @hostname = hostname
         end
 
-        def init
-          # Register itself in the UIState
-          UIState.instance.select_page(tree_path)
-        end
-
         # @macro seeAbstractWidget
         def label
           hostname

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -20,6 +20,7 @@
 require "yast"
 require "cwm/tree_pager"
 require "y2partitioner/icons"
+require "y2partitioner/ui_state"
 require "y2partitioner/widgets/configurable_blk_devices_table"
 require "y2partitioner/widgets/rescan_devices_button"
 require "y2partitioner/widgets/import_mount_points_button"
@@ -44,6 +45,10 @@ module Y2Partitioner
 
           @pager = pager
           @hostname = hostname
+        end
+
+        def init
+          UIState.instance.current_node = self
         end
 
         # @macro seeAbstractWidget

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -18,9 +18,9 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "cwm/tree_pager"
 require "y2partitioner/icons"
 require "y2partitioner/ui_state"
+require "y2partitioner/widgets/pages/base"
 require "y2partitioner/widgets/configurable_blk_devices_table"
 require "y2partitioner/widgets/rescan_devices_button"
 require "y2partitioner/widgets/import_mount_points_button"
@@ -33,7 +33,7 @@ module Y2Partitioner
   module Widgets
     module Pages
       # A Page for all storage devices in the system
-      class System < CWM::Page
+      class System < Base
         include Yast::I18n
 
         # Constructor
@@ -49,7 +49,7 @@ module Y2Partitioner
 
         def init
           # Register itself in the UIState
-          UIState.instance.go_to_tree_node(self)
+          UIState.instance.select_page(parents)
         end
 
         # @macro seeAbstractWidget

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -48,7 +48,8 @@ module Y2Partitioner
         end
 
         def init
-          UIState.instance.current_node = self
+          # Register itself in the UIState
+          UIState.instance.go_to_tree_node(self)
         end
 
         # @macro seeAbstractWidget

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -49,7 +49,7 @@ module Y2Partitioner
 
         def init
           # Register itself in the UIState
-          UIState.instance.select_page(parents)
+          UIState.instance.select_page(tree_path)
         end
 
         # @macro seeAbstractWidget

--- a/src/lib/y2partitioner/widgets/rescan_devices_button.rb
+++ b/src/lib/y2partitioner/widgets/rescan_devices_button.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "cwm/widget"
+require "y2partitioner/ui_state"
 require "y2partitioner/widgets/reprobe"
 require "y2partitioner/widgets/execute_and_redraw"
 
@@ -48,6 +49,7 @@ module Y2Partitioner
       def handle
         return nil unless continue?
 
+        UIState.create_instance
         execute_and_redraw do
           reprobe
           :finish

--- a/src/lib/y2partitioner/widgets/tabs.rb
+++ b/src/lib/y2partitioner/widgets/tabs.rb
@@ -11,14 +11,18 @@ module Y2Partitioner
       # Overrides default behavior of tabs to register the new state before
       # doing the real switch
       def switch_page(page)
-        UIState.instance.switch_to_tab(page)
+        UIState.instance.switch_to_tab(page.label)
         super
       end
 
       # Ensures tabs are properly initialized after a redraw according to
       # {UIState}.
       def initial_page
-        UIState.instance.find_tab(@pages) || super
+        find_initial_page || super
+      end
+
+      def find_initial_page
+        @pages.find { |page| page.label == UIState.instance.active_tab }
       end
     end
 

--- a/test/y2partitioner/actions/controllers/lvm_lv_test.rb
+++ b/test/y2partitioner/actions/controllers/lvm_lv_test.rb
@@ -97,7 +97,7 @@ describe Y2Partitioner::Actions::Controllers::LvmLv do
 
     it "select the table row corresponding to the new lv" do
       expect(Y2Partitioner::UIState.instance).to receive(:select_row) do |lv|
-        expect(lv).to eq(controller.lv)
+        expect(lv).to eq(controller.lv.sid)
       end
 
       controller.create_lv

--- a/test/y2partitioner/actions/go_to_device_tab_test.rb
+++ b/test/y2partitioner/actions/go_to_device_tab_test.rb
@@ -21,12 +21,20 @@
 require_relative "../test_helper"
 
 require "cwm/rspec"
+require "y2partitioner/widgets/pages/partition"
 require "y2partitioner/actions/go_to_device_tab"
 
 describe Y2Partitioner::Actions::GoToDeviceTab do
   subject(:action) { described_class.new(device, pager, "&Partitions") }
-  let(:device) { double("Device") }
+
+  let(:scenario) { "empty_disks.yml" }
+
   let(:pager) { double("Pager", device_page: page, widget_id: "pager") }
+  let(:device) { Y2Storage::BlkDevice.find_by_name(fake_devicegraph, "/dev/sda1") }
+
+  before do
+    devicegraph_stub(scenario)
+  end
 
   describe "#run" do
     context "for a device that doesn't have its own page" do
@@ -38,7 +46,7 @@ describe Y2Partitioner::Actions::GoToDeviceTab do
     end
 
     context "for a device with its own page" do
-      let(:page) { double("Page", label: "Device page", widget_id: "page") }
+      let(:page) { Y2Partitioner::Widgets::Pages::Partition.new(device) }
 
       it "returns :finish" do
         expect(action.run).to eq :finish

--- a/test/y2partitioner/actions/go_to_device_tab_test.rb
+++ b/test/y2partitioner/actions/go_to_device_tab_test.rb
@@ -26,7 +26,7 @@ require "y2partitioner/actions/go_to_device_tab"
 describe Y2Partitioner::Actions::GoToDeviceTab do
   subject(:action) { described_class.new(device, pager, "&Partitions") }
   let(:device) { double("Device") }
-  let(:pager) { double("Pager", device_page: page) }
+  let(:pager) { double("Pager", device_page: page, widget_id: "pager") }
 
   describe "#run" do
     context "for a device that doesn't have its own page" do
@@ -38,7 +38,7 @@ describe Y2Partitioner::Actions::GoToDeviceTab do
     end
 
     context "for a device with its own page" do
-      let(:page) { double("Page", label: "Device page") }
+      let(:page) { double("Page", label: "Device page", widget_id: "page") }
 
       it "returns :finish" do
         expect(action.run).to eq :finish

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -334,7 +334,7 @@ describe Y2Partitioner::UIState do
     end
   end
 
-  describe "#row_sid" do
+  describe "#row_id" do
     let(:device_name) { "/dev/sda2" }
 
     let(:overview_tab) { double("Tab", label: "Overview") }
@@ -350,7 +350,7 @@ describe Y2Partitioner::UIState do
       before { described_class.create_instance }
 
       it "returns nil" do
-        expect(ui_state.row_sid).to be_nil
+        expect(ui_state.row_id).to be_nil
       end
     end
 
@@ -359,7 +359,7 @@ describe Y2Partitioner::UIState do
         before { ui_state.select_row(device.sid) }
 
         it "returns the sid of the device" do
-          expect(ui_state.row_sid).to eq device.sid
+          expect(ui_state.row_id).to eq device.sid
         end
       end
 
@@ -367,7 +367,7 @@ describe Y2Partitioner::UIState do
         before { ui_state.select_row(device.sid) }
 
         it "returns the sid of the device" do
-          expect(ui_state.row_sid).to eq device.sid
+          expect(ui_state.row_id).to eq device.sid
         end
       end
     end
@@ -379,7 +379,7 @@ describe Y2Partitioner::UIState do
       end
 
       it "returns nil" do
-        expect(ui_state.row_sid).to be_nil
+        expect(ui_state.row_id).to be_nil
       end
 
       context "and comes back to the previous tab" do
@@ -388,7 +388,7 @@ describe Y2Partitioner::UIState do
         end
 
         it "returns the last selected device row sid in this tab" do
-          expect(ui_state.row_sid).to eq(device.sid)
+          expect(ui_state.row_id).to eq(device.sid)
         end
       end
     end
@@ -400,7 +400,7 @@ describe Y2Partitioner::UIState do
       end
 
       it "returns nil" do
-        expect(ui_state.row_sid).to be_nil
+        expect(ui_state.row_id).to be_nil
       end
 
       context "and comes back to the previous page" do
@@ -409,7 +409,7 @@ describe Y2Partitioner::UIState do
         end
 
         it "returns the sid of last selected device in the page" do
-          expect(ui_state.row_sid).to eq(device.sid)
+          expect(ui_state.row_id).to eq(device.sid)
         end
       end
     end

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -77,18 +77,6 @@ describe Y2Partitioner::UIState do
       it "returns nil" do
         expect(ui_state.find_tree_node(pages)).to be_nil
       end
-
-      context "and there is a selected row" do
-        let(:device_name) { "/dev/sdb" }
-
-        before { ui_state.select_row(device) }
-
-        it "does not clear the selected row" do
-          ui_state.find_tree_node(pages)
-
-          expect(ui_state.row_sid).to eq(device.sid)
-        end
-      end
     end
 
     context "when the user has opened a partition page" do

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -91,7 +91,7 @@ describe Y2Partitioner::UIState do
       let(:another_disk) { Y2Storage::Disk.find_by_name(fake_devicegraph, "/dev/sdb") }
       let(:another_disk_page) { Y2Partitioner::Widgets::Pages::Disk.new(another_disk, pager) }
 
-      before { ui_state.select_page(partition_page.parents) }
+      before { ui_state.select_page(partition_page.tree_path) }
 
       context "if the partition is still there after redrawing" do
         before { pages.concat [partition_page, another_disk_page, disk_page] }
@@ -125,7 +125,7 @@ describe Y2Partitioner::UIState do
       let(:page) { Y2Partitioner::Widgets::Pages::Disk.new(device, pager) }
       let(:another_disk_page) { Y2Partitioner::Widgets::Pages::Disk.new(another_disk, pager) }
 
-      before { ui_state.select_page(page.parents) }
+      before { ui_state.select_page(page.tree_path) }
 
       context "if the disk is still there after redrawing" do
         before { pages.concat [page, another_disk_page] }
@@ -152,7 +152,7 @@ describe Y2Partitioner::UIState do
       let(:page) { Y2Partitioner::Widgets::Pages::MdRaid.new(device, pager) }
 
       before do
-        ui_state.select_page(page.parents)
+        ui_state.select_page(page.tree_path)
       end
 
       context "if the RAID is still there after redrawing" do
@@ -176,7 +176,7 @@ describe Y2Partitioner::UIState do
       let(:page) { Y2Partitioner::Widgets::Pages::LvmLv.new(device) }
       let(:vg_page) { Y2Partitioner::Widgets::Pages::LvmVg.new(device.lvm_vg, pager) }
 
-      before { ui_state.select_page(page.parents) }
+      before { ui_state.select_page(page.tree_path) }
 
       context "if the LV is still there after redrawing" do
         before { pages.concat [page, vg_page] }
@@ -208,7 +208,7 @@ describe Y2Partitioner::UIState do
       let(:page) { Y2Partitioner::Widgets::Pages::LvmVg.new(device, pager) }
       let(:another_vg_page) { Y2Partitioner::Widgets::Pages::LvmVg.new(another_vg, pager) }
 
-      before { ui_state.select_page(page.parents) }
+      before { ui_state.select_page(page.tree_path) }
 
       context "if the VG is still there after redrawing" do
         before { pages.concat [page, another_vg_page] }
@@ -235,7 +235,7 @@ describe Y2Partitioner::UIState do
       let(:page) { Y2Partitioner::Widgets::Pages::Bcache.new(device, pager) }
       let(:another_bcache_page) { Y2Partitioner::Widgets::Pages::Bcache.new(another_bcache, pager) }
 
-      before { ui_state.select_page(page.parents) }
+      before { ui_state.select_page(page.tree_path) }
 
       context "if the bcache is still there after redrawing" do
         before { pages.concat [page, another_bcache_page] }
@@ -262,7 +262,7 @@ describe Y2Partitioner::UIState do
       let(:page) { Y2Partitioner::Widgets::Pages::Btrfs.new(device, pager) }
       let(:another_btrfs_page) { Y2Partitioner::Widgets::Pages::Btrfs.new(another_btrfs, pager) }
 
-      before { ui_state.select_page(page.parents) }
+      before { ui_state.select_page(page.tree_path) }
 
       context "if the filesystem is still there after redrawing" do
         before { pages.concat [page, another_btrfs_page] }
@@ -293,7 +293,7 @@ describe Y2Partitioner::UIState do
     let(:tabs) { [vg_tab, lvs_tab, pvs_tab] }
 
     before do
-      ui_state.select_page(vg_page.parents)
+      ui_state.select_page(vg_page.tree_path)
     end
 
     context "if the user has still not clicked in any tab" do
@@ -314,7 +314,7 @@ describe Y2Partitioner::UIState do
       context "but then moves to a different page" do
         before do
           ui_state.switch_to_tab(lvs_tab.label)
-          ui_state.select_page(system_page.parents)
+          ui_state.select_page(system_page.tree_path)
         end
 
         it "returns nil even if there is another tab with the same label" do
@@ -323,7 +323,7 @@ describe Y2Partitioner::UIState do
 
         context "and comes back to the previous page" do
           before do
-            ui_state.select_page(vg_page.parents)
+            ui_state.select_page(vg_page.tree_path)
           end
 
           it "selects the last active tab in the page" do
@@ -342,7 +342,7 @@ describe Y2Partitioner::UIState do
 
     before do
       described_class.create_instance
-      ui_state.select_page(disk_page.parents)
+      ui_state.select_page(disk_page.tree_path)
       ui_state.switch_to_tab(partitions_tab)
     end
 
@@ -396,7 +396,7 @@ describe Y2Partitioner::UIState do
     context "if the user had selected a row but then moved to a different page" do
       before do
         ui_state.select_row(device)
-        ui_state.select_page(system_page.parents)
+        ui_state.select_page(system_page.tree_path)
       end
 
       it "returns nil" do
@@ -405,7 +405,7 @@ describe Y2Partitioner::UIState do
 
       context "and comes back to the previous page" do
         before do
-          ui_state.select_page(disk_page.parents)
+          ui_state.select_page(disk_page.tree_path)
         end
 
         it "returns the sid of last selected device in the page" do
@@ -461,14 +461,14 @@ describe Y2Partitioner::UIState do
     let(:lv2_page) { Y2Partitioner::Widgets::Pages::LvmLv.new(lv2) }
 
     before do
-      ui_state.select_page(disks_page.parents)
-      ui_state.select_page(sda_page.parents)
-      ui_state.select_page(sda1_page.parents)
-      ui_state.select_page(sda2_page.parents)
-      ui_state.select_page(lvm_page.parents)
-      ui_state.select_page(vg_page.parents)
-      ui_state.select_page(lv1_page.parents)
-      ui_state.select_page(lv2_page.parents)
+      ui_state.select_page(disks_page.tree_path)
+      ui_state.select_page(sda_page.tree_path)
+      ui_state.select_page(sda1_page.tree_path)
+      ui_state.select_page(sda2_page.tree_path)
+      ui_state.select_page(lvm_page.tree_path)
+      ui_state.select_page(vg_page.tree_path)
+      ui_state.select_page(lv1_page.tree_path)
+      ui_state.select_page(lv2_page.tree_path)
     end
 
     context "when a 'parent' device is deleted" do

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -356,7 +356,7 @@ describe Y2Partitioner::UIState do
 
     context "if the user had selected a row in the current page and tab" do
       context "selecting the row by device" do
-        before { ui_state.select_row(device) }
+        before { ui_state.select_row(device.sid) }
 
         it "returns the sid of the device" do
           expect(ui_state.row_sid).to eq device.sid
@@ -364,7 +364,7 @@ describe Y2Partitioner::UIState do
       end
 
       context "selecting the row by sid" do
-        before { ui_state.select_row(device) }
+        before { ui_state.select_row(device.sid) }
 
         it "returns the sid of the device" do
           expect(ui_state.row_sid).to eq device.sid
@@ -374,7 +374,7 @@ describe Y2Partitioner::UIState do
 
     context "if the user had selected a row but then moved to a different tab" do
       before do
-        ui_state.select_row(device)
+        ui_state.select_row(device.sid)
         ui_state.switch_to_tab(overview_tab)
       end
 
@@ -395,7 +395,7 @@ describe Y2Partitioner::UIState do
 
     context "if the user had selected a row but then moved to a different page" do
       before do
-        ui_state.select_row(device)
+        ui_state.select_row(device.sid)
         ui_state.select_page(system_page.tree_path)
       end
 

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -473,29 +473,29 @@ describe Y2Partitioner::UIState do
 
     context "when a 'parent' device is deleted" do
       it "clears all related page statuses" do
-        expect(ui_state.statuses.keys)
+        expect(ui_state.statuses.map(&:page_id))
           .to include(vg_page.id, lv1_page.id, lv2_page.id)
 
         ui_state.clear_statuses_for(vg.sid)
 
-        expect(ui_state.statuses.keys)
+        expect(ui_state.statuses.map(&:page_id))
           .to_not include(vg_page.id, lv1_page.id, lv2_page.id)
       end
     end
 
     context "when a 'child' device is deleted" do
       it "clears its page status" do
-        expect(ui_state.statuses.keys).to include(sda1_page.id)
+        expect(ui_state.statuses.map(&:page_id)).to include(sda1_page.id)
 
         ui_state.clear_statuses_for(sda1.sid)
 
-        expect(ui_state.statuses.keys).to_not include(sda1_page.id)
+        expect(ui_state.statuses.map(&:page_id)).to_not include(sda1_page.id)
       end
 
       it "does not clear either, parent or siblings page statuses" do
         ui_state.clear_statuses_for(sda1.sid)
 
-        expect(ui_state.statuses.keys).to include(sda_page.id, sda2_page.id)
+        expect(ui_state.statuses.map(&:page_id)).to include(sda_page.id, sda2_page.id)
       end
     end
   end

--- a/test/y2partitioner/widgets/configurable_blk_devices_table_test.rb
+++ b/test/y2partitioner/widgets/configurable_blk_devices_table_test.rb
@@ -206,7 +206,7 @@ describe Y2Partitioner::Widgets::ConfigurableBlkDevicesTable do
           let(:device) { Y2Storage::Disk.all(device_graph).first }
 
           it "notifies the selected device to the UIState" do
-            expect(Y2Partitioner::UIState.instance).to receive(:select_row).with(device)
+            expect(Y2Partitioner::UIState.instance).to receive(:select_row).with(device.sid)
             subject.handle(event)
           end
 
@@ -245,7 +245,7 @@ describe Y2Partitioner::Widgets::ConfigurableBlkDevicesTable do
           let(:device) { Y2Storage::Disk.all(device_graph).first }
 
           it "notifies the selected device to the UIState" do
-            expect(Y2Partitioner::UIState.instance).to receive(:select_row).with(device)
+            expect(Y2Partitioner::UIState.instance).to receive(:select_row).with(device.sid)
             subject.handle(event)
           end
 

--- a/test/y2partitioner/widgets/configurable_blk_devices_table_test.rb
+++ b/test/y2partitioner/widgets/configurable_blk_devices_table_test.rb
@@ -71,47 +71,62 @@ describe Y2Partitioner::Widgets::ConfigurableBlkDevicesTable do
       allow(Yast::UI).to receive(:QueryWidget).with(anything, :SelectedItems).and_return []
     end
 
-    context "if UIState contains the sid of a device in table" do
-      let(:device) { devices.last }
-
-      before { Y2Partitioner::UIState.instance.select_row(device.sid) }
-
-      it "sets value to row with the device" do
-        expect(subject).to receive(:value=).with(subject.send(:row_id, device.sid))
-        subject.init
-      end
-
-      context "if the table is associated to a buttons set" do
-        subject { described_class.new(devices, pager, buttons_set) }
-
-        it "initializes the buttons set according to the device" do
-          expect(subject).to receive(:selected_device).and_return(device)
-          expect(buttons_set).to receive(:device=).with device
-          subject.init
-        end
-      end
-    end
-
-    context "if UIState contains a sid that is not in the table" do
-      it "selects any valid device in table" do
-        Y2Partitioner::UIState.instance.select_row("999999999")
-
-        expect(subject).to receive(:value=) do |value|
-          sid = value[/.*:(.*)/, 1].to_i # c&p from code
-          expect(devices.map(&:sid)).to include(sid)
-        end
-
-        subject.init
-      end
-    end
-
-    context "table does not contain any device" do
+    context "when table does not contain any device" do
       let(:devices) { [] }
 
       it "do nothing" do
         expect(subject).to_not receive(:value=)
 
         subject.init
+      end
+    end
+
+    context "when the table contains devices" do
+      before do
+        allow(Y2Partitioner::UIState.instance).to receive(:row_sid).and_return(row_sid)
+      end
+
+      let(:device) { devices.first }
+      let(:selected_row) { subject.send(:row_id, device.sid) }
+
+      shared_examples "selects the first device in the table" do
+        it "selects the first device in the table" do
+          expect(subject).to receive(:value=).with(selected_row)
+
+          subject.init
+        end
+      end
+
+      context "and UIState does not return an sid" do
+        let(:row_sid) { nil }
+
+        include_examples "selects the first device in the table"
+      end
+
+      context "and UIState returns an sid for a device that is not in the table" do
+        let(:row_sid) { "999999999" }
+
+        include_examples "selects the first device in the table"
+      end
+
+      context "and UIState returns an sid of a device in table" do
+        let(:device) { devices.last }
+        let(:row_sid) { device.sid }
+
+        it "sets value to row with the device" do
+          expect(subject).to receive(:value=).with(selected_row)
+          subject.init
+        end
+
+        context "if the table is associated to a buttons set" do
+          subject { described_class.new(devices, pager, buttons_set) }
+
+          it "initializes the buttons set according to the device" do
+            expect(subject).to receive(:selected_device).and_return(device)
+            expect(buttons_set).to receive(:device=).with device
+            subject.init
+          end
+        end
       end
     end
   end
@@ -165,8 +180,17 @@ describe Y2Partitioner::Widgets::ConfigurableBlkDevicesTable do
       context "when there is a buttons set associated to the table" do
         let(:set) { buttons_set }
 
+        before do
+          allow(buttons_set).to receive(:device=).with(device)
+        end
+
         context "and there is no selected device" do
           let(:device) { nil }
+
+          it "does not try to notify the change to the UIState" do
+            expect(Y2Partitioner::UIState.instance).to_not receive(:select_row)
+            subject.handle(event)
+          end
 
           it "does not try to update the buttons set" do
             expect(buttons_set).to_not receive(:device=)
@@ -180,6 +204,11 @@ describe Y2Partitioner::Widgets::ConfigurableBlkDevicesTable do
 
         context "and some device is selected" do
           let(:device) { Y2Storage::Disk.all(device_graph).first }
+
+          it "notifies the selected device to the UIState" do
+            expect(Y2Partitioner::UIState.instance).to receive(:select_row).with(device)
+            subject.handle(event)
+          end
 
           it "updates the buttons set according to the device" do
             expect(buttons_set).to receive(:device=).with(device)
@@ -197,6 +226,11 @@ describe Y2Partitioner::Widgets::ConfigurableBlkDevicesTable do
         context "and there is no selected device" do
           let(:device) { nil }
 
+          it "does not try to notify the change to the UIState" do
+            expect(Y2Partitioner::UIState.instance).to_not receive(:select_row)
+            subject.handle(event)
+          end
+
           it "does not try to update the buttons set" do
             expect(buttons_set).to_not receive(:device=)
             subject.handle(event)
@@ -209,6 +243,11 @@ describe Y2Partitioner::Widgets::ConfigurableBlkDevicesTable do
 
         context "and some device is selected" do
           let(:device) { Y2Storage::Disk.all(device_graph).first }
+
+          it "notifies the selected device to the UIState" do
+            expect(Y2Partitioner::UIState.instance).to receive(:select_row).with(device)
+            subject.handle(event)
+          end
 
           it "does not try to update the buttons set" do
             expect(buttons_set).to_not receive(:device=)

--- a/test/y2partitioner/widgets/configurable_blk_devices_table_test.rb
+++ b/test/y2partitioner/widgets/configurable_blk_devices_table_test.rb
@@ -83,7 +83,7 @@ describe Y2Partitioner::Widgets::ConfigurableBlkDevicesTable do
 
     context "when the table contains devices" do
       before do
-        allow(Y2Partitioner::UIState.instance).to receive(:row_sid).and_return(row_sid)
+        allow(Y2Partitioner::UIState.instance).to receive(:row_id).and_return(row_id)
       end
 
       let(:device) { devices.first }
@@ -98,20 +98,20 @@ describe Y2Partitioner::Widgets::ConfigurableBlkDevicesTable do
       end
 
       context "and UIState does not return an sid" do
-        let(:row_sid) { nil }
+        let(:row_id) { nil }
 
         include_examples "selects the first device in the table"
       end
 
       context "and UIState returns an sid for a device that is not in the table" do
-        let(:row_sid) { "999999999" }
+        let(:row_id) { "999999999" }
 
         include_examples "selects the first device in the table"
       end
 
       context "and UIState returns an sid of a device in table" do
         let(:device) { devices.last }
-        let(:row_sid) { device.sid }
+        let(:row_id) { device.sid }
 
         it "sets value to row with the device" do
           expect(subject).to receive(:value=).with(selected_row)

--- a/test/y2partitioner/widgets/overview_test.rb
+++ b/test/y2partitioner/widgets/overview_test.rb
@@ -47,6 +47,14 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
 
   include_examples "CWM::Pager"
 
+  describe "#init" do
+    it "asks to UIState for a statuses cleaning" do
+      expect(Y2Partitioner::UIState.instance).to receive(:clear_dead_statuses)
+
+      subject.init
+    end
+  end
+
   describe "#device_page" do
     let(:vg) { Y2Storage::LvmVg.find_by_vg_name(current_graph, "vg0") }
 

--- a/test/y2partitioner/widgets/overview_test.rb
+++ b/test/y2partitioner/widgets/overview_test.rb
@@ -53,6 +53,12 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
 
       subject.init
     end
+
+    it "notifies the current page to UIState" do
+      expect(Y2Partitioner::UIState.instance).to receive(:select_page)
+
+      subject.init
+    end
   end
 
   describe "#device_page" do

--- a/test/y2partitioner/widgets/overview_test.rb
+++ b/test/y2partitioner/widgets/overview_test.rb
@@ -49,7 +49,7 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
 
   describe "#init" do
     it "asks to UIState for a statuses cleaning" do
-      expect(Y2Partitioner::UIState.instance).to receive(:clear_dead_statuses)
+      expect(Y2Partitioner::UIState.instance).to receive(:prune)
 
       subject.init
     end

--- a/test/y2partitioner/widgets/pages/base_test.rb
+++ b/test/y2partitioner/widgets/pages/base_test.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com
+
+require_relative "../../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/pages"
+
+describe Y2Partitioner::Widgets::Pages::Base do
+  let(:scenario) { "empty_disks.yml" }
+  let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+
+  let(:disks) { current_graph.disks }
+  let(:disk) { disks.first }
+
+  before do
+    devicegraph_stub(scenario)
+  end
+
+  describe "#id" do
+    let(:pager) { double("Pager") }
+
+    context "when it's a device page" do
+      let(:page) { Y2Partitioner::Widgets::Pages::Disk.new(disk, pager) }
+
+      it "returns the device sid" do
+        expect(page.id).to eq(disk.sid)
+      end
+    end
+
+    context "when it isn't a device page" do
+      let(:page) { Y2Partitioner::Widgets::Pages::Disks.new(disks, pager) }
+
+      it "returns the page label" do
+        expect(page.id).to eq(page.label)
+      end
+    end
+  end
+end

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -40,8 +40,8 @@ describe Y2Partitioner::Widgets::Pages::System do
   include_examples "CWM::Page"
 
   describe "#init" do
-    it "notifies to UIState" do
-      expect(Y2Partitioner::UIState.instance).to receive(:go_to_tree_node).with(subject)
+    it "registers itself in UIState" do
+      expect(Y2Partitioner::UIState.instance).to receive(:select_page).with(["hostname"])
 
       subject.init
     end

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -39,6 +39,14 @@ describe Y2Partitioner::Widgets::Pages::System do
 
   include_examples "CWM::Page"
 
+  describe "#init" do
+    it "sets itself as a current node" do
+      expect(Y2Partitioner::UIState.instance).to receive(:current_node=).with(subject)
+
+      subject.init
+    end
+  end
+
   describe "#contents" do
     # Widget with the list of devices
     def find_table(widgets)

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -40,8 +40,8 @@ describe Y2Partitioner::Widgets::Pages::System do
   include_examples "CWM::Page"
 
   describe "#init" do
-    it "sets itself as a current node" do
-      expect(Y2Partitioner::UIState.instance).to receive(:current_node=).with(subject)
+    it "notifies to UIState" do
+      expect(Y2Partitioner::UIState.instance).to receive(:go_to_tree_node).with(subject)
 
       subject.init
     end

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -39,14 +39,6 @@ describe Y2Partitioner::Widgets::Pages::System do
 
   include_examples "CWM::Page"
 
-  describe "#init" do
-    it "registers itself in UIState" do
-      expect(Y2Partitioner::UIState.instance).to receive(:select_page).with(["hostname"])
-
-      subject.init
-    end
-  end
-
   describe "#contents" do
     # Widget with the list of devices
     def find_table(widgets)

--- a/test/y2partitioner/widgets/rescan_devices_button_test.rb
+++ b/test/y2partitioner/widgets/rescan_devices_button_test.rb
@@ -55,6 +55,12 @@ describe Y2Partitioner::Widgets::RescanDevicesButton do
     context "when rescanning is canceled" do
       let(:accepted) { false }
 
+      it "does not create a new UIState instance" do
+        expect(Y2Partitioner::UIState).to_not receive(:create_instance)
+
+        subject.handle
+      end
+
       it "returns nil" do
         expect(subject.handle).to be_nil
       end
@@ -69,6 +75,12 @@ describe Y2Partitioner::Widgets::RescanDevicesButton do
         before { allow(manager).to receive(:activate).and_return true }
 
         include_examples "reprobing"
+
+        it "creates a new UIState instance" do
+          expect(Y2Partitioner::UIState).to receive(:create_instance)
+
+          subject.handle
+        end
 
         it "runs activation again" do
           expect(manager).to receive(:activate).and_return true
@@ -85,6 +97,12 @@ describe Y2Partitioner::Widgets::RescanDevicesButton do
         let(:install) { false }
 
         include_examples "reprobing"
+
+        it "creates a new UIState instance" do
+          expect(Y2Partitioner::UIState).to receive(:create_instance)
+
+          subject.handle
+        end
 
         it "does not re-run activation" do
           expect(manager).to_not receive(:activate)


### PR DESCRIPTION
## Problem

The UI only can remember the selected tab for the current node. Thus, if the user changes from, let's say, _Hard Disks -> sda -> `Partitions`_ to _Hard Disks -> sdb_ and then comes back to _Hard Disks -> sda_, the _`Overview`_ tab is shown instead of _`Partitions`_. Exactly the same happens for the selected row: only is remembered when the current node is _redrawn_, being forgotten when changing to another node.

- https://bugzilla.suse.com/show_bug.cgi?id=1159883

## Solution

Keep the _status_ per node to be able to restore, when possible, the UI as it was before leaving the node. The solution includes

* To "register" the system page too, needed to track its status
* To restore `.label` class method for some pages (kind of revert of https://github.com/yast/yast-storage-ng/pull/752/commits/b107fc5b13662b10fe8904f7d6331a2b057eaa61)
* To fix the _dependency cycles in Ruby requires_ between UIState and some actions 
* To "discard" the `UIState` before re-scanning devices
* An UI blink mitigation

## Testing

- Added unit tests
- Tested manually (both, during installation and in a running system)

## Screencast

<details>
<summary>Click to show/hide</summary>

---

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1691872/72930564-19f11a80-3d54-11ea-97ca-f411a84ddd0a.gif)
</details>

---

<details>
<summary>Show/hide some notes about UI blinks</summary>

---

This set of changes also includes a commit mitigating the UI blinks originated by the fact that tabs are being rendered in two steps and the first one (before rendering the content from the _initial tab_):

* was being shown in a vertically centered position.
  
  <details>
    <summary>Click to show/hide</summary>

    ---
    
    ![vertically_centered_first_render](https://user-images.githubusercontent.com/1691872/72929374-9c2c0f80-3d51-11ea-8b95-46c3eef8d282.png)
  </details>
  
* does not occupy the full available space.
  
  <details>
    <summary>Click to show/hide</summary>

    ---
    
    ![dumbtab_first_render](https://user-images.githubusercontent.com/1691872/72929463-c7aefa00-3d51-11ea-9a16-1274e84d7503.png)

  </details>
  




Starting always in the top left corner of its container avoids the _first blink_. Actually, we only can see one of them because the _second render step_ fits all the space with the tab content. Sadly, fixing the first makes the second "visible", which probably will require changes in YaST2 CWM library.


---

Note: you cannot see the mentioned blink in the attached screencast because of the frame rate. But you can see it in the original video  (if available yet) [here](https://www.veed.io/download/d4b7ad53-596b-4e74-a10f-6e60fa4791eb).

</details>