### PR TITLE
Fix a bug preventing some partitions to be deleted (bsc#1161331)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Feb 19 10:49:56 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Proposal: fixed the infinite loop when trying to create a new
+  partition out of the candidate devices (related to bsc#1161331
+  and bsc#1161678).
+- 4.2.88
+
+-------------------------------------------------------------------
 Tue Feb 18 15:04:21 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Partitioner: do no show button for editing devices when the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.87
+Version:        4.2.88
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/test/y2storage/proposal/space_maker_test.rb
+++ b/test/y2storage/proposal/space_maker_test.rb
@@ -1037,5 +1037,19 @@ describe Y2Storage::Proposal::SpaceMaker do
         expect(aligned).to eq [true, true]
       end
     end
+
+    # Test for bug#1161331 found in the beta versions of SLE-15-SP2. Instead of just
+    # reporting the error (like SLE-15-SP1 used to do), this scenario made SpaceMaker
+    # enter an infinite loop trying to delete sda1 over and over again.
+    context "when a planned device needs to be created out of the candidate devices" do
+      let(:scenario) { "empty-md_raid" }
+      let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 1.GiB, disk: "/dev/sda") }
+      before { settings.candidate_devices = fake_devicegraph.raids }
+
+      it "raises an Error exception" do
+        expect { maker.provide_space(fake_devicegraph, volumes, lvm_helper) }
+          .to raise_error Y2Storage::Error
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

When a planned device needs to be created out of the candidate devices, the SpaceMaker entered an infinite loop. See [bug#1161331](https://bugzilla.suse.com/show_bug.cgi?id=1161331) (and also [bug#1161678](https://bugzilla.suse.com/show_bug.cgi?id=1161678)) and https://trello.com/c/6FDBka8e/.

After having merged #1046, devices should never be planned out of the candidate devices, so the error cannot affect users anymore. But the SpaceMaker was still not fixed and it could still enter in the infinite loop if the proposal changes in the future.

This is the commit that opened the door for the infinite loops in SpaceMaker: https://github.com/yast/yast-storage-ng/commit/c61035961a06e5301f0b0d3c51392d0252f531d5

It changed the semantic of `PartitionKiller#disks`. Originally, that was only intended to restrict the scope of the collateral actions. That is, `#delete_by_sid` would always delete the indicated partition, no matter in which disk it was and, in addition, would delete related partitions that belonged to `#disks`.

But after the change, `#delete_by_sid` refuses to delete the indicated partition if it does not belong to any of the `#disks`.

That is, before that commit `#delete_by_sid` always returned an array containing at least one partition (the one it was told to delete). After that commit, the returned array has more possibilities to be empty... and an empty array leads to the infinite loop in `SpaceMaker`.

## Solution

This pull request restores the initial behavior of `PartitionKiller#delete_by_sid` to never refuse to delete the given partition.

## Testing

Added a new unit test verifying this fixes the infinite loop in [bug#1161331](https://bugzilla.suse.com/show_bug.cgi?id=1161331)
