### PR TITLE
Added references to changelog for the bots

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Wed Feb 12 09:53:44 CET 2020 - aschnell@suse.com
 
-- added texts for RAID1C3 and RAID1C4
+- added texts for RAID1C3 and RAID1C4 as required by
+  gh#openSUSE/libstorage-ng#706 (related to jsc#SLE-3877)
 - 4.2.84
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The changed introduced in #1042 failed at Jenkins with our beloved error: "_Stopping, missing new bugzilla or fate entry in the *.changes file. e.g. bnc#<number> or fate#<number>_"


## Solution

Just add some numbers that are traceable by our build service bots.
