### PR TITLE
Adapt Dockerfile for SLE15-SP2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
+FROM registry.opensuse.org/yast/sle-15/sp2/containers/yast-ruby
 COPY . /usr/src/app


### PR DESCRIPTION
## Problem

- The `Dockerfile` was not adapted when branching SP2 (at that time the image did not exist)

## Solution

- Adapt it :wink:

