### PR TITLE
Partitioner: fix button to delete all partitions (bsc#1162290) 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 31 16:49:28 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Partitioner: the button to delete all partitions does no longer
+  fail for devices containing logical partitions (bsc#1162290).
+- 4.2.81
+
+-------------------------------------------------------------------
 Tue Jan 29 10:00:18 UTC 2020 - Christopher Hofmann <cwh@suse.com>
 
 - Added package requirement for UF_PLAIN_ENCRYPTION (bsc#1160773)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.80
+Version:        4.2.81
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/delete_partitions.rb
+++ b/src/lib/y2partitioner/actions/delete_partitions.rb
@@ -39,7 +39,7 @@ module Y2Partitioner
       def delete
         log.info "deleting partitions from #{device}"
 
-        device.partitions.each { |p| device.partition_table.delete_partition(p) }
+        device.partition_table.delete_all_partitions
         UIState.instance.select_row(device)
       end
 

--- a/test/y2partitioner/actions/delete_partitions_test.rb
+++ b/test/y2partitioner/actions/delete_partitions_test.rb
@@ -123,19 +123,29 @@ describe Y2Partitioner::Actions::DeletePartitions do
       context "and the confirm message is accepted" do
         let(:accept) { true }
 
-        it "deletes the partitions" do
-          subject.run
+        RSpec.shared_examples "delete all partitions" do
+          it "deletes the partitions" do
+            subject.run
 
-          expect(device.partitions).to be_empty
+            expect(device.partitions).to be_empty
+          end
+
+          it "refreshes btrfs subvolumes shadowing" do
+            expect(Y2Storage::Filesystems::Btrfs).to receive(:refresh_subvolumes_shadowing)
+            subject.run
+          end
+
+          it "returns :finish" do
+            expect(subject.run).to eq(:finish)
+          end
         end
 
-        it "refreshes btrfs subvolumes shadowing" do
-          expect(Y2Storage::Filesystems::Btrfs).to receive(:refresh_subvolumes_shadowing)
-          subject.run
-        end
+        include_examples "delete all partitions"
 
-        it "returns :finish" do
-          expect(subject.run).to eq(:finish)
+        context "if there are some logical partitions" do
+          let(:scenario) { "spaces_4_4" }
+
+          include_examples "delete all partitions"
         end
       end
     end


### PR DESCRIPTION
## Problem

The "Delete all" button in the "Partitions" tab of any partitionable device failed when there were logical partitions involved.

- https://bugzilla.suse.com/show_bug.cgi?id=1162290

The Partitioner got the list of all partitions in the device and then iterated over that list deleting each. But after having deleted the extended partitions, the logical partitions were not longer there. Still, the Partitioner tried to delete the not-longer-existent partitions because they were in its list.

## Solution

Simply use the method `PartitionTables:Base#delete_all_partitions` that already have all that into account.

## Testing

- Added a new unit test
- Tested manually also
