### PR TITLE
install nvme-cli if NVMe devices are present

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 container:
-  image: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+  image: registry.opensuse.org/yast/sle-15/sp2/containers/yast-ruby
 
 task:
   name: Rubocop

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun 30 09:18:15 CEST 2020 - aschnell@suse.com
+
+- install nvme-cli if NVMe devices are present (bsc#1172866)
+- 4.2.110
+
+-------------------------------------------------------------------
 Tue May 12 11:08:12 UTC 2020 - Ancor Gonzalez Sosa <ags@localhost>
 
 - Partitioner: fixed a crash when libstorage-ng fails to report

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.109
+Version:        4.2.110
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# RAID1C{3,4}
-BuildRequires:	libstorage-ng-ruby >= 4.2.61
+# UF_NVME
+BuildRequires:	libstorage-ng-ruby >= 4.2.76
 BuildRequires:  update-desktop-files
 # CWM::DynamicProgressBar
 BuildRequires:  yast2 >= 4.2.63
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# RAID1C{3,4}
-Requires:       libstorage-ng-ruby >= 4.2.61
+# UF_NVME
+Requires:       libstorage-ng-ruby >= 4.2.76
 # CWM::DynamicProgressBar
 Requires:       yast2 >= 4.2.63
 # Y2Packager::Repository

--- a/src/lib/y2storage/storage_feature.rb
+++ b/src/lib/y2storage/storage_feature.rb
@@ -91,6 +91,7 @@ module Y2Storage
         UF_FCOE:             "fcoe-utils",
         UF_FC:               [],
         UF_DASD:             [],
+        UF_NVME:             "nvme-cli",
 
         # Other
         UF_QUOTA:            "quota",


### PR DESCRIPTION
## Problem

With NVMeOF devices the NVMe tools in the package nvme-cli are needed.

## Solution

Install the tools if libstorage-ng reports the new feature UF_NVME.

## Testing

- Tested manually.

## See

- https://trello.com/c/QIyuWNgI/1911-5-sles15-sp2-p2-1172866-nvme-cli-not-installed-when-root-is-an-nvme-device
- https://bugzilla.suse.com/show_bug.cgi?id=1172866
