### PR TITLE
reanimate saving USED_FS_LIST (bsc#1161533)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 26 15:18:33 CET 2020 - aschnell@suse.com
+
+- Reanimate saving USED_FS_LIST (bsc#1161533).
+- 4.2.103
+
+-------------------------------------------------------------------
 Wed Mar 25 07:23:03 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Extend and improve the API to get udev names for a block device

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.102
+Version:        4.2.103
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only
@@ -81,6 +81,7 @@ rake test:unit
 %yast_metainfo
 
 %post
+%{fillup_only -ans storage %{name}.common}
 %ifarch s390 s390x
 %{fillup_only -ans storage %{name}.s390}
 %else

--- a/src/fillup/sysconfig.storage-yast2-storage-ng.common
+++ b/src/fillup/sysconfig.storage-yast2-storage-ng.common
@@ -1,0 +1,5 @@
+## Path: System/Yast2/Storage
+
+## Type: string
+# List of used filesystem types.
+USED_FS_LIST=""

--- a/src/lib/y2partitioner/widgets/commit_actions.rb
+++ b/src/lib/y2partitioner/widgets/commit_actions.rb
@@ -21,6 +21,7 @@ require "cwm"
 
 require "y2storage/storage_manager"
 require "y2storage/callbacks/commit"
+require "y2storage/used_filesystems"
 require "y2partitioner/device_graphs"
 
 module Y2Partitioner
@@ -56,6 +57,7 @@ module Y2Partitioner
       # @see Y2Storage::Callbacks::Commit
       def init
         Y2Storage::StorageManager.instance.commit(callbacks: callbacks)
+        Y2Storage::UsedFilesystems.new(Y2Storage::StorageManager.instance.staging).write
       end
 
       # An event is auto-sent after initializing the widget, see {#init}. Here, the workflow is returned

--- a/src/lib/y2storage/clients/finish.rb
+++ b/src/lib/y2storage/clients/finish.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "installation/finish_client"
+require "y2storage/used_filesystems"
 
 module Y2Storage
   module Clients
@@ -56,11 +57,15 @@ module Y2Storage
       end
 
       # Updates sysconfig file (/etc/sysconfig/storage) with current values
-      # at StorageManager.
+      # at StorageManager and other locations.
+      #
+      # Since the sysconfig file is not copied from the inst-sys to the target
+      # each variable needs it own handling.
       #
       # @note This updates the sysconfig file in the target system.
       def update_sysconfig
         StorageManager.instance.configuration.update_sysconfig
+        Y2Storage::UsedFilesystems.new(Y2Storage::StorageManager.instance.staging).write
       end
 
       # Checks whether multipath will be used in the target system

--- a/src/lib/y2storage/clients/inst_disk_proposal.rb
+++ b/src/lib/y2storage/clients/inst_disk_proposal.rb
@@ -2,7 +2,7 @@
 #
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -30,6 +30,7 @@ require "y2storage/dialogs/proposal"
 require "y2storage/dialogs/guided_setup"
 require "y2partitioner/dialogs/main"
 require "y2storage/partitioning_features"
+require "y2storage/used_filesystems"
 
 module Y2Storage
   module Clients
@@ -109,6 +110,7 @@ module Y2Storage
           storage_manager.staging = @devicegraph
         end
         add_storage_packages
+        save_used_fs_list
       end
 
       def guided_setup
@@ -157,6 +159,11 @@ module Y2Storage
         features = storage_manager.staging.used_features
         pkg_handler = Y2Storage::PackageHandler.new(features.pkg_list)
         pkg_handler.set_proposal_packages
+      end
+
+      # Save the list of filesystem to /etc/sysconfig/storage.
+      def save_used_fs_list
+        Y2Storage::UsedFilesystems.new(storage_manager.staging).write
       end
 
       def new_settings

--- a/src/lib/y2storage/sysconfig_storage.rb
+++ b/src/lib/y2storage/sysconfig_storage.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -23,6 +23,9 @@ require "y2storage/filesystems/mount_by_type"
 
 module Y2Storage
   # Class to read and write /etc/sysconfig/storage file
+  #
+  # The class is basically a simply wrapper for the SCR. The class does not
+  # remember any values.
   #
   # @example Read raw value for key DEVICE_NAMES
   #   sysconfig = SysconfigStorage.instance
@@ -81,11 +84,19 @@ module Y2Storage
       write(DEVICE_NAMES, value)
     end
 
+    # Writes the value for the USED_FS_LIST key
+    #
+    # @param value [String]
+    def used_fs_list=(value)
+      write(USED_FS_LIST, value)
+    end
+
     private
 
     SYSCONFIG_PATH = ".sysconfig.storage".freeze
 
     DEVICE_NAMES = "DEVICE_NAMES".freeze
+    USED_FS_LIST = "USED_FS_LIST".freeze
 
     MOUNT_BY_FALLBACK = :uuid
 

--- a/src/lib/y2storage/used_filesystems.rb
+++ b/src/lib/y2storage/used_filesystems.rb
@@ -1,0 +1,78 @@
+# Copyright (c) 2020 SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage/sysconfig_storage"
+
+module Y2Storage
+  #
+  # Class to obtain the used filesystems of a devicegraph.
+  #
+  class UsedFilesystems
+    include Yast::Logger
+
+    # Constructor
+    #
+    # @param devicegraph Devicegraph
+    def initialize(devicegraph)
+      @devicegraph = devicegraph
+    end
+
+    # Write the used filesystems to /etc/sysconfig/storage.
+    def write
+      value = filesystems.join(" ")
+      log.info("writing USED_FS_LIST #{value}")
+      SysconfigStorage.instance.used_fs_list = value
+    end
+
+    private
+
+    # Mapping from storage feature to filesystem.
+    FEATURE_FILESYSTEM =
+      {
+        UF_BTRFS:    "btrfs",
+        UF_EXT2:     "ext2",
+        UF_EXT3:     "ext3",
+        UF_EXT4:     "ext4",
+        UF_XFS:      "xfs",
+        UF_REISERFS: "reiserfs",
+        UF_NFS:      "nfs",
+        UF_NTFS:     "ntfs",
+        UF_VFAT:     "vfat",
+        UF_EXFAT:    "exfat",
+        UF_F2FS:     "f2fs",
+        UF_UDF:      "udf",
+        UF_JFS:      "jfs",
+        UF_SWAP:     "swap"
+      }
+
+    # Get the used filesystems.
+    #
+    # @return [Array<String>] Used filesystems of the devicegraph.
+    def filesystems
+      features = @devicegraph.used_features.map(&:id)
+
+      filesystems = []
+      FEATURE_FILESYSTEM.each do |feature, filesystem|
+        filesystems.append(filesystem) if features.include?(feature)
+      end
+      filesystems
+    end
+  end
+end

--- a/test/y2storage/used_filesystems_test.rb
+++ b/test/y2storage/used_filesystems_test.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+require "y2storage/used_filesystems"
+
+describe Y2Storage::UsedFilesystems do
+  describe "#write" do
+    before do
+      fake_scenario("btrfs2-devicegraph.xml")
+    end
+
+    let(:devicegraph) { Y2Storage::StorageManager.instance.staging }
+
+    it "writes USED_FS_LIST with correct filesystem list" do
+      expect(Y2Storage::SysconfigStorage.instance).to receive("used_fs_list=").with("btrfs swap")
+      Y2Storage::UsedFilesystems.new(devicegraph).write
+    end
+  end
+end


### PR DESCRIPTION
## Problem

With the rewrite of yast2-storage it did no longer write the used filesystems to USED_FS_LIST in /etc/sysconfig/storage. AFAIS this has no further consequences.

- https://bugzilla.suse.com/show_bug.cgi?id=1161533

## Solution

The list is written again.

## Testing

- Added a new unit test.
- Tested manually.
