### PR TITLE
added texts for RAID1C3 and RAID1C4

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 12 09:53:44 CET 2020 - aschnell@suse.com
+
+- added texts for RAID1C3 and RAID1C4
+- 4.2.84
+
+-------------------------------------------------------------------
 Wed Feb  5 12:38:51 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Partitioner: usability improved by remembering the last active

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.83
+Version:        4.2.84
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# Fix mount/unmount
-BuildRequires:	libstorage-ng-ruby >= 4.2.54
+# RAID1C{3,4}
+BuildRequires:	libstorage-ng-ruby >= 4.2.61
 BuildRequires:  update-desktop-files
 # CWM::DynamicProgressBar
 BuildRequires:  yast2 >= 4.2.63
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# Fix mount/unmount
-Requires:       libstorage-ng-ruby >= 4.2.54
+# RAID1C{3,4}
+Requires:       libstorage-ng-ruby >= 4.2.61
 # CWM::DynamicProgressBar
 Requires:       yast2 >= 4.2.63
 # Y2Packager::Repository

--- a/src/lib/y2storage/btrfs_raid_level.rb
+++ b/src/lib/y2storage/btrfs_raid_level.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2019-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -42,6 +42,8 @@ module Y2Storage
       dup:     N_("DUP"),
       raid0:   N_("RAID0"),
       raid1:   N_("RAID1"),
+      raid1c3: N_("RAID1C3"),
+      raid1c4: N_("RAID1C4"),
       raid5:   N_("RAID5"),
       raid6:   N_("RAID6"),
       raid10:  N_("RAID10")

--- a/test/y2partitioner/actions/controllers/btrfs_devices_test.rb
+++ b/test/y2partitioner/actions/controllers/btrfs_devices_test.rb
@@ -133,6 +133,8 @@ describe Y2Partitioner::Actions::Controllers::BtrfsDevices do
       let(:dup_level) { Y2Storage::BtrfsRaidLevel::DUP }
       let(:raid0) { Y2Storage::BtrfsRaidLevel::RAID0 }
       let(:raid1) { Y2Storage::BtrfsRaidLevel::RAID1 }
+      let(:raid1c3) { Y2Storage::BtrfsRaidLevel::RAID1C3 }
+      let(:raid1c4) { Y2Storage::BtrfsRaidLevel::RAID1C4 }
       let(:raid5) { Y2Storage::BtrfsRaidLevel::RAID5 }
       let(:raid6) { Y2Storage::BtrfsRaidLevel::RAID6 }
       let(:raid10) { Y2Storage::BtrfsRaidLevel::RAID10 }
@@ -161,11 +163,11 @@ describe Y2Partitioner::Actions::Controllers::BtrfsDevices do
             filesystem.add_device(sdb2)
           end
 
-          it "contains DEFAULT, SINGLE, RAID0 and RAID1" do
+          it "contains DEFAULT, SINGLE, RAID0, RAID1 and RAID1C3" do
             expect(subject.filesystem.blk_devices.size).to eq(3)
 
             expect(subject.allowed_raid_levels(data))
-              .to contain_exactly(default_level, single_level, raid0, raid1)
+              .to contain_exactly(default_level, single_level, raid0, raid1, raid1c3)
           end
         end
 
@@ -184,11 +186,11 @@ describe Y2Partitioner::Actions::Controllers::BtrfsDevices do
             filesystem.add_device(sdb3)
           end
 
-          it "contains DEFAULT, SINGLE, RAID0, RAID1 and RAID10" do
+          it "contains DEFAULT, SINGLE, RAID0, RAID1, RAID1C3, RAID1C4 and RAID10" do
             expect(subject.filesystem.blk_devices.size).to eq(4)
 
             expect(subject.allowed_raid_levels(data))
-              .to contain_exactly(default_level, single_level, raid0, raid1, raid10)
+              .to contain_exactly(default_level, single_level, raid0, raid1, raid1c3, raid1c4, raid10)
           end
         end
       end


### PR DESCRIPTION
## Problem

libstorage gained support for btrfs RAID levels RAID1C3 and RAID1C4. That makes the testsuite here fail. 

## Solution

Add minimal support for btrfs RAID levels RAID1C3 and RAID1C4.

## Testing

- Extended unit test.
