### PR TITLE
add x-initrd.attach option to crypttab if needed (bsc#1168465)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 29 08:26:48 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- add x-initrd.attach option to crypttab if needed (bsc#1168465)
+- 4.3.3
+
+-------------------------------------------------------------------
 Thu Apr 23 14:32:38 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - update /etc/crypttab status properly (bsc#1118977)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1168465
- https://trello.com/c/01yaT7SA

The new crypttab option `x-initrd.attach` should be added for filesystems that are attached in the initrd.

See [crypttab(5)](https://www.freedesktop.org/software/systemd/man/crypttab.html).

## Solution

Add this option for newly created filesystems mounted at `/` and all filesytems with `x-initrd.mount` fstab option.