### PR TITLE
[AutoYaST] Fix profile element paths

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 26 10:08:03 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Unify profile element paths (bsc#1175680).
+- 4.3.15
+
+-------------------------------------------------------------------
 Thu Aug  6 12:00:08 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - AutoinstProposal now properly reports the proposal as failed when

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.14
+Version:        4.3.15
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -28,8 +28,8 @@ Source:         %{name}-%{version}.tar.bz2
 # UF_PMEM and UF_NVME
 BuildRequires:	libstorage-ng-ruby >= 4.3.30
 BuildRequires:  update-desktop-files
-# AutoYaST issue handling
-BuildRequires:  yast2 >= 4.3.2
+# AutoYaST ElementPath class
+BuildRequires:  yast2 >= 4.3.20
 BuildRequires:  yast2-devtools >= 4.2.2
 # for AbortException and handle direct abort
 BuildRequires:  yast2-ruby-bindings >= 4.0.6
@@ -49,8 +49,9 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 Requires:       findutils
 # UF_PMEM and UF_NVME
 Requires:       libstorage-ng-ruby >= 4.3.30
-# Updated Xen detection
-Requires:       yast2 >= 4.3.6
+# AutoYaST issue handling
+Requires:  yast2 >= 4.3.20
+
 # Y2Packager::Repository
 Requires:       yast2-packager >= 3.3.7
 # for AbortException and handle direct abort

--- a/src/lib/y2storage/autoinst_profile/bcache_options_section.rb
+++ b/src/lib/y2storage/autoinst_profile/bcache_options_section.rb
@@ -43,9 +43,10 @@ module Y2Storage
       # Clones Bcache device options into an AutoYaST <bcache_options> profile section
       #
       # @param device [Bcache] bcache device
+      # @param parent [SectionWithAttributes,nil] Parent section
       # @return [BcacheOptionsSection] bcache options section
-      def self.new_from_storage(device)
-        result = new
+      def self.new_from_storage(device, parent = nil)
+        result = new(parent)
         result.init_from_bcache(device)
         result
       end

--- a/src/lib/y2storage/autoinst_profile/btrfs_options_section.rb
+++ b/src/lib/y2storage/autoinst_profile/btrfs_options_section.rb
@@ -46,9 +46,10 @@ module Y2Storage
       # Clones Btrfs options into an AutoYaST <btrfs_options> profile section
       #
       # @param filesystem [Filesystems::Btrfs]
+      # @param parent [SectionWithAttributes,nil]
       # @return [BtrfsOptionsSection] Btrfs options section
-      def self.new_from_storage(filesystem)
-        section = new
+      def self.new_from_storage(filesystem, parent = nil)
+        section = new(parent)
         section.init_from_btrfs(filesystem)
         section
       end

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "installation/autoinst_profile/section_with_attributes"
+require "installation/autoinst_profile/element_path"
 require "y2storage/autoinst_profile/skip_list_section"
 require "y2storage/autoinst_profile/partition_section"
 require "y2storage/autoinst_profile/raid_options_section"
@@ -241,11 +242,18 @@ module Y2Storage
         hash
       end
 
-      # Return section name
+      # Returns the section path
       #
-      # @return [String] "drives"
-      def section_name
-        "drives"
+      # The <drive> section is an special case of a collection, so
+      # we need to redefine the #section_path method completely.
+      #
+      # @return [Installation::AutoinstProfile::ElementPath] Section path or
+      #   nil if the parent is not set
+      def section_path
+        return nil unless parent
+
+        idx = parent.drives.index(self)
+        parent.section_path.join(idx)
       end
 
       # @return [String] disklabel value which indicates that no partition table is wanted.

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -194,8 +194,8 @@ module Y2Storage
       # @param device [Device] a device that can be cloned into a <partition> section,
       #   like a partition, an LVM logical volume, an MD RAID or a NFS filesystem.
       # @return [PartitionSection]
-      def self.new_from_storage(device)
-        result = new
+      def self.new_from_storage(device, parent = nil)
+        result = new(parent)
         result.init_from_device(device)
         result
       end

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -307,7 +307,7 @@ module Y2Storage
       # Return section name
       #
       # @return [String] "partitions"
-      def section_name
+      def collection_name
         "partitions"
       end
 

--- a/src/lib/y2storage/autoinst_profile/partitioning_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partitioning_section.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "installation/autoinst_profile/section_with_attributes"
 require "y2storage/autoinst_profile/drive_section"
 
 module Y2Storage
@@ -27,7 +28,7 @@ module Y2Storage
     #
     # More information can be found in the 'Partitioning' section of the AutoYaST documentation:
     # https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#CreateProfile.Partitioning
-    class PartitioningSection
+    class PartitioningSection < ::Installation::AutoinstProfile::SectionWithAttributes
       # @return [Array<DriveSection] drives whithin the <partitioning> section
       attr_accessor :drives
 
@@ -136,13 +137,6 @@ module Y2Storage
       # @return [Array<DriveSection>]
       def btrfs_drives
         drives.select { |d| d.type == :CT_BTRFS }
-      end
-
-      # Return section name
-      #
-      # @return [String] "partitioning"
-      def section_name
-        "partitioning"
       end
 
       # All drive sections generated from a given devicegraph

--- a/src/lib/y2storage/autoinst_profile/raid_options_section.rb
+++ b/src/lib/y2storage/autoinst_profile/raid_options_section.rb
@@ -75,9 +75,10 @@ module Y2Storage
       # Clones RAID device options into an AutoYaST <raid_options> profile section
       #
       # @param device [Md] RAID device
+      # @param parent [SectionWithAttributes,nil] Parent section
       # @return [RaidOptionsSection] RAID options section
-      def self.new_from_storage(device)
-        result = new
+      def self.new_from_storage(device, parent = nil)
+        result = new(parent)
         result.init_from_raid(device)
         result
       end

--- a/test/y2storage/autoinst_issues/issues_presenter_test.rb
+++ b/test/y2storage/autoinst_issues/issues_presenter_test.rb
@@ -85,8 +85,9 @@ describe Installation::AutoinstIssues::IssuesPresenter do
       end
 
       it "includes the location information" do
+        section = list.first.section
         expect(presenter.to_html).to include(
-          "<li>partitioning > drives[1] > partitions[2] > raid_options:<ul>"
+          "<li>#{section.section_path}:<ul>"
         )
       end
     end
@@ -134,8 +135,9 @@ describe Installation::AutoinstIssues::IssuesPresenter do
       end
 
       it "includes the location information" do
+        section = list.first.section
         expect(presenter.to_plain).to include(
-          "* partitioning > drives[1] > partitions[2] > raid_options:"
+          "* #{section.section_path}:"
         )
       end
     end

--- a/test/y2storage/autoinst_profile/bcache_options_section_test.rb
+++ b/test/y2storage/autoinst_profile/bcache_options_section_test.rb
@@ -1,0 +1,42 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require_relative "#{TEST_PATH}/support/autoinst_profile_sections_examples"
+require "y2storage"
+
+describe Y2Storage::AutoinstProfile::BcacheOptionsSection do
+  include_examples "autoinst section"
+
+  describe "#section_path" do
+    let(:partitioning) do
+      Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
+        [{ "device" => "/dev/vda", "bcache_options" => { "cache_mode" => "writethrough" } }]
+      )
+    end
+
+    let(:drive) { partitioning.drives.first }
+
+    subject(:section) { drive.bcache_options }
+
+    it "returns the section path" do
+      expect(section.section_path.to_s).to eq("partitioning,0,bcache_options")
+    end
+  end
+end

--- a/test/y2storage/autoinst_profile/btrfs_options_section_test.rb
+++ b/test/y2storage/autoinst_profile/btrfs_options_section_test.rb
@@ -78,5 +78,26 @@ describe Y2Storage::AutoinstProfile::BtrfsOptionsSection do
     it "initializes metadata_raid_level" do
       expect(section.metadata_raid_level).to eq("single")
     end
+
+    it "sets the parent section" do
+      section = described_class.new_from_storage(filesystem, parent)
+      expect(section.parent).to eq(parent)
+    end
+  end
+
+  describe "#section_path" do
+    let(:partitioning) do
+      Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
+        [{ "device" => "/dev/vda", "btrfs_options" => { "data_raid_level" => "SINGLE" } }]
+      )
+    end
+
+    let(:drive) { partitioning.drives.first }
+
+    subject(:section) { drive.btrfs_options }
+
+    it "returns the section path" do
+      expect(section.section_path.to_s).to eq("partitioning,0,btrfs_options")
+    end
   end
 end

--- a/test/y2storage/autoinst_profile/btrfs_options_section_test.rb
+++ b/test/y2storage/autoinst_profile/btrfs_options_section_test.rb
@@ -71,6 +71,8 @@ describe Y2Storage::AutoinstProfile::BtrfsOptionsSection do
       )
     end
 
+    let(:parent) { double("Installation::AutoinstProfile::SectionWithAttributes") }
+
     it "initializes data_raid_level" do
       expect(section.data_raid_level).to eq("raid1")
     end

--- a/test/y2storage/autoinst_profile/drive_section_test.rb
+++ b/test/y2storage/autoinst_profile/drive_section_test.rb
@@ -922,12 +922,6 @@ describe Y2Storage::AutoinstProfile::DriveSection do
     end
   end
 
-  describe "#section_name" do
-    it "returns 'drives'" do
-      expect(section.section_name).to eq("drives")
-    end
-  end
-
   describe "#name_for_md" do
     let(:part1) do
       instance_double(
@@ -1095,6 +1089,20 @@ describe Y2Storage::AutoinstProfile::DriveSection do
           expect(section.master_partition).to eq(part0_spec)
         end
       end
+    end
+  end
+
+  describe "#section_path" do
+    let(:partitioning) do
+      Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
+        [{ "device" => "/dev/vda", "partitions" => [{ "mount" => "/" }] }]
+      )
+    end
+
+    subject(:section) { partitioning.drives.first }
+
+    it "returns 'partitioning,index'" do
+      expect(section.section_path.to_s).to eq("partitioning,0")
     end
   end
 end

--- a/test/y2storage/autoinst_profile/drive_section_test.rb
+++ b/test/y2storage/autoinst_profile/drive_section_test.rb
@@ -179,6 +179,8 @@ describe Y2Storage::AutoinstProfile::DriveSection do
   end
 
   describe ".new_from_storage" do
+    let(:parent) { double("Installation::AutoinstProfile::SectionWithAttributes") }
+
     it "returns nil for a disk or DASD with no partitions" do
       expect(described_class.new_from_storage(device("dasda"))).to eq nil
       expect(described_class.new_from_storage(device("sda"))).to eq nil
@@ -221,6 +223,11 @@ describe Y2Storage::AutoinstProfile::DriveSection do
       btrfs.add_device(sdd1)
 
       expect(described_class.new_from_storage(btrfs)).to be_a described_class
+    end
+
+    it "sets the parent section" do
+      section = described_class.new_from_storage(device("sdc"), parent)
+      expect(section.parent).to eq(parent)
     end
 
     it "stores the exportable partitions as PartitionSection objects" do

--- a/test/y2storage/autoinst_profile/partition_section_test.rb
+++ b/test/y2storage/autoinst_profile/partition_section_test.rb
@@ -1170,9 +1170,19 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
     end
   end
 
-  describe "#section_name" do
-    it "returns 'partitions'" do
-      expect(section.section_name).to eq("partitions")
+  describe "#section_path" do
+    let(:partitioning) do
+      Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
+        [{ "device" => "/dev/vda", "partitions" => [{ "mount" => "/" }] }]
+      )
+    end
+
+    let(:drive) { partitioning.drives.first }
+
+    subject(:section) { drive.partitions.first }
+
+    it "returns the section path" do
+      expect(section.section_path.to_s).to eq("partitioning,0,partitions,0")
     end
   end
 end

--- a/test/y2storage/autoinst_profile/partition_section_test.rb
+++ b/test/y2storage/autoinst_profile/partition_section_test.rb
@@ -38,12 +38,19 @@ describe Y2Storage::AutoinstProfile::PartitionSection do
   end
 
   describe ".new_from_storage" do
+    let(:parent) { double("Installation::AutoinstProfile::SectionWithAttributes") }
+
     def section_for(name)
       described_class.new_from_storage(device(name))
     end
 
     it "returns a PartitionSection object" do
       expect(section_for("dasdb1")).to be_a Y2Storage::AutoinstProfile::PartitionSection
+    end
+
+    it "sets the parent section" do
+      section = described_class.new_from_storage(device("dasdb1"), parent)
+      expect(section.parent).to eq(parent)
     end
 
     context "given a partition" do

--- a/test/y2storage/autoinst_profile/raid_options_section_test.rb
+++ b/test/y2storage/autoinst_profile/raid_options_section_test.rb
@@ -161,4 +161,20 @@ describe Y2Storage::AutoinstProfile::RaidOptionsSection do
       end
     end
   end
+
+  describe "#section_path" do
+    let(:partitioning) do
+      Y2Storage::AutoinstProfile::PartitioningSection.new_from_hashes(
+        [{ "device" => "/dev/vda", "raid_options" => { "raid_name" => "/dev/md0" } }]
+      )
+    end
+
+    let(:drive) { partitioning.drives.first }
+
+    subject(:section) { drive.raid_options }
+
+    it "returns the section path" do
+      expect(section.section_path.to_s).to eq("partitioning,0,raid_options")
+    end
+  end
 end

--- a/test/y2storage/autoinst_profile/raid_options_section_test.rb
+++ b/test/y2storage/autoinst_profile/raid_options_section_test.rb
@@ -100,6 +100,7 @@ describe Y2Storage::AutoinstProfile::RaidOptionsSection do
 
   describe ".new_from_storage" do
     let(:numeric?) { false }
+    let(:parent) { double("Installation::AutoinstProfile::SectionWithAttributes") }
 
     let(:sda1) do
       instance_double(
@@ -159,6 +160,11 @@ describe Y2Storage::AutoinstProfile::RaidOptionsSection do
       it "does not initialize raid_name" do
         expect(raid_options.raid_name).to be_nil
       end
+    end
+
+    it "sets the parent section" do
+      section = described_class.new_from_storage(md, parent)
+      expect(section.parent).to eq(parent)
     end
   end
 


### PR DESCRIPTION
## Problem

The new error reporting mechanism and the <ask-list> features use different syntax to point to a specific element in a profile (`partitioning,0,partitions,1` vs `drives [1] > partitions [2]`).

## Solution

Use the same syntax that the ask-list. This PR relies on https://github.com/yast/yast-yast2/pull/1090.

## Screenshots

![ask-list-autoinst-issues](https://user-images.githubusercontent.com/15836/91294247-211c5300-e791-11ea-9b7a-d5953b85b04c.png)



