### PR TITLE
Hide edit button for DASD devices

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb 18 15:04:21 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: do no show button for editing devices when the
+  device cannot be used as block device (bsc#1163597).
+- Revert changes from 4.2.85.
+- 4.2.87
+
+-------------------------------------------------------------------
 Tue Feb 18 11:59:05 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Initial Guided Proposal: place the boot-related partitions in

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.86
+Version:        4.2.87
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/edit_blk_device.rb
+++ b/src/lib/y2partitioner/actions/edit_blk_device.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2020] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -116,8 +116,7 @@ module Y2Partitioner
           used_device_error,
           partitions_error,
           extended_partition_error,
-          lvm_thin_pool_error,
-          no_usable_as_blk_device_error
+          lvm_thin_pool_error
         ].compact
       end
 
@@ -206,7 +205,7 @@ module Y2Partitioner
         _("An extended partition cannot be edited")
       end
 
-      # Error message if trying to edit an LVM thin pool
+      # Error message is trying to edit an LVM thin pool
       #
       # @return [String, nil] nil if the device is not a thin pool.
       def lvm_thin_pool_error
@@ -215,20 +214,6 @@ module Y2Partitioner
         # TRANSLATORS: Error message when trying to edit an LVM thin pool. %{name} is
         # replaced by a logical volume name (e.g., /dev/system/lv1)
         format(_("The volume %{name} is a thin pool.\nIt cannot be edited."), name: device.name)
-      end
-
-      # Error message if trying to edit a block device that cannot be used as block device (e.g., a DASD)
-      #
-      # @return [String, nil] nil if the device can be used as block device
-      def no_usable_as_blk_device_error
-        return nil if device.usable_as_blk_device?
-
-        # TRANSLATORS: Error message where %{name} is replaced by a device name (e.g., /dev/dasda).
-        format(
-          _("The device %{name} is not usable as block device.\n" \
-            "It cannot be edited."),
-          name: device.name
-        )
       end
 
       # Whether the device is an extended partition

--- a/src/lib/y2partitioner/actions/edit_blk_device.rb
+++ b/src/lib/y2partitioner/actions/edit_blk_device.rb
@@ -205,7 +205,7 @@ module Y2Partitioner
         _("An extended partition cannot be edited")
       end
 
-      # Error message is trying to edit an LVM thin pool
+      # Error message if trying to edit an LVM thin pool
       #
       # @return [String, nil] nil if the device is not a thin pool.
       def lvm_thin_pool_error

--- a/src/lib/y2partitioner/widgets/device_buttons_set.rb
+++ b/src/lib/y2partitioner/widgets/device_buttons_set.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018-2019] SUSE LLC
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -30,6 +30,7 @@ require "y2partitioner/widgets/lvm_logical_volumes_button"
 require "y2partitioner/widgets/device_delete_button"
 require "y2partitioner/widgets/blk_device_edit_button"
 require "y2partitioner/widgets/btrfs_modify_button"
+require "y2partitioner/widgets/partition_table_add_button"
 
 module Y2Partitioner
   module Widgets
@@ -139,7 +140,7 @@ module Y2Partitioner
       # Buttons to display if {#device} is a disk device
       def disk_device_buttons
         [
-          DiskModifyButton.new(device),
+          modify_disk_button,
           PartitionsButton.new(device, pager)
         ]
       end
@@ -173,6 +174,18 @@ module Y2Partitioner
           BtrfsModifyButton.new(device),
           DeviceDeleteButton.new(pager: pager, device: device)
         ]
+      end
+
+      # Button to modify a disk device
+      #
+      # Note that some block devices cannot be edited because they cannot be used as block devices,
+      # (e.g., DASD devices).
+      #
+      # @return [CWM::AbstractWidget]
+      def modify_disk_button
+        return DiskModifyButton.new(device) if device.usable_as_blk_device?
+
+        PartitionTableAddButton.new(device: device)
       end
 
       # Simple widget to represent an HBox with a CWM API

--- a/src/lib/y2partitioner/widgets/pages/disk.rb
+++ b/src/lib/y2partitioner/widgets/pages/disk.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -137,12 +137,26 @@ module Y2Partitioner
           @contents ||= VBox(
             DiskDeviceDescription.new(@disk),
             Left(
-              HBox(
-                BlkDeviceEditButton.new(device: @disk),
-                PartitionTableButton.new(@disk)
-              )
+              HBox(*buttons)
             )
           )
+        end
+
+        private
+
+        # Buttons for the device
+        #
+        # Note that some block devices cannot be edited because they cannot be used as block devices,
+        # (e.g., DASD devices).
+        #
+        # @return [Array<CWM::AbstractWidget>]
+        def buttons
+          buttons = []
+
+          buttons << BlkDeviceEditButton.new(device: @disk) if @disk.usable_as_blk_device?
+          buttons << PartitionTableButton.new(@disk)
+
+          buttons
         end
       end
     end

--- a/test/y2partitioner/actions/edit_blk_device_test.rb
+++ b/test/y2partitioner/actions/edit_blk_device_test.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env rspec
-
-# Copyright (c) [2017-2020] SUSE LLC
+# Copyright (c) [2017-2019] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -146,27 +145,6 @@ describe Y2Partitioner::Actions::EditBlkDevice do
       let(:dev_name) { "/dev/vg1/pool1" }
 
       include_examples "edit_error"
-    end
-
-    context "if called on a device that cannot be used as block device" do
-      let(:scenario) { "dasd_50GiB.yml" }
-
-      let(:dev_name) { "/dev/dasda" }
-
-      before do
-        device.delete_partition_table
-      end
-
-      it "shows a not editable error popup" do
-        expect(Yast2::Popup).to receive(:show)
-          .with(/not usable as block device/, hash_including(headline: :error))
-
-        sequence.run
-      end
-
-      it "quits returning :back" do
-        expect(sequence.run).to eq :back
-      end
     end
 
     context "if called on a device that can be edited" do

--- a/test/y2partitioner/widgets/device_buttons_set_test.rb
+++ b/test/y2partitioner/widgets/device_buttons_set_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2018-2019] SUSE LLC
+
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -80,19 +81,40 @@ describe Y2Partitioner::Widgets::DeviceButtonsSet do
     end
 
     context "when targeting a disk device" do
-      let(:device) { device_graph.disks.first }
+      context "and the device can be used as a block device" do
+        let(:device) { device_graph.disks.first }
 
-      it "replaces the content with buttons to modify and to manage partitions" do
-        expect(widget).to receive(:replace) do |content|
-          widgets = Yast::CWM.widgets_in_contents([content])
-          expect(widgets.map(&:class)).to contain_exactly(
-            Y2Partitioner::Widgets::DeviceButtonsSet::ButtonsBox,
-            Y2Partitioner::Widgets::DiskModifyButton,
-            Y2Partitioner::Widgets::PartitionsButton
-          )
+        it "replaces the content with buttons to modify and to manage partitions" do
+          expect(widget).to receive(:replace) do |content|
+            widgets = Yast::CWM.widgets_in_contents([content])
+            expect(widgets.map(&:class)).to contain_exactly(
+              Y2Partitioner::Widgets::DeviceButtonsSet::ButtonsBox,
+              Y2Partitioner::Widgets::DiskModifyButton,
+              Y2Partitioner::Widgets::PartitionsButton
+            )
+          end
+
+          widget.device = device
         end
+      end
 
-        widget.device = device
+      context "and the device cannot be used as a block device" do
+        let(:scenario) { "dasd_50GiB" }
+
+        let(:device) { device_graph.dasds.first }
+
+        it "replaces the content with buttons to create a partiton table and to manage partitions" do
+          expect(widget).to receive(:replace) do |content|
+            widgets = Yast::CWM.widgets_in_contents([content])
+            expect(widgets.map(&:class)).to contain_exactly(
+              Y2Partitioner::Widgets::DeviceButtonsSet::ButtonsBox,
+              Y2Partitioner::Widgets::PartitionTableAddButton,
+              Y2Partitioner::Widgets::PartitionsButton
+            )
+          end
+
+          widget.device = device
+        end
       end
     end
 

--- a/test/y2partitioner/widgets/pages/disk_test.rb
+++ b/test/y2partitioner/widgets/pages/disk_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017] SUSE LLC
+
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -116,14 +117,38 @@ describe Y2Partitioner::Widgets::Pages::Disk do
         expect(description).to_not be_nil
       end
 
-      it "shows a button for editing the device" do
-        button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDeviceEditButton) }
-        expect(button).to_not be_nil
+      context "and the device can be used as a block device" do
+        let(:disk) { current_graph.disks.first }
+
+        it "shows a button for editing the device" do
+          button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDeviceEditButton) }
+
+          expect(button).to_not be_nil
+        end
+
+        it "shows a menu-button for expert options on the partition table" do
+          button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::PartitionTableButton) }
+
+          expect(button).to_not be_nil
+        end
       end
 
-      it "shows a menu-button for expert options on the partition table" do
-        button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::PartitionTableButton) }
-        expect(button).to_not be_nil
+      context "and the device cannot be used as a block device" do
+        let(:scenario) { "dasd_50GiB" }
+
+        let(:disk) { current_graph.dasds.first }
+
+        it "does not show a button for editing the device" do
+          button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDeviceEditButton) }
+
+          expect(button).to be_nil
+        end
+
+        it "shows a menu-button for expert options on the partition table" do
+          button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::PartitionTableButton) }
+
+          expect(button).to_not be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
## Problem

Some block devices cannot be used as block devices (e.g., DASD devices). Therefore, these devices cannot be directly formatted, but the Expert Partitioner does not prevent it.

* https://bugzilla.suse.com/show_bug.cgi?id=1163597
* https://trello.com/c/NsJWnEWd/1651-sles15-sp2-p2-1163597-partitioner-allows-to-install-on-an-unpartitioned-dasd

## Solution

A solution was already proposed in the PR https://github.com/yast/yast-storage-ng/pull/1045, but now a more convenient approach is implemented. The buttons for editing a device are hidden (i.e., when the device cannot be used as block device) instead of showing an error popup.

## Testing

- Added a new unit tests
- Tested manually

## Screenshots

<details>

<summary>Show/Hide</summary>

* Before:

![Screenshot from 2020-02-18 15-10-09](https://user-images.githubusercontent.com/1112304/74748702-dad5bc80-5260-11ea-8544-d292c23ac413.png)

![Screenshot from 2020-02-18 15-09-48](https://user-images.githubusercontent.com/1112304/74748704-db6e5300-5260-11ea-8a19-b0fd4e1d49ba.png)

* After:

![Screenshot from 2020-02-18 15-08-39](https://user-images.githubusercontent.com/1112304/74748720-e3c68e00-5260-11ea-8607-11e523aa08af.png)

![Screenshot from 2020-02-18 15-08-01](https://user-images.githubusercontent.com/1112304/74748722-e45f2480-5260-11ea-95d9-5c5875be3a9b.png)

</details>
