### PR TITLE
allow to disable LUKS activation (bsc#1162545)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr 06 09:14:25 CEST 2020 - aschnell@suse.com
+
+- allow to disable LUKS activation (bsc#1162545)
+- 4.1.95
+
+-------------------------------------------------------------------
 Fri Apr  3 14:18:30 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Partitioner: fixed a crash when some devices are modified both

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.1.94
+Version:        4.1.95
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/callbacks/activate.rb
+++ b/src/lib/y2storage/callbacks/activate.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# Copyright (c) [2017-2018] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,6 +22,7 @@
 require "yast"
 require "y2storage/dialogs/callbacks/activate_luks"
 require "y2storage/callbacks/libstorage_callback"
+require "y2storage/storage_env"
 
 Yast.import "Popup"
 
@@ -60,6 +61,9 @@ module Y2Storage
 
       def luks(uuid, attempt)
         log.info("Trying to open luks UUID: #{uuid} (#{attempt} attempts)")
+
+        return Storage::PairBoolString.new(false, "") if !StorageEnv.instance.activate_luks?
+
         dialog = Dialogs::Callbacks::ActivateLuks.new(uuid, attempt)
         result = dialog.run
 

--- a/test/y2storage/callbacks/activate_test.rb
+++ b/test/y2storage/callbacks/activate_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,6 +33,8 @@ describe Y2Storage::Callbacks::Activate do
   end
 
   describe "#luks" do
+    before { mock_env(env_vars) }
+
     let(:dialog) { instance_double(Y2Storage::Dialogs::Callbacks::ActivateLuks) }
 
     before do
@@ -45,6 +47,7 @@ describe Y2Storage::Callbacks::Activate do
     let(:attempts) { 1 }
     let(:action) { nil }
     let(:encryption_password) { "123456" }
+    let(:env_vars) { {} }
 
     it "opens a dialog to request the password" do
       expect(dialog).to receive(:run).once
@@ -72,6 +75,17 @@ describe Y2Storage::Callbacks::Activate do
         result = subject.luks(uuid, attempts)
         expect(result.first).to eq(false)
         expect(result.second).to eq("")
+      end
+    end
+
+    context "and YAST_ACTIVATE_LUKS was deactivated on boot" do
+      let(:env_vars) do
+        { "YAST_ACTIVATE_LUKS" => "0" }
+      end
+
+      it "does not ask the user" do
+        expect(dialog).to_not receive(:run)
+        subject.luks(uuid, attempts)
       end
     end
   end

--- a/test/y2storage/storage_env_test.rb
+++ b/test/y2storage/storage_env_test.rb
@@ -1,0 +1,71 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+require "y2storage/storage_env"
+
+describe Y2Storage::StorageEnv do
+  before do
+    mock_env(env_vars)
+  end
+
+  describe "#activate_luks?" do
+    context "YAST_ACTIVATE_LUKS is not set" do
+      let(:env_vars) do
+        {}
+      end
+
+      it "returns true" do
+        expect(Y2Storage::StorageEnv.instance.activate_luks?).to be true
+      end
+    end
+
+    context "YAST_ACTIVATE_LUKS is empty" do
+      let(:env_vars) do
+        { "YAST_ACTIVATE_LUKS" => "" }
+      end
+
+      it "returns true" do
+        expect(Y2Storage::StorageEnv.instance.activate_luks?).to be true
+      end
+    end
+
+    context "YAST_ACTIVATE_LUKS is set to '1'" do
+      let(:env_vars) do
+        { "YAST_ACTIVATE_LUKS" => "1" }
+      end
+
+      it "returns true" do
+        expect(Y2Storage::StorageEnv.instance.activate_luks?).to be true
+      end
+    end
+
+    context "YAST_ACTIVATE_LUKS is set to '0'" do
+      let(:env_vars) do
+        { "YAST_ACTIVATE_LUKS" => "0" }
+      end
+
+      it "returns false" do
+        expect(Y2Storage::StorageEnv.instance.activate_luks?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

If the system has many LUKS devices users do not like to have to cancel activation several times during upgrade.

- https://bugzilla.suse.com/show_bug.cgi?id=1162545

## Solution

Allow to disable LUKS activation by setting the environment variable YAST_ACTIVATE_LUKS=0.

## Testing

- Added a new unit test.
- Tested manually.
