### PR TITLE
Refresh the system devicegraph when reprobing (bsc#1168325)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr  3 14:18:30 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Partitioner: fixed a crash when some devices are modified both
+  before and after reprobing the hardware (bsc#1168325).
+- 4.1.94
+
+-------------------------------------------------------------------
 Mon Mar  9 09:53:50 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: show an error when no suitable physical volumes are

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.1.93
+Version:        4.1.94
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -386,6 +386,7 @@ module Y2Storage
     def reset_probed
       @raw_probed_graph = nil
       @probed_graph = nil
+      @system_graph = nil
       @probed_disk_analyzer = nil
       @committed = false
       Y2Storage::HWInfoReader.instance.reset

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -628,16 +628,19 @@ describe Y2Storage::StorageManager do
       manager.probed
       manager.probed_disk_analyzer
       manager.staging
+      manager.system
       manager.proposal
 
       # And now mock subsequent Storage calls
       allow(manager.storage).to receive(:probe)
       allow(manager.storage).to receive(:probed).and_return st_probed
       allow(manager.storage).to receive(:staging).and_return st_staging
+      allow(manager.storage).to receive(:system).and_return st_system
     end
 
     let(:st_probed) { Storage::Devicegraph.new(manager.storage) }
     let(:st_staging) { Storage::Devicegraph.new(manager.storage) }
+    let(:st_system) { Storage::Devicegraph.new(manager.storage) }
     let(:devicegraph) { Y2Storage::Devicegraph.new(st_staging) }
     let(:proposal) { double("Y2Storage::GuidedProposal", devices: devicegraph) }
 
@@ -663,6 +666,18 @@ describe Y2Storage::StorageManager do
 
       expect(manager.probed.disks.size).to eq 0
       expect(manager.probed.to_storage_value).to eq st_staging
+    end
+
+    it "refreshes #system" do
+      expect(manager.system.disks.size).to eq 6
+      # Calling twice (or more) does not result in a refresh
+      expect(manager.system.disks.size).to eq 6
+      expect(manager.system.to_storage_value).to_not eq st_system
+
+      manager.probe
+
+      expect(manager.system.disks.size).to eq 0
+      expect(manager.system.to_storage_value).to eq st_probed
     end
 
     it "increments the staging revision" do


### PR DESCRIPTION
## Problem

This sequence of steps in the Partitioner leaded to a crash:

- Delete a partition containing a filesystem
- Reprobe
- Delete a partition containing a filesystem (not necessarily the same)

The problem was an outdated `Y2Storage::StorageManager.instance.system` pointing to a devicegraph that had been already killed by libstorage-ng.

The possibility to access to `Storage.system` (in addition to `probed` and `staging`) was added to `Y2Storage::StorageManager` in #725. But, although the libstorage-ng documentation specifies that reprobing invalidates the three devicegraphs `probed`, `system` and `staging`, the memoization of the latter was not being cleared up.

- Report for SLE-15-SP2: https://bugzilla.suse.com/show_bug.cgi?id=1168325
- https://trello.com/c/UgS6aENr/1765-sle15-sp2-p1-1168325-installer-crash-segv-in-partitioner-rescan-delete-partition

## Solution

Reset `StorageManager#system` in the same moment in which `StorageManager#probed` is reset.

## Testing

- Added a new unit test
- Tested manually
