### PR TITLE
write nocow attribute correctly into YAML

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 13 14:02:15 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- write nocow attribute correctly into YAML
+- 4.2.97
+
+-------------------------------------------------------------------
 Thu Mar 12 11:51:13 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: report the user when conflicting attributes are set

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.96
+Version:        4.2.97
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -533,7 +533,7 @@ module Y2Storage
       return nil if subvol.path.empty?
 
       content = { "path" => subvol.path }
-      content["nocow"] = "true" if subvol.nocow?
+      content["nocow"] = true if subvol.nocow?
       { "subvolume" => content }
     end
 


### PR DESCRIPTION
## Problem

Working on https://github.com/openSUSE/libstorage-ng/pull/709 I noticed that the `nocow` btrfs attribute is not written correctly into YAML, resulting in invalid YAML files.

It stored the value as string (`'true'`) instead of as `true`.