### PR TITLE
Add not usable as block device error

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 18 10:26:02 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: do not allow to edit a device when the device cannot
+  be used as block device (bsc#1163597).
+- 4.2.85
+
+-------------------------------------------------------------------
 Wed Feb 12 09:53:44 CET 2020 - aschnell@suse.com
 
 - added texts for RAID1C3 and RAID1C4 as required by

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.84
+Version:        4.2.85
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/edit_blk_device.rb
+++ b/src/lib/y2partitioner/actions/edit_blk_device.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -116,7 +116,8 @@ module Y2Partitioner
           used_device_error,
           partitions_error,
           extended_partition_error,
-          lvm_thin_pool_error
+          lvm_thin_pool_error,
+          no_usable_as_blk_device_error
         ].compact
       end
 
@@ -205,7 +206,7 @@ module Y2Partitioner
         _("An extended partition cannot be edited")
       end
 
-      # Error message is trying to edit an LVM thin pool
+      # Error message if trying to edit an LVM thin pool
       #
       # @return [String, nil] nil if the device is not a thin pool.
       def lvm_thin_pool_error
@@ -214,6 +215,20 @@ module Y2Partitioner
         # TRANSLATORS: Error message when trying to edit an LVM thin pool. %{name} is
         # replaced by a logical volume name (e.g., /dev/system/lv1)
         format(_("The volume %{name} is a thin pool.\nIt cannot be edited."), name: device.name)
+      end
+
+      # Error message if trying to edit a block device that cannot be used as block device (e.g., a DASD)
+      #
+      # @return [String, nil] nil if the device can be used as block device
+      def no_usable_as_blk_device_error
+        return nil if device.usable_as_blk_device?
+
+        # TRANSLATORS: Error message where %{name} is replaced by a device name (e.g., /dev/dasda).
+        format(
+          _("The device %{name} is not usable as block device.\n" \
+            "It cannot be edited."),
+          name: device.name
+        )
       end
 
       # Whether the device is an extended partition

--- a/test/y2partitioner/actions/edit_blk_device_test.rb
+++ b/test/y2partitioner/actions/edit_blk_device_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017-2019] SUSE LLC
+
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -145,6 +146,27 @@ describe Y2Partitioner::Actions::EditBlkDevice do
       let(:dev_name) { "/dev/vg1/pool1" }
 
       include_examples "edit_error"
+    end
+
+    context "if called on a device that cannot be used as block device" do
+      let(:scenario) { "dasd_50GiB.yml" }
+
+      let(:dev_name) { "/dev/dasda" }
+
+      before do
+        device.delete_partition_table
+      end
+
+      it "shows a not editable error popup" do
+        expect(Yast2::Popup).to receive(:show)
+          .with(/not usable as block device/, hash_including(headline: :error))
+
+        sequence.run
+      end
+
+      it "quits returning :back" do
+        expect(sequence.run).to eq :back
+      end
     end
 
     context "if called on a device that can be edited" do


### PR DESCRIPTION
## Problem

Some block devices cannot used as block devices (e.g., DASD devices). Therefore, these devices cannot be directly formatted, but the Expert Partitioner does not prevent it.

* https://bugzilla.suse.com/show_bug.cgi?id=1163597
* https://trello.com/c/NsJWnEWd/1651-sles15-sp2-p2-1163597-partitioner-allows-to-install-on-an-unpartitioned-dasd

## Solution

A new error was added to the action for editing block devices. Now, an error popup is shown when the user tries to edit a device that cannot be used as block device.

Note that `BootRequirementsChecker` was working correctly and some warnings were generated when a DASD device was directly formatted for root. See screenshots.

## Testing

- Added a new unit test
- Tested manually


## Screenshots

<details>
<summary>Show/Hide</summary>

* New error

![Screenshot from 2020-02-18 09-46-26](https://user-images.githubusercontent.com/1112304/74728551-e0b8a700-523a-11ea-8ce5-93107ab18f33.png)

* `BootRequirementsChecker` was showing warnings correctly

![Screenshot from 2020-02-18 09-06-50](https://user-images.githubusercontent.com/1112304/74728565-e7471e80-523a-11ea-84e7-78cdafdd5f4a.png)

</details>

