### PR TITLE
Select APQNs for a new secure key

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 28 17:05:15 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: allow to select APQNs when encrypting with pervasive
+  encryption (jsc#SLE-7376).
+- 4.2.91
+-------------------------------------------------------------------
 Thu Feb 20 16:02:54 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Add API methods to get preferred mount by option and the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.90
+Version:        4.2.91
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/encryption.rb
+++ b/src/lib/y2partitioner/actions/controllers/encryption.rb
@@ -157,9 +157,8 @@ module Y2Partitioner
         # Tests the generation of a secure key
         #
         # Note that the command for generating a secure key might fail when the APQNs are not correctly
-        # configured. An APQN without a master key makes the command to tail. Theoretically, all the
-        # APQNs used for generating the secure key must have the same master key, but for some reason
-        # the command is not failing when different master keys are used.
+        # configured. An APQN without a master key makes the command to tail. All the APQNs used for
+        # generating the secure key must have the same master key.
         #
         # @param apqns [Array<Y2Storage::EncryptionProcesses::Apqn>]
         # @return [String, nil] error message or nil if the secure key can be generated

--- a/src/lib/y2partitioner/widgets/apqn_selector.rb
+++ b/src/lib/y2partitioner/widgets/apqn_selector.rb
@@ -73,7 +73,7 @@ module Y2Partitioner
 
       private
 
-      # @return [Actions::Controllers::ClonePartitionTable]
+      # @return [Actions::Controllers::Encryption]
       attr_reader :controller
 
       # @return [Boolean]

--- a/src/lib/y2partitioner/widgets/apqn_selector.rb
+++ b/src/lib/y2partitioner/widgets/apqn_selector.rb
@@ -1,0 +1,83 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast2/popup"
+require "cwm"
+require "y2partitioner/actions/controllers/encryption"
+
+module Y2Partitioner
+  module Widgets
+    # Widget to select APQNs for generating a new secure key for pervasive encryption
+    class ApqnSelector < CWM::MultiSelectionBox
+      # Constructor
+      #
+      # @param controller [Actions::Controllers::Encryption]
+      # @param enable [Boolean] whether the widget should be enabled on init
+      def initialize(controller, enable: true)
+        textdomain "storage"
+
+        @controller = controller
+        @enable_on_init = enable
+      end
+
+      # @return [String]
+      def label
+        _("Available APQNs:")
+      end
+
+      # @macro seeAbstractWidget
+      def init
+        enable_on_init ? enable : disable
+        self.value = controller.apqns
+      end
+
+      # @return [Array<String, String>]
+      def items
+        controller.online_apqns.map { |d| [d.name, d.name] }
+      end
+
+      # All selected APQNs
+      #
+      # @return [Array<Y2Storage::EncryptionProcesses::Apqn>]
+      def value
+        super.map { |d| controller.find_apqn(d) }.compact
+      end
+
+      # Sets selected APQNs
+      #
+      # @param apqns [Array<Y2Storage::EncryptionProcesses::Apqn>]
+      def value=(apqns)
+        super(apqns.map(&:name))
+      end
+
+      # Saves the selected APQNs into the controller
+      def store
+        controller.apqns = value
+      end
+
+      private
+
+      # @return [Actions::Controllers::ClonePartitionTable]
+      attr_reader :controller
+
+      # @return [Boolean]
+      attr_reader :enable_on_init
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/encrypt.rb
+++ b/src/lib/y2partitioner/widgets/encrypt.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2019-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -185,7 +185,8 @@ module Y2Partitioner
            "<p>If the cryptographic system already contains a secure key associated to this " \
            "volume, that key will be used. Otherwise, a new secure key will be generated and " \
            "registered in the system. You need to provide an encryption password that will be " \
-           "used to protect the access to that master key.</p>"),
+           "used to protect the access to that master key. Moreover, when there are several APQNs " \
+           "in the system, you can select which ones to use.</p>"),
           label: encrypt_method.to_human_string
         )
       end

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -305,10 +305,19 @@ module Y2Storage
     # @param method [EncryptionMethod, Symbol] encryption method to create the new device
     # @param dm_name [String, nil] DeviceMapper table name of the new device
     # @param password [String, nil] password of the new device
+    # @param apqns [Array<EncryptionProcesses::Apqn>] APQNs to use when generating a secure key for
+    #   pervasive encryption.
+    #
     # @return [Encryption]
-    def encrypt(method: EncryptionMethod::LUKS1, dm_name: nil, password: nil)
+    def encrypt(method: EncryptionMethod::LUKS1, dm_name: nil, password: nil, apqns: [])
       method = EncryptionMethod.find(method) if method.is_a?(Symbol)
-      enc = method.create_device(self, dm_name)
+
+      enc = if method.is_a?(EncryptionMethod::PervasiveLuks2)
+        method.create_device(self, dm_name, apqns: apqns)
+      else
+        method.create_device(self, dm_name)
+      end
+
       enc.auto_dm_name = enc.dm_table_name.empty?
       enc.password = password if password
       enc.ensure_suitable_mount_by

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -268,6 +268,19 @@ module Y2Storage
       encryption_process ? encryption_process.method : EncryptionMethod.for_device(self)
     end
 
+    # Returns the process used to perform the encryption
+    #
+    # @note The EncryptionProcess object is persisted using the userdata mechanism,
+    #   but it's also cached in an instance variable because, otherwise, every call
+    #   to #encryption_process would be accessing the object that was stored in the
+    #   devicegraph, with its former state. Thus, all the modifications would be lost.
+    #   See {#encryption_process=} and {#save_encryption_process}.
+    #
+    # @return [EncryptionProcess::Base, nil]
+    def encryption_process
+      @encryption_process ||= userdata_value(:encryption_process)
+    end
+
     # Saves the given encryption process
     #
     # @note Keeping the state of this object is important, so see {#encryption_process}
@@ -351,19 +364,6 @@ module Y2Storage
     # @see Device#update_etc_attributes
     def assign_etc_attribute(value)
       self.storage_in_etc_crypttab = value
-    end
-
-    # Returns the process used to perform the encryption
-    #
-    # @note The EncryptionProcess object is persisted using the userdata mechanism,
-    #   but it's also cached in an instance variable because, otherwise, every call
-    #   to #encryption_process would be accessing the object that was stored in the
-    #   devicegraph, with its former state. Thus, all the modifications would be lost.
-    #   See {#encryption_process=} and {#save_encryption_process}.
-    #
-    # @return [EncryptionProcess::Base, nil]
-    def encryption_process
-      @encryption_process ||= userdata_value(:encryption_process)
     end
 
     # Updates the userdata with an up-to-date version of the encryption process

--- a/src/lib/y2storage/encryption_method/pervasive_luks2.rb
+++ b/src/lib/y2storage/encryption_method/pervasive_luks2.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2019-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,6 +33,7 @@ module Y2Storage
 
       def initialize
         textdomain "storage"
+
         super(:pervasive_luks2, _("Pervasive Volume Encryption"))
       end
 
@@ -44,6 +45,17 @@ module Y2Storage
       # @see Base#available?
       def available?
         EncryptionProcesses::SecureKey.available?
+      end
+
+      # Creates an encryption device for the given block device
+      #
+      # @param blk_device [Y2Storage::BlkDevice]
+      # @param dm_name [String]
+      # @param apqns [Array<EncryptionProcesses::Apqn>] APQNs to use when generating a secure key.
+      #
+      # @return [Y2Storage::Encryption]
+      def create_device(blk_device, dm_name, apqns: [])
+        encryption_process.create_device(blk_device, dm_name, apqns: apqns)
       end
 
       private

--- a/src/lib/y2storage/encryption_processes/apqn.rb
+++ b/src/lib/y2storage/encryption_processes/apqn.rb
@@ -1,0 +1,147 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast2/execute"
+
+module Y2Storage
+  module EncryptionProcesses
+    # Class representing an APQN used for generating a new secure key, see {SecureKey}.
+    #
+    # For more information, see
+    # https://www.ibm.com/support/knowledgecenter/linuxonibm/com.ibm.linux.z.lxdc/lxdc_zkey_reference.html
+    class Apqn
+      # Location of the lszcrypt command
+      LSZCRYPT = "/sbin/lszcrypt".freeze
+      private_constant :LSZCRYPT
+
+      class << self
+        # All APQNs found in the system
+        #
+        # @return [Array<Apqn>]
+        def all
+          create_apqns
+        end
+
+        # All online APQNs found in the system
+        #
+        # @return [Array<Apqn>]
+        def online
+          all.select(&:online?)
+        end
+
+        private
+
+        # Creates APQNs from the data read in the system
+        #
+        # @return [Array<Apqn>]
+        def create_apqns
+          apqns_data.map { |d| new(*d) }
+        end
+
+        # Data of the APQNs found in the system
+        #
+        # For each APQN, it returns its name (card.domain), type, mode, status and requests, see
+        # {#execute_lszcrypt}.
+        #
+        # @return [Array<Array<String>>]
+        def apqns_data
+          data = execute_lszcrypt.split("\n").map(&:split)
+          return [] if data.size == 2
+
+          # remove header
+          data.shift(2)
+
+          # select card.domain entries
+          data.select { |d| d.first.match?(/.*\..*/) }
+        end
+
+        # Executes lszcrypt command
+        #
+        # Example of lszcrypt output:
+        #
+        #   "CARD.DOMAIN TYPE  MODE        STATUS  REQUESTS\n" \
+        #   "----------------------------------------------\n" \
+        #   "01          CEX5C CCA-Coproc  online         1\n" \
+        #   "01.0001     CEX5C CCA-Coproc  online         1\n" \
+        #   "01.0004     CEX5C CCA-Coproc  online         0\n" \
+        #   "01.0005     CEX5C CCA-Coproc  online         0"
+        #
+        # @return [String]
+        def execute_lszcrypt
+          Yast::Execute.locally!(LSZCRYPT, stdout: :capture)
+        rescue Cheetah::ExecutionFailed
+          ""
+        end
+      end
+
+      # Card number
+      #
+      # @return [String] e.g., "01"
+      attr_reader :card
+
+      # Domain number
+      #
+      # @return [String] e.g., "0001"
+      attr_reader :domain
+
+      # Card type
+      #
+      # @return [String] e.g., "CEX5C"
+      attr_reader :type
+
+      # Card mode
+      #
+      # @return [String] e.g., "CCA-Coproc"
+      attr_reader :mode
+
+      # APQN status
+      #
+      # @return [String] e.g., "online", "offline"
+      attr_reader :status
+
+      # Constructor
+      #
+      # @param name [String]
+      # @param type [String]
+      # @param mode [String]
+      # @param status [String]
+      # @param _others [Array<String>]
+      def initialize(name, type, mode, status, *_others)
+        @card, @domain = name.split(".")
+        @type = type
+        @mode = mode
+        @status = status
+      end
+
+      # APQN name
+      #
+      # @return [String]
+      def name
+        "#{card}.#{domain}"
+      end
+
+      # Whether the APQN is online
+      #
+      # @return [Boolean]
+      def online?
+        status == "online"
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/encryption_processes/apqn.rb
+++ b/src/lib/y2storage/encryption_processes/apqn.rb
@@ -35,7 +35,7 @@ module Y2Storage
         #
         # @return [Array<Apqn>]
         def all
-          create_apqns
+          read_apqns
         end
 
         # All online APQNs found in the system
@@ -47,11 +47,15 @@ module Y2Storage
 
         private
 
-        # Creates APQNs from the data read in the system
+        # Reads APQNs data from the system and creates APQNs objects
         #
         # @return [Array<Apqn>]
-        def create_apqns
-          apqns_data.map { |d| new(*d) }
+        def read_apqns
+          apqns_data.map do |data|
+            name, type, mode, status, = data
+
+            new(name, type, mode, status)
+          end
         end
 
         # Data of the APQNs found in the system
@@ -68,7 +72,7 @@ module Y2Storage
           data.shift(2)
 
           # select card.domain entries
-          data.select { |d| d.first.match?(/.*\..*/) }
+          data.select { |d| d.first.match?(/.+\..+/) }
         end
 
         # Executes lszcrypt command

--- a/src/lib/y2storage/encryption_processes/base.rb
+++ b/src/lib/y2storage/encryption_processes/base.rb
@@ -44,6 +44,8 @@ module Y2Storage
       #
       # @param blk_device [Y2Storage::BlkDevice]
       # @param dm_name [String]
+      #
+      # @return [Encryption]
       def create_device(blk_device, dm_name)
         enc = blk_device.create_encryption(dm_name || "", encryption_type)
         enc.open_options = open_command_options(blk_device)

--- a/test/data/lszcrypt/three-apqns.txt
+++ b/test/data/lszcrypt/three-apqns.txt
@@ -1,0 +1,6 @@
+CARD.DOMAIN TYPE  MODE        STATUS  REQUESTS
+----------------------------------------------
+01          CEX5C CCA-Coproc  online         1
+01.0001     CEX5C CCA-Coproc  online         1
+01.0002     CEX5C CCA-Coproc  offline        0
+01.0003     CEX5C CCA-Coproc  online         0

--- a/test/y2partitioner/widgets/apqn_selector_test.rb
+++ b/test/y2partitioner/widgets/apqn_selector_test.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "cwm/rspec"
+require "y2partitioner/widgets/apqn_selector"
+
+describe Y2Partitioner::Widgets::ApqnSelector do
+  subject { described_class.new(controller) }
+
+  let(:controller) do
+    instance_double(Y2Partitioner::Actions::Controllers::Encryption, online_apqns: apqns)
+  end
+
+  let(:apqns) { [apqn1, apqn2] }
+
+  let(:apqn1) { instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "01.0001") }
+
+  let(:apqn2) { instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "01.0002") }
+
+  include_examples "CWM::MultiSelectionBox"
+
+  describe "#store" do
+    before do
+      allow(subject).to receive(:value).and_return(apqns)
+    end
+
+    it "saves selected APQNs in the controller" do
+      expect(controller).to receive(:apqns=).with(apqns)
+
+      subject.store
+    end
+  end
+end

--- a/test/y2partitioner/widgets/encrypt_method_options_test.rb
+++ b/test/y2partitioner/widgets/encrypt_method_options_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2019] SUSE LLC
+
+# Copyright (c) [2019-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -36,6 +37,7 @@ describe Y2Partitioner::Widgets::EncryptMethodOptions do
   let(:controller) { Y2Partitioner::Actions::Controllers::Encryption.new(fs_controller) }
   let(:random_swap) { Y2Storage::EncryptionMethod.find(:random_swap) }
   let(:luks1) { Y2Storage::EncryptionMethod.find(:luks1) }
+  let(:pervasive) { Y2Storage::EncryptionMethod.find(:pervasive_luks2) }
 
   before do
     devicegraph_stub("empty_hard_disk_50GiB.yml")
@@ -46,10 +48,12 @@ describe Y2Partitioner::Widgets::EncryptMethodOptions do
   describe "#refresh" do
     let(:fake_random_swap_options) { CWM::Empty.new("__fake_plain_options__") }
     let(:fake_luks1_options) { CWM::Empty.new("__fake_luks1_options__") }
+    let(:fake_pervasive_options) { CWM::Empty.new("__fake_pervasive_options__") }
 
     before do
       allow(Y2Partitioner::Widgets::SwapOptions).to receive(:new).and_return(fake_random_swap_options)
       allow(Y2Partitioner::Widgets::LuksOptions).to receive(:new).and_return(fake_luks1_options)
+      allow(Y2Partitioner::Widgets::PervasiveOptions).to receive(:new).and_return(fake_pervasive_options)
     end
 
     it "generates the new content based on the selected method" do
@@ -58,6 +62,9 @@ describe Y2Partitioner::Widgets::EncryptMethodOptions do
 
       expect(Y2Partitioner::Widgets::LuksOptions).to receive(:new)
       subject.refresh(luks1)
+
+      expect(Y2Partitioner::Widgets::PervasiveOptions).to receive(:new)
+      subject.refresh(pervasive)
     end
 
     it "replaces the content using the new generated content" do
@@ -66,6 +73,9 @@ describe Y2Partitioner::Widgets::EncryptMethodOptions do
 
       expect(subject).to receive(:replace).with(fake_luks1_options)
       subject.refresh(luks1)
+
+      expect(subject).to receive(:replace).with(fake_pervasive_options)
+      subject.refresh(pervasive)
     end
   end
 
@@ -90,9 +100,132 @@ describe Y2Partitioner::Widgets::EncryptMethodOptions do
 
     describe "#contents" do
       it "displays the encryption password widget" do
-        expect(Y2Partitioner::Widgets::EncryptPassword).to receive(:new).with(controller, anything)
+        widget = subject.contents.nested_find { |i| i.is_a?(Y2Partitioner::Widgets::EncryptPassword) }
 
-        subject.contents
+        expect(widget).to_not be_nil
+      end
+    end
+  end
+
+  describe Y2Partitioner::Widgets::PervasiveOptions do
+    subject { described_class.new(controller) }
+
+    before do
+      allow(Yast2::Popup).to receive(:show)
+    end
+
+    include_examples "CWM::CustomWidget"
+
+    describe "#contents" do
+      before do
+        allow(controller).to receive(:online_apqns).and_return(apqns)
+      end
+
+      let(:apqns) { [] }
+
+      let(:apqn1) { instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "01.0001") }
+
+      let(:apqn2) { instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "01.0002") }
+
+      it "displays the encryption password widget" do
+        widget = subject.contents.nested_find { |i| i.is_a?(Y2Partitioner::Widgets::EncryptPassword) }
+
+        expect(widget).to_not be_nil
+      end
+
+      context "when there are more than one online APQNs" do
+        let(:apqns) { [apqn1, apqn2] }
+
+        it "displays the APQN selector widget" do
+          widget = subject.contents.nested_find { |i| i.is_a?(Y2Partitioner::Widgets::ApqnSelector) }
+
+          expect(widget).to_not be_nil
+        end
+      end
+
+      context "when there is only one online APQN" do
+        let(:apqns) { [apqn1] }
+
+        it "does not display the APQN selector widget" do
+          widget = subject.contents.nested_find { |i| i.is_a?(Y2Partitioner::Widgets::ApqnSelector) }
+
+          expect(widget).to be_nil
+        end
+      end
+    end
+
+    describe "#validate" do
+      before do
+        allow(Y2Partitioner::Widgets::ApqnSelector).to receive(:new).and_return(apqn_widget)
+
+        allow(controller).to receive(:online_apqns).and_return(apqns)
+
+        allow(controller).to receive(:test_secure_key_generation).and_return(generation_test_error)
+      end
+
+      let(:apqn_widget) { instance_double(Y2Partitioner::Widgets::ApqnSelector, value: selected_apqns) }
+
+      let(:apqns) { [apqn1, apqn2] }
+
+      let(:selected_apqns) { [apqn1, apqn2] }
+
+      let(:apqn1) { instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "01.0001") }
+
+      let(:apqn2) { instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "01.0002") }
+
+      context "and the secure key cannot be generated" do
+        let(:generation_test_error) { "error" }
+
+        it "returns false" do
+          expect(subject.validate).to eq(false)
+        end
+
+        context "when there are more than one selected APQNs" do
+          let(:selected_apqns) { [apqn1, apqn2] }
+
+          it "shows an specific error" do
+            expect(Yast2::Popup).to receive(:show)
+              .with(/all selected APQNs are configured/, headline: :error, details: "error")
+
+            subject.validate
+          end
+        end
+
+        context "when there is only one selected APQN" do
+          let(:selected_apqns) { [apqn1] }
+
+          it "shows an specific error" do
+            expect(Yast2::Popup).to receive(:show)
+              .with(/the selected APQN is configured/, headline: :error, details: "error")
+
+            subject.validate
+          end
+        end
+
+        context "when there is no selected APQN" do
+          let(:selected_apqns) { [] }
+
+          it "shows an specific error" do
+            expect(Yast2::Popup).to receive(:show)
+              .with(/all available APQNs are configured/, headline: :error, details: "error")
+
+            subject.validate
+          end
+        end
+      end
+
+      context "and the secure key can be generated" do
+        let(:generation_test_error) { nil }
+
+        it "does not show an error" do
+          expect(Yast2::Popup).to_not receive(:show)
+
+          subject.validate
+        end
+
+        it "returns true" do
+          expect(subject.validate).to eq(true)
+        end
       end
     end
   end

--- a/test/y2partitioner/widgets/encrypt_password_test.rb
+++ b/test/y2partitioner/widgets/encrypt_password_test.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env rspec
 
-#
 # Copyright (c) [2018] SUSE LLC
 #
 # All Rights Reserved.

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -1307,6 +1307,19 @@ describe Y2Storage::BlkDevice do
       let(:enc) { device.encrypt(dm_name: "cr_manual", method: method) }
 
       include_examples "given method"
+
+      context "and the method is pervasive encryption" do
+        let(:method) { Y2Storage::EncryptionMethod::PERVASIVE_LUKS2 }
+
+        let(:apqn) { instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "01.0001") }
+
+        it "creates the encryption with the given APQNs" do
+          enc = device.encrypt(dm_name: "cr_manual", method: method, apqns: [apqn])
+
+          expect(enc).to be_a Y2Storage::Encryption
+          expect(enc.encryption_process.apqns).to contain_exactly(apqn)
+        end
+      end
     end
 
     context "when a name is provided with no password" do

--- a/test/y2storage/encryption_method_test.rb
+++ b/test/y2storage/encryption_method_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2019-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -55,11 +55,10 @@ describe Y2Storage::EncryptionMethod do
     end
 
     before do
-      allow(Yast::Execute).to receive(:locally!).with(/lszcrypt/, "--verbose", stdout: :capture)
-        .and_return lszcrypt
+      allow(Yast::Execute).to receive(:locally!).with(/lszcrypt/, anything).and_return(lszcrypt)
     end
 
-    let(:lszcrypt) { nil }
+    let(:lszcrypt) { "" }
 
     context "if there are online Crypto Express CCA coprocessors" do
       let(:lszcrypt) { lszcrypt_output("ok") }
@@ -80,7 +79,7 @@ describe Y2Storage::EncryptionMethod do
     end
 
     context "if secure AES keys are not supported" do
-      let(:lszcrypt) { nil }
+      let(:lszcrypt) { "" }
 
       it "returns methods for LUKS1 and random swap" do
         expect(described_class.available.map(&:to_sym))
@@ -89,11 +88,9 @@ describe Y2Storage::EncryptionMethod do
     end
 
     context "if the lszcrypt tool is not available" do
-      let(:lszcrypt) { nil }
-
       before do
-        allow(Yast::Execute).to receive(:locally!).with(/lszcrypt/, "--verbose", stdout: :capture)
-          .and_raise Cheetah::ExecutionFailed
+        allow(Yast::Execute).to receive(:locally!).with(/lszcrypt/, anything)
+          .and_raise Cheetah::ExecutionFailed.new("", "", "", "")
       end
 
       it "returns methods for LUKS1 and random swap" do

--- a/test/y2storage/encryption_processes/apqn_test.rb
+++ b/test/y2storage/encryption_processes/apqn_test.rb
@@ -1,0 +1,92 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::EncryptionProcesses::Apqn do
+  def lszcrypt(file)
+    File.read(File.join(DATA_PATH, "lszcrypt", "#{file}.txt"))
+  end
+
+  before do
+    Y2Storage::StorageManager.create_test_instance
+
+    allow(Yast::Execute).to receive(:locally!).with(/lszcrypt/, anything).and_return(lszcrypt_output)
+  end
+
+  let(:lszcrypt_output) { lszcrypt("three-apqns") }
+
+  describe ".all" do
+    it "returns a list of Apqn objets" do
+      expect(described_class.all).to all(be_a(Y2Storage::EncryptionProcesses::Apqn))
+    end
+
+    it "returns all available APQNs" do
+      expect(described_class.all.map(&:name)).to contain_exactly("01.0001", "01.0002", "01.0003")
+    end
+
+    context "when the command to find APQNs fails" do
+      before do
+        allow(Yast::Execute).to receive(:locally!).with(/lszcrypt/, anything)
+          .and_raise(Cheetah::ExecutionFailed.new("", "", "", ""))
+      end
+
+      it "returns an empty list" do
+        expect(described_class.all).to be_empty
+      end
+    end
+  end
+
+  describe ".online" do
+    it "returns all online APQNs" do
+      expect(described_class.online.map(&:name)).to contain_exactly("01.0001", "01.0003")
+    end
+  end
+
+  subject { described_class.new("01.0001", "type", "mode", status) }
+
+  let(:status) { "online" }
+
+  describe "#name" do
+    it "returns the APQN name" do
+      expect(subject.name).to eq("01.0001")
+    end
+  end
+
+  describe "online?" do
+    context "when the APQN is online" do
+      let(:status) { "online" }
+
+      it "returns true" do
+        expect(subject.online?).to eq(true)
+      end
+    end
+
+    context "when the APQN is offline" do
+      let(:status) { "offline" }
+
+      it "returns false" do
+        expect(subject.online?).to eq(false)
+      end
+    end
+  end
+end

--- a/test/y2storage/encryption_processes/pervasive_test.rb
+++ b/test/y2storage/encryption_processes/pervasive_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2019] SUSE LLC
+
+# Copyright (c) [2019-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -84,9 +85,11 @@ describe Y2Storage::EncryptionProcesses::Pervasive do
   end
 
   describe "#pre_commit" do
-    let(:encryption) { subject.create_device(blk_device, dm_name) }
+    let(:encryption) { subject.create_device(blk_device, dm_name, apqns: [apqn]) }
 
     let(:secure_key) { nil }
+
+    let(:apqn) { instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "01.0001") }
 
     let(:generated_key) do
       instance_double(Y2Storage::EncryptionProcesses::SecureKey,
@@ -102,7 +105,7 @@ describe Y2Storage::EncryptionProcesses::Pervasive do
 
     it "generates a new secure key for the device" do
       expect(Y2Storage::EncryptionProcesses::SecureKey).to receive(:generate)
-        .with("YaST_cr_sda", sector_size: 4096).and_return(generated_key)
+        .with("YaST_cr_sda", sector_size: 4096, apqns: [apqn]).and_return(generated_key)
       subject.pre_commit(encryption)
     end
 

--- a/test/y2storage/encryption_processes/secure_key_test.rb
+++ b/test/y2storage/encryption_processes/secure_key_test.rb
@@ -1,4 +1,6 @@
-# Copyright (c) [2019] SUSE LLC
+#!/usr/bin/env rspec
+
+# Copyright (c) [2019-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -16,6 +18,7 @@
 #
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
+
 require_relative "../spec_helper"
 require "y2storage"
 
@@ -24,69 +27,161 @@ describe Y2Storage::EncryptionProcesses::SecureKey do
     File.read(File.join(DATA_PATH, "zkey", "#{file}.txt"))
   end
 
-  subject(:key) { described_class.new("cr", sector_size: 2048) }
+  before do
+    fake_scenario("several-dasds")
+
+    allow(Yast::Execute).to receive(:locally).with(/zkey/, "list", anything).and_return(zkey_list)
+  end
+
+  let(:zkey_list) { zkey_output("list-no-dasdc1") }
+
+  let(:devicegraph) { Y2Storage::StorageManager.instance.staging }
 
   describe ".for_device" do
-    before do
-      fake_scenario("several-dasds")
-
-      allow(Yast::Execute).to receive(:locally).with(/zkey/, "list", any_args)
-        .and_return(zkey_list)
-    end
-
-    let(:manager) { Y2Storage::StorageManager.instance }
-    let(:zkey_list) { zkey_output("list-no-dasdc1") }
-    let(:blk_device) { manager.staging.find_by_name("/dev/dasdb1") }
+    let(:device) { devicegraph.find_by_name("/dev/dasdb1") }
 
     it "returns the secure key for the given device" do
-      key = described_class.for_device(blk_device)
-      expect(key).to be_for_device(blk_device)
+      key = described_class.for_device(device)
+
+      expect(key).to be_for_device(device)
       expect(key.sector_size).to eq(4096)
     end
   end
 
   describe ".new_from_zkey" do
-    let(:zkey_list) { zkey_output("list-no-dasdc1") }
-
     it "returns a secure key using the values from the string" do
       key = described_class.new_from_zkey(zkey_list)
+
       expect(key.sector_size).to eq(4096)
     end
 
     context "when the sector size is not defined" do
       let(:zkey_list) { zkey_output("list-no-sector-size") }
+
       it "sets the sector size to nil" do
         key = described_class.new_from_zkey(zkey_list)
+
         expect(key.sector_size).to be_nil
       end
     end
   end
 
-  describe "#generate" do
-    it "runs zkey to create the LUKS2 key with the given name and sector size" do
-      expect(Yast::Execute).to receive(:locally).with(
-        "/usr/bin/zkey", "generate", "--name", key.name, "--xts", "--keybits", "256",
-        "--volume-type", "LUKS2", "--sector-size", key.sector_size.to_s
+  shared_examples "zkey_generate" do |testing_method, execute_method|
+    it "runs zkey to create the LUKS2" do
+      expect(Yast::Execute).to receive(execute_method).with(
+        "/usr/bin/zkey", "generate", "-V", "--name", "YaST_cr", "--xts", "--keybits", "256",
+        "--volume-type", "LUKS2"
       )
-      key.generate
+
+      described_class.send(testing_method, "YaST_cr")
     end
 
-    context "when sector size is not set" do
-      subject(:key) { described_class.new("cr") }
+    context "when the given secure key name already exists" do
+      let(:name) { "YaST_cr_dasdc1" }
 
-      it "does not specify any sector size value" do
-        expect(Yast::Execute).to receive(:locally) do |*args|
-          expect(args).to_not include("--sector-size")
-        end
+      it "ensures uniq name by adding a suffix number" do
+        expect(Yast::Execute).to receive(execute_method).with(
+          "/usr/bin/zkey", "generate", "-V", "--name", "YaST_cr_dasdc1_1", "--xts", "--keybits", "256",
+          "--volume-type", "LUKS2"
+        )
 
-        key.generate
+        described_class.send(testing_method, name)
+      end
+    end
+
+    context "when a sector size is given" do
+      let(:params) { { sector_size: 2048 } }
+
+      it "runs zkey with the given sector size" do
+        expect(Yast::Execute).to receive(execute_method).with(
+          "/usr/bin/zkey", "generate", "-V", "--name", "YaST_cr", "--xts", "--keybits", "256",
+          "--volume-type", "LUKS2", "--sector-size", "2048"
+        )
+
+        described_class.send(testing_method, "YaST_cr", params)
+      end
+    end
+
+    context "when volumes are given" do
+      let(:params) { { volumes: volumes } }
+
+      before do
+        device = devicegraph.find_by_name("/dev/dasdc1")
+        device.create_encryption("cr_test")
+      end
+
+      let(:encryption) { devicegraph.find_by_name("/dev/mapper/cr_test") }
+
+      let(:volumes) { [encryption] }
+
+      it "runs zkey with the given volumnes" do
+        expect(Yast::Execute).to receive(execute_method).with(
+          "/usr/bin/zkey", "generate", "-V", "--name", "YaST_cr", "--xts", "--keybits", "256",
+          "--volume-type", "LUKS2", "--volumes", "/dev/dasdc1:cr_test"
+        )
+
+        described_class.send(testing_method, "YaST_cr", params)
+      end
+    end
+
+    context "when APQNs are given" do
+      let(:params) { { apqns: [apqn1, apqn2] } }
+
+      let(:apqn1) { instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "01.0001") }
+      let(:apqn2) { instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "01.0002") }
+
+      it "runs zkey with the given APQNs" do
+        expect(Yast::Execute).to receive(execute_method).with(
+          "/usr/bin/zkey", "generate", "-V", "--name", "YaST_cr", "--xts", "--keybits", "256",
+          "--volume-type", "LUKS2", "--apqns", "01.0001,01.0002"
+        )
+
+        described_class.send(testing_method, "YaST_cr", params)
       end
     end
   end
 
+  describe ".generate" do
+    it "returns a secure key" do
+      allow(Yast::Execute).to receive(:locally)
+
+      expect(described_class.generate("YaST_cr")).to be_a(Y2Storage::EncryptionProcesses::SecureKey)
+    end
+
+    include_examples "zkey_generate", :generate, :locally
+  end
+
+  describe ".generate!" do
+    context "when the key can be generated" do
+      before do
+        allow(Yast::Execute).to receive(:locally!).with(/zkey/, "generate", any_args)
+      end
+
+      it "returns a secure key" do
+        expect(described_class.generate!("YaST_cr")).to be_a(Y2Storage::EncryptionProcesses::SecureKey)
+      end
+    end
+
+    context "when the key cannot be generated" do
+      before do
+        allow(Yast::Execute).to receive(:locally!).with(/zkey/, "generate", any_args).and_raise(an_error)
+      end
+
+      let(:an_error) { RuntimeError }
+
+      it "raises an error" do
+        expect { described_class.generate!("YaST_cr") }.to raise_error(an_error)
+      end
+    end
+
+    include_examples "zkey_generate", :generate!, :locally!
+  end
+
   describe "#filename" do
+    subject { described_class.new("cr", sector_size: 2048) }
+
     it "returns the correct filename" do
-      expect(key.filename).to eq("/etc/zkey/repository/cr.skey")
+      expect(subject.filename).to eq("/etc/zkey/repository/cr.skey")
     end
   end
 
@@ -99,11 +194,23 @@ describe Y2Storage::EncryptionProcesses::SecureKey do
       instance_double(Y2Storage::Encryption, blk_device: blk_device, dm_table_name: "cr_1")
     end
 
+    subject { described_class.new("cr", sector_size: 2048) }
+
     it "calls zkey to add the volume" do
       expect(Yast::Execute).to receive(:locally).with(/zkey/, "change", "--name", "cr",
         "--volumes", "+/dev/dasdc1:cr_1", any_args)
 
-      key.add_device_and_write(device)
+      subject.add_device_and_write(device)
+    end
+  end
+
+  describe "#remove" do
+    subject { described_class.new("cr_YaST") }
+
+    it "runs zkey remove" do
+      expect(Yast::Execute).to receive(:locally!).with(/zkey/, "remove", "--force", "--name", "cr_YaST")
+
+      subject.remove
     end
   end
 end

--- a/test/y2storage/pervasive_encryption_test.rb
+++ b/test/y2storage/pervasive_encryption_test.rb
@@ -165,7 +165,7 @@ describe "pervasive encryption" do
 
       it "tries to generate a new secure key with the appropriate name and arguments" do
         expect(Yast::Execute).to receive(:locally).with(
-          /zkey/, "generate", "--name", "YaST_cr_dasdc1_1", "--xts", "--keybits", "256",
+          /zkey/, "generate", "-V", "--name", "YaST_cr_dasdc1_1", "--xts", "--keybits", "256",
           "--volume-type", "LUKS2", "--sector-size", "4096"
         )
 


### PR DESCRIPTION
## Problem

When a device is going to be encrypted with pervasive encryption (s390), a new secure key is generated for the device (if there is none yet). By default, this new secure key will be generated for all adapters/domains available in the system. But this could fail when the adapters/domains are set with different master keys. In that case, only adapters using the same master key should be taken into account for generating the new secure key.  

* https://jira.suse.com/browse/IBM-495?focusedCommentId=974832&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-974832

* https://trello.com/c/KwTmeWhi/1587-5-sle-7376-pervasive-encryption-second-round-specifying-the-apqns


## Solution

Now, the dialog for pervasive encryption allows to select APQNs when a new secure key is going to be generated. An error is shown when the secure key cannot be generated with the selected APQNs.

Theoretically, *zkey generate* command should fail when the APQNs used to generate the secure key are configured with different master keys. But, according to my tests, the command does not fail in that case. It only fails when none of the given APQNs are configured with a master key.   


## Testing

* Added unit tests.
* Manually tested.

## Screenshots

<details>
<summary>Show/Hide</summary>

![Screenshot from 2020-01-27 15-15-45](https://user-images.githubusercontent.com/1112304/73194084-83da3d00-4123-11ea-862a-7896908d7aa1.png)

![Screenshot from 2020-02-28 17-34-28](https://user-images.githubusercontent.com/1112304/75571343-e25f4780-5a50-11ea-801e-bbc8d9a92942.png)

</details>
