### PR TITLE
Fix the /boot in bcache detection

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 23 17:36:02 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Prevents to put /boot in a bcache (bsc#1165903).
+- 4.2.101
+
+-------------------------------------------------------------------
 Fri Mar 20 12:25:12 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: show an error when no suitable components are found

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.100
+Version:        4.2.101
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
@@ -570,9 +570,9 @@ module Y2Storage
           # If this is not a BlkFilesystem (e.g. NFS), it can't be in a BCache
           return false unless device.respond_to?(:plain_blk_devices)
 
-          # Let's trust in the hierarchy to determine if the device belongs to a Bcache, although
-          # there may be some advanced configuration for which this is not totally true because the
-          # device is reachable from a not BCache ancestor.
+          # Strictly speaking, with very advanced storage configurations it may be possible to
+          # access a filesystem with bcache ancestors in the devicegraph without actually accessing
+          # the bcache. But that would be an extreme case and is not supported by YaST.
           device.ancestors.any? { |dev| dev.is?(:bcache) }
         end
       end

--- a/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
@@ -570,7 +570,10 @@ module Y2Storage
           # If this is not a BlkFilesystem (e.g. NFS), it can't be in a BCache
           return false unless device.respond_to?(:plain_blk_devices)
 
-          device.plain_blk_devices.any? { |dev| dev.is?(:bcache) }
+          # Let's trust in the hierarchy to determine if the device belongs to a Bcache, although
+          # there may be some advanced configuration for which this is not totally true because the
+          # device is reachable from a not BCache ancestor.
+          device.ancestors.any? { |dev| dev.is?(:bcache) }
         end
       end
 

--- a/test/y2storage/boot_requirements_strategies/analyzer_test.rb
+++ b/test/y2storage/boot_requirements_strategies/analyzer_test.rb
@@ -816,6 +816,22 @@ describe Y2Storage::BootRequirementsStrategies::Analyzer do
         expect(analyzer.boot_in_bcache?).to eq true
       end
     end
+
+    # Regression test for bsc#1165903: recognizes that /boot is in a BCache also when placed
+    # explicitly or implicitly in a formatted BCache partition.
+    context "when /boot is placed in a formatted BCache partition" do
+      let(:scenario) { "partitioned_btrfs_bcache.xml" }
+      let(:device_name) { "/dev/bcache0p1" }
+      let(:boot_part) { fake_devicegraph.find_by_name("/dev/vda2") }
+
+      it "returns true" do
+        # Remove the /boot mount point, which means
+        # it will be on the root filesystem, i.e., /dev/bcache0p1
+        boot_part.filesystem.mount_path = ""
+
+        expect(analyzer.boot_in_bcache?).to eq true
+      end
+    end
   end
 
   describe "#boot_encryption_type" do


### PR DESCRIPTION
## Problem

The installer allows to proceed even when `/boot` is explicitly or implicitly mounted in a [bcache](https://bcache.evilpiepirate.org/) formatted partition.

However, the installed system is not able to boot.

- https://trello.com/c/KK7xbNps
- https://bugzilla.suse.com/show_bug.cgi?id=1165903
- Related to https://github.com/yast/yast-storage-ng/pull/944


## Solution

To show an alert when `/boot` will be mounted in a bcache.


## Testing

- Added a new unit test
- Tested manually


## Screenshots

<details>
<summary>Click to show/hide</summary>

---

![Screenshot_sl5sp2_2020-03-23_20:44:18](https://user-images.githubusercontent.com/1691872/77361411-22aba000-6d47-11ea-858f-e4cb267226a7.png)

![Screenshot_sl5sp2_2020-03-23_20:44:25](https://user-images.githubusercontent.com/1691872/77361441-30612580-6d47-11ea-9d5a-8195e79bef33.png)
</details>

