### PR TITLE
Add preferred_name to BlkDevice and BlkFilesystem (needed for bsc#1166096)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 25 07:23:03 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Extend and improve the API to get udev names for a block device
+  (needed for bsc#1166096).
+- 4.2.102
+
+-------------------------------------------------------------------
 Mon Mar 23 17:36:02 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Prevents to put /boot in a bcache (bsc#1165903).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# RAID1C{3,4}
-BuildRequires:	libstorage-ng-ruby >= 4.2.61
+# Storage::BlkDevice#possible_mount_bys
+BuildRequires:	libstorage-ng-ruby >= 4.2.70
 BuildRequires:  update-desktop-files
 # CWM::DynamicProgressBar
 BuildRequires:  yast2 >= 4.2.63
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# RAID1C{3,4}
-Requires:       libstorage-ng-ruby >= 4.2.61
+# Storage::BlkDevice#possible_mount_bys
+Requires:       libstorage-ng-ruby >= 4.2.70
 # CWM::DynamicProgressBar
 Requires:       yast2 >= 4.2.63
 # Y2Packager::Repository

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.101
+Version:        4.2.102
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -288,6 +288,15 @@ module Y2Storage
     #   @return [Encryption] nil if the device is not encrypted
     storage_forward :encryption, as: "Encryption", check_with: :has_encryption
 
+    # @!method possible_mount_bys
+    #   Possible mount-by methods to reference the block device itself, regardless of its content
+    #
+    #   @see #preferred_name
+    #
+    #   @return [Array<Filesystems::MountByType>]
+    storage_forward :possible_mount_bys, as: "Filesystems::MountByType"
+    private :possible_mount_bys
+
     # Checks whether the device is encrypted
     #
     # @return [boolean]
@@ -658,6 +667,30 @@ module Y2Storage
     # @return [Boolean]
     def windows_suitable?
       false
+    end
+
+    # Most suitable mount by option to reference the block device itself,
+    # regardless of its content
+    #
+    # This would return the same result if the device is formatted or if it's
+    # empty. To determine the MountByType to reference a filesytem (e.g. in
+    # fstab), call {Mountable#preferred_mount_by} on the filesystem object.
+    #
+    # Only the options that are indeed available are considered, which means
+    # this method always returns an option that can be used safely.
+    #
+    # @return [Filesystems::MountByType]
+    def preferred_mount_by
+      Filesystems::MountByType.best_for(self, possible_mount_bys)
+    end
+
+    # Most suitable name to reference the block device
+    #
+    # @see #preferred_mount_by
+    #
+    # @return [String]
+    def preferred_name
+      path_for_mount_by(preferred_mount_by)
     end
 
     protected

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -183,7 +183,7 @@ module Y2Storage
     # @see #udev_paths
     # @return [Array<String>]
     def udev_full_paths
-      udev_paths.map { |path| File.join("/dev", "disk", "by-path", path) }
+      udev_paths.map { |path| Filesystems::MountByType::PATH.udev_name(path) }
     end
 
     # @!method udev_ids
@@ -208,7 +208,7 @@ module Y2Storage
     # @see #udev_ids
     # @return [Array<String>]
     def udev_full_ids
-      udev_ids.map { |id| File.join("/dev", "disk", "by-id", id) }
+      udev_ids.map { |id| Filesystems::MountByType::ID.udev_name(id) }
     end
 
     # @!attribute dm_table_name
@@ -477,17 +477,17 @@ module Y2Storage
       component_of.map(&:display_name).compact
     end
 
-    # Device path to use depending on the mount by option
+    # Device name (full path) to use for the given mount by option
     #
-    # @return [String, nil] nil if the path cannot be determined for the given mount by option
+    # This returns a file name that references the block device itself, regardless of its content.
+    # I.e. this would return the same result if the device is formatted or if it's empty.
+    # See also {Filesystems::BlkFilesystem#path_for_mount_by}.
+    #
+    # @return [String, nil] nil if the name cannot be determined for the given mount by option
     def path_for_mount_by(mount_by)
       case mount_by
       when Filesystems::MountByType::DEVICE
         name
-      when Filesystems::MountByType::UUID
-        udev_full_uuid
-      when Filesystems::MountByType::LABEL
-        udev_full_label
       when Filesystems::MountByType::ID
         udev_full_ids.first
       when Filesystems::MountByType::PATH
@@ -508,11 +508,7 @@ module Y2Storage
     # @see #udev_paths
     # @return [String, nil]
     def udev_full_label
-      label = filesystem_label
-
-      return nil if label.nil? || label.empty?
-
-      File.join("/dev", "disk", "by-label", label)
+      Filesystems::MountByType::LABEL.udev_name(filesystem_label)
     end
 
     # UUID of the filesystem, if any
@@ -528,11 +524,7 @@ module Y2Storage
     # @see #udev_paths
     # @return [String, nil]
     def udev_full_uuid
-      uuid = filesystem_uuid
-
-      return nil if uuid.nil? || uuid.empty?
-
-      File.join("/dev", "disk", "by-uuid", uuid)
+      Filesystems::MountByType::UUID.udev_name(filesystem_uuid)
     end
 
     # Type of the filesystem, if any

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -256,6 +256,29 @@ module Y2Storage
         Y2Storage::VolumeSpecification.for(mount_point.path)
       end
 
+      # File path to reference the filesystem based on the current mount by option
+      #
+      # @see #mount_by
+      #
+      # @return [String, nil] nil if the name cannot be determined for the current mount by option
+      def mount_by_name
+        return nil unless mount_by
+
+        path_for_mount_by(mount_by)
+      end
+
+      # Name (full path) that can be used to reference the filesystem for the given mount by option
+      #
+      # @return [String, nil] nil if the name cannot be determined for the given mount by option
+      def path_for_mount_by(mount_by)
+        if mount_by.is?(:label, :uuid)
+          attr_value = public_send(mount_by.to_sym)
+          mount_by.udev_name(attr_value)
+        else
+          blk_devices.first.path_for_mount_by(mount_by)
+        end
+      end
+
       protected
 
       # @see Device#is?

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -256,6 +256,15 @@ module Y2Storage
         Y2Storage::VolumeSpecification.for(mount_point.path)
       end
 
+      # Most suitable file path to reference the filesystem
+      #
+      # @see Mountable#preferred_mount_by
+      #
+      # @return [String]
+      def preferred_name
+        path_for_mount_by(preferred_mount_by)
+      end
+
       # File path to reference the filesystem based on the current mount by option
       #
       # @see #mount_by

--- a/src/lib/y2storage/filesystems/mount_by_type.rb
+++ b/src/lib/y2storage/filesystems/mount_by_type.rb
@@ -77,6 +77,18 @@ module Y2Storage
         name.nil? ? to_s : _(name)
       end
 
+      # Full path of the udev by-* link for this type, given a value of the
+      # referenced attribute
+      #
+      # @param value [String, nil] label, uuid, path or id of the device to point to
+      # @return [String, nil] nil if it's not possible to build the path of an udev
+      #   link that points to the device
+      def udev_name(value)
+        return nil if value.nil? || value.empty? || is?(:device)
+
+        File.join("/dev", "disk", "by-#{to_sym}", value)
+      end
+
       class << self
         # Type corresponding to the given fstab spec
         #

--- a/src/lib/y2storage/luks.rb
+++ b/src/lib/y2storage/luks.rb
@@ -70,6 +70,17 @@ module Y2Storage
       super
     end
 
+    # @see BlkDevice#path_for_mount_by
+    def path_for_mount_by(mount_by)
+      # Unlike most block devices, LUKS devices have an UUID and can have a label
+      if mount_by.is?(:label, :uuid)
+        attr_value = public_send(mount_by.to_sym)
+        mount_by.udev_name(attr_value)
+      else
+        super
+      end
+    end
+
     protected
 
     # @see Device#is?

--- a/src/lib/y2storage/md.rb
+++ b/src/lib/y2storage/md.rb
@@ -308,6 +308,16 @@ module Y2Storage
       in_etc_mdadm?
     end
 
+    # @see BlkDevice#path_for_mount_by
+    def path_for_mount_by(mount_by)
+      # Unlike most block devices, MD RAIDs have an UUID
+      if mount_by.is?(:uuid)
+        mount_by.udev_name(uuid)
+      else
+        super
+      end
+    end
+
     protected
 
     # Holders connecting the MD Raid to its component block devices in the

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -329,6 +329,9 @@ module Y2Storage
     #
     # Note that this method does not take into account the currently assigned mount by value
     #
+    # Only the options that are indeed available are considered (see {#suitable_mount_bys}),
+    # which means this method always returns an option that can be used safely.
+    #
     # @return [Filesystems::MountByType]
     def preferred_mount_by
       Filesystems::MountByType.best_for(filesystem, suitable_mount_bys)

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -445,23 +445,57 @@ describe Y2Storage::BlkDevice do
     context "when mounting by UUID" do
       let(:mount_by) { Y2Storage::Filesystems::MountByType::UUID }
 
-      before do
-        allow(subject).to receive(:udev_full_uuid).and_return(path_by_uuid)
-      end
-
-      context "and the device has by-uuid udev path" do
-        let(:path_by_uuid) { "/dev/disk/by-uuid/111222333444" }
-
-        it "returns the by-uuid udev path" do
-          expect(subject.path_for_mount_by(mount_by)).to eq(path_by_uuid)
-        end
-      end
-
-      context "and the device has no by-uuid udev path" do
-        let(:path_by_uuid) { nil }
+      context "and the device contains a filesystem with uuid" do
+        before { subject.filesystem.uuid = "111222333444" }
 
         it "returns nil" do
           expect(subject.path_for_mount_by(mount_by)).to be_nil
+        end
+      end
+
+      context "and the device constains no filesystem" do
+        before { subject.remove_descendants }
+
+        it "returns nil" do
+          expect(subject.path_for_mount_by(mount_by)).to be_nil
+        end
+      end
+
+      context "and the device is an MD" do
+        let(:scenario) { "md-imsm1-devicegraph.xml" }
+        let(:device_name) { "/dev/md/a" }
+
+        context "with uuid" do
+          it "returns the by-uuid udev path" do
+            expect(subject.path_for_mount_by(mount_by))
+              .to eq "/dev/disk/by-uuid/8f600ff3:ccc9872c:539cd6c8:91e3b4a1"
+          end
+        end
+
+        context "with not uuid defined yet" do
+          before { allow(subject).to receive(:uuid).and_return("") }
+
+          it "returns nil" do
+            expect(subject.path_for_mount_by(mount_by)).to be_nil
+          end
+        end
+      end
+
+      context "and the device is a LUKS" do
+        let(:device_name) { "/dev/mapper/cr_sda4" }
+
+        context "with uuid" do
+          before { allow(subject).to receive(:uuid).and_return("111222333444") }
+
+          it "returns the by-uuid udev path" do
+            expect(subject.path_for_mount_by(mount_by)).to eq "/dev/disk/by-uuid/111222333444"
+          end
+        end
+
+        context "with not uuid defined yet" do
+          it "returns nil" do
+            expect(subject.path_for_mount_by(mount_by)).to be_nil
+          end
         end
       end
     end
@@ -469,48 +503,23 @@ describe Y2Storage::BlkDevice do
     context "when mounting by label" do
       let(:mount_by) { Y2Storage::Filesystems::MountByType::LABEL }
 
-      before do
-        allow(subject).to receive(:udev_full_label).and_return(path_by_label)
-      end
-
-      context "and the device has by-label udev path" do
-        let(:path_by_label) { "/dev/disk/by-label/fslabel" }
-
-        it "returns the by-label udev path" do
-          expect(subject.path_for_mount_by(mount_by)).to eq(path_by_label)
+      context "and the device contains a filesystem a label" do
+        it "returns nil" do
+          expect(subject.filesystem.label).to_not be_empty
+          expect(subject.path_for_mount_by(mount_by)).to be_nil
         end
       end
 
-      context "and the device has no by-label udev path" do
-        let(:path_by_label) { nil }
+      context "and the device contains a filesystem with no label" do
+        before { subject.filesystem.label = "" }
 
         it "returns nil" do
           expect(subject.path_for_mount_by(mount_by)).to be_nil
         end
       end
-    end
 
-    context "when mounting by id" do
-      let(:mount_by) { Y2Storage::Filesystems::MountByType::ID }
-
-      before do
-        allow(subject).to receive(:udev_full_ids).and_return(paths_by_id)
-      end
-
-      context "and the device has by-id udev paths" do
-        let(:paths_by_id) { [path_by_id1, path_by_id2] }
-
-        let(:path_by_id1) { "/dev/disk/by-id/1111" }
-
-        let(:path_by_id2) { "/dev/disk/by-id/2222" }
-
-        it "returns the first by-id udev path" do
-          expect(subject.path_for_mount_by(mount_by)).to eq(path_by_id1)
-        end
-      end
-
-      context "and the device has no by-id udev paths" do
-        let(:paths_by_id) { [] }
+      context "and the device constains no filesystem" do
+        before { subject.remove_descendants }
 
         it "returns nil" do
           expect(subject.path_for_mount_by(mount_by)).to be_nil
@@ -521,15 +530,12 @@ describe Y2Storage::BlkDevice do
     context "when mounting by path" do
       let(:mount_by) { Y2Storage::Filesystems::MountByType::PATH }
 
-      before do
-        allow(subject).to receive(:udev_full_paths).and_return(paths_by_path)
-      end
-
       context "and the device has by-path udev paths" do
-        let(:paths_by_path) { [path_by_path1, path_by_path2] }
+        before do
+          allow(subject).to receive(:udev_full_paths).and_return [path_by_path1, path_by_path2]
+        end
 
         let(:path_by_path1) { "/dev/disk/by-path/pci1111-part1" }
-
         let(:path_by_path2) { "/dev/disk/by-path/pci2222-part1" }
 
         it "returns the first by-path udev path" do
@@ -538,7 +544,26 @@ describe Y2Storage::BlkDevice do
       end
 
       context "and the device has no by-path udev paths" do
-        let(:paths_by_path) { [] }
+        before do
+          allow(subject).to receive(:udev_full_paths).and_return []
+        end
+
+        it "returns nil" do
+          expect(subject.path_for_mount_by(mount_by)).to be_nil
+        end
+      end
+
+      context "and the device is a LUKS" do
+        let(:device_name) { "/dev/mapper/cr_sda4" }
+
+        it "returns nil" do
+          expect(subject.path_for_mount_by(mount_by)).to be_nil
+        end
+      end
+
+      context "and the device is an MD" do
+        let(:scenario) { "md-imsm1-devicegraph.xml" }
+        let(:device_name) { "/dev/md/a" }
 
         it "returns nil" do
           expect(subject.path_for_mount_by(mount_by)).to be_nil

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -1451,4 +1451,38 @@ describe Y2Storage::BlkDevice do
       expect(subject.windows_suitable?).to eq(false)
     end
   end
+
+  describe "#preferred_mount_by" do
+    let(:scenario) { "md-imsm1-devicegraph.xml" }
+    let(:device_name) { "/dev/sda1" }
+
+    let(:by_device) { Y2Storage::Filesystems::MountByType::DEVICE }
+    let(:by_path) { Y2Storage::Filesystems::MountByType::PATH }
+    let(:by_id) { Y2Storage::Filesystems::MountByType::ID }
+    let(:all_suitable) { [by_device, by_path, by_id] }
+
+    it "returns the best mount by from all the suitable ones" do
+      expect(Y2Storage::Filesystems::MountByType).to receive(:best_for)
+        .with(device, all_suitable).and_return(by_path)
+
+      expect(device.preferred_mount_by).to eq(by_path)
+    end
+  end
+
+  describe "#preferred_name" do
+    let(:scenario) { "md-imsm1-devicegraph.xml" }
+    let(:device_name) { "/dev/sda1" }
+
+    let(:by_device) { Y2Storage::Filesystems::MountByType::DEVICE }
+    let(:by_path) { Y2Storage::Filesystems::MountByType::PATH }
+    let(:by_id) { Y2Storage::Filesystems::MountByType::ID }
+    let(:all_suitable) { [by_device, by_path, by_id] }
+
+    it "returns the best mount by from all the suitable ones" do
+      expect(Y2Storage::Filesystems::MountByType).to receive(:best_for)
+        .with(device, all_suitable).and_return(by_path)
+
+      expect(device.preferred_name).to eq "/dev/disk/by-path/pci-0000:00:1f.2-ata-1-part1"
+    end
+  end
 end

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -453,7 +453,7 @@ describe Y2Storage::BlkDevice do
         end
       end
 
-      context "and the device constains no filesystem" do
+      context "and the device contains no filesystem" do
         before { subject.remove_descendants }
 
         it "returns nil" do
@@ -503,7 +503,7 @@ describe Y2Storage::BlkDevice do
     context "when mounting by label" do
       let(:mount_by) { Y2Storage::Filesystems::MountByType::LABEL }
 
-      context "and the device contains a filesystem a label" do
+      context "and the device contains a filesystem with a label" do
         it "returns nil" do
           expect(subject.filesystem.label).to_not be_empty
           expect(subject.path_for_mount_by(mount_by)).to be_nil
@@ -518,7 +518,7 @@ describe Y2Storage::BlkDevice do
         end
       end
 
-      context "and the device constains no filesystem" do
+      context "and the device contains no filesystem" do
         before { subject.remove_descendants }
 
         it "returns nil" do
@@ -1461,7 +1461,7 @@ describe Y2Storage::BlkDevice do
     let(:by_id) { Y2Storage::Filesystems::MountByType::ID }
     let(:all_suitable) { [by_device, by_path, by_id] }
 
-    it "returns the best mount by from all the suitable ones" do
+    it "returns the best mount_by type from all the suitable ones" do
       expect(Y2Storage::Filesystems::MountByType).to receive(:best_for)
         .with(device, all_suitable).and_return(by_path)
 
@@ -1478,7 +1478,7 @@ describe Y2Storage::BlkDevice do
     let(:by_id) { Y2Storage::Filesystems::MountByType::ID }
     let(:all_suitable) { [by_device, by_path, by_id] }
 
-    it "returns the best mount by from all the suitable ones" do
+    it "returns the best mount_by type from all the suitable ones" do
       expect(Y2Storage::Filesystems::MountByType).to receive(:best_for)
         .with(device, all_suitable).and_return(by_path)
 

--- a/test/y2storage/filesystems/blk_filesystem_test.rb
+++ b/test/y2storage/filesystems/blk_filesystem_test.rb
@@ -280,6 +280,23 @@ describe Y2Storage::Filesystems::BlkFilesystem do
     end
   end
 
+  describe "#preferred_name" do
+    let(:dev_name) { "/dev/sdb2" }
+
+    before do
+      allow(subject).to receive(:mount_point).and_return(mount_point)
+      allow(mount_point).to receive(:preferred_mount_by).and_return(preferred_mount_by)
+    end
+
+    let(:mount_point) { subject.mount_point }
+
+    let(:preferred_mount_by) { Y2Storage::Filesystems::MountByType::LABEL }
+
+    it "returns the name corresponding to the preferred mount_by" do
+      expect(subject.preferred_name).to eq "/dev/disk/by-label/suse_root"
+    end
+  end
+
   describe "#mount_options" do
     context "when filesystem has no mount point" do
       let(:dev_name) { "/dev/sdb3" }

--- a/test/y2storage/filesystems/blk_filesystem_test.rb
+++ b/test/y2storage/filesystems/blk_filesystem_test.rb
@@ -466,4 +466,103 @@ describe Y2Storage::Filesystems::BlkFilesystem do
       end
     end
   end
+
+  describe "#mount_by_name" do
+    let(:dev_name) { "/dev/sda2" }
+    before { subject.mount_point.mount_by = mount_by }
+
+    context "when mounting by device" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::DEVICE }
+
+      it "returns the kernel name of the block device" do
+        expect(subject.mount_by_name).to eq(dev_name)
+      end
+    end
+
+    context "when mounting by UUID" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::UUID }
+
+      context "if the uuid of the filesystem is known already" do
+        before { subject.uuid = "111222333444" }
+
+        it "returns the by-uuid udev path" do
+          expect(subject.mount_by_name).to eq "/dev/disk/by-uuid/111222333444"
+        end
+      end
+
+      context "if the uuid is still not known" do
+        it "returns nil" do
+          expect(subject.mount_by_name).to be_nil
+        end
+      end
+    end
+
+    context "when mounting by label" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::LABEL }
+
+      context "if the filesystem has a label" do
+        it "returns the by-label udev path" do
+          expect(subject.mount_by_name).to eq "/dev/disk/by-label/root"
+        end
+      end
+
+      context "if the filesystem has no label" do
+        before { subject.label = "" }
+
+        it "returns nil" do
+          expect(subject.mount_by_name).to be_nil
+        end
+      end
+    end
+
+    context "when mounting by path" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::PATH }
+
+      before do
+        allow(subject).to receive(:blk_devices).and_return [blk_device]
+        allow(blk_device).to receive(:udev_full_paths).and_return(paths)
+      end
+
+      context "if the block device has by-path udev paths" do
+        let(:paths) { ["/dev/disk/by-path/pci1111-part2"] }
+
+        it "returns the first by-path udev path" do
+          expect(subject.mount_by_name).to eq(paths.first)
+        end
+      end
+
+      context "if the block device has no by-path udev paths" do
+        let(:paths) { [] }
+
+        it "returns nil" do
+          expect(subject.mount_by_name).to be_nil
+        end
+      end
+    end
+
+    context "when mounting by id" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::ID }
+
+      before do
+        allow(subject).to receive(:blk_devices).and_return [blk_device]
+        allow(blk_device).to receive(:udev_full_ids).and_return(ids)
+      end
+
+      context "if the block device has by-id udev paths" do
+        let(:ids) { ["/dev/disk/by-id/id:pci:00"] }
+
+        it "returns the first by-id udev path" do
+          expect(subject.mount_by_name).to eq(ids.first)
+        end
+      end
+
+      context "if the block device has no by-id udev paths" do
+        let(:ids) { [] }
+
+        it "returns nil" do
+          expect(subject.mount_by_name).to be_nil
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Recently yast2-booloader was modified to not contain the logic about what is the best file path to reference a file, but to delegate that calculation to yast2-storage-ng. See https://github.com/yast/yast-bootloader/pull/591

Unfortunately, the logic implemented in that pull request is not really a direct translation of the previous one. If the device contains no filesystem (for example, PReP partitions and bios_boot ones), the logic implemented in https://github.com/yast/yast-bootloader/pull/591 fallbacks immediately to use the kernel device name.

In fact, the API offered by yast2-storage-ng only contained method to get the preferred name for `BlkFilesystem` objects, but not for `BlkDevice` objects themselves. Moreover, the distinction was not so clear and the method `BlkDevice#path_for_mount_by` was in fact calculating a path to point to the filesystem (if any), not to the block device.

**References:**

- https://bugzilla.suse.com/show_bug.cgi?id=1166096
- https://trello.com/c/SFYLkAIX/1703-3-tw-1166096-openqa-yast2bootloader-invalid-path-by-id-string 

## Solution

This pull request extends the yast2-storage-ng API to get udev names for a block device:

- `BlkFilesystem#mount_by_name` allows to get an udev name that matches the `mount_by` attribute of the filesystem (if any).
- `BlkFilesystem#preferred_name` allows to get the best (most stable) udev name to reference a filesystem. Useful for the bootloader when the previous one is not available.
- `BlkDevice#preferred_name` allows to get the best (most stable) udev name to reference a block device. Useful for the bootloader when the device does not contain any filesystem (e.g. PReP).

The new API is then used from https://github.com/yast/yast-bootloader/pull/593 to effectively fix the bug.

As part of the fix, `BlkDevice#path_for_mount_by` now always returns a file path that points to the device itself and `BlkFilesystem#path_for_mount_by` was added, for cases in which a path to the filesystem is needed. Note that, with the new API, the bootloader module doesn't need to call these methods anymore (there are more high-level methods to directly get the names).

## Testing

Added a new unit tests
Verified in the yast2-booloader side with a regression test.