### PR TITLE
Partitioner: fix reported stripe size

### DIFF
--- a/doc/lvm.md
+++ b/doc/lvm.md
@@ -52,8 +52,7 @@ It shows "_Resizing not supported since the logical volume has snapshots_".
 - Thin pools and thin LVs are identified as such in the tables. On the other hand, the description
   page of a thin pool or a thin LV looks just like the one of a normal LV.
 - In LVM is not possible to define striping for thin LVs, they use the striping defined for their thin
-  pools. The partitioner UI reports correctly the number of stripes, **but reports 0.00B for the
-  stripes size**.
+  pools.
 
 #### What can be done?
 

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 17 11:44:48 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Partitioner: fix stripes size reported for thin LVs.
+- Partitioner: do not show stripes size when its value is zero.
+
+-------------------------------------------------------------------
 Tue Jul  7 10:57:59 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Partitioner: fix and improve the information shown for each

--- a/src/lib/y2partitioner/widgets/lvm_lv_attributes.rb
+++ b/src/lib/y2partitioner/widgets/lvm_lv_attributes.rb
@@ -44,7 +44,7 @@ module Y2Partitioner
 
       # @return [String]
       def stripes_info(lvm_lv)
-        if lvm_lv.stripes <= 1
+        if lvm_lv.stripe_size.zero?
           lvm_lv.stripes.to_i
         else
           format(

--- a/src/lib/y2storage/lvm_lv.rb
+++ b/src/lib/y2storage/lvm_lv.rb
@@ -67,10 +67,14 @@ module Y2Storage
     #     (i.e., bigger than 128)
     storage_forward :stripes=
 
-    # @!attribute stripe_size
-    #   Size of a stripe. DiskSize.zero if the LV is not striped.
-    #   @return [DiskSize]
-    storage_forward :stripe_size, as: "DiskSize"
+    # @see #stripe_size
+    storage_forward :storage_stripe_size, to: :stripe_size, as: "DiskSize"
+    private :storage_stripe_size
+
+    # @!method stripe_size=(stripe_size)
+    #   Sets the size of a stripe
+    #
+    #   @param stripe_size [DiskSize, Integer]
     storage_forward :stripe_size=
 
     # @!method max_size_for_lvm_lv(lv_type)
@@ -137,6 +141,16 @@ module Y2Storage
     # @return [Integer] 0 when the LV is not striped; Storage::LvmLv#stripes otherwise
     def stripes
       thin_pool ? thin_pool.stripes : storage_stripes
+    end
+
+    # Size of a stripe
+    #
+    # @note it returns the value of Storage::LvmLv#stripe_size, except for thin volumes that are
+    #   going to report the striping size defined for their thin pools.
+    #
+    # @return [DiskSize]
+    def stripe_size
+      thin_pool ? thin_pool.stripe_size : storage_stripe_size
     end
 
     # Whether the thin pool is overcommitted

--- a/test/y2storage/lvm_lv_test.rb
+++ b/test/y2storage/lvm_lv_test.rb
@@ -175,6 +175,25 @@ describe Y2Storage::LvmLv do
     end
   end
 
+  describe "#stripe_size" do
+    context "when volume is a thin LV" do
+      let(:thin_pool) { fake_devicegraph.find_by_name("/dev/vg0/thinpool0") }
+      let(:device_name) { "/dev/vg0/thinvol1" }
+
+      it "returns the stripe size defined by its thin pool" do
+        expect(subject.stripe_size).to eq(thin_pool.stripe_size)
+      end
+    end
+
+    context "when volume is not a thin LV" do
+      let(:device_name) { "/dev/vg0/striped1" }
+
+      it "returns its stripping value" do
+        expect(subject.stripe_size).to eq(4.KiB)
+      end
+    end
+  end
+
   describe "#origin" do
     context "when called over a snapshot volume" do
       let(:original_volume) { fake_devicegraph.find_by_name("/dev/vg0/normal1") }


### PR DESCRIPTION
## Problem

As documented in [doc/lvm.md](https://github.com/yast/yast-storage-ng/blob/47201dfdb855d468ba735ffe46bf16544002eea0/doc/lvm.md),

> the partitioner UI reports correctly the number of stripes, **but reports 0.00B for the stripes size**.

for thin and mirror LVs.

<sub>Related to https://github.com/yast/yast-storage-ng/pull/1105</sub>

## Solution

* Manage the #stripe_size method in `Y2Storage::LvmLv` instead of forwarding it directly to libstorage-ng.
* Do not display the stripe size in the overview when it is zero.

## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

#### Before

| Mirror LV | Thin LV |
|-|-|
| ![mirror_lv](https://user-images.githubusercontent.com/1691872/87782269-1ed9e700-c82a-11ea-9263-adc5f385f07f.png) | ![thin_lv](https://user-images.githubusercontent.com/1691872/87782288-24cfc800-c82a-11ea-989e-826ae190a047.png) |

#### After

| Mirror LV | Thin LV |
|-|-|
| ![mirror_lv_a](https://user-images.githubusercontent.com/1691872/87782820-277eed00-c82b-11ea-9507-ff7606b45b18.png) | ![thin_lv_a](https://user-images.githubusercontent.com/1691872/87782837-2ea5fb00-c82b-11ea-8196-707b9e39bf1f.png) |


