### PR TITLE
Check block sizes when cloning partitions (bsc#1166363) 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 19 11:16:31 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Partitioner: do not allow to clone a partition table to another
+  device with a different block size (bsc#1166363)
+- 4.2.99
+
+-------------------------------------------------------------------
 Wed Mar 18 16:37:28 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Restricted the scenarios in which software-defined RAIDs are

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.98
+Version:        4.2.99
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/clone_partition_table.rb
+++ b/src/lib/y2partitioner/actions/controllers/clone_partition_table.rb
@@ -159,7 +159,10 @@ module Y2Partitioner
         # @param target_device [Y2Storage::Partitionable] device where to clone
         # @return [Boolean]
         def same_topology?(target_device)
-          target_device.topology == device.topology
+          # Checking the topology object is not enough, block sizes also need to
+          # match (bsc#1166363)
+          target_device.topology == device.topology &&
+            target_device.block_size == device.block_size
         end
 
         # Whether the target device holds mount points

--- a/test/data/devicegraphs/mixed_disks_clone.yml
+++ b/test/data/devicegraphs/mixed_disks_clone.yml
@@ -71,6 +71,11 @@
     name: /dev/sde
     size: 100 GiB
 
+- disk:
+    name:       /dev/sdf
+    size:       200 GiB
+    block_size: 4 KiB
+
 - dasd:
     name:            /dev/dasda
     type:            eckd

--- a/test/y2partitioner/actions/controllers/clone_partition_table_test.rb
+++ b/test/y2partitioner/actions/controllers/clone_partition_table_test.rb
@@ -124,6 +124,10 @@ describe Y2Partitioner::Actions::Controllers::ClonePartitionTable do
         expect(subject.suitable_devices_for_cloning.map(&:name)).to_not include("/dev/dasda")
       end
 
+      it "does not include devices with a different block size" do
+        expect(subject.suitable_devices_for_cloning.map(&:name)).to_not include("/dev/sdf")
+      end
+
       context "when some devices do not support the partition table type" do
         let(:device_name) { "/dev/dasda" }
 


### PR DESCRIPTION
## Problem

The YaST Partitioner offers an option to clone the partition table from one device to others. During that action the Partitioner tries to only offer destination devices that make sense. That means they have to be as least as big as the source device, they have to have the same topology, etc.

Unfortunately, the Partitioner didn't check the block size of the devices, which must also match in order for the cloning to be possible.

- https://bugzilla.suse.com/show_bug.cgi?id=1166363
- https://trello.com/c/b9VsyvXH/1702-2-sle15-sp2-1166363-cloning-a-partition-table-with-different-sector-sizes-runs-into-an-internal-error

## Solution

After verifying that is perfectly possible for two devices with different block sizes to have identical `Topology` objects in libstorage-ng, I created this pull request that extends the existing check. In addition to verifying the topologies of both disks are equivalent, yast-storage-ng also checks the block sizes.

## Testing

- Extended the unit test
- Tested manually with mocked devices