### PR TITLE
AutoYaST: modify the LVM VG name only when really needed

### DIFF
--- a/src/lib/y2storage/proposal/autoinst_space_maker.rb
+++ b/src/lib/y2storage/proposal/autoinst_space_maker.rb
@@ -196,6 +196,9 @@ module Y2Storage
             all.concat(vg.lvm_pvs)
           when Y2Storage::Planned::Md
             all << devicegraph.md_raids.find { |r| device.reuse_name == r.name }
+          when Y2Storage::Planned::Bcache
+            bcache = devicegraph.bcaches.find { |b| device.reuse_name == b.name }
+            all << bcache
           end
         end
 

--- a/src/lib/y2storage/proposal/autoinst_space_maker.rb
+++ b/src/lib/y2storage/proposal/autoinst_space_maker.rb
@@ -200,23 +200,31 @@ module Y2Storage
       # @param planned_devices [Array<Planned::Partition>] set of partitions
       # @return [Hash<String,Array<String>>] disk name to list of reused partitions map
       def find_reused_devices(devicegraph, planned_devices)
-        reused_devices = planned_devices.select(&:reuse_name).each_with_object([]) do |device, all|
-          case device
-          when Y2Storage::Planned::Partition
-            all << devicegraph.partitions.find { |p| device.reuse_name == p.name }
-          when Y2Storage::Planned::LvmVg
-            vg = devicegraph.lvm_vgs.find { |v| File.join("/dev", device.reuse_name) == v.name }
-            all.concat(vg.lvm_pvs)
-          when Y2Storage::Planned::Md
-            all << devicegraph.md_raids.find { |r| device.reuse_name == r.name }
-          when Y2Storage::Planned::Bcache
-            bcache = devicegraph.bcaches.find { |b| device.reuse_name == b.name }
-            all << bcache
-          end
+        reused_devices = planned_devices.select(&:reuse_name).each_with_object([]) do |planned, all|
+          real_devices = real_reused_devices_for(devicegraph, planned)
+          all.concat(real_devices) if real_devices
         end
 
         ancestors = reused_devices.map(&:ancestors).flatten
         (reused_devices + ancestors).select { |p| p.is?(:disk_device, :partition) }
+      end
+
+      # Real devices from the devicegraph that will be reused for the given planned device
+      #
+      # @param devicegraph    [Devicegraph]     devicegraph
+      # @param planned_device [Planned::Device] planned_device
+      def real_reused_devices_for(devicegraph, planned_device)
+        case planned_device
+        when Y2Storage::Planned::Partition
+          [devicegraph.partitions.find { |p| planned_device.reuse_name == p.name }]
+        when Y2Storage::Planned::LvmVg
+          vg = devicegraph.lvm_vgs.find { |v| File.join("/dev", planned_device.reuse_name) == v.name }
+          [vg] + vg.lvm_pvs
+        when Y2Storage::Planned::Md
+          [devicegraph.md_raids.find { |r| planned_device.reuse_name == r.name }]
+        when Y2Storage::Planned::Bcache
+          [devicegraph.bcaches.find { |b| planned_device.reuse_name == b.name }]
+        end
       end
 
       # Build a device name to sid map

--- a/src/lib/y2storage/proposal/autoinst_space_maker.rb
+++ b/src/lib/y2storage/proposal/autoinst_space_maker.rb
@@ -49,14 +49,14 @@ module Y2Storage
       def cleaned_devicegraph(original_devicegraph, drives_map, planned_devices)
         devicegraph = original_devicegraph.dup
 
-        reused_partitions = reused_partitions_by_disk(devicegraph, planned_devices)
+        reused_devices = reused_devices_by_disk(devicegraph, planned_devices)
         sid_map = partitions_sid_map(devicegraph)
 
         drives_map.each_pair do |disk_name, drive_spec|
           disk = BlkDevice.find_by_name(devicegraph, disk_name)
           next unless disk
 
-          delete_stuff(devicegraph, disk, drive_spec, reused_partitions[disk.name])
+          delete_stuff(devicegraph, disk, drive_spec, reused_devices[disk.name])
         end
 
         adjust_reuse_values(devicegraph, planned_devices, sid_map)
@@ -69,40 +69,40 @@ module Y2Storage
 
       # Deletes unwanted partitions for the given disk
       #
-      # @param devicegraph  [Devicegraph]
-      # @param disk         [Disk]
-      # @param drive_spec   [AutoinstProfile::DriveSection]
-      # @param reused_parts [Array<String>] Reused partitions names
-      def delete_stuff(devicegraph, disk, drive_spec, reused_parts)
-        reused_parts ||= []
-        if drive_spec.initialize_attr && reused_parts.empty?
+      # @param devicegraph    [Devicegraph]
+      # @param disk           [Disk]
+      # @param drive_spec     [AutoinstProfile::DriveSection]
+      # @param reused_devices [Array<String>] Reused disks and partitions names
+      def delete_stuff(devicegraph, disk, drive_spec, reused_devices)
+        reused_devices ||= []
+        if drive_spec.initialize_attr && reused_devices.empty?
           disk.remove_descendants
           return
         end
 
         if partition_table?(disk)
-          delete_by_use(devicegraph, disk, drive_spec, reused_parts)
+          delete_by_use(devicegraph, disk, drive_spec, reused_devices)
         else
-          clean_up_disk_by_use(disk, drive_spec, reused_parts)
+          clean_up_disk_by_use(disk, drive_spec, reused_devices)
         end
       end
 
       # Deletes unwanted partition according to the "use" element
       #
-      # @param devicegraph  [Devicegraph]
-      # @param disk         [Disk]
-      # @param drive_spec   [AutoinstProfile::DriveSection]
-      # @param reused_parts [Array<String>] Reused partitions names
-      def delete_by_use(devicegraph, disk, drive_spec, reused_parts)
+      # @param devicegraph    [Devicegraph]
+      # @param disk           [Disk]
+      # @param drive_spec     [AutoinstProfile::DriveSection]
+      # @param reused_devices [Array<String>] Reused disks and partitions names
+      def delete_by_use(devicegraph, disk, drive_spec, reused_devices)
         return if drive_spec.use == "free" || !partition_table?(disk)
 
         case drive_spec.use
         when "all"
-          delete_partitions(devicegraph, disk.partitions, reused_parts)
+          delete_partitions(devicegraph, disk.partitions, reused_devices)
         when "linux"
-          delete_linux_partitions(devicegraph, disk, reused_parts)
+          delete_linux_partitions(devicegraph, disk, reused_devices)
         when Array
-          delete_partitions_by_number(devicegraph, disk, drive_spec.use, reused_parts)
+          delete_partitions_by_number(devicegraph, disk, drive_spec.use, reused_devices)
         else
           register_invalid_use_value(drive_spec)
         end
@@ -110,11 +110,11 @@ module Y2Storage
 
       # Cleans up the disk according to the "use" element
       #
-      # @param disk         [Disk]
-      # @param drive_spec   [AutoinstProfile::DriveSection]
-      # @param reused_parts [Array<String>] Reused partitions names
-      def clean_up_disk_by_use(disk, drive_spec, reused_parts)
-        return if drive_spec.use != "all" || reused_parts.include?(disk.name)
+      # @param disk           [Disk]
+      # @param drive_spec     [AutoinstProfile::DriveSection]
+      # @param reused_devices [Array<String>] Reused disks and partitions names
+      def clean_up_disk_by_use(disk, drive_spec, reused_devices)
+        return if drive_spec.use != "all" || reused_devices.include?(disk.name)
 
         disk.remove_descendants
       end
@@ -128,12 +128,12 @@ module Y2Storage
 
       # Deletes Linux partitions from a disk in the given devicegraph
       #
-      # @param devicegraph  [Devicegraph] Working devicegraph
-      # @param disk         [Disk]        Disk to remove partitions from
-      # @param reused_parts [Array<String>] Reused partitions names
-      def delete_linux_partitions(devicegraph, disk, reused_parts)
+      # @param devicegraph    [Devicegraph] Working devicegraph
+      # @param disk           [Disk]        Disk to remove partitions from
+      # @param reused_devices [Array<String>] Reused disks and partitions names
+      def delete_linux_partitions(devicegraph, disk, reused_devices)
         parts = disk_analyzer.linux_partitions(disk)
-        delete_partitions(devicegraph, parts, reused_parts)
+        delete_partitions(devicegraph, parts, reused_devices)
       end
 
       # Deletes Linux partitions which number is included in a list
@@ -141,9 +141,9 @@ module Y2Storage
       # @param devicegraph [Devicegraph]    Working devicegraph
       # @param disk        [Disk]           Disk to remove partitions from
       # @param partition_nrs [Array<Integer>] List of partition numbers
-      def delete_partitions_by_number(devicegraph, disk, partition_nrs, reused_partitions)
+      def delete_partitions_by_number(devicegraph, disk, partition_nrs, reused_devices)
         parts = disk.partitions.select { |n| partition_nrs.include?(n.number) }
-        delete_partitions(devicegraph, parts, reused_partitions)
+        delete_partitions(devicegraph, parts, reused_devices)
       end
 
       # Deletes the indicated partitions
@@ -154,10 +154,10 @@ module Y2Storage
       #
       # @param devicegraph     [Devicegraph]               devicegraph
       # @param parts           [Array<Planned::Partition>] parts to delete
-      # @param reused_parts    [Array<String>]             reused partitions names
-      def delete_partitions(devicegraph, parts, reused_parts)
+      # @param reused_devices  [Array<String>]             reused disks and partitions names
+      def delete_partitions(devicegraph, parts, reused_devices)
         partition_killer = Proposal::PartitionKiller.new(devicegraph)
-        parts_to_delete = parts.reject { |p| reused_parts.include?(p.name) }
+        parts_to_delete = parts.reject { |p| reused_devices.include?(p.name) }
         parts_to_delete.map(&:sid).each do |sid|
           partition = partition_by_sid(devicegraph, sid)
           next unless partition
@@ -186,20 +186,20 @@ module Y2Storage
       # @param devicegraph     [Devicegraph]               devicegraph
       # @param planned_devices [Array<Planned::Partition>] set of partitions
       # @return [Hash<String,Array<String>>] disk name to list of reused partitions map
-      def reused_partitions_by_disk(devicegraph, planned_devices)
-        find_reused_partitions(devicegraph, planned_devices).each_with_object({}) do |part, map|
+      def reused_devices_by_disk(devicegraph, planned_devices)
+        find_reused_devices(devicegraph, planned_devices).each_with_object({}) do |part, map|
           disk_name = part.is?(:disk_device) ? part.name : part.partitionable.name
           map[disk_name] ||= []
           map[disk_name] << part.name
         end
       end
 
-      # Determine which partitions will be reused
+      # Determine which disks and partitions will be reused
       #
       # @param devicegraph     [Devicegraph]               devicegraph
       # @param planned_devices [Array<Planned::Partition>] set of partitions
       # @return [Hash<String,Array<String>>] disk name to list of reused partitions map
-      def find_reused_partitions(devicegraph, planned_devices)
+      def find_reused_devices(devicegraph, planned_devices)
         reused_devices = planned_devices.select(&:reuse_name).each_with_object([]) do |device, all|
           case device
           when Y2Storage::Planned::Partition

--- a/src/lib/y2storage/proposal/autoinst_space_maker.rb
+++ b/src/lib/y2storage/proposal/autoinst_space_maker.rb
@@ -80,9 +80,11 @@ module Y2Storage
           return
         end
 
-        # TODO: resizing of partitions
-
-        delete_by_use(devicegraph, disk, drive_spec, reused_parts)
+        if partition_table?(disk)
+          delete_by_use(devicegraph, disk, drive_spec, reused_parts)
+        else
+          clean_up_disk_by_use(disk, drive_spec, reused_parts)
+        end
       end
 
       # Deletes unwanted partition according to the "use" element
@@ -104,6 +106,17 @@ module Y2Storage
         else
           register_invalid_use_value(drive_spec)
         end
+      end
+
+      # Cleans up the disk according to the "use" element
+      #
+      # @param disk         [Disk]
+      # @param drive_spec   [AutoinstProfile::DriveSection]
+      # @param reused_parts [Array<String>] Reused partitions names
+      def clean_up_disk_by_use(disk, drive_spec, reused_parts)
+        return if drive_spec.use != "all" || reused_parts.include?(disk.name)
+
+        disk.remove_descendants
       end
 
       # Search a partition by its sid
@@ -175,7 +188,7 @@ module Y2Storage
       # @return [Hash<String,Array<String>>] disk name to list of reused partitions map
       def reused_partitions_by_disk(devicegraph, planned_devices)
         find_reused_partitions(devicegraph, planned_devices).each_with_object({}) do |part, map|
-          disk_name = part.partitionable.name
+          disk_name = part.is?(:disk_device) ? part.name : part.partitionable.name
           map[disk_name] ||= []
           map[disk_name] << part.name
         end
@@ -203,7 +216,7 @@ module Y2Storage
         end
 
         ancestors = reused_devices.map(&:ancestors).flatten
-        (reused_devices + ancestors).select { |p| p.is_a?(Y2Storage::Partition) }
+        (reused_devices + ancestors).select { |p| p.is?(:disk_device, :partition) }
       end
 
       # Build a device name to sid map

--- a/test/y2storage/autoinst_proposal_system0_test.rb
+++ b/test/y2storage/autoinst_proposal_system0_test.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env rspec
+
+#
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+describe Y2Storage::AutoinstProposal do
+  using Y2Storage::Refinements::SizeCasts
+
+  before do
+    fake_scenario("lvm-disk-as-pv.xml")
+
+    allow(Yast::Mode).to receive(:auto).and_return(true)
+  end
+
+  subject(:proposal) do
+    described_class.new(
+      partitioning: partitioning, devicegraph: fake_devicegraph, issues_list: issues_list
+    )
+  end
+
+  let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
+
+  let(:partitioning) do
+    [
+      {
+        "device"     => "/dev/system",
+        "initialize" => false,
+        "type"       => :CT_LVM,
+        "partitions" => [
+          {
+            "lv_name" => "root", "mount" => "/", "filesystem" => :ext4,
+            "create" => true, "size" => 90.GiB
+          },
+          {
+            "lv_name" => "swap", "mount" => "swap", "filesystem" => :swap,
+            "create" => true, "size" => 2.GiB
+          }
+        ]
+      },
+      {
+        "device"     => "/dev/sda",
+        "initialize" => false,
+        "type"       => :CT_DISK,
+        "use"        => "all",
+        "disklabel"  => "none",
+        "partitions" => [
+          { "create" => false, "lvm_group" => "system" }
+        ]
+      }
+    ]
+  end
+
+  describe "#propose" do
+    # Regression test for bsc#1115749
+    it "does not allow deleted LVM volume groups affect the name of new VGs" do
+      proposal.propose
+      vgs = proposal.devices.lvm_vgs
+
+      expect(vgs.size).to eq 1
+      # With bsc#1115749, the new (and only) volume group used to be called
+      # "system0" because there was a previous "system" VG... that was deleted,
+      # so it should not affect the name of the new one.
+      expect(vgs.first.vg_name).to eq "system"
+    end
+  end
+end

--- a/test/y2storage/proposal/autoinst_space_maker_test.rb
+++ b/test/y2storage/proposal/autoinst_space_maker_test.rb
@@ -43,6 +43,9 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
   let(:planned_vg) do
     Y2Storage::Planned::LvmVg.new(volume_group_name: "vg0").tap { |p| p.reuse_name = "vg0" }
   end
+  let(:planned_md) do
+    Y2Storage::Planned::Md.new(name: "/dev/md/md0").tap { |m| m.reuse_name = m.name }
+  end
   let(:issues_list) do
     Y2Storage::AutoinstIssues::List
   end
@@ -96,7 +99,22 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
       end
 
       context "and a RAID device will be reused" do
-        it "keeps the physical partition"
+        let(:scenario) { "md_raid" }
+        let(:planned_devices) { [planned_md] }
+
+        it "keeps the physical partition" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          expect(devicegraph.partitions).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/sda1"),
+            an_object_having_attributes("name" => "/dev/sda2")
+          )
+        end
+
+        it "keeps the RAID device" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          md = devicegraph.md_raids.first
+          expect(md.name).to eq("/dev/md/md0")
+        end
       end
     end
 

--- a/test/y2storage/proposal/autoinst_space_maker_test.rb
+++ b/test/y2storage/proposal/autoinst_space_maker_test.rb
@@ -141,6 +141,29 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
           )
         end
       end
+
+      context "and a full disk is used as component of a device to be reused" do
+        let(:partitioning_array) do
+          [{ "device" => "/dev/vda", "use" => "all" }, { "device" => "/dev/vdb", "use" => "all" }]
+        end
+        let(:scenario) { "partitioned_btrfs_bcache.xml" }
+        let(:planned_devices) { [planned_bcache] }
+
+        it "does not initialize the disk" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          vdb = devicegraph.find_by_name("/dev/vdb")
+          expect(vdb.children).to_not be_empty
+        end
+
+        it "keeps the Bcache device" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          bcache = devicegraph.bcaches.first
+          expect(bcache.name).to eq("/dev/bcache0")
+          expect(bcache.partitions).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/bcache0p1")
+          )
+        end
+      end
     end
 
     context "when 'use' key is set to 'linux'" do

--- a/test/y2storage/proposal/autoinst_space_maker_test.rb
+++ b/test/y2storage/proposal/autoinst_space_maker_test.rb
@@ -46,6 +46,9 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
   let(:planned_md) do
     Y2Storage::Planned::Md.new(name: "/dev/md/md0").tap { |m| m.reuse_name = m.name }
   end
+  let(:planned_bcache) do
+    Y2Storage::Planned::Bcache.new.tap { |b| b.reuse_name = "/dev/bcache0" }
+  end
   let(:issues_list) do
     Y2Storage::AutoinstIssues::List
   end
@@ -114,6 +117,28 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
           devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
           md = devicegraph.md_raids.first
           expect(md.name).to eq("/dev/md/md0")
+        end
+      end
+
+      context "and a Bcache device will be reused" do
+        let(:partitioning_array) { [{ "device" => "/dev/vda", "use" => "all" }] }
+        let(:scenario) { "partitioned_btrfs_bcache.xml" }
+        let(:planned_devices) { [planned_bcache] }
+
+        it "keeps the physical partition" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          expect(devicegraph.partitions).to include(
+            an_object_having_attributes("name" => "/dev/vda3")
+          )
+        end
+
+        it "keeps the Bcache device" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          bcache = devicegraph.bcaches.first
+          expect(bcache.name).to eq("/dev/bcache0")
+          expect(bcache.partitions).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/bcache0p1")
+          )
         end
       end
     end


### PR DESCRIPTION
## Problem

Given a system where there is already an LVM VG named (e.g., `system`), if you
try to reinstall using a new VG with the same name, it might happen that
AutoYaST modifies the wanted name (like `system0`) to avoid *colliding* with the
old name. It does not make sense, as you do not want to keep the old one.

- [bsc#1115749](https://bugzilla.suse.com/show_bug.cgi?id=1115749)

## Solution

The problem happens when you are using a full disk as a PV (it will not happen
when using partitions). The reason is that `AutoinstSpaceMaker` will not have
full disks into account, even when you have set the `use` to `all`.

Additionally, this PR also fixes the reusing of Bcache devices when, for some reason, the user does not mark the caching/backing devices to be reused.