### PR TITLE
Added package requirement for UF_PLAIN_ENCRYPTION (bsc#1160773)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 29 10:00:18 UTC 2020 - Christopher Hofmann <cwh@suse.com>
+
+- Added package requirement for UF_PLAIN_ENCRYPTION (bsc#1160773)
+- 4.2.80
+
+-------------------------------------------------------------------
 Tue Jan 28 20:20:50 CET 2020 - aschnell@suse.com
 
 - also mask swap units in mask-systemd-units (bsc#1152545)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.79
+Version:        4.2.80
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/used_storage_features.rb
+++ b/src/lib/y2storage/used_storage_features.rb
@@ -52,39 +52,39 @@ module Y2Storage
     FEATURE_PACKAGES =
       {
         # SUSE standard technologies
-        UF_LVM:           "lvm2",
+        UF_LVM:              "lvm2",
         # Btrfs needs e2fsprogs for 'lsattr' and 'chattr' to check for CoW
-        UF_BTRFS:         ["btrfsprogs", "e2fsprogs"],
-        UF_SNAPSHOTS:     "snapper",
+        UF_BTRFS:            ["btrfsprogs", "e2fsprogs"],
+        UF_SNAPSHOTS:        "snapper",
 
         # RAID technologies and related
-        UF_DM:            "device-mapper",
-        UF_MULTIPATH:     ["device-mapper", "multipath-tools"],
-        UF_DMRAID:        ["device-mapper", "dmraid"],
-        UF_MDRAID:        "mdadm",
+        UF_DM:               "device-mapper",
+        UF_MULTIPATH:        ["device-mapper", "multipath-tools"],
+        UF_DMRAID:           ["device-mapper", "dmraid"],
+        UF_MDRAID:           "mdadm",
 
         # Other filesystems
-        UF_EXT2:          "e2fsprogs",
-        UF_EXT3:          "e2fsprogs",
-        UF_EXT4:          "e2fsprogs",
-        UF_XFS:           "xfsprogs",
-        UF_REISERFS:      "reiserfs",
-        UF_NFS:           "nfs-client",
-        UF_NTFS:          ["ntfs-3g", "ntfsprogs"],
-        UF_VFAT:          "dosfstools",
+        UF_EXT2:             "e2fsprogs",
+        UF_EXT3:             "e2fsprogs",
+        UF_EXT4:             "e2fsprogs",
+        UF_XFS:              "xfsprogs",
+        UF_REISERFS:         "reiserfs",
+        UF_NFS:              "nfs-client",
+        UF_NTFS:             ["ntfs-3g", "ntfsprogs"],
+        UF_VFAT:             "dosfstools",
 
         # Crypto technologies
-        UF_LUKS:          "cryptsetup",
-        UF_CRYPT_TWOFISH: "cryptsetup",
+        UF_LUKS:             "cryptsetup",
+        UF_PLAIN_ENCRYPTION: "cryptsetup",
 
         # Data transport methods
-        UF_ISCSI:         "open-iscsi",
-        UF_FCOE:          "fcoe-utils",
-        UF_FC:            [],
+        UF_ISCSI:            "open-iscsi",
+        UF_FCOE:             "fcoe-utils",
+        UF_FC:               [],
 
         # Other
-        UF_QUOTA:         "quota",
-        UF_BCACHE:        "bcache-tools",
+        UF_QUOTA:            "quota",
+        UF_BCACHE:           "bcache-tools",
 
         # FIXME: This is not related to the devicegraph, so libstorage doesn't
         # return it yet. The "efibootmgr" package is available in the inst-sys
@@ -92,8 +92,8 @@ module Y2Storage
         # system: Only if the user wishes to delete a partition (e.g. his
         # Windows partition) the EFI bootloader could boot from. Adding a
         # partition to it is handled by yast-bootloader in the inst-sys.
-        UF_EFIBOOT:       "efibootmgr",
-        UF_UDF:           "udftools"
+        UF_EFIBOOT:          "efibootmgr",
+        UF_UDF:              "udftools"
       }
 
     # Storage-related packages that are nice to have, but not absolutely


### PR DESCRIPTION
## Problem

When user tries to encrypt a swap partition using YaST the error message "Command not found: "/sbin/cryptsetup…" appears instead of a request to install that package.

libstorage suggests UF_PLAIN_ENCRYPTION for encrypting swap, but the package requirement for that feature was missing in yast-storage-ng. So the package `cryptsetup` was not installed before commiting the changes.

- [bsc#1160773](https://bugzilla.suse.com/show_bug.cgi?id=1160773)

## Solution

Added package requirement for `cryptsetup` to UF_PLAIN_ENCRYPTION in yast-storage-ng.

By this opportunity removed the obsolete feature UF_CRYPT_TWOFISH which libstorage does not use any more.


## Testing

- Tested manually


## Screenshots

![image](https://user-images.githubusercontent.com/336868/73255466-7b840f80-41c0-11ea-896c-ed5666eaab12.png)

