### PR TITLE
Remove obsolete require

### DIFF
--- a/src/lib/y2storage/package_handler.rb
+++ b/src/lib/y2storage/package_handler.rb
@@ -22,7 +22,6 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "y2storage/used_storage_features"
 
 Yast.import "Package"
 Yast.import "PackageSystem"


### PR DESCRIPTION
## Problem

During implementation of #1060, an obsolete require was left behind.

## Solution

Remove the obsolete require. The dependency is not longer true (removing it was in fact one of the goals of the refactoring) and the required file is not longer there (unless you have an old version of yast2-storage-ng installed).