### PR TITLE
Reduce tree nesting

### DIFF
--- a/src/lib/y2partitioner/widgets/bcache_edit_button.rb
+++ b/src/lib/y2partitioner/widgets/bcache_edit_button.rb
@@ -27,8 +27,8 @@ module Y2Partitioner
   module Widgets
     # Button for editing a bcache
     class BcacheEditButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/blk_device_edit_button.rb
+++ b/src/lib/y2partitioner/widgets/blk_device_edit_button.rb
@@ -28,8 +28,8 @@ module Y2Partitioner
   module Widgets
     # Button for editing a block device
     class BlkDeviceEditButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/btrfs_edit_button.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_edit_button.rb
@@ -27,8 +27,8 @@ module Y2Partitioner
   module Widgets
     # Button for editing a BTRFS filesystem
     class BtrfsEditButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/device_delete_button.rb
+++ b/src/lib/y2partitioner/widgets/device_delete_button.rb
@@ -30,8 +30,8 @@ module Y2Partitioner
   module Widgets
     # Button for deleting a device
     class DeviceDeleteButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/device_resize_button.rb
+++ b/src/lib/y2partitioner/widgets/device_resize_button.rb
@@ -27,8 +27,8 @@ module Y2Partitioner
   module Widgets
     # Button for resizing a block device
     class DeviceResizeButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/lvm_lv_add_button.rb
+++ b/src/lib/y2partitioner/widgets/lvm_lv_add_button.rb
@@ -25,8 +25,8 @@ module Y2Partitioner
   module Widgets
     # Button for opening the workflow to add a logical volume to a volume group
     class LvmLvAddButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/lvm_lvs_delete_button.rb
+++ b/src/lib/y2partitioner/widgets/lvm_lvs_delete_button.rb
@@ -25,8 +25,8 @@ module Y2Partitioner
   module Widgets
     # Button for deleting all logical volumes
     class LvmLvsDeleteButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/lvm_vg_resize_button.rb
+++ b/src/lib/y2partitioner/widgets/lvm_vg_resize_button.rb
@@ -25,8 +25,8 @@ module Y2Partitioner
   module Widgets
     # Button for editing the list of physical volumes of an LVM VG
     class LvmVgResizeButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -45,7 +45,7 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def label
-        _("System View")
+        _("View")
       end
 
       attr_reader :items
@@ -98,7 +98,20 @@ module Y2Partitioner
 
       # @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FTree:items
       def items
-        [system_items]
+        [
+          system_section,
+          disks_section,
+          raids_section,
+          lvm_section,
+          bcache_section,
+          # TODO: Bring this back to life - disabled for now (bsc#1078849)
+          # crypt_files_items,
+          # device_mapper_items,
+          nfs_section,
+          btrfs_section
+          # TODO: Bring this back to life - disabled for now (bsc#1078849)
+          # unused_items
+        ].compact
       end
 
       # Overrides default behavior of TreePager to register the new state with
@@ -203,23 +216,10 @@ module Y2Partitioner
       end
 
       # @return [CWM::PagerTreeItem]
-      def system_items
+      def system_section
         page = Pages::System.new(hostname, self)
-        children = [
-          disks_section,
-          raids_section,
-          lvm_section,
-          bcache_section,
-          # TODO: Bring this back to life - disabled for now (bsc#1078849)
-          # crypt_files_items,
-          # device_mapper_items,
-          nfs_section,
-          btrfs_section
-          # TODO: Bring this back to life - disabled for now (bsc#1078849)
-          # unused_items
-        ].compact
 
-        section_item(page, Icons::ALL, children: children)
+        section_item(page, Icons::ALL)
       end
 
       # @return [CWM::PagerTreeItem]

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -45,7 +45,7 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def label
-        _("View")
+        _("Devices")
       end
 
       attr_reader :items
@@ -107,10 +107,10 @@ module Y2Partitioner
           # TODO: Bring this back to life - disabled for now (bsc#1078849)
           # crypt_files_items,
           # device_mapper_items,
-          nfs_section,
-          btrfs_section
+          btrfs_section,
           # TODO: Bring this back to life - disabled for now (bsc#1078849)
           # unused_items
+          nfs_section
         ].compact
       end
 

--- a/src/lib/y2partitioner/widgets/pages/lvm.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm.rb
@@ -37,7 +37,7 @@ module Y2Partitioner
         #
         # @return [String]
         def self.label
-          _("Volume Management")
+          _("LVM")
         end
 
         # Constructor

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -47,7 +47,7 @@ module Y2Partitioner
 
         # @macro seeAbstractWidget
         def label
-          hostname
+          _("System Overview")
         end
 
         # @macro seeCustomWidget

--- a/src/lib/y2partitioner/widgets/partition_add_button.rb
+++ b/src/lib/y2partitioner/widgets/partition_add_button.rb
@@ -25,8 +25,8 @@ module Y2Partitioner
   module Widgets
     # Button for adding a partition
     class PartitionAddButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/partition_move_button.rb
+++ b/src/lib/y2partitioner/widgets/partition_move_button.rb
@@ -25,8 +25,8 @@ module Y2Partitioner
   module Widgets
     # Button for moving a partition
     class PartitionMoveButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/partition_table_add_button.rb
+++ b/src/lib/y2partitioner/widgets/partition_table_add_button.rb
@@ -25,8 +25,8 @@ module Y2Partitioner
   module Widgets
     # Button for adding a partition table
     class PartitionTableAddButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/partitions_delete_button.rb
+++ b/src/lib/y2partitioner/widgets/partitions_delete_button.rb
@@ -25,8 +25,8 @@ module Y2Partitioner
   module Widgets
     # Button for deleting all partitions
     class PartitionsDeleteButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/used_devices_edit_button.rb
+++ b/src/lib/y2partitioner/widgets/used_devices_edit_button.rb
@@ -28,8 +28,8 @@ module Y2Partitioner
   module Widgets
     # Button for editing the used devices (e.g., by a Software RAID)
     class UsedDevicesEditButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/test/y2partitioner/dialogs/device_graph_test.rb
+++ b/test/y2partitioner/dialogs/device_graph_test.rb
@@ -18,42 +18,41 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com
 
-require_relative "../../test_helper"
+require_relative "../test_helper"
 
 require "cwm/rspec"
-require "y2partitioner/widgets/pages"
+require "y2partitioner/dialogs/device_graph"
 require "y2partitioner/device_graphs"
 
-describe Y2Partitioner::Widgets::Pages::DeviceGraph do
+describe Y2Partitioner::Dialogs::DeviceGraph do
   before do
     devicegraph_stub("complex-lvm-encrypt")
   end
 
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
 
-  subject(:page) { described_class.new(pager) }
+  subject { described_class.new }
 
-  let(:pager) { double("OverviewTreePager") }
   let(:system) { Y2Partitioner::DeviceGraphs.instance.system }
   let(:current) { Y2Partitioner::DeviceGraphs.instance.current }
 
-  include_examples "CWM::Page"
+  include_examples "CWM::Dialog"
 
   describe "#contents" do
     it "includes a tab for the current graph and another for the system one" do
-      expect(Y2Partitioner::Widgets::Pages::DeviceGraphTab).to receive(:new)
+      expect(Y2Partitioner::Dialogs::DeviceGraphTab).to receive(:new)
         .with("Planned Devices", current, any_args)
-      expect(Y2Partitioner::Widgets::Pages::DeviceGraphTab).to receive(:new)
+      expect(Y2Partitioner::Dialogs::DeviceGraphTab).to receive(:new)
         .with("Current System Devices", system, any_args)
-      page.contents
+      subject.contents
     end
   end
 
-  describe Y2Partitioner::Widgets::Pages::DeviceGraphTab do
+  describe Y2Partitioner::Dialogs::DeviceGraphTab do
     let(:device_graph_widget) { double("DeviceGraphWithButtons") }
     let(:device_graph) { double("Devicegraph") }
 
-    subject(:widget) { described_class.new("Label", device_graph, "Description", pager) }
+    subject(:widget) { described_class.new("Label", device_graph, "Description") }
 
     include_examples "CWM::Tab"
 
@@ -66,7 +65,7 @@ describe Y2Partitioner::Widgets::Pages::DeviceGraph do
     describe "#contents" do
       it "includes the description and the graph widget" do
         expect(Y2Partitioner::Widgets::DeviceGraphWithButtons).to receive(:new)
-          .with(device_graph, pager).and_return device_graph_widget
+          .with(device_graph).and_return device_graph_widget
         contents = widget.contents
 
         found = contents.nested_find { |i| i == device_graph_widget }

--- a/test/y2partitioner/dialogs/settings_test.rb
+++ b/test/y2partitioner/dialogs/settings_test.rb
@@ -18,28 +18,28 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com
 
-require_relative "../../test_helper"
+require_relative "../test_helper"
 
 require "cwm/rspec"
-require "y2partitioner/widgets/pages"
+require "y2partitioner/dialogs/settings"
 
-describe Y2Partitioner::Widgets::Pages::Settings do
+describe Y2Partitioner::Dialogs::Settings do
   subject(:page) { described_class.new }
 
-  include_examples "CWM::Page"
+  include_examples "CWM::Dialog"
 
   describe "#contents" do
     it "includes a widget to select default mount by" do
-      expect(Y2Partitioner::Widgets::Pages::Settings::MountBySelector).to receive(:new)
+      expect(Y2Partitioner::Dialogs::Settings::MountBySelector).to receive(:new)
       page.contents
     end
   end
 end
 
-describe Y2Partitioner::Widgets::Pages::Settings::MountBySelector do
+describe Y2Partitioner::Dialogs::Settings::MountBySelector do
   include_examples "CWM::ComboBox"
 
-  describe "#handle" do
+  describe "#store" do
     before do
       allow(subject).to receive(:value).and_return(value)
       allow(subject).to receive(:widget_id).and_return(widget_id)
@@ -60,38 +60,19 @@ describe Y2Partitioner::Widgets::Pages::Settings::MountBySelector do
 
     let(:mount_by_label) { Y2Storage::Filesystems::MountByType::LABEL }
 
-    context "when a mount_by is selected" do
-      let(:events) { { "ID" => widget_id } }
-
-      it "updates the default value for mount_by" do
-        expect(configuration.default_mount_by).to_not eq(value)
-        subject.handle(events)
-        expect(configuration.default_mount_by).to eq(value)
-      end
-
-      it "saves the selected value into the config file" do
-        expect(Yast::SCR).to receive(:Write) do |path, value|
-          expect(path.to_s).to match(/storage/)
-          expect(value).to eq("id")
-        end
-
-        subject.handle(events)
-      end
+    it "updates the default value for mount_by" do
+      expect(configuration.default_mount_by).to_not eq(value)
+      subject.store
+      expect(configuration.default_mount_by).to eq(value)
     end
 
-    context "when other widget has changed" do
-      let(:events) { { "ID" => "other_widget_id" } }
-
-      it "does not update the default value for mount_by" do
-        expect(configuration.default_mount_by.to_sym).to_not eq(value)
-        subject.handle(events)
-        expect(configuration.default_mount_by).to_not eq(value)
+    it "saves the selected value into the config file" do
+      expect(Yast::SCR).to receive(:Write) do |path, value|
+        expect(path.to_s).to match(/storage/)
+        expect(value).to eq("id")
       end
 
-      it "does not save the selected value into the config file" do
-        expect(Yast::SCR).to_not receive(:Write)
-        subject.handle(events)
-      end
+      subject.store
     end
   end
 end

--- a/test/y2partitioner/dialogs/summary_popup_test.rb
+++ b/test/y2partitioner/dialogs/summary_popup_test.rb
@@ -18,20 +18,20 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com
 
-require_relative "../../test_helper"
+require_relative "../test_helper"
 
 require "cwm/rspec"
-require "y2partitioner/widgets/pages"
+require "y2partitioner/dialogs/summary_popup"
 
-describe Y2Partitioner::Widgets::Pages::Summary do
-  subject(:page) { described_class.new }
+describe Y2Partitioner::Dialogs::SummaryPopup do
+  subject { described_class.new }
 
-  include_examples "CWM::Page"
+  include_examples "CWM::Dialog"
 
   describe "#contents" do
     it "includes a widget with the interactive summary" do
       expect(Y2Partitioner::Widgets::SummaryText).to receive(:new)
-      page.contents
+      subject.contents
     end
   end
 end

--- a/test/y2partitioner/widgets/device_graph_with_buttons_test.rb
+++ b/test/y2partitioner/widgets/device_graph_with_buttons_test.rb
@@ -33,16 +33,15 @@ describe Y2Partitioner::Widgets::DeviceGraphWithButtons do
   let(:visual_device_graph) { double("VisualDeviceGraph") }
   let(:xml_button) { double("SaveDeviceGraphButton") }
   let(:gv_button) { double("SaveDeviceGraphButton") }
-  let(:pager) { double("OverviewTreePager") }
 
-  subject(:widget) { described_class.new(device_graph, pager) }
+  subject(:widget) { described_class.new(device_graph) }
 
   include_examples "CWM::CustomWidget"
 
   describe "#contents" do
     it "includes the graph and the two buttons for saving" do
       expect(Y2Partitioner::Widgets::VisualDeviceGraph).to receive(:new)
-        .with(device_graph, pager).and_return visual_device_graph
+        .with(device_graph).and_return visual_device_graph
       expect(Y2Partitioner::Widgets::SaveDeviceGraphButton).to receive(:new)
         .with(device_graph, :xml).and_return xml_button
       expect(Y2Partitioner::Widgets::SaveDeviceGraphButton).to receive(:new)

--- a/test/y2partitioner/widgets/overview_test.rb
+++ b/test/y2partitioner/widgets/overview_test.rb
@@ -107,7 +107,7 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
     end
 
     let(:disks_pager) do
-      system_pager.children.values.find { |i| i.page.is_a?(Y2Partitioner::Widgets::Pages::Disks) }
+      overview_tree.items.find { |i| i.page.is_a?(Y2Partitioner::Widgets::Pages::Disks) }
     end
 
     let(:disks_pages) { disks_pager.pages - [disks_pager.page] }
@@ -117,7 +117,7 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
     end
 
     let(:btrfs_filesystems_page) do
-      system_pager.children.values.find do |i|
+      overview_tree.items.find do |i|
         i.page.is_a?(Y2Partitioner::Widgets::Pages::BtrfsFilesystems)
       end
     end
@@ -140,14 +140,6 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
 
     it "system pager includes a BTRFS filesystems page" do
       expect(btrfs_filesystems_page).to_not be_nil
-    end
-
-    it "includes a 'Summary' page" do
-      expect(summary_page).to_not be_nil
-    end
-
-    it "includes a 'Settings' page" do
-      expect(settings_page).to_not be_nil
     end
 
     before do
@@ -270,22 +262,6 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
       it "disk pager has no BTRFS pages" do
         btrfs_pages = disks_pages.select { |p| p.is_a?(Y2Partitioner::Widgets::Pages::Btrfs) }
         expect(btrfs_pages).to be_empty
-      end
-    end
-
-    context "when the UI supports the Graph widget (Qt)" do
-      let(:graph_available) { true }
-
-      it "includes the 'Device Graph' page" do
-        expect(device_graph_page).to_not be_nil
-      end
-    end
-
-    context "when the UI does not support the Graph widget (ncurses)" do
-      let(:graph_available) { false }
-
-      it "does not include the 'Device Graph' page" do
-        expect(device_graph_page).to be_nil
       end
     end
   end
@@ -445,12 +421,17 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
     let(:scenario) { "lvm-two-vgs.yml" }
 
     let(:with_children) do
-      ["Y2Partitioner::Widgets::Pages::System", "Y2Partitioner::Widgets::Pages::Disks",
-       "Y2Partitioner::Widgets::Pages::Lvm", "disk:/dev/sda", "lvm_vg:vg0", "lvm_vg:vg1"]
+      [
+        "Y2Partitioner::Widgets::Pages::Disks",
+        "Y2Partitioner::Widgets::Pages::Lvm",
+        "disk:/dev/sda",
+        "lvm_vg:vg0",
+        "lvm_vg:vg1"
+      ]
     end
 
     let(:ui_open_items) do
-      { "Y2Partitioner::Widgets::Pages::System" => "ID", "disk:/dev/sda" => "ID" }
+      { "Y2Partitioner::Widgets::Pages::Lvm" => "ID", "disk:/dev/sda" => "ID" }
     end
 
     it "contains an entry for each item with children" do
@@ -458,13 +439,12 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
     end
 
     it "sets the value of open items to true" do
-      expect(subject.open_items["Y2Partitioner::Widgets::Pages::System"]).to eq true
+      expect(subject.open_items["Y2Partitioner::Widgets::Pages::Lvm"]).to eq true
       expect(subject.open_items["disk:/dev/sda"]).to eq true
     end
 
     it "sets the value of closed items to false" do
       expect(subject.open_items["Y2Partitioner::Widgets::Pages::Disks"]).to eq false
-      expect(subject.open_items["Y2Partitioner::Widgets::Pages::Lvm"]).to eq false
       expect(subject.open_items["lvm_vg:vg0"]).to eq false
       expect(subject.open_items["lvm_vg:vg1"]).to eq false
     end

--- a/test/y2partitioner/widgets/visual_device_graph_test.rb
+++ b/test/y2partitioner/widgets/visual_device_graph_test.rb
@@ -30,66 +30,10 @@ describe Y2Partitioner::Widgets::VisualDeviceGraph do
   end
 
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
-  let(:pager) { Y2Partitioner::Widgets::OverviewTreePager.new("hostname") }
 
-  subject(:widget) { described_class.new(device_graph, pager) }
+  subject(:widget) { described_class.new(device_graph) }
 
   include_examples "CWM::CustomWidget"
-
-  describe "#handle" do
-    before do
-      Y2Storage::Filesystems::Nfs.create(device_graph, "new", "/device")
-      allow(Yast::UI).to receive(:QueryWidget).and_return item
-    end
-
-    context "when there is no device with the clicked sid" do
-      # The first sid used by libstorage-ng is 42. And when a devicegraph is loaded from a yaml file,
-      # sids are continuously increasing after each new load. So using a big sid number to represent a
-      # missing device is not safe enough. Such big number could be reached if several yaml files are
-      # loaded before this test. The safer solution is to use a sid less than 42 (for example, 1).
-      let(:item) { "1" }
-
-      it "doesn't change the current section" do
-        expect(pager).to_not receive(:switch_page)
-        widget.handle
-      end
-    end
-
-    context "when an NFS device is clicked" do
-      let(:item) { device_graph.nfs_mounts.first.sid.to_s }
-
-      it "switches to the NFS section" do
-        expect(pager).to receive(:switch_page) do |page|
-          expect(page.label).to eq "NFS"
-        end
-        widget.handle
-      end
-    end
-
-    context "when a device with its own page is clicked" do
-      let(:partition) { device_graph.find_by_name("/dev/sda1") }
-      let(:item) { partition.sid.to_s }
-
-      it "switches to the corresponding section" do
-        expect(pager).to receive(:switch_page) do |page|
-          expect(page.label).to eq "sda1"
-        end
-        widget.handle
-      end
-    end
-
-    context "when a file system is clicked" do
-      let(:device) { device_graph.find_by_name("/dev/vg0/lv1") }
-      let(:item) { device.filesystem.sid.to_s }
-
-      it "switches to the section of the host device" do
-        expect(pager).to receive(:switch_page) do |page|
-          expect(page.label).to eq "lv1"
-        end
-        widget.handle
-      end
-    end
-  end
 
   describe "#init" do
     it "updates the content of the graph widget" do


### PR DESCRIPTION
## Problem

The tree options *Device Graphs*, *Installation Summary* and *Settings* were moved from the left tree to the new menu bar. Now, having a first level in the tree with everything hanging on it simply does not make sense. We can remove the outer nesting of the left tree, so the first level would be "Hard disks", "Volume Management", etc.

See https://github.com/yast/yast-storage-ng/blob/master/doc/partitioner_ui.md#agreed-plan-so-far for a sketch of the expected result.

* Related to: https://bugzilla.suse.com/show_bug.cgi?id=1175489
* PBI: https://trello.com/c/9fXaJujC/2044-2-partitioner-left-tree-less-nesting


## Solution

The first level was removed.

Note: ruby 2.7 deprecates the usage of last argument as keyword parameters. Because that, we start to see a lot warnings like this:

~~~
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
~~~

This was fixed to avoid warnings. See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/ for more details.

## Testing

* Adapted unit tests
* Tested manually


## Screenshots

![Screenshot from 2020-09-15 11-49-28](https://user-images.githubusercontent.com/1112304/93207057-4548cf80-f752-11ea-9a5a-311f6bc1259e.png)
