### PR TITLE
rework VFAT mount option handling (bsc#1161771)

### DIFF
--- a/doc/vfat-notes.md
+++ b/doc/vfat-notes.md
@@ -1,0 +1,84 @@
+## VFAT and case-insensitve file names
+
+When mounting a vfat file system the options `iocharset` and `codepage`
+control the file name encoding.
+
+For a discussion of vfat mount options see
+[this](https://www.kernel.org/doc/Documentation/filesystems/vfat.txt)
+kernel doc.
+
+The current system defaults compiled into the kernel can be seen in
+
+- `/proc/config.gz::CONFIG_FAT_DEFAULT_IOCHARSET` and
+- `/proc/config.gz::CONFIG_FAT_DEFAULT_CODEPAGE`
+
+`codepage` is used to convert long file names to legacy (DOS-like) 8.3 file
+names. That's mostly irrelevant and users can stick to the default
+(compiled-in) code page 437.
+
+`iocharset` is used to convert from the vfat internally used utf16 to
+whatever is needed by the current unix locale.
+
+Ideally that is utf8.
+
+Now here comes the catch: the kernel doesn't implement case conversion for
+unicode **at all**. The kernel's `nls_strnicmp()` resp. `charset2lower()`
+work byte-wise and won't do for utf8. That's why the `nls_utf8.ko` module doesn't
+bother to provide any case conversion.
+
+This means that `iocharset=utf8` will not have case-insensitive file names.
+No matter what.
+
+To still get the case-insensitivity wanted by vfat, there's a separate
+code path triggered by the `utf8` option.
+
+As it happens, the `utf8` option solves the case-insensitivity only partly
+when it comes to non-ASCII chars.
+
+Note that you can have both `iocharset=NOT_UTF8` **and** `utf8`. It is actually
+**expected** that you do. The `iocharset` is used for the needed case-insensitve
+comparision. From this follows that `iocharset=utf8,utf8` is doing you no
+good.
+
+See this shell session run on a vfat file system mounted with (only) `utf8`:
+
+```sh
+> touch ü
+> touch Ü
+> touch Ä
+> touch ä
+touch: cannot touch 'ä': File exists
+> touch 1234567_ä
+> touch 1234567_Ä
+> touch 1234567_X
+> touch 1234567_x
+> ls
+1234567_X 1234567_Ä  1234567_ä  Ä  ü
+```
+
+You can see that it works as long as you stick to ASCII. For other chars it
+works 'somewhat'.
+
+For example, starting with `ü` it sees that `Ü` is the same. But starting
+with an uppercase letter like `Ä` it runs into a kernel bug when you try to
+access `ä` (the `EEXIST` error in `touch` - in fact, any file open
+triggers this).
+
+File names with non-ASCII chars that don't fit into the 8.3 scheme are
+completely case-sensitive.
+
+The intention of the `utf8` options seems to have been to use `iocharset`
+for case-insensitive comparison while still using utf8 encoding. But it is
+not working this way.
+
+A tentative explanation of the above behavior (including the bug) is that
+
+1. the case-insensitive comparision of long file names does not work
+2. instead, the match of `Ü` to `ü` occurs because `Ü` matches the existing valid 8.3 name `Ü`
+  that has been created for `ü`
+3. the bug happens because `ä` does not match `Ä` (and also not `Ä`'s 8.3
+  name `Ä`) - and the kernel then tries to create a new `ä` but fails as the
+  corresponding 8.3 name `Ä` already exists
+
+Finally, note that `iocharset=NOT_UTF8` does have no issues and works fine.
+But is mostly useless since utf8 locales are used everywhere.

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 15 11:10:16 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- rework VFAT mount option handling (bsc#1161771)
+- 4.2.108
+
+-------------------------------------------------------------------
 Mon Apr 06 09:14:25 CEST 2020 - aschnell@suse.com
 
 - allow to disable LUKS activation (bsc#1162545)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.107
+Version:        4.2.108
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -869,7 +869,7 @@ module Y2Partitioner
           "<p><b>Charset for File Names:</b>\n" \
           "Set the charset used for display of file names in Windows partitions.<br>\n" \
           "Note that choosing 'utf8' here will implicitly make " \
-          "filename comparision case-sensitve.<br>\n" \
+          "filename comparison case-sensitve.<br>\n" \
           "To avoid this, leave this field empty and instead add 'utf8' " \
           "to the Arbitrary Option Value field." \
           "</p>\n"

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -722,10 +722,14 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def help
-        _("<p><b>Arbitrary Option Value:</b> " \
+        _(
+          "<p><b>Arbitrary Option Value:</b> " \
           "Enter any other mount options here, separated with commas. " \
-          "Notice that this does not do any checking, so be careful " \
-          "what you enter here!</p>")
+          "Notice that this does not do any checking, so be careful what you enter here!<br>" \
+          "If you want to have utf8 encoded filenames with limited case-insensitivity then " \
+          "add 'utf8' here and leave the Charset for File Names field empty." \
+          "</p>"
+        )
       end
 
       private
@@ -861,8 +865,15 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def help
-        _("<p><b>Charset for File Names:</b>\nSet the charset used for display " \
-        "of file names in Windows partitions.</p>\n")
+        _(
+          "<p><b>Charset for File Names:</b>\n" \
+          "Set the charset used for display of file names in Windows partitions.<br>\n" \
+          "Note that choosing 'utf8' here will implicitly make " \
+          "filename comparision case-sensitve.<br>\n" \
+          "To avoid this, leave this field empty and instead add 'utf8' " \
+          "to the Arbitrary Option Value field." \
+          "</p>\n"
+        )
       end
     end
 

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -840,16 +840,18 @@ module Y2Partitioner
       end
 
       def default_value
-        iocharset = filesystem.type.iocharset
-        ITEMS.include?(iocharset) ? iocharset : ITEMS.first
+        ITEMS.first
       end
 
       def supported_by_mount_path?
         return false if mount_path.nil?
 
-        # "iocharset=utf8" breaks VFAT case insensitivity (bsc#1080731).
-        # See also boot_fstab_options() in lib/y2storage/filesystems/type.rb
-        mount_path != "/boot" && !mount_path.start_with?("/boot/")
+        # We used to disable the iocharset dialog for filesystems used for booting since
+        # iocharset=utf8 breaks VFAT case insensitivity (bsc#1080731).
+        #
+        # That's taken care of now in {Filesystems::Type#patch_iocharset}
+        # when we create a new file system.
+        true
       end
 
       # @macro seeAbstractWidget
@@ -872,8 +874,7 @@ module Y2Partitioner
       ITEMS = ["", "437", "852", "932", "936", "949", "950"].freeze
 
       def default_value
-        cp = filesystem.type.codepage
-        ITEMS.include?(cp) ? cp : ITEMS.first
+        ITEMS.first
       end
 
       # @macro seeAbstractWidget

--- a/src/lib/y2storage/filesystems/type.rb
+++ b/src/lib/y2storage/filesystems/type.rb
@@ -44,6 +44,15 @@ module Y2Storage
       # if not needed because in many cases no such filesystem is used.
       IOCHARSET_OPTIONS = ["iocharset="].freeze
       CODEPAGE_OPTIONS = ["codepage="].freeze
+
+      # The default system values are in principle visible in
+      #
+      # /proc/config.gz::CONFIG_FAT_DEFAULT_IOCHARSET
+      # /proc/config.gz::CONFIG_FAT_DEFAULT_CODEPAGE
+      #
+      # but it's always iso8859-1 & 437 anyway.
+      #
+      DEFAULT_IOCHARSET = "iso8859-1".freeze
       DEFAULT_CODEPAGE = "437".freeze
 
       # Base for valid characters (as a string): "ABC...XYZabc...xyz012..89"
@@ -444,7 +453,7 @@ module Y2Storage
           next opt unless opt.start_with?("codepage")
 
           cp = codepage
-          if cp == "437" # Default according to "man mount"
+          if cp == DEFAULT_CODEPAGE # Default according to "man mount"
             nil
           else
             "codepage=" + cp
@@ -463,8 +472,20 @@ module Y2Storage
           next opt unless opt.start_with?("iocharset")
 
           iocharset = lang_typical_encoding
-          "iocharset=" + iocharset
-        end
+
+          case iocharset
+          when DEFAULT_IOCHARSET
+            nil
+          when "utf8"
+            # Avoid iocharset=utf8 since that makes the mount case-sensitve as a side effect.
+            # Instead, use the separate utf8 option.
+            #
+            # See doc/vfat-notes.md for some background.
+            iocharset
+          else
+            "iocharset=" + iocharset
+          end
+        end.compact
       end
 
       # Return the codepage for FAT filesystems. This is used to convert

--- a/test/data/devicegraphs/output/raspi_empty.yml
+++ b/test/data/devicegraphs/output/raspi_empty.yml
@@ -10,6 +10,8 @@
         type: primary
         id: dos32
         file_system: vfat
+        fstab_options:
+          - utf8
         mount_point: /boot/efi
     - partition:
         size: 40 GiB

--- a/test/data/devicegraphs/output/raspi_firmware.yml
+++ b/test/data/devicegraphs/output/raspi_firmware.yml
@@ -17,6 +17,8 @@
         type: primary
         id: esp
         file_system: vfat
+        fstab_options:
+          - utf8
         mount_point: /boot/efi
     - partition:
         size: 40 GiB

--- a/test/y2storage/filesystems/type_test.rb
+++ b/test/y2storage/filesystems/type_test.rb
@@ -166,7 +166,7 @@ describe Y2Storage::Filesystems::Type do
       it "vfat has the correct fstab options for a utf8 locale" do
         Yast::Encoding.SetUtf8Lang(true)
         Yast::Encoding.SetEncLang("de_DE")
-        expect(described_class::VFAT.default_fstab_options).to eq ["iocharset=utf8"]
+        expect(described_class::VFAT.default_fstab_options).to eq ["utf8"]
       end
 
       it "vfat has the correct fstab options for a non-utf8 cs_CZ locale" do
@@ -202,9 +202,9 @@ describe Y2Storage::Filesystems::Type do
         it "vfat has the correct fstab options for a utf8 locale" do
           Yast::Encoding.SetUtf8Lang(true)
           Yast::Encoding.SetEncLang("de_DE")
-          expect(described_class::VFAT.default_fstab_options("/boot")).to eq []
-          expect(described_class::VFAT.default_fstab_options("/boot/efi")).to eq []
-          expect(described_class::VFAT.default_fstab_options("/boot/whatever")).to eq []
+          expect(described_class::VFAT.default_fstab_options("/boot")).to eq ["utf8"]
+          expect(described_class::VFAT.default_fstab_options("/boot/efi")).to eq ["utf8"]
+          expect(described_class::VFAT.default_fstab_options("/boot/whatever")).to eq ["utf8"]
         end
 
         it "vfat has the correct fstab options for a non-utf8 de_DE locale" do
@@ -219,7 +219,7 @@ describe Y2Storage::Filesystems::Type do
         it "vfat has the correct fstab options for a utf8 locale" do
           Yast::Encoding.SetUtf8Lang(true)
           Yast::Encoding.SetEncLang("de_DE")
-          expect(described_class::VFAT.default_fstab_options("/bootme")).to eq ["iocharset=utf8"]
+          expect(described_class::VFAT.default_fstab_options("/bootme")).to eq ["utf8"]
         end
 
         it "vfat has the correct fstab options for a non-utf8 de_DE locale" do


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1161771
- and also revisiting https://bugzilla.suse.com/show_bug.cgi?id=1080731
- https://trello.com/c/vBCU6H1R

TL;DR: VFAT mounts with `iocharset=utf8` are implicitly case-sensitive. There's a separate `utf8` option (without `iocharset=`) that is to be used instead. `utf8` is case-insensitve in some limited fashion which is good enough to avoid the `EFI` spelling ambiguity that caused [bsc#108073]( https://bugzilla.suse.com/show_bug.cgi?id=108073).

## Solution

The goal is to avoid `iocharset=utf8` in favor of `utf8`.

This also changes the defaults of `iocharset` and `codepage` for newly created vfat filesystems to "" (empty) if the default encoding and code page are used. This has the advantage that entering the fstab option dialog no longer adds `iocharset` and `codepage` options with default values.

The net effect is that for a utf8 locale the default vfat mount option is just `utf8` and for a latin1 locale even `defaults`.

Users can still set any combination they like in the fstab option dialog. Existing values from `/etc/fstab` are kept unchanged. Even combining `iocharset=utf8` with `utf8` is possible.

## Todo

- MAYBE? (rather not): add warning popup if the user goes for `iocharset=utf8` for /boot - this looks like something for the boot requirements checker