### PR TITLE
Fix bug when AutoinstProposal find no devices (bsc#1174469) 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug  6 12:00:08 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- AutoinstProposal now properly reports the proposal as failed when
+  it fails to find the disks (bsc#1174469)
+- 4.2.113
+
+-------------------------------------------------------------------
 Wed Aug  5 15:06:26 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Proposal: fixed detection of shadowed subvolumes for roles using

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.112
+Version:        4.2.113
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/autoinst_proposal.rb
+++ b/src/lib/y2storage/autoinst_proposal.rb
@@ -75,7 +75,7 @@ module Y2Storage
     def calculate_proposal
       drives = Proposal::AutoinstDrivesMap.new(initial_devicegraph, partitioning, issues_list)
       if issues_list.fatal?
-        @devices = []
+        @devices = nil
         return @devices
       end
 

--- a/src/lib/y2storage/proposal/base.rb
+++ b/src/lib/y2storage/proposal/base.rb
@@ -39,7 +39,9 @@ module Y2Storage
       attr_reader :planned_devices
 
       # Proposed layout of devices, nil if the proposal has not been calculated yet
-      # @return [Devicegraph]
+      # or if it was impossible to calculate one
+      #
+      # @return [Devicegraph, nil]
       attr_reader :devices
 
       # If this proposal was generated via {GuidedProposal.initial}, this

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -730,6 +730,11 @@ describe Y2Storage::AutoinstProposal do
           end
           expect(issue).to_not be_nil
         end
+
+        it "marks the proposal as failed" do
+          proposal.propose
+          expect(proposal.failed?).to eq true
+        end
       end
     end
 


### PR DESCRIPTION
## Problem

`Y2Storage::AutoinstProposal` provides a method called `#failed?`. It returns true when it was not possible to calculate a devicegraph for the system that can satisfy the provided AutoYaST profile.

SLES15-SP2 Installer for SAP Business ONE relies on such method to implement its own storage proposal.

But when `AutoinstProposal` found a critical error while matching `<drive>` sections in the profile with devices in the system (for example, it didn't find a disk that was supposed to be there), the proposal was indeed not calculated... but `#failed?` returned false instead of true.

- https://bugzilla.suse.com/show_bug.cgi?id=1174469
- https://trello.com/c/FSrfXADT/1992-2-sle15-sp2-p2-1174469-yast-storage-error-in-copytostaging
- A gist with some extra information about stuff discussed in the bug https://gist.github.com/ancorgs/d03b1c703bd76c23352b2276e4353e1a

## Solution

Fix the value set for `Y2Storage::AutoinstProposal#devices` when the calculation is aborted due to the cause explained above.

## Testing

Added a new unit test
