### PR TITLE
reduce size of dialogs

### DIFF
--- a/doc/user-stories/expert-partitioner.md
+++ b/doc/user-stories/expert-partitioner.md
@@ -357,7 +357,6 @@ The specs are based on current version of expert partitioner for TW. The goal is
     * Mount in /etc/fstab by: Device name, Volume label, UUID (default), Device ID, Device path
     * Volume label:
     * Mount Read-only: false
-    * No access time: false
     * Mountable by user: false
     * Do not mount at system start-up: false
     * *(pending) Arbitrary option value: subvol=@*
@@ -366,32 +365,25 @@ The specs are based on current version of expert partitioner for TW. The goal is
     * Mount in /etc/fstab by: Device name, Volume label, UUID (default), Device ID, Device path.
     * Volume label:
     * Mount Read-only: false
-    * No access time: false
     * Mountable by user: false
     * Do not mount at system start-up: false
     * Enable quota support: false
-    * Access control lists (ACL): true
-    * Extended user attributes: true
     * Arbitrary option value:
 * and 'File system' is EXT3 or EXT4
   * shows a dialog with the following fields
     * Mount in /etc/fstab by: Device name, Volume label, UUID (default), Device ID, Device path.
     * Volume label:
     * Mount Read-only: false
-    * No access time: false
     * Mountable by user: false
     * Do not mount at system start-up: false
     * Enable quota support: false
     * Data journaling mode: journal, ordered (default), writeback
-    * Access control lists (ACL): true
-    * Extended user attributes: true
     * Arbitrary option value:
 * and 'File system' is FAT
   * shows a dialog with the following fields
     * Mount in /etc/fstab by: Device name, Volume label, UUID (default), Device ID, Device path.
     * Volume label:
     * Mount Read-only: false
-    * No access time: false
     * Mountable by user: false
     * Do not mount at system start-up: false
     * *(pending) Charset for file names: iso, utf8, etc (default blank)*
@@ -402,7 +394,6 @@ The specs are based on current version of expert partitioner for TW. The goal is
     * Mount in /etc/fstab by: Device name, Volume label, UUID (default), Device ID, Device path.
     * Volume label:
     * Mount Read-only: false
-    * No access time: false
     * Mountable by user: false
     * Do not mount at system start-up: false
     * Enable quota support: false

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -2,6 +2,8 @@
 Fri Jan 24 14:08:28 CET 2020 - aschnell@suse.com
 
 - reduce min height of dialogs (bsc#1161651)
+- drop noatime, acl and xattr options in "Fstab Options" dialog
+  (bsc#1135723)
 - 4.2.78
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 24 14:08:28 CET 2020 - aschnell@suse.com
+
+- reduce min height of dialogs (bsc#1161651)
+- 4.2.78
+
+-------------------------------------------------------------------
 Thu Jan 23 15:56:36 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Avoided crash when libstorage-ng provides a non-UTF string as

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -4,6 +4,8 @@ Fri Jan 24 14:08:28 CET 2020 - aschnell@suse.com
 - reduce min height of dialogs (bsc#1161651)
 - drop noatime, acl and xattr options in "Fstab Options" dialog
   (bsc#1135723)
+- change mount by method to combobox in "Fstab Options" dialog
+  (bsc#1135723)
 - 4.2.78
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.77
+Version:        4.2.78
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/dialogs/popup.rb
+++ b/src/lib/y2partitioner/dialogs/popup.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -37,13 +37,10 @@ module Y2Partitioner
 
       def layout
         VBox(
-          HSpacing(50),
           Left(Heading(Id(:title), title)),
-          VStretch(),
           VSpacing(1),
-          MinSize(min_width, min_height, ReplacePoint(Id(:contents), Empty())),
-          VSpacing(1),
-          VStretch(),
+          VCenter(MinSize(min_width, min_height, ReplacePoint(Id(:contents), Empty()))),
+          VSpacing(0.45),
           ButtonBox(*buttons)
         )
       end
@@ -61,7 +58,7 @@ module Y2Partitioner
       #
       # @return [Integer]
       def min_height
-        18
+        14
       end
 
       def ok_button_label

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -212,7 +212,6 @@ module Y2Partitioner
             VSpacing(1),
             Left(GeneralOptions.new(@controller)),
             Left(FilesystemsOptions.new(@controller)),
-            Left(AclOptions.new(@controller)),
             * ui_term_with_vspace(JournalOptions.new(@controller)),
             Left(ArbitraryOptions.new(@controller, self))
           )
@@ -451,7 +450,6 @@ module Y2Partitioner
       def widgets
         [
           ReadOnly.new(@controller),
-          Noatime.new(@controller),
           MountUser.new(@controller),
           Noauto.new(@controller),
           Quota.new(@controller)
@@ -518,23 +516,6 @@ module Y2Partitioner
       end
     end
 
-    # CheckBox to enable the noatime option
-    class Noatime < FstabCheckBox
-      # Possible values of the widget
-      VALUES = ["noatime", "atime"].freeze
-
-      # @macro seeAbstractWidget
-      def label
-        _("No &Access Time")
-      end
-
-      # @macro seeAbstractWidget
-      def help
-        _("<p><b>No Access Time:</b>\nAccess times are not " \
-        "updated when a file is read. Default is false.</p>\n")
-      end
-    end
-
     # CheckBox to enable the user option which means allow to mount the
     # filesystem by an ordinary user
     class MountUser < FstabCheckBox
@@ -581,65 +562,6 @@ module Y2Partitioner
       def store
         delete_fstab_option!(Regexp.union(VALUES))
         add_fstab_options("usrquota", "grpquota") if value
-      end
-    end
-
-    # A group of options related to ACLs (access control lists)
-    class AclOptions < CWM::CustomWidget
-      include FstabCommon
-
-      # @macro seeCustomWidget
-      def contents
-        return Empty() unless widgets.any?(&:supported_by_filesystem?)
-
-        VBox(* widgets.map { |w| to_ui_term(w) }, VSpacing(1))
-      end
-
-      def widgets
-        [
-          Acl.new(@controller),
-          UserXattr.new(@controller)
-        ]
-      end
-    end
-
-    # CheckBox to enable access control lists (acl)
-    class Acl < FstabCheckBox
-      include FstabCommon
-
-      # Possible values of the widget
-      VALUES = ["acl", "noacl"].freeze
-
-      # @macro seeAbstractWidget
-      def label
-        _("&Access Control Lists (ACL)")
-      end
-
-      # @macro seeAbstractWidget
-      def help
-        _("<p><b>Access Control Lists (acl):</b>\n" \
-          "Enable POSIX access control lists and thus more fine-grained " \
-          "user permissions on the file system. See also man 5 acl.\n")
-      end
-    end
-
-    # CheckBox to enable extended user attributes (user_xattr)
-    class UserXattr < FstabCheckBox
-      include FstabCommon
-
-      # Possible values of the widget
-      VALUES = ["user_xattr", "nouser_xattr"].freeze
-
-      # @macro seeAbstractWidget
-      def label
-        _("&Extended User Attributes")
-      end
-
-      # @macro seeAbstractWidget
-      def help
-        _("<p><b>Extended User Attributes (user_xattr):</b>\n" \
-          "Enable extended attributes (name:value pairs) on files and directories.\n" \
-          "This is an extension to ACLs. See also man 7 xattr.\n")
       end
     end
 

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -35,10 +35,8 @@ module Y2Storage
       # See "man mount" for all those options.
       COMMON_FSTAB_OPTIONS = ["async", "atime", "noatime", "user", "nouser",
                               "auto", "noauto", "ro", "rw", "defaults"].freeze
-      EXT_FSTAB_OPTIONS = ["dev", "nodev", "usrquota", "grpquota", "acl",
-                           "noacl", "user_xattr", "nouser_xattr"].freeze
+      EXT_FSTAB_OPTIONS = ["dev", "nodev", "usrquota", "grpquota"].freeze
       JOURNAL_OPTIONS = ["data=ordered"].freeze
-      ACL_OPTIONS = ["acl", "user_xattr"].freeze
 
       # For "iocharset" and "codepage" the value will be added on demand.
       #
@@ -129,12 +127,10 @@ module Y2Storage
           name:          "XFS"
         },
         iso9660:   {
-          fstab_options: ["acl", "noacl"],
-          name:          "ISO9660"
+          name: "ISO9660"
         },
         udf:       {
-          fstab_options: ["acl", "noacl"],
-          name:          "UDF"
+          name: "UDF"
         },
         bitlocker: {
           name: "BitLocker"
@@ -175,7 +171,7 @@ module Y2Storage
       private_constant :PROPERTIES, :ROOT_FILESYSTEMS, :HOME_FILESYSTEMS,
         :COMMON_FSTAB_OPTIONS, :EXT_FSTAB_OPTIONS, :LEGACY_ROOT_FILESYSTEMS,
         :LEGACY_HOME_FILESYSTEMS, :ZIPL_FILESYSTEMS, :JOURNAL_OPTIONS,
-        :ACL_OPTIONS, :IOCHARSET_OPTIONS, :CODEPAGE_OPTIONS, :LANG_ENCODINGS
+        :IOCHARSET_OPTIONS, :CODEPAGE_OPTIONS, :LANG_ENCODINGS
 
       # Allowed filesystems for root
       #

--- a/test/y2partitioner/widgets/fstab_options_test.rb
+++ b/test/y2partitioner/widgets/fstab_options_test.rb
@@ -162,12 +162,11 @@ describe Y2Partitioner::Widgets do
       allow(subject).to receive(:value).and_return(:uuid)
     end
 
-    include_examples "CWM::CustomWidget"
+    include_examples "CWM::ComboBox"
     include_examples "CWM::AbstractWidget#init#store"
 
-    describe "#init" do
+    describe "#items" do
       before do
-        allow(Yast::UI).to receive(:ChangeWidget).and_call_original
         allow(controller).to receive(:mount_point).and_return(mount_point)
         allow(mount_point).to receive(:suitable_mount_bys).and_return(possible_mount_bys)
       end
@@ -185,10 +184,12 @@ describe Y2Partitioner::Widgets do
         ]
       end
 
-      it "disables not suitable mount bys" do
-        expect(Yast::UI).to receive(:ChangeWidget).once.with(Id(:label), :Enabled, false)
-        expect(Yast::UI).to receive(:ChangeWidget).once.with(Id(:id), :Enabled, false)
-        subject.init
+      it "only includes the allowed mount bys" do
+        expect(subject.items).to eq [
+          ["device", "Device Name"],
+          ["path", "Device Path"],
+          ["uuid", "UUID"]
+        ]
       end
     end
   end

--- a/test/y2partitioner/widgets/fstab_options_test.rb
+++ b/test/y2partitioner/widgets/fstab_options_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -205,10 +205,6 @@ describe Y2Partitioner::Widgets do
     include_examples "FstabCheckBox"
   end
 
-  describe Y2Partitioner::Widgets::Noatime do
-    include_examples "FstabCheckBox"
-  end
-
   describe Y2Partitioner::Widgets::MountUser do
     include_examples "FstabCheckBox"
   end
@@ -220,10 +216,6 @@ describe Y2Partitioner::Widgets do
   describe Y2Partitioner::Widgets::JournalOptions do
     include_examples "CWM::ComboBox"
     include_examples "CWM::AbstractWidget#init#store"
-  end
-
-  describe Y2Partitioner::Widgets::AclOptions do
-    include_examples "CWM::CustomWidget"
   end
 
   describe Y2Partitioner::Widgets::ArbitraryOptions do


### PR DESCRIPTION
## Problem

Some dialogs do not fit on small screens, neither ncurses nor qt UI.

- https://trello.com/c/YWiwQnng/1580-3-leap-151-p3-1135723-installation-fstab-options-window-extended-below-screen-bottom-on-1280x800-screen
- https://bugzilla.suse.com/show_bug.cgi?id=1135723
- https://bugzilla.suse.com/show_bug.cgi?id=1161651

## Solution

Drop some obsolete options:

- noatime (likely not use often since relatime is the default for years)
- acl and xattrs (default for years; not supported for UDF)

Replace the five radio buttons for the mount by method by a combobox.

User can still enable options using the text field for arbitrary options.

## Testing

- Adapted unit test.
- Tested manually.

## Screenshots

![ncurses](https://user-images.githubusercontent.com/908062/73072156-d235d480-3eb4-11ea-9476-9bec9fa46470.png)
