### PR TITLE
Fix grammar in error message (bsc#1166241)

### DIFF
--- a/src/lib/y2storage/autoinst_issues/no_disk.rb
+++ b/src/lib/y2storage/autoinst_issues/no_disk.rb
@@ -49,7 +49,7 @@ module Y2Storage
           # TRANSLATORS: kernel device name (eg. '/dev/sda1')
           _("Disk '%s' was not found") % section.device
         else
-          _("Not suitable disk was found")
+          _("No suitable disk was found")
         end
       end
     end

--- a/test/y2storage/autoinst_issues/no_disk_test.rb
+++ b/test/y2storage/autoinst_issues/no_disk_test.rb
@@ -35,7 +35,7 @@ describe Y2Storage::AutoinstIssues::NoDisk do
       let(:device_name) { nil }
 
       it "returns a general description of the issue" do
-        expect(issue.message).to include "Not suitable disk"
+        expect(issue.message).to include "No suitable disk"
       end
     end
 


### PR DESCRIPTION
## Problem

The bug report is only about "Not suitable disk found" -> "No suitable disk found".

- https://bugzilla.suse.com/show_bug.cgi?id=1166241

I assume it is better to keep translations so we should merge this after branching SP3.

## Solution

Fix the typo

## Testing + Screenshots

Not tested
