### PR TITLE
integrate new #adjust_block_size method (bsc#1164295)

### DIFF
--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -74,7 +74,9 @@ module Y2Storage
           "name", "size", "block_size", "io_size", "min_grain", "align_ofs", "mbr_gap"
         ].concat(FILE_SYSTEM_PARAM),
         "md"              => [
-          "name", "md_level", "md_parity", "chunk_size", "md_uuid", "in_etc_mdadm", "metadata"
+          "name", "md_level", "md_parity", "chunk_size", "md_uuid", "in_etc_mdadm", "metadata",
+           # size and block_size are ignored
+          "size", "block_size"
         ].concat(FILE_SYSTEM_PARAM),
         "md_device"       => ["blk_device"],
         "partition_table" => [],

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -75,7 +75,7 @@ module Y2Storage
         ].concat(FILE_SYSTEM_PARAM),
         "md"              => [
           "name", "md_level", "md_parity", "chunk_size", "md_uuid", "in_etc_mdadm", "metadata",
-           # size and block_size are ignored
+          # size and block_size are ignored
           "size", "block_size"
         ].concat(FILE_SYSTEM_PARAM),
         "md_device"       => ["blk_device"],

--- a/src/lib/y2storage/region.rb
+++ b/src/lib/y2storage/region.rb
@@ -88,6 +88,15 @@ module Y2Storage
     #   @param delta [Integer]
     storage_forward :adjust_length
 
+    # @!method adjust_block_size(block_size)
+    #   Sets new block size without changing the region size
+    #
+    #   @raise [storage::InvalidBlockSize] if region start or region end are not
+    #   aligned to block_size
+    #
+    #   @param block_size [DiskSize]
+    storage_forward :adjust_block_size
+
     # @!method <(other)
     #   Checks whether the region starts before the other
     #

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -533,7 +533,7 @@ module Y2Storage
       return nil if subvol.path.empty?
 
       content = { "path" => subvol.path }
-      content["nocow"] = "true" if subvol.nocow?
+      content["nocow"] = true if subvol.nocow?
       { "subvolume" => content }
     end
 

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -189,6 +189,8 @@ module Y2Storage
     def basic_md_attributes(md)
       {
         "name"         => md.name,
+        "size"         => md.size.to_s,
+        "block_size"   => md.region.block_size.to_s,
         "md_level"     => md.md_level.to_s,
         "md_parity"    => md.md_parity.to_s,
         "chunk_size"   => md.chunk_size.to_s,


### PR DESCRIPTION
## Task 1

- https://github.com/openSUSE/libstorage-ng/pull/709

`libstorage-ng` got a new method in its `Region` class.

## Task 2

Show RAID size and block size also in YAML file.

Note
> I've seen no good way to set the values in FakeDeviceFactory (because devices are added to the RAID at the end and overwrite the values), so they are just ignored when reading YAML.