### PR TITLE
Fix CommitActions tests

### DIFF
--- a/test/y2partitioner/widgets/commit_actions_test.rb
+++ b/test/y2partitioner/widgets/commit_actions_test.rb
@@ -26,7 +26,8 @@ require "y2partitioner/widgets/commit_actions"
 
 describe Y2Partitioner::Widgets::CommitActions do
   before do
-    Y2Storage::StorageManager.create_test_instance
+    storage = Y2Storage::StorageManager.create_test_instance
+    Y2Partitioner::DeviceGraphs.create_instance(storage.probed, storage.staging)
   end
 
   subject { described_class.new }


### PR DESCRIPTION
Tests are failing in IBS/OBS. We have reproduced the problem by running the tests in a given order.

Thanks to @joseivanlopez who spotted the problem.