### PR TITLE
Relax SetupChecker errors

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 17 15:08:48 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Fix the severity of some boot checks, making them warnings
+  instead of errors.
+
+-------------------------------------------------------------------
 Fri Apr 17 11:45:31 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Proposal: in the initial attempt, consider only a reasonable

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -92,6 +92,12 @@ module Y2Storage
           res << SetupError.new(message: error_message)
         end
 
+        if boot_in_thin_lvm?
+          error_message =
+            _("The device mounted at '/boot' should not be in a thinly provisioned LVM VG.")
+          res << SetupError.new(message: error_message)
+        end
+
         res
       end
 
@@ -105,6 +111,7 @@ module Y2Storage
       # @return [Array<SetupError>]
       def errors
         res = []
+
         if root_filesystem_missing?
           error_message = _("There is no device mounted at '/'")
           res << SetupError.new(message: error_message)
@@ -116,18 +123,12 @@ module Y2Storage
           res << SetupError.new(message: error_message)
         end
 
-        if boot_in_thin_lvm?
-          error_message =
-            _("The device mounted at '/boot' cannot be in a thinly provisioned LVM VG.")
-          res << SetupError.new(message: error_message)
-        end
 
         if boot_in_bcache?
           error_message =
             _("The device mounted at '/boot' cannot be in a BCache.")
           res << SetupError.new(message: error_message)
         end
-
         res
       end
 

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -98,6 +98,12 @@ module Y2Storage
           res << SetupError.new(message: error_message)
         end
 
+        if boot_in_bcache?
+          error_message =
+            _("The device mounted at '/boot' should not be in a BCache.")
+          res << SetupError.new(message: error_message)
+        end
+
         res
       end
 
@@ -123,12 +129,6 @@ module Y2Storage
           res << SetupError.new(message: error_message)
         end
 
-
-        if boot_in_bcache?
-          error_message =
-            _("The device mounted at '/boot' cannot be in a BCache.")
-          res << SetupError.new(message: error_message)
-        end
         res
       end
 

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -111,7 +111,7 @@ module Y2Storage
       # is missing
       #
       # @note errors must be raised only in those scenarios making the installation impossible.
-      #   For the rest circumstances please use {#warnings} instead.
+      #   For any other circumstance please use {#warnings} instead.
       #
       # @note This method can be overloaded for derived classes.
       #

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -110,6 +110,9 @@ module Y2Storage
       # All fatal boot errors detected in the setup, for example, when a / partition
       # is missing
       #
+      # @note errors must be raised only in those scenarios making the installation impossible.
+      #   For the rest circumstances please use {#warnings} instead.
+      #
       # @note This method can be overloaded for derived classes.
       #
       # @see SetupError

--- a/test/y2storage/boot_requirements_errors_test.rb
+++ b/test/y2storage/boot_requirements_errors_test.rb
@@ -158,18 +158,6 @@ describe Y2Storage::BootRequirementsChecker do
       end
     end
 
-    context "/boot is in a thin LVM volume" do
-      let(:use_thin_lvm) { true }
-
-      it "contains an error that /boot cannot be in a thin LVM volume" do
-        expect(checker.errors.size).to eq(1)
-        expect(checker.errors).to all(be_a(Y2Storage::SetupError))
-
-        message = checker.errors.first.message
-        expect(message).to match(/boot.*thin.*LVM/)
-      end
-    end
-
     context "/boot is in a BCache" do
       let(:use_bcache) { true }
 
@@ -233,6 +221,18 @@ describe Y2Storage::BootRequirementsChecker do
     RSpec.shared_examples "no warnings" do
       it "does not contain any warning" do
         expect(checker.warnings).to be_empty
+      end
+    end
+
+    context "/boot is in a thin LVM volume" do
+      let(:use_thin_lvm) { true }
+
+      it "contains a warning warning /boot should not be in a thin LVM volume" do
+        expect(checker.warnings.size).to eq(1)
+        expect(checker.warnings).to all(be_a(Y2Storage::SetupError))
+
+        message = checker.warnings.first.message
+        expect(message).to match(/boot.*thin.*LVM/)
       end
     end
 

--- a/test/y2storage/boot_requirements_errors_test.rb
+++ b/test/y2storage/boot_requirements_errors_test.rb
@@ -158,18 +158,6 @@ describe Y2Storage::BootRequirementsChecker do
       end
     end
 
-    context "/boot is in a BCache" do
-      let(:use_bcache) { true }
-
-      it "contains an error that /boot cannot be in a BCache" do
-        expect(checker.errors.size).to eq(1)
-        expect(checker.errors).to all(be_a(Y2Storage::SetupError))
-
-        message = checker.errors.first.message
-        expect(message).to match(/boot.*BCache/)
-      end
-    end
-
     context "in a x86 system not using UEFI (legacy PC)" do
       let(:architecture) { :x86 }
       let(:efiboot) { false }
@@ -233,6 +221,18 @@ describe Y2Storage::BootRequirementsChecker do
 
         message = checker.warnings.first.message
         expect(message).to match(/boot.*thin.*LVM/)
+      end
+    end
+
+    context "/boot is in a BCache" do
+      let(:use_bcache) { true }
+
+      it "contains a warning because /boot should not be in a BCache" do
+        expect(checker.warnings.size).to eq(1)
+        expect(checker.warnings).to all(be_a(Y2Storage::SetupError))
+
+        message = checker.warnings.first.message
+        expect(message).to match(/boot.*BCache/)
       end
     end
 


### PR DESCRIPTION
## Problem

The `SetupChecker` is considering some clear `warnings` as `errors`.

- https://trello.com/c/QSNRwq5E/1742-1-relax-boot-related-errors-make-them-warnings

  <details>
  <summary>Click to show/hide more details</summary>

  ---

  Extracted from Trello card description:

  > The `SetupChecker` contains two levels of errors:
  > 
  > - `errors` for things that really make impossible for the installation process to continue. Basically missing mountpoint for "/" and similar disasters. The user simply cannot press "next" in the Partitioner if an error is reported.
  > - `warnings` for stuff that can lead to a non-supported and/or non-bootable system but should not interrupt the installation process. For those power users that know what they are doing.
  > 
  > Things like the lack of a `/boot/efi` partition in the EFI scenario or placing `/boot` in a device encrypted with LUKS2 fall into the category of `warnings`. But having `/boot` in a thin LVM or in a bcache are categorized as fatal errors for no good reason. That's inconsistent.
  </details>


- Slightly related to https://github.com/yast/yast-storage-ng/pull/1068

## Solution

Relax those errors and improve the documentation.

:warning: No version bump required :warning:

## Testing

- Added a new unit test
- Manual testing done using [`yupdate`](https://github.com/lslezak/scripts/blob/master/yast/yupdate/yupdate)

  > yupdate patch yast-storage-ng relax_boot_errors


## Screenshots

<details>
<summary>Click to show/hide screenshots</summary>

---

| Boot placed in a Bcache |
|-|
| ![Screenshot_sle15-sp1_2020-04-16_14:09:05](https://user-images.githubusercontent.com/1691872/79460866-5350c380-7fed-11ea-9169-4b0451d6590e.png)|

| Boot placed in a thin LV|
|-|
| ![Screenshot_sle15-sp1_2020-04-16_14:14:09](https://user-images.githubusercontent.com/1691872/79460971-77140980-7fed-11ea-8716-f9134b82ec9f.png)|
| ![Screenshot_sle15-sp1_2020-04-16_14:14:28](https://user-images.githubusercontent.com/1691872/79461002-7ed3ae00-7fed-11ea-9777-27a7195e56b1.png)|
</details>