### PR TITLE
also mask swap units in mask-systemd-units

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 28 20:20:50 CET 2020 - aschnell@suse.com
+
+- also mask swap units in mask-systemd-units (bsc#1152545)
+- 4.2.79
+
+-------------------------------------------------------------------
 Fri Jan 24 14:08:28 CET 2020 - aschnell@suse.com
 
 - reduce min height of dialogs (bsc#1161651)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.78
+Version:        4.2.79
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/bin/mask-systemd-units
+++ b/src/bin/mask-systemd-units
@@ -23,9 +23,10 @@ query_units()
 	fi
 
 	# skip mount points below /dev, /run, /proc and /sys since these are
-	# usually not on block devices and masking them could maybe lead to
-	# problems
-	if [[ $unit == dev-* || $unit == run-* || $unit == proc-* || $unit == sys-* ]] ; then
+	# usually not on block devices (e.g. dev-hugepages.mount) and masking
+	# them could maybe lead to problems
+	if [[ $unit == dev-*.mount || $unit == run-*.mount || $unit == proc-*.mount ||
+	      $unit == sys-*.mount ]] ; then
 	   continue
 	fi
 
@@ -39,6 +40,7 @@ mask_units()
 {
     query_units | /usr/bin/xargs --verbose --no-run-if-empty --delimiter='\n' /usr/bin/systemctl --runtime $1 --
 }
+
 
 usage()
 {


### PR DESCRIPTION
## Problem

The mask-systemd-units did not mask swap units of systemd. Thus systemd could mount swaps while YaST was running causing failures when YaST tries to mount swaps.

- https://trello.com/c/BDMvJros/1570-3-sles15-sp2-p5-1152545-error-re-creating-plain-encryption
- https://bugzilla.suse.com/show_bug.cgi?id=1152545

## Solution

Also mask/unmask swap units (by not filtering them out).

## Testing

- Tested manually.
