### PR TITLE
Remove CONTRIBUTING.md from the spec file

### DIFF
--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -100,6 +100,5 @@ rake test:unit
 %{yast_icondir}
 %license COPYING
 %doc README.md
-%doc CONTRIBUTING.md
 
 %changelog


### PR DESCRIPTION
## Problem

The **CONTRIBUTING.md** file was removed (#1076) from the repository but the file is still referenced in the spec file

## Solution

Remove the file from the spec file
