### PR TITLE
AutoYaST: warn about conflicting elements

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Mar 12 11:51:13 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: report the user when conflicting attributes are set
+  in a partition section (i.e., mount, raid_name, lvm_group,
+  btrfs_name, bcache_backing_for and bcache_caching_for)
+  (bsc#1165907).
+- 4.2.96
+
+-------------------------------------------------------------------
 Wed Mar 11 12:53:13 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Usability improvements when asking the user to install packages

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.95
+Version:        4.2.96
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/autoinst_issues.rb
+++ b/src/lib/y2storage/autoinst_issues.rb
@@ -34,6 +34,7 @@ end
 
 require "y2storage/autoinst_issues/list"
 require "y2storage/autoinst_issues/issue"
+require "y2storage/autoinst_issues/conflicting_attrs"
 require "y2storage/autoinst_issues/could_not_calculate_boot"
 require "y2storage/autoinst_issues/could_not_create_boot"
 require "y2storage/autoinst_issues/exception"

--- a/src/lib/y2storage/autoinst_issues/conflicting_attrs.rb
+++ b/src/lib/y2storage/autoinst_issues/conflicting_attrs.rb
@@ -1,0 +1,68 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+require "y2storage/autoinst_issues/issue"
+
+module Y2Storage
+  module AutoinstIssues
+    # Conflicting attributes where specified for the given section.
+    #
+    # The conflict is resolved and the 'selected_attr' is honored while the rest
+    # is ignored.
+    class ConflictingAttrs < Issue
+      # @return [Symbol] Selected attribute
+      attr_reader :selected_attr
+      # @return [Array<Symbol>] List of ignored attributes
+      attr_reader :ignored_attrs
+
+      # @param section [#parent,#section_name] Section where it was detected (see {AutoinstProfile})
+      # @param selected_attr [Symbol] Name of the attribute that will be used
+      # @param ignored_attrs [Array<Symbol>] List of attributes to be ignored
+      def initialize(section, selected_attr, ignored_attrs = [])
+        textdomain "storage"
+
+        @section = section
+        @selected_attr = selected_attr
+        @ignored_attrs = ignored_attrs
+      end
+
+      # Fatal problem
+      #
+      # @return [Symbol] :warn
+      # @see Issue#severity
+      def severity
+        :warn
+      end
+
+      # Return the error message to be displayed
+      #
+      # @return [String] Error message
+      # @see Issue#message
+      def message
+        attrs = [selected_attr] + ignored_attrs
+        format(
+          # TRANSLATORS: %{attr_list} is a list of AutoYaST profile elements. %{selected_attr}
+          # is the element that will be taken into account.
+          _("These elements are conflicting: %{attrs_list}. " \
+            "Only '%{selected_attr}' will be considered."),
+          attrs_list: attrs.join(", "), selected_attr: selected_attr
+        )
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/autoinst_issues/conflicting_attrs.rb
+++ b/src/lib/y2storage/autoinst_issues/conflicting_attrs.rb
@@ -33,7 +33,7 @@ module Y2Storage
       # @param section [#parent,#section_name] Section where it was detected (see {AutoinstProfile})
       # @param selected_attr [Symbol] Name of the attribute that will be used
       # @param ignored_attrs [Array<Symbol>] List of attributes to be ignored
-      def initialize(section, selected_attr, ignored_attrs = [])
+      def initialize(section, selected_attr, ignored_attrs)
         textdomain "storage"
 
         @section = section
@@ -41,7 +41,7 @@ module Y2Storage
         @ignored_attrs = ignored_attrs
       end
 
-      # Fatal problem
+      # Returns problem severity
       #
       # @return [Symbol] :warn
       # @see Issue#severity

--- a/src/lib/y2storage/proposal/autoinst_disk_device_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_disk_device_planner.rb
@@ -92,10 +92,6 @@ module Y2Storage
         issues_list.add(:surplus_partitions, drive) if drive.partitions.size > 1
         planned_disk = Y2Storage::Planned::Disk.new
         device_config(planned_disk, part, drive)
-        planned_disk.lvm_volume_group_name = part.lvm_group
-        planned_disk.raid_name = part.raid_name
-        planned_disk.btrfs_name = part.btrfs_name
-        add_bcache_attrs(planned_disk, part)
         add_device_reuse(planned_disk, disk, part)
 
         [planned_disk]
@@ -129,9 +125,6 @@ module Y2Storage
         issues_list.add(:surplus_partitions, drive) if drive.partitions.size > 1
         master_partition = drive.partitions.first
         planned_stray_device = Y2Storage::Planned::StrayBlkDevice.new
-        planned_stray_device.lvm_volume_group_name = master_partition.lvm_group
-        planned_stray_device.raid_name = master_partition.raid_name
-        planned_stray_device.btrfs_name = master_partition.btrfs_name
         device_config(planned_stray_device, master_partition, drive)
         add_device_reuse(planned_stray_device, stray_blk_device, master_partition)
         [planned_stray_device]

--- a/src/lib/y2storage/proposal/autoinst_md_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_md_planner.rb
@@ -70,7 +70,6 @@ module Y2Storage
         md = Planned::Md.new(name: drive.name_for_md)
         part_section = drive.partitions.first
         device_config(md, part_section, drive)
-        md.lvm_volume_group_name = part_section.lvm_group
         add_md_reuse(md, part_section) if part_section.create == false
         add_raid_options(md, drive.raid_options || part_section.raid_options)
         md
@@ -103,7 +102,6 @@ module Y2Storage
 
         md = Planned::Md.new(name: part_section.name_for_md)
         device_config(md, part_section, drive)
-        md.lvm_volume_group_name = part_section.lvm_group
         add_md_reuse(md, part_section) if part_section.create == false
         add_raid_options(md, part_section.raid_options)
         md

--- a/src/lib/y2storage/proposal/autoinst_vg_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_vg_planner.rb
@@ -62,10 +62,8 @@ module Y2Storage
         planned_lv = Y2Storage::Planned::LvmLv.new(nil, nil)
         planned_lv.logical_volume_name = section.lv_name
         planned_lv.lv_type = lv_type_for(section)
-        planned_lv.btrfs_name = section.btrfs_name
         add_stripes(planned_lv, section)
         device_config(planned_lv, section, drive)
-        add_bcache_attrs(planned_lv, section)
 
         return if section.used_pool && !add_to_thin_pool(planned_lv, planned_vg, section)
 

--- a/test/support/autoinst_devices_planner_bcache.rb
+++ b/test/support/autoinst_devices_planner_bcache.rb
@@ -33,7 +33,7 @@ RSpec.shared_examples "handles bcache configuration" do
 
     before do
       device_from_profile.bcache_backing_for = "/dev/bcache0"
-      device_from_profile.filesystem = nil
+      device_from_profile.mount = nil
     end
 
     it "sets the device to be used as backing device for the given bcache" do
@@ -44,6 +44,7 @@ RSpec.shared_examples "handles bcache configuration" do
   context "when a bcache is specified (as caching)" do
     before do
       device_from_profile.bcache_caching_for = ["/dev/bcache0"]
+      device_from_profile.mount = nil
     end
 
     it "sets the device to be used as caching device for the given bcache" do

--- a/test/support/autoinst_devices_planner_conflicts.rb
+++ b/test/support/autoinst_devices_planner_conflicts.rb
@@ -26,6 +26,10 @@ RSpec.shared_examples "handles conflicts" do
     end
   end
 
+  def added_issue
+    issues_list.find { |i| i.is_a?(Y2Storage::AutoinstIssues::ConflictingAttrs) }
+  end
+
   context "when conflicting attributes specify different usages for the device" do
     let(:root_spec) do
       {
@@ -46,9 +50,8 @@ RSpec.shared_examples "handles conflicts" do
     end
 
     it "registers an issue" do
-      expect(issues_list).to receive(:add)
-        .with(:conflicting_attrs, drive.partitions.first, :mount, Array)
       planner.planned_devices(drive)
+      expect(added_issue.selected_attr).to eq(:mount)
     end
 
     context "and the 'mount' attribute is missing" do
@@ -60,9 +63,8 @@ RSpec.shared_examples "handles conflicts" do
       end
 
       it "registers an issue" do
-        expect(issues_list).to receive(:add)
-          .with(:conflicting_attrs, drive.partitions.first, :raid_name, Array)
         planner.planned_devices(drive)
+        expect(added_issue.selected_attr).to eq(:raid_name)
       end
     end
 
@@ -75,9 +77,8 @@ RSpec.shared_examples "handles conflicts" do
       end
 
       it "registers an issue" do
-        expect(issues_list).to receive(:add)
-          .with(:conflicting_attrs, drive.partitions.first, :lvm_group, Array)
         planner.planned_devices(drive)
+        expect(added_issue.selected_attr).to eq(:lvm_group)
       end
     end
 
@@ -90,9 +91,8 @@ RSpec.shared_examples "handles conflicts" do
       end
 
       it "registers an issue" do
-        expect(issues_list).to receive(:add)
-          .with(:conflicting_attrs, drive.partitions.first, :btrfs_name, Array)
         planner.planned_devices(drive)
+        expect(added_issue.selected_attr).to eq(:btrfs_name)
       end
     end
 
@@ -105,9 +105,8 @@ RSpec.shared_examples "handles conflicts" do
       end
 
       it "registers an issue" do
-        expect(issues_list).to receive(:add)
-          .with(:conflicting_attrs, drive.partitions.first, :bcache_backing_for, Array)
         planner.planned_devices(drive)
+        expect(added_issue.selected_attr).to eq(:bcache_backing_for)
       end
     end
 
@@ -120,8 +119,8 @@ RSpec.shared_examples "handles conflicts" do
       end
 
       it "does not register an issue" do
-        expect(issues_list).to_not receive(:add)
         planner.planned_devices(drive)
+        expect(added_issue).to be_nil
       end
     end
   end

--- a/test/support/autoinst_devices_planner_conflicts.rb
+++ b/test/support/autoinst_devices_planner_conflicts.rb
@@ -1,0 +1,128 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+RSpec.shared_examples "handles conflicts" do
+  def planned_device(disk)
+    if disk.partitions.empty?
+      disk
+    else
+      disk.partitions.first
+    end
+  end
+
+  context "when conflicting attributes specify different usages for the device" do
+    let(:root_spec) do
+      {
+        "mount" => "/", "raid_name" => "/dev/md0", "lvm_group" => "vg0",
+        "btrfs_name" => "root", "bcache_backing_for" => "/dev/bcache0",
+        "bcache_caching_for" => "/dev/bcache1"
+      }
+    end
+    let(:missing_attrs) { [] }
+
+    before do
+      root_spec.delete_if { |k, _v| missing_attrs.include?(k) }
+    end
+
+    it "prefers the filesystem" do
+      disk = planner.planned_devices(drive).first
+      expect(planned_device(disk).mount_point).to eq("/")
+    end
+
+    it "registers an issue" do
+      expect(issues_list).to receive(:add)
+        .with(:conflicting_attrs, drive.partitions.first, :mount, Array)
+      planner.planned_devices(drive)
+    end
+
+    context "and the 'mount' attribute is missing" do
+      let(:missing_attrs) { ["mount"] }
+
+      it "prefers the raid_name" do
+        disk = planner.planned_devices(drive).first
+        expect(planned_device(disk).raid_name).to eq("/dev/md0")
+      end
+
+      it "registers an issue" do
+        expect(issues_list).to receive(:add)
+          .with(:conflicting_attrs, drive.partitions.first, :raid_name, Array)
+        planner.planned_devices(drive)
+      end
+    end
+
+    context "and 'mount' and 'raid_name' attributes are missing" do
+      let(:missing_attrs) { ["mount", "raid_name"] }
+
+      it "prefers the lvm_group" do
+        disk = planner.planned_devices(drive).first
+        expect(planned_device(disk).lvm_volume_group_name).to eq("vg0")
+      end
+
+      it "registers an issue" do
+        expect(issues_list).to receive(:add)
+          .with(:conflicting_attrs, drive.partitions.first, :lvm_group, Array)
+        planner.planned_devices(drive)
+      end
+    end
+
+    context "and 'mount', 'raid_name' and 'lvm_group' attributes are missing" do
+      let(:missing_attrs) { ["mount", "raid_name", "lvm_group"] }
+
+      it "prefers the btrfs_name" do
+        disk = planner.planned_devices(drive).first
+        expect(planned_device(disk).btrfs_name).to eq("root")
+      end
+
+      it "registers an issue" do
+        expect(issues_list).to receive(:add)
+          .with(:conflicting_attrs, drive.partitions.first, :btrfs_name, Array)
+        planner.planned_devices(drive)
+      end
+    end
+
+    context "and 'mount', 'raid_name' and 'lvm_group' and 'btrfs_name' attributes are missing" do
+      let(:missing_attrs) { ["mount", "raid_name", "lvm_group", "btrfs_name"] }
+
+      it "prefers the bcache_backing_for" do
+        disk = planner.planned_devices(drive).first
+        expect(planned_device(disk).bcache_backing_for).to eq("/dev/bcache0")
+      end
+
+      it "registers an issue" do
+        expect(issues_list).to receive(:add)
+          .with(:conflicting_attrs, drive.partitions.first, :bcache_backing_for, Array)
+        planner.planned_devices(drive)
+      end
+    end
+
+    context "only 'bcache_caching_for' is present" do
+      let(:missing_attrs) { ["mount", "raid_name", "lvm_group", "btrfs_name", "bcache_backing_for"] }
+
+      it "prefers the bcache_caching_for" do
+        disk = planner.planned_devices(drive).first
+        expect(planned_device(disk).bcache_caching_for).to eq("/dev/bcache1")
+      end
+
+      it "does not register an issue" do
+        expect(issues_list).to_not receive(:add)
+        planner.planned_devices(drive)
+      end
+    end
+  end
+end

--- a/test/y2storage/autoinst_issues/conflicting_attrs_test.rb
+++ b/test/y2storage/autoinst_issues/conflicting_attrs_test.rb
@@ -24,7 +24,9 @@ describe Y2Storage::AutoinstIssues::ConflictingAttrs do
   subject(:issue) { described_class.new(section, :raid_name, [:lvm_group]) }
 
   let(:section) do
-    instance_double(Y2Storage::AutoinstProfile::PartitionSection, lvm_group: "vg0", raid_name: "/dev/md0")
+    instance_double(
+      Y2Storage::AutoinstProfile::PartitionSection, lvm_group: "vg0", raid_name: "/dev/md0"
+    )
   end
 
   describe "#message" do

--- a/test/y2storage/autoinst_issues/conflicting_attrs_test.rb
+++ b/test/y2storage/autoinst_issues/conflicting_attrs_test.rb
@@ -1,0 +1,41 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "y2storage/autoinst_issues"
+
+describe Y2Storage::AutoinstIssues::ConflictingAttrs do
+  subject(:issue) { described_class.new(section, :raid_name, [:lvm_group]) }
+
+  let(:section) do
+    instance_double(Y2Storage::AutoinstProfile::PartitionSection, lvm_group: "vg0", raid_name: "/dev/md0")
+  end
+
+  describe "#message" do
+    it "returns a description of the issue" do
+      expect(issue.message).to include("Only 'raid_name' will be considered.")
+    end
+  end
+
+  describe "#severity" do
+    it "returns :warn" do
+      expect(issue.severity).to eq(:warn)
+    end
+  end
+end

--- a/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
@@ -50,6 +50,112 @@ describe Y2Storage::Proposal::AutoinstDiskDevicePlanner do
 
     include_examples "handles bcache configuration"
 
+    context "when conflicting attributes specify different usages for the device" do
+      let(:root_spec) do
+        {
+          "mount" => "/", "raid_name" => "/dev/md0", "lvm_group" => "vg0",
+          "btrfs_name" => "root", "bcache_backing_for" => "/dev/bcache0",
+          "bcache_caching_for" => "/dev/bcache1"
+        }
+      end
+      let(:missing_attrs) { [] }
+
+      before do
+        root_spec.delete_if { |k, _v| missing_attrs.include?(k) }
+      end
+
+      it "prefers the filesystem" do
+        disk = planner.planned_devices(drive).first
+        part = disk.partitions.first
+        expect(part.filesystem_type).to eq(Y2Storage::Filesystems::Type::BTRFS)
+      end
+
+      it "registers an issue" do
+        expect(issues_list).to receive(:add)
+          .with(:conflicting_attrs, drive.partitions.first, :mount, Array)
+        planner.planned_devices(drive)
+      end
+
+      context "and the 'mount' attribute is missing" do
+        let(:missing_attrs) { ["mount"] }
+
+        it "prefers the raid_name" do
+          disk = planner.planned_devices(drive).first
+          part = disk.partitions.first
+          expect(part.raid_name).to eq("/dev/md0")
+        end
+
+        it "registers an issue" do
+          expect(issues_list).to receive(:add)
+            .with(:conflicting_attrs, drive.partitions.first, :raid_name, Array)
+          planner.planned_devices(drive)
+        end
+      end
+
+      context "and 'mount' and 'raid_name' attributes are missing" do
+        let(:missing_attrs) { ["mount", "raid_name"] }
+
+        it "prefers the lvm_group" do
+          disk = planner.planned_devices(drive).first
+          part = disk.partitions.first
+          expect(part.lvm_volume_group_name).to eq("vg0")
+        end
+
+        it "registers an issue" do
+          expect(issues_list).to receive(:add)
+            .with(:conflicting_attrs, drive.partitions.first, :lvm_group, Array)
+          planner.planned_devices(drive)
+        end
+      end
+
+      context "and 'mount', 'raid_name' and 'lvm_group' attributes are missing" do
+        let(:missing_attrs) { ["mount", "raid_name", "lvm_group"] }
+
+        it "prefers the btrfs_name" do
+          disk = planner.planned_devices(drive).first
+          part = disk.partitions.first
+          expect(part.btrfs_name).to eq("root")
+        end
+
+        it "registers an issue" do
+          expect(issues_list).to receive(:add)
+            .with(:conflicting_attrs, drive.partitions.first, :btrfs_name, Array)
+          planner.planned_devices(drive)
+        end
+      end
+
+      context "and 'mount', 'raid_name' and 'lvm_group' and 'btrfs_name' attributes are missing" do
+        let(:missing_attrs) { ["mount", "raid_name", "lvm_group", "btrfs_name"] }
+
+        it "prefers the bcache_backing_for" do
+          disk = planner.planned_devices(drive).first
+          part = disk.partitions.first
+          expect(part.bcache_backing_for).to eq("/dev/bcache0")
+        end
+
+        it "registers an issue" do
+          expect(issues_list).to receive(:add)
+            .with(:conflicting_attrs, drive.partitions.first, :bcache_backing_for, Array)
+          planner.planned_devices(drive)
+        end
+      end
+
+      context "only 'bcache_caching_for' is present" do
+        let(:missing_attrs) { ["mount", "raid_name", "lvm_group", "btrfs_name", "bcache_backing_for"] }
+
+        it "prefers the bcache_caching_for" do
+          disk = planner.planned_devices(drive).first
+          part = disk.partitions.first
+          expect(part.bcache_caching_for).to eq("/dev/bcache1")
+        end
+
+        it "does not register an issue" do
+          expect(issues_list).to_not receive(:add)
+          planner.planned_devices(drive)
+        end
+      end
+    end
+
     context "specifying partition type" do
       context "when partition_type is set to 'primary'" do
         let(:root_spec) { { "mount" => "/", "size" => "max", "partition_type" => "primary" } }

--- a/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
@@ -21,6 +21,7 @@
 require_relative "../spec_helper"
 require_relative "../../support/autoinst_devices_planner_btrfs"
 require_relative "../../support/autoinst_devices_planner_bcache"
+require_relative "../../support/autoinst_devices_planner_conflicts"
 require "y2storage/proposal/autoinst_disk_device_planner"
 Yast.import "Arch"
 
@@ -50,111 +51,7 @@ describe Y2Storage::Proposal::AutoinstDiskDevicePlanner do
 
     include_examples "handles bcache configuration"
 
-    context "when conflicting attributes specify different usages for the device" do
-      let(:root_spec) do
-        {
-          "mount" => "/", "raid_name" => "/dev/md0", "lvm_group" => "vg0",
-          "btrfs_name" => "root", "bcache_backing_for" => "/dev/bcache0",
-          "bcache_caching_for" => "/dev/bcache1"
-        }
-      end
-      let(:missing_attrs) { [] }
-
-      before do
-        root_spec.delete_if { |k, _v| missing_attrs.include?(k) }
-      end
-
-      it "prefers the filesystem" do
-        disk = planner.planned_devices(drive).first
-        part = disk.partitions.first
-        expect(part.filesystem_type).to eq(Y2Storage::Filesystems::Type::BTRFS)
-      end
-
-      it "registers an issue" do
-        expect(issues_list).to receive(:add)
-          .with(:conflicting_attrs, drive.partitions.first, :mount, Array)
-        planner.planned_devices(drive)
-      end
-
-      context "and the 'mount' attribute is missing" do
-        let(:missing_attrs) { ["mount"] }
-
-        it "prefers the raid_name" do
-          disk = planner.planned_devices(drive).first
-          part = disk.partitions.first
-          expect(part.raid_name).to eq("/dev/md0")
-        end
-
-        it "registers an issue" do
-          expect(issues_list).to receive(:add)
-            .with(:conflicting_attrs, drive.partitions.first, :raid_name, Array)
-          planner.planned_devices(drive)
-        end
-      end
-
-      context "and 'mount' and 'raid_name' attributes are missing" do
-        let(:missing_attrs) { ["mount", "raid_name"] }
-
-        it "prefers the lvm_group" do
-          disk = planner.planned_devices(drive).first
-          part = disk.partitions.first
-          expect(part.lvm_volume_group_name).to eq("vg0")
-        end
-
-        it "registers an issue" do
-          expect(issues_list).to receive(:add)
-            .with(:conflicting_attrs, drive.partitions.first, :lvm_group, Array)
-          planner.planned_devices(drive)
-        end
-      end
-
-      context "and 'mount', 'raid_name' and 'lvm_group' attributes are missing" do
-        let(:missing_attrs) { ["mount", "raid_name", "lvm_group"] }
-
-        it "prefers the btrfs_name" do
-          disk = planner.planned_devices(drive).first
-          part = disk.partitions.first
-          expect(part.btrfs_name).to eq("root")
-        end
-
-        it "registers an issue" do
-          expect(issues_list).to receive(:add)
-            .with(:conflicting_attrs, drive.partitions.first, :btrfs_name, Array)
-          planner.planned_devices(drive)
-        end
-      end
-
-      context "and 'mount', 'raid_name' and 'lvm_group' and 'btrfs_name' attributes are missing" do
-        let(:missing_attrs) { ["mount", "raid_name", "lvm_group", "btrfs_name"] }
-
-        it "prefers the bcache_backing_for" do
-          disk = planner.planned_devices(drive).first
-          part = disk.partitions.first
-          expect(part.bcache_backing_for).to eq("/dev/bcache0")
-        end
-
-        it "registers an issue" do
-          expect(issues_list).to receive(:add)
-            .with(:conflicting_attrs, drive.partitions.first, :bcache_backing_for, Array)
-          planner.planned_devices(drive)
-        end
-      end
-
-      context "only 'bcache_caching_for' is present" do
-        let(:missing_attrs) { ["mount", "raid_name", "lvm_group", "btrfs_name", "bcache_backing_for"] }
-
-        it "prefers the bcache_caching_for" do
-          disk = planner.planned_devices(drive).first
-          part = disk.partitions.first
-          expect(part.bcache_caching_for).to eq("/dev/bcache1")
-        end
-
-        it "does not register an issue" do
-          expect(issues_list).to_not receive(:add)
-          planner.planned_devices(drive)
-        end
-      end
-    end
+    include_examples "handles conflicts"
 
     context "specifying partition type" do
       context "when partition_type is set to 'primary'" do
@@ -786,6 +683,8 @@ describe Y2Storage::Proposal::AutoinstDiskDevicePlanner do
       end
 
       include_examples "handles bcache configuration"
+
+      include_examples "handles conflicts"
 
       context "when a partition_nr is set to '0'" do
         include_examples "handles Btrfs snapshots"


### PR DESCRIPTION
## Problem

[bsc#1165907](https://bugzilla.suse.com/show_bug.cgi?id=1165907) revealed a problem when setting two mutually exclusive options in an AutoYaST partition section. In that case, setting the `lvm_group` and `raid_name` caused `libstorage-ng` to crash.

## Solution

There are a few elements that determine how is the device going to be used: `mount`, `raid_name`, `lvm_name`, `btrfs_name`, `bcache_backing_for` and `bcache_caching_for`. The truth is that all those elements should be exclusive.

Now, if more than one of those attributes are present, AutoYaST will select just one and ignore the rest. For the time being, the logic is pretty simple (just a matter of precedence), but in the future, we might consider a smarter mechanism.

## Testing

The PR contains some unit tests and I have tried the changes manually.

## Screenshots

<details>
<summary>AutoYaST warning</summary>

![conflicting-attrs](https://user-images.githubusercontent.com/15836/76522268-3e1cce00-645e-11ea-9129-3ddd012434f8.png)
</details>


