### PR TITLE
Do not propose the _netdev option for the root filesystem (bsc#1165937)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  1 12:27:01 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Never add the _netdev option to fstab for the root mount point
+  (bsc#1165937).
+- 4.2.105
+
+-------------------------------------------------------------------
 Fri Mar 27 13:14:08 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Reverted the changes done to support the calculation of udev

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.104
+Version:        4.2.105
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -184,7 +184,7 @@ module Y2Storage
         #  - We don't specify extra options for Btrfs subvolumes because the current
         #    libstorage-ng implementation would ignore them (BtrfsSubvolume#mount_options
         #    is bypassed to only return subvol=$path).
-        if in_network?
+        if needs_network_mount_options?
           (super + [NETWORK_OPTION]).uniq
         else
           super
@@ -257,6 +257,16 @@ module Y2Storage
       end
 
       protected
+
+      # Whether the network-related mount options (e.g. _netdev) should be part
+      # of {#extra_default_mount_options}
+      #
+      # @return [Boolean]
+      def needs_network_mount_options?
+        # Adding "_netdev" and similar options in fstab for / should not be necessary
+        # and it confuses (or used to confuse) systemd. See bsc#1165937.
+        in_network? && !root?
+      end
 
       # @see Device#is?
       def types_for_is

--- a/test/y2storage/encryption_test.rb
+++ b/test/y2storage/encryption_test.rb
@@ -226,7 +226,7 @@ describe Y2Storage::Encryption do
 
       def create_btrfs(blk_dev)
         fs = blk_dev.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
-        fs.create_mount_point("/")
+        fs.create_mount_point("/var")
         # To have full effect, this must be done after creating the mount point
         fs.add_btrfs_subvolumes(Y2Storage::SubvolSpecification.fallback_list)
         fs.mount_point.set_default_mount_options


### PR DESCRIPTION
## Problem

YaST adds the `_netdev` fstab option to all network-based file-systems. In the case of the root file-system that can be a problem. Copy&pasting the explanation directly from [the bugzilla entry](https://bugzilla.suse.com/show_bug.cgi?id=1165937):

_Adding `_netdev` for rootfs in /etc/fstab should not be necessary and it confuses systemd for the time being._

_It's not necessary because the main description of rootfs should be given through the kernel command line via "root*=" options. These options are parsed by the fstab generator, which should generate the correct dependencies especially if these options specify a remote root._

_OTOH `_netdev` is obviously not available until the rootfs is mounted._

_The entry in fstab for '/' is used but only to apply the final mount options, and it's done in a second step._

_It's confusing for systemd because `_netdev` is still parsed by the main system and it adds dependencies on the network for the root block device, which is problematic if other local mount points depend on the root block device too (like it's the case when btrfs is used)._

See also https://trello.com/c/cXymsayP/1731-2-sle15-sp2-p1-1165937-systemd-unit-ordering-for-root-fs-on-network-yast-should-not-use-netdev

## Solution

Do not add the `_netdev` fstab option for the root filesystem.

## Testing

Added a new unit tests