### PR TITLE
[bsc#1115749]  AutoYaST: modify the LVM VG name only when really needed

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 17 12:37:24 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not append a suffix to LVM Volume Group names unless it
+  is needed (bsc#1115749).
+- 4.1.96
+
+-------------------------------------------------------------------
 Mon Apr 06 09:14:25 CEST 2020 - aschnell@suse.com
 
 - allow to disable LUKS activation (bsc#1162545)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.1.95
+Version:        4.1.96
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/proposal/autoinst_space_maker.rb
+++ b/src/lib/y2storage/proposal/autoinst_space_maker.rb
@@ -190,6 +190,9 @@ module Y2Storage
             all.concat(vg.lvm_pvs)
           when Y2Storage::Planned::Md
             all << devicegraph.md_raids.find { |r| device.reuse_name == r.name }
+          when Y2Storage::Planned::Bcache
+            bcache = devicegraph.bcaches.find { |b| device.reuse_name == b.name }
+            all << bcache
           end
         end
 

--- a/src/lib/y2storage/proposal/autoinst_space_maker.rb
+++ b/src/lib/y2storage/proposal/autoinst_space_maker.rb
@@ -76,7 +76,7 @@ module Y2Storage
       # @param devicegraph    [Devicegraph]
       # @param disk           [Disk]
       # @param drive_spec     [AutoinstProfile::DriveSection]
-      # @param reused_devices [Array<String>] Reused disks and partitions names
+      # @param reused_devices [Array<String>,nil] Reused disks and partitions names
       def delete_stuff(devicegraph, disk, drive_spec, reused_devices)
         reused_devices ||= []
         if drive_spec.initialize_attr && reused_devices.empty?

--- a/test/y2storage/autoinst_proposal_system0_test.rb
+++ b/test/y2storage/autoinst_proposal_system0_test.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env rspec
+
+#
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+describe Y2Storage::AutoinstProposal do
+  using Y2Storage::Refinements::SizeCasts
+
+  before do
+    fake_scenario("lvm-disk-as-pv.xml")
+
+    allow(Yast::Mode).to receive(:auto).and_return(true)
+  end
+
+  subject(:proposal) do
+    described_class.new(
+      partitioning: partitioning, devicegraph: fake_devicegraph, issues_list: issues_list
+    )
+  end
+
+  let(:issues_list) { Y2Storage::AutoinstIssues::List.new }
+
+  let(:partitioning) do
+    [
+      {
+        "device"     => "/dev/system",
+        "initialize" => false,
+        "type"       => :CT_LVM,
+        "partitions" => [
+          {
+            "lv_name" => "root", "mount" => "/", "filesystem" => :ext4,
+            "create" => true, "size" => 90.GiB
+          },
+          {
+            "lv_name" => "swap", "mount" => "swap", "filesystem" => :swap,
+            "create" => true, "size" => 2.GiB
+          }
+        ]
+      },
+      {
+        "device"     => "/dev/sda",
+        "initialize" => false,
+        "type"       => :CT_DISK,
+        "use"        => "all",
+        "disklabel"  => "none",
+        "partitions" => [
+          { "create" => false, "lvm_group" => "system" }
+        ]
+      }
+    ]
+  end
+
+  describe "#propose" do
+    # Regression test for bsc#1115749
+    it "does not allow deleted LVM volume groups affect the name of new VGs" do
+      proposal.propose
+      vgs = proposal.devices.lvm_vgs
+
+      expect(vgs.size).to eq 1
+      # With bsc#1115749, the new (and only) volume group used to be called
+      # "system0" because there was a previous "system" VG... that was deleted,
+      # so it should not affect the name of the new one.
+      expect(vgs.first.vg_name).to eq "system"
+    end
+  end
+end

--- a/test/y2storage/proposal/autoinst_space_maker_test.rb
+++ b/test/y2storage/proposal/autoinst_space_maker_test.rb
@@ -45,6 +45,9 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
   let(:planned_vg) do
     Y2Storage::Planned::LvmVg.new(volume_group_name: "vg0").tap { |p| p.reuse_name = "vg0" }
   end
+  let(:planned_md) do
+    Y2Storage::Planned::Md.new(name: "/dev/md/md0").tap { |m| m.reuse_name = m.name }
+  end
   let(:issues_list) do
     Y2Storage::AutoinstIssues::List
   end
@@ -98,7 +101,22 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
       end
 
       context "and a RAID device will be reused" do
-        it "keeps the physical partition"
+        let(:scenario) { "md_raid" }
+        let(:planned_devices) { [planned_md] }
+
+        it "keeps the physical partition" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          expect(devicegraph.partitions).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/sda1"),
+            an_object_having_attributes("name" => "/dev/sda2")
+          )
+        end
+
+        it "keeps the RAID device" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          md = devicegraph.md_raids.first
+          expect(md.name).to eq("/dev/md/md0")
+        end
       end
     end
 

--- a/test/y2storage/proposal/autoinst_space_maker_test.rb
+++ b/test/y2storage/proposal/autoinst_space_maker_test.rb
@@ -143,6 +143,29 @@ describe Y2Storage::Proposal::AutoinstSpaceMaker do
           )
         end
       end
+
+      context "and a full disk is used as component of a device to be reused" do
+        let(:partitioning_array) do
+          [{ "device" => "/dev/vda", "use" => "all" }, { "device" => "/dev/vdb", "use" => "all" }]
+        end
+        let(:scenario) { "partitioned_btrfs_bcache.xml" }
+        let(:planned_devices) { [planned_bcache] }
+
+        it "does not initialize the disk" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          vdb = devicegraph.find_by_name("/dev/vdb")
+          expect(vdb.children).to_not be_empty
+        end
+
+        it "keeps the Bcache device" do
+          devicegraph = subject.cleaned_devicegraph(fake_devicegraph, drives_map, planned_devices)
+          bcache = devicegraph.bcaches.first
+          expect(bcache.name).to eq("/dev/bcache0")
+          expect(bcache.partitions).to contain_exactly(
+            an_object_having_attributes("name" => "/dev/bcache0p1")
+          )
+        end
+      end
     end
 
     context "when 'use' key is set to 'linux'" do


### PR DESCRIPTION
Backport of https://github.com/yast/yast-storage-ng/pull/1056 as [suggested in the bug report](https://bugzilla.suse.com/show_bug.cgi?id=1115749#c14).

## Problem

Given a system where there is already an LVM VG named (e.g., `system`), if you try to reinstall using a new VG with the same name, it might happen that AutoYaST modifies the wanted name (like `system0`) to avoid *colliding* with the old name. It does not make sense, as you do not want to keep the old one.

- [bsc#1115749](https://bugzilla.suse.com/show_bug.cgi?id=1115749)

## Solution

The problem happens when you are using a full disk as a PV (it will not happen when using partitions). The reason is that `AutoinstSpaceMaker` will not have full disks into account, even when you have set the `use` to `all`.

Additionally, this PR also fixes the reusing of Bcache devices when, for some reason, the user does not mark the caching/backing devices to be reused.

## Screenshots

Before the fix:

![reuse-lvm-ko](https://user-images.githubusercontent.com/15836/90442570-c91b8780-e0d2-11ea-8f4d-b0ce66f4cacb.png)

After the fix:

![reuse-lvm-ok](https://user-images.githubusercontent.com/15836/90442584-cde03b80-e0d2-11ea-849c-52de5083a023.png)
