### PR TITLE
Bcache Caching Sets popup

### DIFF
--- a/src/lib/y2partitioner/dialogs/bcache_csets.rb
+++ b/src/lib/y2partitioner/dialogs/bcache_csets.rb
@@ -1,0 +1,86 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2partitioner/dialogs/popup"
+require "y2partitioner/widgets/blk_devices_table"
+require "y2partitioner/widgets/columns"
+
+module Y2Partitioner
+  module Dialogs
+    # Dialog to show the list of Bcache Caching Sets
+    class BcacheCsets < Popup
+      # Constructor
+      def initialize
+        textdomain "storage"
+      end
+
+      # Title of the dialog
+      #
+      # @return [String]
+      def title
+        _("Bcache Caching Sets")
+      end
+
+      # Contents of the dialog
+      #
+      # @return [Yast::Term]
+      def contents
+        @contents ||= VBox(BcacheCsetsTable.new)
+      end
+
+      private
+
+      # @see Y2Partitioner::Dialogs::Popup
+      def buttons
+        [ok_button]
+      end
+
+      # @see Y2Partitioner::Dialogs::Popup
+      def min_width
+        77
+      end
+
+      # Table for caching set devices
+      class BcacheCsetsTable < Widgets::BlkDevicesTable
+        # Returns all caching set devices
+        #
+        # @see Widgets::BlkDevicesTable
+        #
+        # @return [Array<Y2Storage::BcacheCset>]
+        def devices
+          DeviceGraphs.instance.current.bcache_csets
+        end
+
+        # Columns to show
+        #
+        # @see Widgets::BlkDevicesTable
+        #
+        # @return [Array<Y2Partitioner::Widgets::Columns::Base>]
+        def columns
+          [
+            Widgets::Columns::CachingDevice,
+            Widgets::Columns::Size,
+            Widgets::Columns::Uuid,
+            Widgets::Columns::UsedBy
+          ]
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/dialogs/device_graph.rb
+++ b/src/lib/y2partitioner/dialogs/device_graph.rb
@@ -17,8 +17,6 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "yast"
-require "yast/i18n"
 require "y2partitioner/dialogs/popup"
 require "y2partitioner/device_graphs"
 require "y2partitioner/widgets/device_graph_with_buttons"
@@ -29,8 +27,6 @@ module Y2Partitioner
     # A dialog for displaying the device graphs (both current and system) in
     # interfaces supporting the Graph widget (Qt). Don't use in NCurses.
     class DeviceGraph < Popup
-      include Yast::I18n
-
       # Constructor
       def initialize
         textdomain "storage"

--- a/src/lib/y2partitioner/dialogs/settings.rb
+++ b/src/lib/y2partitioner/dialogs/settings.rb
@@ -17,8 +17,6 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "yast"
-require "yast/i18n"
 require "y2partitioner/dialogs/popup"
 require "y2partitioner/icons"
 require "y2storage/filesystems/mount_by_type"
@@ -29,8 +27,6 @@ module Y2Partitioner
   module Dialogs
     # A page for displaying the Partitioner settings
     class Settings < Popup
-      include Yast::I18n
-
       # Constructor
       def initialize
         textdomain "storage"

--- a/src/lib/y2partitioner/dialogs/summary_popup.rb
+++ b/src/lib/y2partitioner/dialogs/summary_popup.rb
@@ -17,20 +17,13 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "yast"
-require "yast/i18n"
 require "y2partitioner/dialogs/popup"
 require "y2partitioner/widgets/summary_text"
-require "y2partitioner/actions/quit_partitioner"
-
-Yast.import "Label"
 
 module Y2Partitioner
   module Dialogs
     # Dialog to show the summary of changes performed by the user
     class SummaryPopup < Popup
-      include Yast::I18n
-
       def initialize
         textdomain "storage"
       end

--- a/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
@@ -155,7 +155,7 @@ module Y2Partitioner
       #   partitioner
       attr_reader :pager
 
-      # @return [Array<Y2Partitioner::DevicePresenter>] list of devices to display
+      # @return [Array<Y2Storage::Device>] list of devices to display
       attr_reader :devices
 
       DEFAULT_COLUMNS = [

--- a/src/lib/y2partitioner/widgets/menus/view.rb
+++ b/src/lib/y2partitioner/widgets/menus/view.rb
@@ -22,6 +22,7 @@ require "y2partitioner/widgets/menus/base"
 require "y2partitioner/dialogs/summary_popup"
 require "y2partitioner/dialogs/device_graph"
 require "y2partitioner/dialogs/settings"
+require "y2partitioner/dialogs/bcache_csets"
 
 module Y2Partitioner
   module Widgets
@@ -62,6 +63,8 @@ module Y2Partitioner
             Dialogs::SummaryPopup.new
           when :settings
             Dialogs::Settings.new
+          when :bcache_csets
+            Dialogs::BcacheCsets.new
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018-2019] SUSE LLC
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -22,7 +22,6 @@ require "y2partitioner/widgets/pages/base"
 require "y2partitioner/widgets/bcache_add_button"
 require "y2partitioner/widgets/device_buttons_set"
 require "y2partitioner/widgets/configurable_blk_devices_table"
-require "y2partitioner/widgets/columns"
 
 module Y2Partitioner
   module Widgets
@@ -71,69 +70,30 @@ module Y2Partitioner
                   Heading(label)
                 )
               ),
-              Left(tabs)
+              Left(
+                VBox(
+                  table,
+                  Left(device_buttons),
+                  Right(table_buttons)
+                )
+              )
             )
           )
         end
 
-        # @macro seeAbstractWidget
-        def init
-          # Start always in the first tab
-          tabs.switch_page(tabs.initial_page)
-        end
-
         private
 
-        # Page icon
-        #
-        # @return [String]
-        def icon
-          Icons::BCACHE
-        end
-
-        # Tabs to show
-        #
-        # @return [Array<CWM::Tab>]
-        def tabs
-          @tabs ||= Tabs.new(
-            BcachesTab.new(@bcaches, @pager),
-            BcacheCsetsTab.new(@pager)
-          )
-        end
-      end
-
-      # A Tab for the list of bcache devices
-      class BcachesTab < CWM::Tab
         # @return [Array<Y2Storage::Bcache>]
         attr_reader :bcaches
 
         # @return [CWM::TreePager]
         attr_reader :pager
 
-        # Constructor
+        # Page icon
         #
-        # @param bcaches [Array<Y2Storage::Bcache>]
-        # @param pager [CWM::TreePager]
-        def initialize(bcaches, pager)
-          textdomain "storage"
-
-          @bcaches = bcaches
-          @pager = pager
-        end
-
-        # @macro seeAbstractWidget
-        def label
-          _("Bcache Devices")
-        end
-
-        # @macro seeCustomWidget
-        def contents
-          @contents ||=
-            VBox(
-              table,
-              Left(device_buttons),
-              Right(table_buttons)
-            )
+        # @return [String]
+        def icon
+          Icons::BCACHE
         end
 
         # Table to list all bcache devices and their partitions
@@ -163,65 +123,6 @@ module Y2Partitioner
             devices << bcache
             devices.concat(bcache.partitions)
           end
-        end
-      end
-
-      # A Tab for the list of caching set devices
-      class BcacheCsetsTab < CWM::Tab
-        # @return [CWM::TreePager]
-        attr_reader :pager
-
-        # Constructor
-        #
-        # @param pager [CWM::TreePager]
-        def initialize(pager)
-          textdomain "storage"
-
-          @pager = pager
-        end
-
-        # @macro seeAbstractWidget
-        def label
-          _("Caching Set Devices")
-        end
-
-        # @macro seeCustomWidget
-        def contents
-          @contents ||= VBox(table)
-        end
-
-        # Table to list all caching set devices
-        #
-        # @return [BcacheCsetsTable]
-        def table
-          @table ||= BcacheCsetsTable.new(devices, pager)
-        end
-
-        # Returns all caching set devices
-        #
-        # @return [Array<Y2Storage::BcacheCset>]
-        def devices
-          DeviceGraphs.instance.current.bcache_csets
-        end
-      end
-
-      # Table for caching set devices
-      class BcacheCsetsTable < ConfigurableBlkDevicesTable
-        # Constructor
-        #
-        # @param devices [Array<Y2Storage::BcacheCsets>] see {#devices}
-        # @param pager [CWM::Pager] see {#pager}
-        # @param buttons_set [DeviceButtonsSet] see {#buttons_set}
-        def initialize(devices, pager, buttons_set = nil)
-          textdomain "storage"
-
-          super
-          show_columns(
-            Columns::CachingDevice,
-            Columns::Size,
-            Columns::Uuid,
-            Columns::UsedBy
-          )
         end
       end
     end


### PR DESCRIPTION
## Problem

A menu bar is being added to the Expert Partitioner. We are taking the opportunity for improving some other parts, for example the Bcache presentation. Right now, the Bcache page contains two tabs, one to list the Bcache devices and a second one to list the Bcache Caching Sets. This last tab is only informative (no actions can be done over the Bcache Caching Sets). Note that this is the only general page with two tabs. For example, Hard Disk, LVM, etc have no tabs. For a matter of homogeneity, it would be better to remove the tabs in this Bcache page and show that information as a popup by using an option of the new menu bar. 

* Part of PBI: https://trello.com/c/NITXJRBE/2055-menu-driven-interface-finish-it


## Solution

Removed tabs in the Bcache page and added a new option in the menu bar that opens a popup with the Bcache Caching Sets.


## Testing

- Added unit test
- Tested manually


## Screenshots

![Screenshot from 2020-09-17 09-45-25](https://user-images.githubusercontent.com/1112304/93447694-9bd91980-f8ca-11ea-9384-c4d01879168e.png)

![Screenshot from 2020-09-17 09-46-01](https://user-images.githubusercontent.com/1112304/93447707-9f6ca080-f8ca-11ea-92db-9ac33a2bf8de.png)
