### PR TITLE
Fix 1161442

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 23 15:56:36 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Avoided crash when libstorage-ng provides a non-UTF string as
+  partition id (bsc#1161442).
+- 4.2.77
+
+-------------------------------------------------------------------
 Tue Jan 21 12:11:46 UTC 2020 - aschnell@suse.com
 
 - added warning before resizing block devices which were probed

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.76
+Version:        4.2.77
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/partition_id.rb
+++ b/src/lib/y2storage/partition_id.rb
@@ -69,7 +69,10 @@ module Y2Storage
     end
 
     def to_human_string
-      id_name = Storage.partition_id_name(to_i)
+      # Normally, strings coming from libstorage-ng are enforced to UTF-8 by
+      # StorageClassWrapper. Here we are accessing the libstorage-ng value
+      # directly, so we need to perform the same force_encoding operation.
+      id_name = Storage.partition_id_name(to_i).force_encoding("UTF-8")
 
       if id_name.empty?
         log.warn "Unhandled Partition ID '#{inspect}'"


### PR DESCRIPTION
## Problem

The partitioner was crashing with some locales (Russian and French, according to the report) when trying to display some partition IDs.

- https://bugzilla.suse.com/show_bug.cgi?id=1161442

The problem was that the result of this libstorage-ng function call was being passed directly to Ruby's `#format`.

```ruby
Storage.partition_id_name(id)
```

But, as we learned some time ago, we should enforce the encoding of all strings coming from libstorage-ng before trying to process them. Normally, that's done by `StorageClassWrapper`. But that, of course, does not cover direct calls to libstorage-ng like the one above.

## Solution

Enforce the encoding for the mentioned string.

## Testing

- Tested manually (in Russian)
