### PR TITLE
Add methods for preferred mount by

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 20 16:02:54 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Add API methods to get preferred mount by option and the
+  associated device path.
+- 4.2.90
+
+-------------------------------------------------------------------
 Thu Feb 20 14:37:41 CET 2020 - aschnell@suse.com
 
 - allow to install packages needed for probing

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.89
+Version:        4.2.90
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -23,6 +23,7 @@ require "y2storage/hwinfo_reader"
 require "y2storage/comparable_by_name"
 require "y2storage/match_volume_spec"
 require "y2storage/encryption_method"
+require "y2storage/filesystems/mount_by_type"
 
 module Y2Storage
   # Base class for most devices having a device name, udev path and udev ids.
@@ -465,6 +466,24 @@ module Y2Storage
     # @return [Array<String>]
     def component_of_names
       component_of.map(&:display_name).compact
+    end
+
+    # Device path to use depending on the mount by option
+    #
+    # @return [String, nil] nil if the path cannot be determined for the given mount by option
+    def path_for_mount_by(mount_by)
+      case mount_by
+      when Filesystems::MountByType::DEVICE
+        name
+      when Filesystems::MountByType::UUID
+        udev_full_uuid
+      when Filesystems::MountByType::LABEL
+        udev_full_label
+      when Filesystems::MountByType::ID
+        udev_full_ids.first
+      when Filesystems::MountByType::PATH
+        udev_full_paths.first
+      end
     end
 
     # Label of the filesystem, if any

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -325,6 +325,15 @@ module Y2Storage
       assign_mount_by(Filesystems::MountByType.best_for(filesystem, suitable))
     end
 
+    # Most suitable mount by option
+    #
+    # Note that this method does not take into account the currently assigned mount by value
+    #
+    # @return [Filesystems::MountByType]
+    def preferred_mount_by
+      Filesystems::MountByType.best_for(filesystem, suitable_mount_bys)
+    end
+
     # Whether {#mount_by} was explicitly set by the user
     #
     # @note This relies on the userdata mechanism, see {#userdata_value}.

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -428,6 +428,122 @@ describe Y2Storage::BlkDevice do
 
     it "returns the basename of the device's name" do
       expect(device.basename).to eq("sda1")
+    end
+  end
+
+  describe "#path_for_mount_by" do
+    let(:device_name) { "/dev/sda1" }
+
+    context "when mounting by device" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::DEVICE }
+
+      it "returns the kernel name" do
+        expect(subject.path_for_mount_by(mount_by)).to eq(device_name)
+      end
+    end
+
+    context "when mounting by UUID" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::UUID }
+
+      before do
+        allow(subject).to receive(:udev_full_uuid).and_return(path_by_uuid)
+      end
+
+      context "and the device has by-uuid udev path" do
+        let(:path_by_uuid) { "/dev/disk/by-uuid/111222333444" }
+
+        it "returns the by-uuid udev path" do
+          expect(subject.path_for_mount_by(mount_by)).to eq(path_by_uuid)
+        end
+      end
+
+      context "and the device has no by-uuid udev path" do
+        let(:path_by_uuid) { nil }
+
+        it "returns nil" do
+          expect(subject.path_for_mount_by(mount_by)).to be_nil
+        end
+      end
+    end
+
+    context "when mounting by label" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::LABEL }
+
+      before do
+        allow(subject).to receive(:udev_full_label).and_return(path_by_label)
+      end
+
+      context "and the device has by-label udev path" do
+        let(:path_by_label) { "/dev/disk/by-label/fslabel" }
+
+        it "returns the by-label udev path" do
+          expect(subject.path_for_mount_by(mount_by)).to eq(path_by_label)
+        end
+      end
+
+      context "and the device has no by-label udev path" do
+        let(:path_by_label) { nil }
+
+        it "returns nil" do
+          expect(subject.path_for_mount_by(mount_by)).to be_nil
+        end
+      end
+    end
+
+    context "when mounting by id" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::ID }
+
+      before do
+        allow(subject).to receive(:udev_full_ids).and_return(paths_by_id)
+      end
+
+      context "and the device has by-id udev paths" do
+        let(:paths_by_id) { [path_by_id1, path_by_id2] }
+
+        let(:path_by_id1) { "/dev/disk/by-id/1111" }
+
+        let(:path_by_id2) { "/dev/disk/by-id/2222" }
+
+        it "returns the first by-id udev path" do
+          expect(subject.path_for_mount_by(mount_by)).to eq(path_by_id1)
+        end
+      end
+
+      context "and the device has no by-id udev paths" do
+        let(:paths_by_id) { [] }
+
+        it "returns nil" do
+          expect(subject.path_for_mount_by(mount_by)).to be_nil
+        end
+      end
+    end
+
+    context "when mounting by path" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::PATH }
+
+      before do
+        allow(subject).to receive(:udev_full_paths).and_return(paths_by_path)
+      end
+
+      context "and the device has by-path udev paths" do
+        let(:paths_by_path) { [path_by_path1, path_by_path2] }
+
+        let(:path_by_path1) { "/dev/disk/by-path/pci1111-part1" }
+
+        let(:path_by_path2) { "/dev/disk/by-path/pci2222-part1" }
+
+        it "returns the first by-path udev path" do
+          expect(subject.path_for_mount_by(mount_by)).to eq(path_by_path1)
+        end
+      end
+
+      context "and the device has no by-path udev paths" do
+        let(:paths_by_path) { [] }
+
+        it "returns nil" do
+          expect(subject.path_for_mount_by(mount_by)).to be_nil
+        end
+      end
     end
   end
 

--- a/test/y2storage/filesystems/blk_filesystem_test.rb
+++ b/test/y2storage/filesystems/blk_filesystem_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017-2019] SUSE LLC
+
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -232,6 +233,49 @@ describe Y2Storage::Filesystems::BlkFilesystem do
 
       it "returns the mount by of the mount point" do
         expect(filesystem.mount_by).to eq(Y2Storage::Filesystems::MountByType::ID)
+      end
+    end
+  end
+
+  describe "#preferred_mount_by" do
+    let(:scenario) { "mixed_disks" }
+
+    context "when the filesystem has no mount point" do
+      let(:dev_name) { "/dev/sda2" }
+
+      before do
+        allow_any_instance_of(Y2Storage::MountPoint).to receive(:preferred_mount_by)
+          .and_return(preferred_mount_by)
+      end
+
+      let(:preferred_mount_by) { Y2Storage::Filesystems::MountByType::UUID }
+
+      it "returns the preferred mount by option from a temporary mount point" do
+        expect(subject.preferred_mount_by).to eq(preferred_mount_by)
+      end
+
+      it "removes the temporary mount point" do
+        subject.preferred_mount_by
+
+        expect(subject.mount_point).to be_nil
+      end
+    end
+
+    context "when the filesystem has a mount point" do
+      let(:dev_name) { "/dev/sdb2" }
+
+      before do
+        allow(subject).to receive(:mount_point).and_return(mount_point)
+
+        allow(mount_point).to receive(:preferred_mount_by).and_return(preferred_mount_by)
+      end
+
+      let(:mount_point) { subject.mount_point }
+
+      let(:preferred_mount_by) { Y2Storage::Filesystems::MountByType::LABEL }
+
+      it "returns the preferred mount by option from the current mount point" do
+        expect(subject.preferred_mount_by).to eq(preferred_mount_by)
       end
     end
   end

--- a/test/y2storage/mount_point_test.rb
+++ b/test/y2storage/mount_point_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2018] SUSE LLC
+
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -311,6 +312,27 @@ describe Y2Storage::MountPoint do
       it "returns an array containing only DEVICE" do
         expect(mount_point.suitable_mount_bys).to eq [Y2Storage::Filesystems::MountByType::DEVICE]
       end
+    end
+  end
+
+  describe "#preferred_mount_by" do
+    before do
+      allow(subject).to receive(:suitable_mount_bys).and_return(all_suitable)
+
+      allow(Y2Storage::Filesystems::MountByType).to receive(:best_for)
+        .with(anything, all_suitable).and_return(uuid)
+    end
+
+    let(:uuid) { Y2Storage::Filesystems::MountByType::UUID }
+
+    let(:label) { Y2Storage::Filesystems::MountByType::LABEL }
+
+    let(:path) { Y2Storage::Filesystems::MountByType::PATH }
+
+    let(:all_suitable) { [uuid, label, path] }
+
+    it "returns the best mount by from all the suitable ones" do
+      expect(subject.preferred_mount_by).to eq(uuid)
     end
   end
 


### PR DESCRIPTION
## Problem

This module has some logic to obtain the most reasonable mount by option. See https://github.com/yast/yast-storage-ng/pull/985. That logic is kind of duplicated by *yast2-bootloader* module, see https://github.com/yast/yast-bootloader/blob/master/src/lib/bootloader/udev_mapping.rb#L110.

But *yast2-storage-ng* does not offer a proper public API to get the preferred mount by option.

* https://trello.com/c/TyCrUgrP/1401-use-the-suitablemountby-mechanism-in-yast-bootloader

## Solution

New API methods have been added to obtain the preferred mount by option and the associated udev path of the device: `Mountable#preferred_mount_by`, `BlkDevice#path_for_mount_by`.

See also https://github.com/yast/yast-bootloader/pull/591.

## Testing

* Added new unit tests
