### PR TITLE
AutoYaST delegates to initial proposal

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jul  3 12:31:39 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- AutoYaST: delegate to initial guided proposal when no partitions
+  are defined in the profile (bsc#1173610).
+- AutoYaST: fix enable_snapshots option.
+- 4.2.111
+
+-------------------------------------------------------------------
 Tue Jun 30 09:18:15 CEST 2020 - aschnell@suse.com
 
 - install nvme-cli if NVMe devices are present (bsc#1172866)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.110
+Version:        4.2.111
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/autoinst_proposal.rb
+++ b/src/lib/y2storage/autoinst_proposal.rb
@@ -283,7 +283,7 @@ module Y2Storage
     # @see Y2Storage::BlkDevice#name
     def proposal_settings_for_disks(drives)
       settings = @proposal_settings || ProposalSettings.new_for_current_product
-      settings.use_snapshots = drives.use_snapshots?
+      drives.use_snapshots? ? settings.force_enable_snapshots : settings.force_disable_snapshots
       settings.candidate_devices = drives.disk_names
       settings
     end

--- a/src/lib/y2storage/autoinst_proposal.rb
+++ b/src/lib/y2storage/autoinst_proposal.rb
@@ -22,6 +22,7 @@ require "y2storage/proposal_settings"
 require "y2storage/exceptions"
 require "y2storage/planned"
 require "y2storage/proposal"
+require "y2storage/guided_proposal"
 
 module Y2Storage
   # Class to calculate a storage proposal for autoinstallation
@@ -190,23 +191,24 @@ module Y2Storage
       issues_list.add(:missing_root)
     end
 
-    # Finds a suitable devicegraph using the guided proposal approach
+    # Finds a suitable devicegraph using the initial guided proposal approach
     #
-    # If the :desired target fails, it will retry with the :min target.
-    #
-    # @param devicegraph [Devicegraph]       Starting point
-    # @param drives      [AutoinstDrivesMap] Devices map from an AutoYaST profile
-    # @return [Devicegraph] Proposed devicegraph using the guided proposal approach
+    # @see Y2Storage::GuidedProposal.initial
     #
     # @raise [Error] No suitable devicegraph was found
-    # @see proposed_guided_devicegraph
+    #
+    # @param devicegraph [Devicegraph] Starting point
+    # @param drives [AutoinstDrivesMap] Devices map from an AutoYaST profile
+    #
+    # @return [Devicegraph] Proposed devicegraph using the guided proposal approach
     def propose_guided_devicegraph(devicegraph, drives)
       devicegraph = clean_graph(devicegraph, drives, [])
-      begin
-        guided_devicegraph_for_target(devicegraph, drives, :desired)
-      rescue Error
-        guided_devicegraph_for_target(devicegraph, drives, :min)
-      end
+
+      settings = proposal_settings_for_disks(drives)
+
+      proposal = GuidedProposal.initial(devicegraph: devicegraph, settings: settings)
+
+      proposal.devices
     end
 
     # Calculates list of planned devices
@@ -233,21 +235,6 @@ module Y2Storage
     def clean_graph(devicegraph, drives, planned_devices)
       space_maker = Proposal::AutoinstSpaceMaker.new(disk_analyzer, issues_list)
       space_maker.cleaned_devicegraph(devicegraph, drives, planned_devices)
-    end
-
-    # Creates a devicegraph using the same approach as guided partitioning
-    #
-    # @param devicegraph [Devicegraph]       Starting point
-    # @param drives      [AutoinstDrivesMap] Devices map from an AutoYaST profile
-    # @param target      [Symbol] :desired means the sizes of the partitions should
-    #   be the ideal ones, :min for generating the smallest functional partitions
-    # @return [Devicegraph] Copy of devicegraph containing the planned devices
-    def guided_devicegraph_for_target(devicegraph, drives, target)
-      guided_settings = proposal_settings_for_disks(drives)
-      guided_planner = Proposal::DevicesPlanner.new(guided_settings, devicegraph)
-      @planned_devices = Planned::DevicesCollection.new(guided_planner.planned_devices(target))
-      result = create_devices(devicegraph, @planned_devices, drives.disk_names)
-      result.devicegraph
     end
 
     # Creates planned devices on a given devicegraph

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -406,6 +406,30 @@ module Y2Storage
       ng_format? ? ng_check_root_snapshots : legacy_check_root_snapshots
     end
 
+    # Forces to enable snapshots for the root subvolume
+    #
+    # After calling this method, snapshots will not be configurable.
+    #
+    # @note This method only applies to the ng format.
+    def force_enable_snapshots
+      return unless root_volume
+
+      root_volume.snapshots = true
+      root_volume.snapshots_configurable = false
+    end
+
+    # Forces to disable snapshots for the root subvolume
+    #
+    # After calling this method, snapshots will not be configurable.
+    #
+    # @note This method only applies to the ng format.
+    def force_disable_snapshots
+      return unless root_volume
+
+      root_volume.snapshots = false
+      root_volume.snapshots_configurable = false
+    end
+
     def ng_format?
       format == NG_FORMAT
     end

--- a/test/y2storage/proposal_settings_test.rb
+++ b/test/y2storage/proposal_settings_test.rb
@@ -1041,6 +1041,74 @@ describe Y2Storage::ProposalSettings do
     end
   end
 
+  describe "#force_enable_snapshots" do
+    subject(:settings) { described_class.new_for_current_product }
+
+    let(:initial_partitioning_features) { { "proposal" => [], "volumes" => volumes } }
+
+    context "when there is no root volume" do
+      let(:volumes) { [] }
+
+      it "does not fail" do
+        expect { subject.force_enable_snapshots }.to_not raise_error
+      end
+    end
+
+    context "when there is a root volume" do
+      let(:volumes) { [{ "mount_point" => "/" }] }
+
+      it "enables snapshots for the root volume" do
+        subject.force_enable_snapshots
+
+        root = subject.volumes.find(&:root?)
+
+        expect(root.snapshots?).to eq(true)
+      end
+
+      it "set snapshots as not configurable for the root volume" do
+        subject.force_enable_snapshots
+
+        root = subject.volumes.find(&:root?)
+
+        expect(root.snapshots_configurable?).to eq(false)
+      end
+    end
+  end
+
+  describe "#force_disable_snapshots" do
+    subject(:settings) { described_class.new_for_current_product }
+
+    let(:initial_partitioning_features) { { "proposal" => [], "volumes" => volumes } }
+
+    context "when there is no root volume" do
+      let(:volumes) { [] }
+
+      it "does not fail" do
+        expect { subject.force_disable_snapshots }.to_not raise_error
+      end
+    end
+
+    context "when there is a root volume" do
+      let(:volumes) { [{ "mount_point" => "/" }] }
+
+      it "disables snapshots for the root volume" do
+        subject.force_disable_snapshots
+
+        root = subject.volumes.find(&:root?)
+
+        expect(root.snapshots?).to eq(false)
+      end
+
+      it "set snapshots as not configurable for the root volume" do
+        subject.force_disable_snapshots
+
+        root = subject.volumes.find(&:root?)
+
+        expect(root.snapshots_configurable?).to eq(false)
+      end
+    end
+  end
+
   describe "#to_s" do
     subject(:settings) { described_class.new_for_current_product }
 


### PR DESCRIPTION
## Problem

AutoYaST proposal falls back to the guided proposal when no partitions are indicated in the AutoYaST profile. This fallback only performs two tries at most: with max and desired device sizes. For example, it does not try with every candidate disk as possible boot disk.

Because of that, the boot disk is always fixed to the default disk reported by the "Boot Requirements Checker" (first disk as general default), making the installation impossible when the boot disk does not belong to the list of candidates devices.

This bug becomes very evident when the AutoYaST profile does not include the first disk as possible candidate disk:

~~~
<partitioning config:type="list">
    <drive>
      <device>/dev/sdc</device>
      <disklabel>gpt</disklabel>
      <initialize config:type="boolean">true</initialize>
      <use>all</use>
    </drive>
</partitioning>
~~~  

In this case, */dev/sdc* is the only one candidate disk to perform the installation, but the BIOS BOOT partition would always be proposed in the first disk (i.e., */dev/sda*).

* https://bugzilla.suse.com/show_bug.cgi?id=1173610


## Solution

Now on AutoYaST falls back to the "Initial Guided Proposal", so more proposal attempts are performed (e.g., by rotating the boot disk among all the candidate disks).

BONUS: AutoYaST profile allows to specify the *enable_snapshots* attribute for a *drive*, but this attribute is not properly transferred to the proposal settings. This was also fixed as part of this PR.

## Testing

* Added unit tests.



