### PR TITLE
Detect subvolumes shadowed by a separate_vg (bug#1174475)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug  5 15:06:26 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Proposal: fixed detection of shadowed subvolumes for roles using
+  separate LVM volume groups for each filesystem (bsc#1174475).
+- 4.2.112
+
+-------------------------------------------------------------------
 Fri Jul  3 12:31:39 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - AutoYaST: delegate to initial guided proposal when no partitions

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.111
+Version:        4.2.112
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/planned/can_be_formatted.rb
+++ b/src/lib/y2storage/planned/can_be_formatted.rb
@@ -137,7 +137,7 @@ module Y2Storage
         return [] if subvolumes.nil?
 
         other_devices = all_devices - [self]
-        other_mount_points = other_devices.map { |dev| mount_point_for(dev) }.compact
+        other_mount_points = other_devices.flat_map { |dev| mount_points_for(dev) }
         subvolumes.select { |s| s.shadowed?(mount_point, other_mount_points) }
       end
 
@@ -252,6 +252,18 @@ module Y2Storage
 
         filesystem.mount_path = mount_point
         filesystem.mount_point.mount_by = mount_by if mount_by
+      end
+
+      # @param device [Planned::Device]
+      def mount_points_for(device)
+        points =
+          if device.is_a?(LvmVg)
+            device.lvs.map { |lv| mount_point_for(lv) }
+          else
+            [mount_point_for(device)]
+          end
+
+        points.compact
       end
 
       # @param device [Planned::Device]


### PR DESCRIPTION
## Problem

The proposals contain logic to avoid creating Btrfs subvolumes if their mount points are shadowed by any other filesystem. But that was not working properly for roles using `separate_vgs` in the configuration of the proposal.

So far, that setting is used only by the following SUSE Manager roles: `suma_multidisc_role` and `suma_retail_multidisc_role`. When one of such roles was selected, the proposal created a separate `/srv` LVM logical volume in its own dedicated volume group... but also a `/srv` subvolume for the root filesystem. That, of course, caused problems.

- https://bugzilla.suse.com/show_bug.cgi?id=1174475
- https://trello.com/c/b2NAhJzv/1990-susemanager-41-p5-1174475-srv-mountpoint-is-declared-twice-in-etc-fstab

## Solution

Make sure the detection of shadowed subvolumes also has into account the mount points of separate LVs located in their own VGs (represented by the class `Y2Storage::Planned::LvmVg`).

## Testing

Added a new unit test