### PR TITLE
Speed up the initial proposal, specially for suma_multidisc_role

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,8 @@
 
 require "yast/rake"
 
+Yast::Tasks.submit_to :sle15sp2
+
 Yast::Tasks.configuration do |conf|
   conf.skip_license_check << /.*/
   conf.documentation_minimal = 91

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Apr 17 11:45:31 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Proposal: in the initial attempt, consider only a reasonable
+  number of disks (bsc#1154070).
+- Proposal: speed up the initial attempt when "allocate_volume_mode"
+  is set to "device" in the control file (part of jsc#SLE-7238).
+- 4.2.108
+
+-------------------------------------------------------------------
 Mon Apr 06 09:14:25 CEST 2020 - aschnell@suse.com
 
 - allow to disable LUKS activation (bsc#1162545)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.107
+Version:        4.2.108
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/initial_guided_proposal.rb
+++ b/src/lib/y2storage/initial_guided_proposal.rb
@@ -255,9 +255,10 @@ module Y2Storage
 
     # Sorted list of disks to be tried as root device.
     #
-    # If the current settings already specify a root_device, the list will contain only that one.
+    # In the theoretical case in which the current settings already specify a root_device (in practice,
+    # the initial guided proposal never receives such settings), the list will contain only that device.
     #
-    # Otherwise, it will contain all the candidate devices, sorted from bigger to smaller disk size.
+    # Otherwise, it will contain all the candidate devices, sorted in the order they should be tried.
     #
     # @return [Array<String>]
     def candidate_roots
@@ -325,7 +326,7 @@ module Y2Storage
     #
     # @return [Array<VolumeSpecificationsSet>]
     def non_root_volumes_sets
-      settings.volumes_sets.select(&:proposed?).reject(&:root?)
+      proposed_volumes_sets.reject(&:root?)
     end
   end
 end

--- a/src/lib/y2storage/initial_guided_proposal.rb
+++ b/src/lib/y2storage/initial_guided_proposal.rb
@@ -265,23 +265,7 @@ module Y2Storage
       return [settings.root_device] if settings.explicit_root_device
 
       disk_names = settings.explicit_candidate_devices
-      candidates = disk_names.map { |n| initial_devicegraph.find_by_name(n) }.compact
-
-      # FIXME: the use of .reverse method changes the expected precedence
-      # (alphabetically) when the "contiguous" devices has the equal sizes. See
-      # the example:
-      #
-      #   Given the below `candidates`
-      #   [<Disk /dev/sdc 20 GiB>, <Disk /dev/sdd 20 GiB>, <Disk /dev/sdb 80 GiB>]
-      #
-      #   the `candidates.reverse` will return
-      #   [<Disk /dev/sdb 80 GiB>, <Disk /dev/sdd 20 GiB>, <Disk /dev/sdc 20 GiB>]
-      #
-      #   but the expected result actually would be
-      #   [<Disk /dev/sdb 80 GiB>, <Disk /dev/sdc 20 GiB>, <Disk /dev/sdd 20 GiB>]
-      candidates = candidates.sort_by(&:size).reverse
-
-      candidates.map(&:name)
+      disk_names.select { |n| initial_devicegraph.find_by_name(n) }
     end
 
     # All possible combinations of candidate devices to assign to the non-root

--- a/src/lib/y2storage/volume_specifications_set.rb
+++ b/src/lib/y2storage/volume_specifications_set.rb
@@ -90,5 +90,12 @@ module Y2Storage
     def root?
       volumes.any?(&:root?)
     end
+
+    # Total minimal size of all the volume specifications included in the set
+    #
+    # @return [DiskSize]
+    def min_size
+      DiskSize.sum(volumes.map(&:min_size))
+    end
   end
 end

--- a/test/data/control_files/suma_multidisk.xml
+++ b/test/data/control_files/suma_multidisk.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0"?>
+<productDefines xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <!--
+    Based on suma_multidisc_role from SUSE Manager Server. See
+    https://github.com/yast/skelcd-control-suse-manager-server/pull/15
+  -->
+  <partitioning>
+    <proposal>
+      <lvm config:type="boolean">true</lvm>
+      <encrypt config:type="boolean">false</encrypt>
+      <windows_delete_mode>all</windows_delete_mode>
+      <linux_delete_mode>all</linux_delete_mode>
+      <other_delete_mode>all</other_delete_mode>
+      <lvm_vg_strategy>use_available</lvm_vg_strategy>
+      <separate_vgs config:type="boolean">true</separate_vgs>
+      <multidisk_first config:type="boolean">true</multidisk_first>
+      <delete_resize_configurable config:type="boolean">false</delete_resize_configurable>
+      <allocate_volume_mode config:type="symbol">device</allocate_volume_mode>
+    </proposal>
+    <volumes config:type="list">
+      <volume>
+        <mount_point>/</mount_point>
+        <fs_type>btrfs</fs_type>
+        <desired_size>100GiB</desired_size>
+        <min_size>6GiB</min_size>
+        <max_size>100GiB</max_size>
+        <snapshots config:type="boolean">true</snapshots>
+        <snapshots_configurable config:type="boolean">false</snapshots_configurable>
+        <btrfs_default_subvolume>@</btrfs_default_subvolume>
+        <subvolumes config:type="list">
+          <!-- simplified list of subvolumes, just to shorten the xml -->
+          <subvolume>
+            <path>home</path>
+          </subvolume>
+          <subvolume>
+            <path>opt</path>
+          </subvolume>
+        </subvolumes>
+      </volume>
+      <volume>
+        <mount_point>swap</mount_point>
+        <fs_type>swap</fs_type>
+        <desired_size>2GiB</desired_size>
+        <min_size>2GiB</min_size>
+        <max_size>2GiB</max_size>
+      </volume>
+      <volume>
+        <mount_point>/var/spacewalk</mount_point>
+        <fs_type>xfs</fs_type>
+        <separate_vg_name>spacewalk</separate_vg_name>
+        <proposed_configurable config:type="boolean">true</proposed_configurable>
+        <proposed config:type="boolean">true</proposed>
+        <desired_size config:type="disksize">300 GiB</desired_size>
+        <min_size config:type="disksize">100 GiB</min_size>
+        <max_size config:type="disksize">unlimited</max_size>
+        <max_size_lvm config:type="disksize">300 GiB</max_size_lvm>
+        <weight config:type="integer">40</weight>
+        <disable_order config:type="integer">4</disable_order>
+        <fallback_for_desired_size>/</fallback_for_desired_size>
+        <fallback_for_max_size>/</fallback_for_max_size>
+        <fallback_for_max_size_lvm>/</fallback_for_max_size_lvm>
+        <fallback_for_weight>/</fallback_for_weight>
+      </volume>
+      <volume>
+        <mount_point>/var/lib/pgsql</mount_point>
+        <fs_type>xfs</fs_type>
+        <separate_vg_name>pgsql</separate_vg_name>
+        <proposed_configurable config:type="boolean">true</proposed_configurable>
+        <proposed config:type="boolean">true</proposed>
+        <desired_size config:type="disksize">60 GiB</desired_size>
+        <min_size config:type="disksize">50 GiB</min_size>
+        <max_size config:type="disksize">unlimited</max_size>
+        <max_size_lvm config:type="disksize">60 GiB</max_size_lvm>
+        <weight config:type="integer">40</weight>
+        <disable_order config:type="integer">3</disable_order>
+        <fallback_for_desired_size>/</fallback_for_desired_size>
+        <fallback_for_max_size>/</fallback_for_max_size>
+        <fallback_for_max_size_lvm>/</fallback_for_max_size_lvm>
+        <fallback_for_weight>/</fallback_for_weight>
+      </volume>
+      <volume>
+        <mount_point>/var/cache</mount_point>
+        <fs_type>xfs</fs_type>
+        <separate_vg_name>system_cache</separate_vg_name>
+        <proposed_configurable config:type="boolean">true</proposed_configurable>
+        <proposed config:type="boolean">true</proposed>
+        <desired_size config:type="disksize">10 GiB</desired_size>
+        <min_size config:type="disksize">4 GiB</min_size>
+        <max_size config:type="disksize">unlimited</max_size>
+        <max_size_lvm config:type="disksize">10 GiB</max_size_lvm>
+        <weight config:type="integer">20</weight>
+        <disable_order config:type="integer">1</disable_order>
+        <fallback_for_desired_size>/</fallback_for_desired_size>
+        <fallback_for_max_size>/</fallback_for_max_size>
+        <fallback_for_max_size_lvm>/</fallback_for_max_size_lvm>
+        <fallback_for_weight>/</fallback_for_weight>
+      </volume>
+      <volume>
+        <mount_point>/srv</mount_point>
+        <fs_type>xfs</fs_type>
+        <separate_vg_name>srv</separate_vg_name>
+        <proposed_configurable config:type="boolean">true</proposed_configurable>
+        <proposed config:type="boolean">true</proposed>
+        <desired_size config:type="disksize">300 GiB</desired_size>
+        <min_size config:type="disksize">200 GiB</min_size>
+        <max_size config:type="disksize">unlimited</max_size>
+        <max_size_lvm config:type="disksize">300 GiB</max_size_lvm>
+        <weight config:type="integer">40</weight>
+        <disable_order config:type="integer">2</disable_order>
+        <fallback_for_desired_size>/</fallback_for_desired_size>
+        <fallback_for_max_size>/</fallback_for_max_size>
+        <fallback_for_max_size_lvm>/</fallback_for_max_size_lvm>
+        <fallback_for_weight>/</fallback_for_weight>
+      </volume>
+    </volumes>
+  </partitioning>
+</productDefines>

--- a/test/data/devicegraphs/many_disks.yml
+++ b/test/data/devicegraphs/many_disks.yml
@@ -1,0 +1,163 @@
+---
+- disk:
+    name: "/dev/sda"
+    size: 100 GiB
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 4 MiB
+        name: "/dev/sda1"
+        id: prep
+    - partition:
+        size: 82.00 GiB
+        name: "/dev/sda2"
+        id: lvm
+- disk:
+    name: "/dev/sdb"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdc"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdd"
+    size: 100 GiB
+- disk:
+    name: "/dev/sde"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdf"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdg"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdh"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdi"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdj"
+    size: 75 GiB
+- disk:
+    name: "/dev/sdk"
+    size: 100 GiB
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 4 MiB
+        name: "/dev/sdk1"
+        id: prep
+    - partition:
+        size: 82.00 GiB
+        name: "/dev/sdk2"
+        id: lvm
+- disk:
+    name: "/dev/sdl"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdm"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdn"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdo"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdp"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdq"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdr"
+    size: 50 GiB
+- disk:
+    name: "/dev/sds"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdt"
+    size: 75 GiB
+- disk:
+    name: "/dev/sdu"
+    size: 100 GiB
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 4 MiB
+        name: "/dev/sdu1"
+        id: prep
+    - partition:
+        size: 82.00 GiB
+        start: 5 MiB
+        name: "/dev/sdu2"
+        id: lvm
+- disk:
+    name: "/dev/sdv"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdw"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdx"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdy"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdz"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdaa"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdab"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdac"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdad"
+    size: 75 GiB
+- disk:
+    name: "/dev/sdae"
+    size: 100 GiB
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 4 MiB
+        name: "/dev/sdae1"
+        id: prep
+    - partition:
+        size: 82.00 GiB
+        start: 5 MiB
+        name: "/dev/sdae2"
+        id: lvm
+- disk:
+    name: "/dev/sdaf"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdag"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdah"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdai"
+    size: 100 GiB
+- disk:
+    name: "/dev/sdaj"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdak"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdal"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdam"
+    size: 50 GiB
+- disk:
+    name: "/dev/sdan"
+    size: 75 GiB

--- a/test/y2storage/initial_guided_proposal_multidisk_first_test.rb
+++ b/test/y2storage/initial_guided_proposal_multidisk_first_test.rb
@@ -196,7 +196,7 @@ describe Y2Storage::InitialGuidedProposal do
         context "without separated volume groups" do
           let(:separate_vgs) { false }
 
-          # NOTE: when separated volumes are note required, the proposal will create only
+          # NOTE: when separated volumes are not required, the proposal will create only
           # the "system" LVM VG in a single device.
           context "and having some devices with enough space to hold the proposal" do
             let(:sda_size) { 20.GiB }
@@ -207,7 +207,8 @@ describe Y2Storage::InitialGuidedProposal do
             it "makes the proposal using only a single device" do
               proposal.propose
 
-              expect(used_devices).to contain_exactly("/dev/sdd")
+              # sda and sdb are too small to hold the proposal
+              expect(used_devices).to contain_exactly("/dev/sdc")
             end
 
             it "creates only the 'system' LVM VG" do
@@ -346,10 +347,10 @@ describe Y2Storage::InitialGuidedProposal do
               expect(created_vgs_names).to contain_exactly("system", "vg-home", "vg-foobar")
             end
 
-            it "creates the proposal using only one device" do
+            it "creates a proposal that uses the first devices as needed" do
               proposal.propose
 
-              expect(used_devices).to contain_exactly("/dev/sdb")
+              expect(used_devices).to contain_exactly("/dev/sda", "/dev/sdb")
             end
           end
 
@@ -399,10 +400,10 @@ describe Y2Storage::InitialGuidedProposal do
               expect(mount_points).to contain_exactly("/", "/home", "/foo/bar")
             end
 
-            it "creates the proposal using only one device" do
+            it "creates a proposal that uses the first devices as needed" do
               proposal.propose
 
-              expect(used_devices).to contain_exactly("/dev/sdb")
+              expect(used_devices).to contain_exactly("/dev/sda", "/dev/sdb")
             end
           end
 

--- a/test/y2storage/proposal_scenarios_multidisk_role_test.rb
+++ b/test/y2storage/proposal_scenarios_multidisk_role_test.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "storage"
+require "y2storage"
+require_relative "#{TEST_PATH}/support/proposal_context"
+
+describe Y2Storage::GuidedProposal do
+  describe ".initial" do
+    include_context "proposal"
+
+    subject(:proposal) { described_class.initial(settings: settings) }
+
+    let(:settings_format) { :ng }
+    let(:architecture) { :x86 }
+
+    # Although this test obviously ensures the right behavior, it was actually added to
+    # detect performance problems. The operation implemented here used to be dreadfully
+    # slow, so this test took many minutes to execute.
+    context "with separate VGs, multidisk_first and many small disks" do
+      let(:control_file) { "suma_multidisk.xml" }
+      let(:scenario) { "many_disks" }
+      let(:lvm) { true }
+
+      it "makes a valid proposal by disabling all the separate VGs" do
+        expect(proposal.devices.lvm_lvs.map(&:lv_name)).to contain_exactly("root", "swap")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Notes for reviewers

This replaces #1080 (I messed up with git)

Review commit by commit, all of them make sense on their own and contain descriptive messages.

This pull request would kickstart the SLE-15-SP2 branch, so it also includes a commit to adapt the Rakefile.

## Problem

Quite some time ago, we implemented several configuration options for the storage proposal to enable the creation of the `suma_multidisc_role` for SUSE Manager Server (see https://github.com/yast/skelcd-control-suse-manager-server/pull/15).

Apart from the three new options (`allocate_volume_mode`, `separate_vgs` and `delete_resize_configurable`) introduced to change how the Guided Setup works, we also added the option `multidisk_first` to influence the initial proposal (the one that is calculated before the user has had any chance to influence the result or to select the disks to use).

But all those changes leaded to two performance problems in some situations.

- In a system with many disks and `multidisk_first` set to true, the initial proposal tried an insane amount of possible combination of the disks. That was very slow. It was also pretty useless, since it's really unlikely that a user installing in a system with more than five disks could be satisfied with the initial proposal.

- In addition, when `allocate_volume_mode` was set to "device" and the disk(s) in the system were small, the initial proposal was also slow because it insisted in trying (by brute-force) combinations that had no chance to work (locating certain volumes in disks that were too small to accommodate them).

Of course, the combination of all these circumstances (`multidisk_first == true` + `allocate_volume_mode == :device` + a system with many small disks) leaded to a dreadfully slow initial proposal that looked like a hung system.

## Solution

Three aspects were improved:

- (A) When `multidisk_first` is set, bring back the limit that was introduced as an installer self-update for SLE-15-GA via #1005. That limit doesn't exist in SLE-15-SP1 because multidisk attempts are almost never tried (since the option `multidisk_first` does not even exist). The limit speeds up  dramatically the calculation of the initial proposal in systems with many disks, both for the `suma_multidisc_role` case and for an hypothetical case in which a more traditional proposal would be configured with `multidisk_first` set.

- (B) When `allocate_volume_mode` is set to "device", many useless combinations of disks and volumes are now discarded much earlier in the initial proposal process. That also leads to a huge speedup.

- (C) Other small fixes and speed improvements implemented along the way (see separate commits).

## Testing

Added a new unit test. It would have been green without the code changes as well, but it would take an insane amount of time to complete. Now is on pair with any other test.

## Benchmark 1

Just executing the unit test mentioned above in a pretty limited machine and verifying the impact of each of the improvements described in "solution" (only one execution of each scenario, so don't take the numbers too literally).

- Without any improvement, the test took >5:00:00 (more than five hours, not sure how much).
- Applying only (A), it took 3:07
- Applying only (B), it took 2:58
- Applying (A) + (C), it took 2:58.
- Applying (A) + (B), it took  0:00.52 (yes, less than one second)
- Applying (A) + (B) + (C), it took also 0:00.52

## Benchmark 2

Yet another setup designed to show the slow points. See all the details of the bechmark [in this gist](https://gist.github.com/dgdavid/ae58a9b0c468fefb974ff3ef3ba19973). In summary:

- Before the changes, it took >11:00:00 (more than eleven hours)
- Applying only (A), it took 45:37
- Applying (A) + (B) + (C), it took 0:14