### PR TITLE
allow to install packages needed for probing

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 06 15:09:57 CET 2020 - aschnell@suse.com
+
+- allow to install packages needed for probing
+- 4.2.84
+
+-------------------------------------------------------------------
 Wed Feb  5 12:38:51 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Partitioner: usability improved by remembering the last active

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.83
+Version:        4.2.84
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# Fix mount/unmount
-BuildRequires:	libstorage-ng-ruby >= 4.2.54
+# ProbeCallbacksV3
+BuildRequires:	libstorage-ng-ruby >= 4.2.59
 BuildRequires:  update-desktop-files
 # CWM::DynamicProgressBar
 BuildRequires:  yast2 >= 4.2.63
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# Fix mount/unmount
-Requires:       libstorage-ng-ruby >= 4.2.54
+# ProbeCallbacksV3
+Requires:       libstorage-ng-ruby >= 4.2.59
 # CWM::DynamicProgressBar
 Requires:       yast2 >= 4.2.63
 # Y2Packager::Repository

--- a/src/lib/y2storage/callbacks/probe.rb
+++ b/src/lib/y2storage/callbacks/probe.rb
@@ -35,7 +35,7 @@ module Y2Storage
       #   (in the ASCII-8BIT encoding! see https://sourceforge.net/p/swig/feature-requests/89/)
       # @param what [String] details coming from libstorage-ng (in the ASCII-8BIT encoding!)
       # @param command [String] missing command coming from libstorage-ng (in the ASCII-8BIT encoding!)
-      # @param used_features used features bit field coming from libstorage-ng
+      # @param used_features [Integer] used features bit field as integer coming from libstorage-ng
       #
       # @return [Boolean] true will make libstorage-ng ignore the error, false
       #   will result in a libstorage-ng exception

--- a/src/lib/y2storage/callbacks/probe.rb
+++ b/src/lib/y2storage/callbacks/probe.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 SUSE LLC
+# Copyright (c) [2018,2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -19,11 +19,116 @@
 
 require "y2storage/callbacks/libstorage_callback"
 
+Yast.import "Mode"
+Yast.import "Label"
+Yast.import "Popup"
+
 module Y2Storage
   module Callbacks
     # Class to implement callbacks used during libstorage-ng probe
-    class Probe < Storage::ProbeCallbacks
+    class Probe < Storage::ProbeCallbacksV3
       include LibstorageCallback
+
+      # Callback for missing commands during probing.
+      #
+      # @param message [String] error title coaming from libstorage-ng
+      #   (in the ASCII-8BIT encoding! see https://sourceforge.net/p/swig/feature-requests/89/)
+      # @param what [String] details coming from libstorage-ng (in the ASCII-8BIT encoding!)
+      # @param command [String] missing command coming from libstorage-ng (in the ASCII-8BIT encoding!)
+      # @param used_features used features bit field coming from libstorage-ng
+      #
+      # @return [Boolean] true will make libstorage-ng ignore the error, false
+      #   will result in a libstorage-ng exception
+      #
+      def missing_command(message, what, command, used_features)
+        textdomain "storage"
+
+        # force the UTF-8 encoding to avoid Encoding::CompatibilityError exception
+        message.force_encoding("UTF-8")
+        what.force_encoding("UTF-8")
+        command.force_encoding("UTF-8")
+
+        log.info "libstorage-ng reported a missing command, asking the user whether to continue"
+        log.info "Error details. message: #{message}. what: #{what}. command: #{command}. "\
+                 "used_features: #{used_features}."
+
+        # Redirect to error callback if no packages can be installed.
+        return error(message, what) if used_features == 0 || Yast::Mode.installation
+
+        package_handler = Y2Storage::PackageHandler.new
+        package_handler.add_feature_packages(used_features)
+
+        # Redirect to error callback if no packages can be installed.
+        return error(message, what) if package_handler.compact.empty?
+
+        description = _("An external command required for probing is missing. When\n"\
+                        "continuing despite the error, the presented system information\n"\
+                        "will be incomplete. You may also install the required packages\n"\
+                        "and restart probing.")
+
+        what += "\n\n" + missing_command_handle_packages_text(package_handler)
+
+        question = _("Continue despite the error, install required packages or abort?")
+        buttons = { continue: Yast::Label.ContinueButton, install: _("Install Packages"),
+                    abort: Yast::Label.AbortButton }
+
+        result = Yast2::Popup.show(full_message(message, description, question, what),
+          details: wrap_text(what), buttons: buttons, focus: :continue)
+        log.info "User answer: #{result}"
+
+        missing_command_handle_user_decision(result, package_handler)
+      end
+
+      # Initialization.
+      #
+      def begin
+        @again = false
+      end
+
+      # Should probing be run again?
+      #
+      # @return [Boolean] Whether probing should be run again.
+      #
+      def again?
+        @again
+      end
+
+      private
+
+      # Generates the text for the packages that must be installed.
+      #
+      # @return [String] The text.
+      #
+      def missing_command_handle_packages_text(package_handler)
+        packages = package_handler.compact
+
+        n_("The following package needs to be installed:",
+          "The following packages need to be installed:", packages.size) + "\n" +
+          packages.sort.join(", ")
+      end
+
+      # Handles the result from the popup.
+      #
+      # @return [Boolean] Whether probing should continue.
+      #
+      def missing_command_handle_user_decision(result, package_handler)
+        case result
+
+        when :install
+          package_handler.commit
+          @again = true
+          false
+
+        when :continue
+          @again = false
+          true
+
+        when :abort
+          @again = false
+          false
+
+        end
+      end
     end
   end
 end

--- a/src/lib/y2storage/exceptions.rb
+++ b/src/lib/y2storage/exceptions.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2016] SUSE LLC
+# Copyright (c) [2016,2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -38,5 +38,8 @@ module Y2Storage
   end
   # Requested access mode is incompatible with current mode
   class AccessModeError < Error
+  end
+  # Operation was aborted
+  class Aborted < Error
   end
 end

--- a/src/lib/y2storage/package_handler.rb
+++ b/src/lib/y2storage/package_handler.rb
@@ -68,7 +68,7 @@ module Y2Storage
     # Add the packages for the storage features to the list of
     # packages to be installed
     #
-    # @param [Integer or ::Storage::Devicegraph] used features or devicegraph
+    # @param arg [Integer or ::Storage::Devicegraph] used features or devicegraph
     #   to obtain the features from
     # @return [Array<String>] new package list (may contain duplicates)
     #

--- a/src/lib/y2storage/package_handler.rb
+++ b/src/lib/y2storage/package_handler.rb
@@ -2,7 +2,7 @@
 #
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017,2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -65,14 +65,15 @@ module Y2Storage
       @pkg_list.concat(pkg_list)
     end
 
-    # Add the packages for the storage features in 'devicegraph' to the list of
+    # Add the packages for the storage features to the list of
     # packages to be installed
     #
-    # @param [::Storage::devicegraph] devicegraph to obtain the features from
+    # @param [Integer or ::Storage::Devicegraph] used features or devicegraph
+    #   to obtain the features from
     # @return [Array<String>] new package list (may contain duplicates)
     #
-    def add_feature_packages(devicegraph)
-      used_features = UsedStorageFeatures.new(devicegraph)
+    def add_feature_packages(arg)
+      used_features = UsedStorageFeatures.new(arg)
       packages = used_features.feature_packages
       packages.delete_if do |pkg|
         if unavailable_optional_package?(pkg)

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -124,7 +124,7 @@ module Y2Storage
     # the user is asked whether to continue on errors reported by libstorage-ng.
     #
     # @param callbacks [Callbacks::Activate]
-    # @return [Boolean] whether activation was successfull, false if
+    # @return [Boolean] whether activation was successful, false if
     #   libstorage-ng found a problem and the corresponding callback returned
     #   false (i.e. it was decided to abort due to the error)
     def activate(callbacks = nil)
@@ -162,13 +162,20 @@ module Y2Storage
     #
     # @param probe_callbacks [Callbacks::Activate]
     # @param sanitize_callbacks [Callbacks::Sanitize]
-    # @return [Boolean] whether probing was successfull, false if libstorage-ng
+    # @return [Boolean] whether probing was successful, false if libstorage-ng
     #   found a problem and the corresponding callback returned false (i.e. it
     #   was decided to abort due to the error)
     def probe(probe_callbacks: nil, sanitize_callbacks: nil)
       probe_callbacks ||= Callbacks::Probe.new
 
-      @storage.probe(probe_callbacks)
+      begin
+        @storage.probe(probe_callbacks)
+      rescue Storage::Aborted
+        retry if probe_callbacks.again?
+
+        raise
+      end
+
       probed_performed
       sanitize_probed(sanitize_callbacks)
       DumpManager.dump(@probed_graph)

--- a/src/lib/y2storage/used_storage_features.rb
+++ b/src/lib/y2storage/used_storage_features.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2016-2017,2019] SUSE LLC
+# Copyright (c) [2016-2017,2019-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -112,8 +112,29 @@ module Y2Storage
     #----------------------------------------------------------------------
     #
 
-    def initialize(devicegraph)
-      @devicegraph = devicegraph
+    # Initialize object.
+    #
+    # @param arg [Integer or ::Storage::Devicegraph] Either a integer with the feature
+    #   bits or a devicegraph from which to get the feature bits.
+    #
+    def initialize(arg)
+      @devicegraph = nil
+      @used_features = nil
+      if arg.is_a?(Integer)
+        @used_features = arg
+      else
+        @devicegraph = arg
+      end
+    end
+
+    # Calculate the feature bits.
+    #
+    # @return [Integer] Feature bits.
+    #
+    def calculate_feature_bits
+      return 0 if @used_features.nil? && @devicegraph.nil?
+
+      @devicegraph.nil? ? @used_features : @devicegraph.used_features
     end
 
     # Collect storage features and return a feature list
@@ -122,9 +143,9 @@ module Y2Storage
     # @return [Array<Symbol>] feature list
     #
     def collect_features
-      return [] if @devicegraph.nil?
+      feature_bits = calculate_feature_bits
+      return [] if feature_bits == 0
 
-      feature_bits = @devicegraph.used_features
       features_dumped = false
       features = []
 

--- a/test/y2storage/callbacks/probe_test.rb
+++ b/test/y2storage/callbacks/probe_test.rb
@@ -38,7 +38,7 @@ describe Y2Storage::Callbacks::Probe do
   end
 
   describe "#again?" do
-    it "is unset after calling begin" do
+    it "returns false after calling begin" do
       subject.begin
       expect(subject.again?).to be false
     end

--- a/test/y2storage/callbacks/probe_test.rb
+++ b/test/y2storage/callbacks/probe_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017,2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -28,5 +28,84 @@ describe Y2Storage::Callbacks::Probe do
   describe "#error" do
     include_examples "general #error examples"
     include_examples "default #error true examples"
+  end
+
+  describe "#begin" do
+    it "clears again flag" do
+      subject.begin
+      expect(subject.again?).to be false
+    end
+  end
+
+  describe "#again?" do
+    it "is unset after calling begin" do
+      subject.begin
+      expect(subject.again?).to be false
+    end
+  end
+
+  describe "#missing_command" do
+    it "just displays the error and the details if used_features is 0" do
+      expect(Yast::Report).to receive(:yesno_popup) do |message, options|
+        expect(message).to include "the message"
+        expect(options[:details]).to eq "the what"
+      end
+      subject.missing_command("the message", "the what", "the command", 0)
+    end
+
+    before do
+      allow(Yast::Mode).to receive(:installation).and_return false
+      allow(Y2Storage::PackageHandler).to receive(:new).and_return package_handler
+    end
+
+    let(:package_handler) do
+      double("PackageHandler", add_feature_packages: packages, compact: packages)
+    end
+
+    let(:packages) { ["btrfsprogs", "e2fsprogs"] }
+
+    it "displays the error and the details including missing packages if used_features is not 0" do
+      expect(Yast2::Popup).to receive(:show) do |message, options|
+        expect(message).to include "the message"
+        expect(options[:details]).to include "the what"
+        expect(options[:details]).to include "btrfsprogs, e2fsprogs"
+      end
+      subject.missing_command("the message", "the what", "the command", 8)
+    end
+  end
+
+  describe "#missing_command_handle_user_decision" do
+    before do
+      allow(Y2Storage::PackageHandler).to receive(:new).and_return package_handler
+    end
+
+    let(:package_handler) do
+      double("PackageHandler")
+    end
+
+    context "when user selected install" do
+      it "returns false, sets again flag and installs packages" do
+        expect(package_handler).to receive(:commit)
+        expect(subject.send(:missing_command_handle_user_decision,
+          :install, package_handler)).to be false
+        expect(subject.again?).to be true
+      end
+    end
+
+    context "when user selected continue" do
+      it "returns true and clears again flag" do
+        expect(subject.send(:missing_command_handle_user_decision,
+          :continue, package_handler)).to be true
+        expect(subject.again?).to be false
+      end
+    end
+
+    context "when user selected abort" do
+      it "returns false and clears again flag" do
+        expect(subject.send(:missing_command_handle_user_decision,
+          :abort, package_handler)).to be false
+        expect(subject.again?).to be false
+      end
+    end
   end
 end

--- a/test/y2storage/used_storage_features_test.rb
+++ b/test/y2storage/used_storage_features_test.rb
@@ -2,7 +2,7 @@
 #
 # encoding: utf-8
 
-# Copyright (c) [2017,2019] SUSE LLC
+# Copyright (c) [2017,2019-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -102,6 +102,18 @@ describe Y2Storage::UsedStorageFeatures do
     it "requires exactly the expected storage-related packages" do
       expect(subject.feature_packages)
         .to contain_exactly("device-mapper", "multipath-tools", "fcoe-utils")
+    end
+  end
+
+  context "Created from integer representing UF_BTRFS" do
+    subject { described_class.new(8) }
+
+    it "has exactly the expected storage features" do
+      expect(subject.collect_features).to eq [:UF_BTRFS]
+    end
+
+    it "requires exactly the expect storage-related packages" do
+      expect(subject.feature_packages).to contain_exactly("btrfsprogs", "e2fsprogs")
     end
   end
 end

--- a/test/y2storage/used_storage_features_test.rb
+++ b/test/y2storage/used_storage_features_test.rb
@@ -105,7 +105,7 @@ describe Y2Storage::UsedStorageFeatures do
     end
   end
 
-  context "Created from integer representing UF_BTRFS" do
+  context "Created from integer representing used features" do
     subject { described_class.new(8) }
 
     it "has exactly the expected storage features" do


### PR DESCRIPTION
For https://trello.com/c/ae4cAtFe/1573-5-improve-probing-when-there-are-missing-tools.

## Problem

Probing can fail if programs are missing.

## Solution

Allow user to install missing packages.

## Testing

- Added a new unit test.
- Tested manually.

## Picture

![popup](https://user-images.githubusercontent.com/908062/73945838-3913ae80-48f5-11ea-9634-fea1b961c1c8.png)
