### PR TITLE
update /etc/crypttab status properly (bsc#1118977)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 23 14:32:38 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- update /etc/crypttab status properly (bsc#1118977)
+- 4.3.2
+
+-------------------------------------------------------------------
 Wed Apr 22 13:29:05 CEST 2020 - aschnell@suse.com
 
 - disallow to edit LVM cache pools (related to bsc#1099744)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/encryption.rb
+++ b/src/lib/y2partitioner/actions/controllers/encryption.rb
@@ -290,6 +290,7 @@ module Y2Partitioner
           end
 
           adjust_mount_point
+          encryption&.update_etc_status
         end
 
         # Sanitizes (removes) the encryption layer when needed

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -322,6 +322,8 @@ module Y2Storage
       enc.ensure_suitable_mount_by
       enc.mount_point&.ensure_suitable_mount_by
       enc.adjust_crypt_options
+      # a new encrypted volume is not in crypttab (yet)
+      enc.assign_etc_attribute(false)
 
       Encryption.update_dm_names(devicegraph)
 

--- a/src/lib/y2storage/device.rb
+++ b/src/lib/y2storage/device.rb
@@ -459,15 +459,12 @@ module Y2Storage
       # Do something only for subclasses defining #assign_etc_attribute
       return unless respond_to?(:assign_etc_attribute, true)
 
-      if descendants.any?(&:in_etc?)
-        # Enable the autoset flag only if the attribute was false before our update
-        self.etc_status_autoset = !in_etc?
-        assign_etc_attribute(true)
-      # We only set the attribute to false if we did set it to true
-      elsif etc_status_autoset?
-        self.etc_status_autoset = false
-        assign_etc_attribute(false)
-      end
+      self.in_etc_initial = in_etc? if in_etc_initial.nil?
+
+      should_be_in_etc = descendants.any?(&:in_etc?)
+
+      # never set to false unless it was initially so
+      assign_etc_attribute(should_be_in_etc) if [true, in_etc_initial].include? should_be_in_etc
     end
 
     # Triggers recalculation of {#in_etc?} for all parent objects
@@ -475,20 +472,21 @@ module Y2Storage
       parents.each(&:update_etc_status)
     end
 
-    # Whether {#in_etc?} was set to true by {#update_etc_attributes}.
+    # The initial value of {#in_etc?}, before {#update_etc_attributes} changed it.
     #
     # @note This relies on the userdata mechanism, see {#userdata_value}.
     #
-    # @return [Boolean]
-    def etc_status_autoset?
-      userdata_value(:etc_status_autoset) || false
+    # @return [Boolean, nil] the initial {#in_etc?} value; nil if the initial value
+    #   hasn't been stored yet
+    def in_etc_initial
+      userdata_value(:in_etc_initial)
     end
 
     # Stores the information for {#etc_status_autoset?}
     #
     # @param value [Boolean]
-    def etc_status_autoset=(value)
-      save_userdata(:etc_status_autoset, value)
+    def in_etc_initial=(value)
+      save_userdata(:in_etc_initial, value)
     end
 
     def types_for_is

--- a/src/lib/y2storage/device.rb
+++ b/src/lib/y2storage/device.rb
@@ -482,7 +482,7 @@ module Y2Storage
       userdata_value(:in_etc_initial)
     end
 
-    # Stores the information for {#etc_status_autoset?}
+    # Stores the information for {#in_etc_initial}
     #
     # @param value [Boolean]
     def in_etc_initial=(value)

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -354,16 +354,16 @@ module Y2Storage
       end
     end
 
+    # @see Device#update_etc_attributes
+    def assign_etc_attribute(value)
+      self.storage_in_etc_crypttab = value
+    end
+
     protected
 
     # @see Device#is?
     def types_for_is
       super << :encryption
-    end
-
-    # @see Device#update_etc_attributes
-    def assign_etc_attribute(value)
-      self.storage_in_etc_crypttab = value
     end
 
     # Updates the userdata with an up-to-date version of the encryption process

--- a/test/y2storage/in_etc_test.rb
+++ b/test/y2storage/in_etc_test.rb
@@ -21,61 +21,167 @@
 require_relative "spec_helper"
 require "y2storage"
 
+describe Y2Storage::BlkDevice do
+  before { fake_scenario("empty_disks") }
+
+  describe "#encrypt" do
+    let(:disk) { fake_devicegraph.find_by_name("/dev/sda1") }
+
+    context "when a new encrypted volume is created" do
+      it "sets in_etc_crypttab to false" do
+        disk.encrypt
+        disk.encryption.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
+
+        expect(disk.encryption.in_etc_crypttab?).to eq false
+      end
+    end
+  end
+end
+
 describe Y2Storage::Device do
-  before { fake_scenario("subvolumes-and-empty-md.xml") }
+  before { fake_scenario("empty_disks") }
 
   describe "#update_etc_status" do
-    let(:md) { fake_devicegraph.find_by_name("/dev/md/strip0") }
-    let(:encryption) { fake_devicegraph.find_by_name("/dev/mapper/cr_sda5") }
+    let(:disk) { fake_devicegraph.find_by_name("/dev/sda1") }
 
-    # Creates a filesystem and mount point in the RAID
-    def create_mount_point
-      fs = md.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
-      fs.create_mount_point("/mnt")
-    end
+    context "in a new encrypted volume" do
+      context "when a mount point is created" do
+        before do
+          disk.encrypt
+          disk.encryption.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
+        end
 
-    context "when a new mount point is created" do
-      it "sets in_etc_crypttab and in_etc_mdadm to true in the underlying devices" do
-        expect(md.in_etc_mdadm?).to eq false
-        expect(encryption.in_etc_crypttab?).to eq false
+        it "sets in_etc_crypttab to true" do
+          disk.encryption.filesystem.create_mount_point("/foo")
 
-        create_mount_point
+          expect(disk.encryption.in_etc_crypttab?).to eq true
+        end
+      end
 
-        expect(md.in_etc_mdadm?).to eq true
-        expect(encryption.in_etc_crypttab?).to eq true
+      context "when this mount point is removed again" do
+        before do
+          disk.encrypt
+          disk.encryption.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
+          disk.encryption.filesystem.create_mount_point("/foo")
+        end
+
+        it "sets in_etc_crypttab to false" do
+          disk.encryption.filesystem.remove_mount_point
+
+          expect(disk.encryption.in_etc_crypttab?).to eq false
+        end
       end
     end
 
-    context "when a mount point is removed" do
-      context "if the /etc flags were automatically set by the mount point creation" do
-        before { create_mount_point }
+    describe "in a setup with an existing encrypted volume" do
+      before { fake_scenario("encrypted_partition.xml") }
 
-        it "restores the false values for in_etc_crypttab and in_etc_mdadm" do
-          expect(md.in_etc_mdadm?).to eq true
-          expect(encryption.in_etc_crypttab?).to eq true
+      let(:disk) { fake_devicegraph.find_by_name("/dev/sda1") }
 
-          md.filesystem.remove_mount_point
+      context "when there is initially no mount point" do
+        it "sets in_etc_crypttab to false" do
+          expect(disk.encryption.in_etc_crypttab?).to eq false
+        end
+      end
 
+      context "when a mount point is created" do
+        it "sets in_etc_crypttab to true" do
+          disk.encryption.filesystem.create_mount_point("/foo")
+
+          expect(disk.encryption.in_etc_crypttab?).to eq true
+        end
+      end
+
+      context "when a mount point is removed" do
+        context "if the /etc flags were automatically set by the mount point creation" do
+          before do
+            disk.encryption.filesystem.create_mount_point("/foo")
+          end
+
+          it "restores the false values for in_etc_crypttab" do
+            disk.encryption.filesystem.remove_mount_point
+
+            expect(disk.encryption.in_etc_crypttab?).to eq false
+          end
+        end
+
+        context "if the /etc flags were already true before creating the mount point" do
+          before do
+            disk.encryption.to_storage_value.in_etc_crypttab = true
+            disk.encryption.filesystem.create_mount_point("/foo")
+          end
+
+          it "keeps the original true values for in_etc_crypttab and in_etc_mdadm" do
+            disk.encryption.filesystem.remove_mount_point
+
+            expect(disk.encryption.in_etc_crypttab?).to eq true
+          end
+        end
+      end
+    end
+
+    describe "in a setup with a RAID on top of an encrypted volume" do
+      before { fake_scenario("subvolumes-and-empty-md.xml") }
+
+      let(:md) { fake_devicegraph.find_by_name("/dev/md/strip0") }
+      let(:encryption) { fake_devicegraph.find_by_name("/dev/mapper/cr_sda5") }
+
+      # create a filesystem and mount point in the RAID
+      def create_raid_mount_point
+        fs = md.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
+        fs.create_mount_point("/foo")
+      end
+
+      context "when there is initially no mount point for the RAID" do
+        it "sets in_etc_crypttab and in_etc_mdadm to false in the underlying devices" do
           expect(md.in_etc_mdadm?).to eq false
           expect(encryption.in_etc_crypttab?).to eq false
         end
       end
 
-      context "if the /etc flags were already true before creating the mount point" do
-        before do
-          md.to_storage_value.in_etc_mdadm = true
-          encryption.to_storage_value.in_etc_crypttab = true
-          create_mount_point
+      context "when a new mount point is created for the RAID" do
+        it "sets in_etc_crypttab and in_etc_mdadm to true in the underlying devices" do
+          expect(md.in_etc_mdadm?).to eq false
+          expect(encryption.in_etc_crypttab?).to eq false
+
+          create_raid_mount_point
+
+          expect(md.in_etc_mdadm?).to eq true
+          expect(encryption.in_etc_crypttab?).to eq true
+        end
+      end
+
+      context "when a mount point is removed" do
+        context "if the /etc flags were automatically set by the mount point creation" do
+          before { create_raid_mount_point }
+
+          it "restores the false values for in_etc_crypttab and in_etc_mdadm" do
+            expect(md.in_etc_mdadm?).to eq true
+            expect(encryption.in_etc_crypttab?).to eq true
+
+            md.filesystem.remove_mount_point
+
+            expect(md.in_etc_mdadm?).to eq false
+            expect(encryption.in_etc_crypttab?).to eq false
+          end
         end
 
-        it "keeps the original true values for in_etc_crypttab and in_etc_mdadm" do
-          expect(md.in_etc_mdadm?).to eq true
-          expect(encryption.in_etc_crypttab?).to eq true
+        context "if the /etc flags were already true before creating the mount point" do
+          before do
+            md.to_storage_value.in_etc_mdadm = true
+            encryption.to_storage_value.in_etc_crypttab = true
+            create_raid_mount_point
+          end
 
-          md.filesystem.remove_mount_point
+          it "keeps the original true values for in_etc_crypttab and in_etc_mdadm" do
+            expect(md.in_etc_mdadm?).to eq true
+            expect(encryption.in_etc_crypttab?).to eq true
 
-          expect(md.in_etc_mdadm?).to eq true
-          expect(encryption.in_etc_crypttab?).to eq true
+            md.filesystem.remove_mount_point
+
+            expect(md.in_etc_mdadm?).to eq true
+            expect(encryption.in_etc_crypttab?).to eq true
+          end
         end
       end
     end


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1118977
- https://trello.com/c/jtojel4R

New encrypted volumes are added to `/etc/crypttab` (even when not mounted).

## Analysis

There are two issues:

1. The default value for `in_etc` is true for newly created encrytpted volumes.  Since the `#update_etc_status` method ensures the status can't be set to false when it was originally true, this unavoidably creates an initial crypttab entry.
To avoid this, set the `in_etc` flag to false explicitly for freshly created encrypted volumes.

2. The `#update_etc_status` method is called when you switch between mounting/not mounting in the fstab dialog.
But when encryption had just been enabled, the encrypted device does not yet exist in the device tree. It's created only after going through the password dialog.
This means `#update_etc_status` has to be called also after creating an encryption device to get a consistent state.

## Comments

- This applies equally to `/etc/mdadm.conf` - currently it's not possible to avoid an entry there - even if the RAID is not mounted. The use-cases are a bit different compared to encryption, so this might be the desired state.

- I've found the logic aroud `etc_status_autoset` very hard to follow and have rewritten that part to something I might still understand in a few years from now...