### PR TITLE
bsc#1159201: export unpartitioned RAID when used for another device (LVM, RAID, bcache)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue Mar  3 12:56:34 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: export the 'disklabel' attribute for software RAID
+  devices.
+- AutoYaST: include a 'partitions' section when exporting an
+  unpartitioned software RAID which is not used as a filesystem
+  (bsc#1159201).
+- 4.2.92
+
+-------------------------------------------------------------------
 Fri Feb 28 17:05:15 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Partitioner: allow to select APQNs when encrypting with pervasive

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.1.92
+Version:        4.2.92
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.91
+Version:        4.1.92
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -375,8 +375,9 @@ module Y2Storage
       def init_from_md(md)
         @type = :CT_MD
         @device = md.name
+        @disklabel = disklabel_from_disk(md)
         collection =
-          if md.filesystem
+          if md.filesystem || md.component_of.any?
             [md]
           else
             md.partitions

--- a/test/data/devicegraphs/md_raid_lvm.yml
+++ b/test/data/devicegraphs/md_raid_lvm.yml
@@ -1,0 +1,60 @@
+# 2020-03-04 09:23:20 +0000
+---
+- disk:
+    name: "/dev/vda"
+    size: 10 GiB
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 8 MiB
+        name: "/dev/vda1"
+        type: primary
+        id: bios_boot
+    - partition:
+        size: 256 MiB
+        name: "/dev/vda2"
+        type: primary
+        id: linux
+        file_system: ext4
+        mount_point: "/boot"
+    - partition:
+        size: 9976 MiB
+        name: "/dev/vda3"
+        type: primary
+        id: lvm
+- disk:
+    name: "/dev/vdb"
+    size: 5 GiB
+- disk:
+    name: "/dev/vdc"
+    size: 5 GiB
+- disk:
+    name: "/dev/vdd"
+    size: 5 GiB
+- md:
+    name: "/dev/md0"
+    md_level: raid5
+    md_parity: default
+    encryption:
+      type: luks
+      name: "/dev/mapper/cr_md0"
+    md_devices:
+    - md_device:
+        blk_device: "/dev/vdb"
+    - md_device:
+        blk_device: "/dev/vdc"
+    - md_device:
+        blk_device: "/dev/vdd"
+- lvm_vg:
+    vg_name: vg0
+    lvm_lvs:
+    - lvm_lv:
+        lv_name: root
+        size: 20048 MiB
+        file_system: ext4
+        mount_point: "/"
+    lvm_pvs:
+    - lvm_pv:
+        blk_device: "/dev/mapper/cr_md0"
+    - lvm_pv:
+        blk_device: "/dev/vda3"

--- a/test/y2storage/autoinst_profile/drive_section_test.rb
+++ b/test/y2storage/autoinst_profile/drive_section_test.rb
@@ -399,6 +399,10 @@ describe Y2Storage::AutoinstProfile::DriveSection do
       context "when the RAID is partitioned" do
         before { fake_scenario("root_partitioned_md_raid") }
 
+        it "initializes #disklabel to 'none'" do
+          expect(described_class.new_from_storage(device("md0")).disklabel).to eq("gpt")
+        end
+
         context "and snapshots are enabled for the root (/) partition" do
           it "initializes enable_snapshots setting to true" do
             expect(described_class.new_from_storage(device("md0")).enable_snapshots).to eq(true)
@@ -427,6 +431,41 @@ describe Y2Storage::AutoinstProfile::DriveSection do
       end
 
       context "when the RAID is not partitioned" do
+        before { fake_scenario("md_raid") }
+
+        it "initializes #disklabel to 'none'" do
+          expect(described_class.new_from_storage(device("md/md0")).disklabel).to eq("none")
+        end
+
+        it "includes a #partitions section containing the filesystem information" do
+          partitions = described_class.new_from_storage(device("md/md0")).partitions
+          expect(partitions).to contain_exactly(
+            an_object_having_attributes(filesystem: :xfs)
+          )
+        end
+
+        context "and it is not used" do
+          before do
+            device("md/md0").remove_descendants
+          end
+
+          it "does not include a #partitions section" do
+            partitions = described_class.new_from_storage(device("md/md0")).partitions
+            expect(partitions).to be_empty
+          end
+        end
+
+        context "and it is used as a component of an LVM" do
+          before { fake_scenario("md_raid_lvm") }
+
+          it "includes a #partition section with LVM and encryption information" do
+            partitions = described_class.new_from_storage(device("md0")).partitions
+            expect(partitions).to contain_exactly(
+              an_object_having_attributes(lvm_group: "vg0", crypt_method: :luks1)
+            )
+          end
+        end
+
         context "and it is mounted at /" do
           before { fake_scenario("root_md_raid") }
 


### PR DESCRIPTION
## Problem

As seen in [bsc#1159201](https://bugzilla.suse.com/show_bug.cgi?id=1159324), AutoYaST omits the `<partitions>` list when cloning an unpartitioned RAID that does not have partitions nor a file system. It may happen that the RAID is used as part of another device (e.g., as part of an LVM volume group).

Additionally, while debugging the issue, I have found that the `<disklabel>` element was not set.

## Solution

This PR fixes both problems, setting the `<disklabe>` to the appropriate value and exporting the `<partitions>` section when the RAID device is used.

## Links

- https://bugzilla.suse.com/show_bug.cgi?id=1159324
- Trello card: https://trello.com/c/lLRXuABJ/1673-3-sles15-sp1-p5-1159201-autoyast-does-not-get-encrypted-setup-with-a-unusual-partition-scheme
