### PR TITLE
First version of a menu bar with all the entries

### DIFF
--- a/src/lib/y2partitioner/dialogs/main.rb
+++ b/src/lib/y2partitioner/dialogs/main.rb
@@ -63,8 +63,13 @@ module Y2Partitioner
         overview_tree_pager = Widgets::OverviewTreePager.new(hostname)
         UIState.instance.overview_tree_pager = overview_tree_pager
 
+        # Something similar happens with {MainMenuBar}, so it also makes sense to
+        # keep a reference to it in the {UIState}.
+        menu_bar = Widgets::MainMenuBar.new
+        UIState.instance.menu_bar = menu_bar
+
         VBox(
-          Widgets::MainMenuBar.new,
+          menu_bar,
           MarginBox(
             0.5,
             0.5,

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -33,6 +33,11 @@ module Y2Partitioner
     # @return [Widgets::OverviewTreePager]
     attr_accessor :overview_tree_pager
 
+    # A reference to the main menu bar, which is a new instance on every dialog redraw
+    #
+    # @return [Widgets::MainMenuBar]
+    attr_accessor :menu_bar
+
     # Hash listing all the items with children of the tree and specifying whether
     # such item should be expanded (true) or collapsed (false) in the next redraw.
     #
@@ -59,6 +64,7 @@ module Y2Partitioner
     # @param row_id [Integer] the id of selected row
     def select_row(row_id)
       current_status&.selected_row = row_id
+      menu_bar.select_row(row_id)
     end
 
     # Method to be called when the user decides to visit a page by clicking in one node of the
@@ -70,6 +76,7 @@ module Y2Partitioner
     # @param pages_ids [Array<String, Integer>] the path to the selected page
     def select_page(pages_ids)
       self.current_status = status_for(pages_ids)
+      menu_bar.select_page(pages_ids)
     end
 
     # Method to be called when the user switches to a tab within a page

--- a/src/lib/y2partitioner/widgets/main_menu_bar.rb
+++ b/src/lib/y2partitioner/widgets/main_menu_bar.rb
@@ -51,7 +51,7 @@ module Y2Partitioner
         refresh
       end
 
-      # @see UIState#select_row
+      # @see UIState#select_page
       def select_page(pages_ids)
         dev_id = pages_ids.reverse.find { |id| id.is_a?(Integer) }
         @page_device = dev_id ? find_device(dev_id) : nil
@@ -118,7 +118,7 @@ module Y2Partitioner
         disable_menu_items(*disabled_items)
       end
 
-      # List of buttons that make sense for the current target device
+      # Set of menus for the current {#device} and {#page_device}
       #
       # @return [Array<Menus::Base>]
       def calculate_menus

--- a/src/lib/y2partitioner/widgets/menus/add.rb
+++ b/src/lib/y2partitioner/widgets/menus/add.rb
@@ -1,0 +1,73 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/widgets/menus/device"
+require "y2partitioner/actions/add_partition"
+require "y2partitioner/actions/add_md"
+
+module Y2Partitioner
+  module Widgets
+    module Menus
+      # Class to represent the Add menu
+      class Add < Device
+        # @see Base
+        def label
+          _("&Add")
+        end
+
+        # @see Base
+        def items
+          @items ||= [
+            Item(Id(:menu_add_raid), _("RAID...")),
+            Item(Id(:menu_add_vg), _("LVM Volume Group...")),
+            Item(Id(:menu_add_btrfs), _("Btrfs...")),
+            Item(Id(:menu_add_bcache), _("Bcache...")),
+            Item("---"),
+            Item(Id(:menu_add_partition), _("Partition...")),
+            Item(Id(:menu_add_lv), _("Logical Volume..."))
+          ]
+        end
+
+        # @see Device
+        def disabled_for_device
+          disabled = []
+          if !device.is?(:disk_device, :software_raid, :bcache, :partition)
+            disabled << :menu_add_partition
+          end
+          disabled << :menu_add_lv unless device.is?(:lvm_vg, :lvm_lv)
+          disabled
+        end
+
+        private
+
+        # @see Base
+        def action_for(event)
+          case event
+          when :menu_add_partition
+            dev = device.is?(:partition) ? device.partitionable : device
+            Actions::AddPartition.new(dev)
+          when :menu_add_md
+            Actions::AddMd.new
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/menus/base.rb
+++ b/src/lib/y2partitioner/widgets/menus/base.rb
@@ -1,0 +1,81 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "abstract_method"
+require "y2partitioner/execute_and_redraw"
+
+module Y2Partitioner
+  module Widgets
+    # Namespace to group all the menus in the main menu bar
+    module Menus
+      # Base class to represent a menu of the main menu bar
+      class Base
+        include Yast::I18n
+        include Yast::UIShortcuts
+        include ExecuteAndRedraw
+
+        # @!method label
+        #   @return [String] localized label for the menu
+        abstract_method :label
+
+        # @!method items
+        #   @return [Array<Yast::Term>] menu entries
+        abstract_method :items
+
+        # @return [Array<Symbol>] ids of the menu items that should be disabled
+        def disabled_items
+          []
+        end
+
+        # @see MainMenuBar#handle
+        #
+        # @param event [Symbol]
+        def handle(event)
+          action = action_for(event)
+          if action
+            execute_and_redraw { action.run }
+          else
+            dialog = dialog_for(event)
+            dialog&.run
+            nil
+          end
+        end
+
+        private
+
+        # Dialog that should be opened for the given UI event
+        #
+        # @param _event [Symbol]
+        # @return [Dialog::Base, nil] nil if the event does not correspond to any dialog
+        def dialog_for(_event)
+          nil
+        end
+
+        # Action that should be executed for the given UI event
+        #
+        # @param _event [Symbol]
+        # @return [Actions::Base, nil] nil if the event does not correspond to any action
+        def action_for(_event)
+          nil
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/menus/configure.rb
+++ b/src/lib/y2partitioner/widgets/menus/configure.rb
@@ -1,0 +1,139 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/icons"
+require "y2partitioner/execute_and_redraw"
+require "y2partitioner/actions/configure_actions"
+
+module Y2Partitioner
+  module Widgets
+    module Menus
+      # Class to represent each one of the entries in the 'Configure' menu
+      class ConfigureEntry
+        include Yast::I18n
+        extend Yast::I18n
+
+        # Constructor
+        def initialize(action_class_name, label, icon)
+          @action_class_name = action_class_name
+          @label = label
+          @icon = icon
+        end
+
+        # All possible entries
+        ALL = [
+          new(:ProvideCryptPasswords, N_("Provide Crypt &Passwords..."), Icons::LOCK),
+          new(:ConfigureIscsi,        N_("Configure &iSCSI..."),         Icons::ISCSI),
+          new(:ConfigureFcoe,         N_("Configure &FCoE..."),          Icons::FCOE),
+          new(:ConfigureDasd,         N_("Configure &DASD..."),          Icons::DASD),
+          new(:ConfigureZfcp,         N_("Configure &zFCP..."),          Icons::ZFCP),
+          new(:ConfigureXpram,        N_("Configure &XPRAM..."),         Icons::XPRAM)
+        ]
+        private_constant :ALL
+
+        # All possible entries
+        #
+        # @return [Array<ConfigureEntry>]
+        def self.all
+          ALL.dup
+        end
+
+        # Entries that should be displayed to the user
+        #
+        # @return [Array<ConfigureEntry>]
+        def self.visible
+          all.select(&:visible?)
+        end
+
+        # @return [String] name of the icon to display next to the label
+        attr_reader :icon
+
+        # @return [String] Internationalized label
+        def label
+          _(@label)
+        end
+
+        # @return [Symbol] identifier for the action to use in the UI
+        def id
+          @id ||= action_class_name.to_s.gsub(/(.)([A-Z])/, '\1_\2').downcase.to_sym
+        end
+
+        # Action to execute when the entry is selected
+        #
+        # @return [Y2Partitioner::Actions::ConfigureAction]
+        def action
+          @action ||= Y2Partitioner::Actions.const_get(action_class_name).new
+        end
+
+        # Whether the entry should be displayed to the user
+        #
+        # @return [Boolean]
+        def visible?
+          action.available?
+        end
+
+        private
+
+        # Name of the class for #{action}
+        #
+        # @return [Symbol]
+        attr_reader :action_class_name
+      end
+
+      class Configure
+        include Yast::I18n
+        include ExecuteAndRedraw
+
+        def initialize
+          @configure_entries = ConfigureEntry.visible
+        end
+
+        def label
+          _("&Configure")         
+        end
+
+        def items
+          @configure_entries.map do |entry|
+            Yast::Term.new(
+              :item,
+              Yast::Term.new(:id, entry.id),
+              Yast::Term.new(:icon, entry.icon),
+              entry.label
+            )
+          end
+        end
+
+        def handle(event)
+          action = action_for(event)
+          return nil unless action
+
+          execute_and_redraw { action.run }
+        end
+
+        private
+
+        def action_for(event)
+          entry = @configure_entries.find { |e| e.id == event }
+          entry&.action
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/menus/configure.rb
+++ b/src/lib/y2partitioner/widgets/menus/configure.rb
@@ -19,7 +19,7 @@
 
 require "yast"
 require "y2partitioner/icons"
-require "y2partitioner/execute_and_redraw"
+require "y2partitioner/widgets/menus/base"
 require "y2partitioner/actions/configure_actions"
 
 module Y2Partitioner
@@ -97,20 +97,21 @@ module Y2Partitioner
         attr_reader :action_class_name
       end
 
-      class Configure
-        include Yast::I18n
-        include ExecuteAndRedraw
-
+      # Class representing the Configure menu
+      class Configure < Base
+        # Constructor
         def initialize
           @configure_entries = ConfigureEntry.visible
         end
 
+        # @see Base
         def label
-          _("&Configure")         
+          _("&Configure")
         end
 
+        # @see Base
         def items
-          @configure_entries.map do |entry|
+          @items ||= configure_entries.map do |entry|
             Yast::Term.new(
               :item,
               Yast::Term.new(:id, entry.id),
@@ -120,17 +121,14 @@ module Y2Partitioner
           end
         end
 
-        def handle(event)
-          action = action_for(event)
-          return nil unless action
-
-          execute_and_redraw { action.run }
-        end
-
         private
 
+        # @return [Array<ConfigureEntry>]
+        attr_reader :configure_entries
+
+        # @see Base
         def action_for(event)
-          entry = @configure_entries.find { |e| e.id == event }
+          entry = configure_entries.find { |e| e.id == event }
           entry&.action
         end
       end

--- a/src/lib/y2partitioner/widgets/menus/device.rb
+++ b/src/lib/y2partitioner/widgets/menus/device.rb
@@ -1,0 +1,76 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/widgets/menus/base"
+
+module Y2Partitioner
+  module Widgets
+    module Menus
+      # Abstract class for menus that act upon a given device
+      class Device < Base
+        # Constructor
+        #
+        # @param device [Y2Storage::Device, nil] see #device
+        def initialize(device)
+          @device_sid = device.sid unless device.nil?
+        end
+
+        # @see Base
+        #
+        # In addition to the implementation of the base class, this includes
+        # memoization and handling when the device is nil
+        #
+        # @return [Array<Symbol>]
+        def disabled_items
+          @disabled_items ||= device ? disabled_for_device : []
+        end
+
+        private
+
+        # @return [Integer] device sid
+        attr_reader :device_sid
+
+        # Items to disable if {#device} is not nil
+        # @see #disabled_items
+        #
+        # @return [Array<Symbol>]
+        def disabled_for_device
+          []
+        end
+
+        # Current devicegraph
+        #
+        # @return [Y2Storage::Devicegraph]
+        def working_graph
+          DeviceGraphs.instance.current
+        end
+
+        # Device on which to act
+        #
+        # @return [Y2Storage::Device]
+        def device
+          return nil unless device_sid
+
+          working_graph.find_device(device_sid)
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/menus/extra.rb
+++ b/src/lib/y2partitioner/widgets/menus/extra.rb
@@ -1,0 +1,60 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/widgets/menus/device"
+
+module Y2Partitioner
+  module Widgets
+    module Menus
+      # Menu with extra actions for a device (beyond those included in Edit/Modify)
+      class Extra < Device
+        # @see Base
+        def label
+          _("Actions")
+        end
+
+        # @see Base
+        def items
+          @items ||= [
+            Item(Id(:menu_change_devs), "Change Used Devices..."),
+            Item(Id(:menu_change_pvs), "Change Physical Volumes..."),
+            Item(Id(:menu_change_cache), "Change Caching..."),
+            Item("---"),
+            Item(Id(:menu_create_ptable), _("Create New Partition Table...")),
+            Item(Id(:menu_clone_ptable), _("Clone Partitions to Another Device..."))
+          ]
+        end
+
+        private
+
+        # @see Device
+        def disabled_for_device
+          items = []
+          items << :menu_change_devs unless device.is?(:software_raid, :btrfs, :lvm_vg)
+          items << :menu_change_pvs unless device.is?(:lvm_vg)
+          items << :menu_change_cache unless device.is?(:bcache)
+          items << :menu_create_ptable unless device.is?(:software_raid, :disk_device, :bcache)
+          items << :menu_clone_ptable unless device.is?(:disk_device)
+          items
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/menus/go.rb
+++ b/src/lib/y2partitioner/widgets/menus/go.rb
@@ -1,0 +1,85 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/widgets/menus/device"
+require "y2partitioner/actions/go_to_device_tab"
+require "y2partitioner/ui_state"
+
+module Y2Partitioner
+  module Widgets
+    module Menus
+      # Menu to go directly to some tabs of the current device
+      class Go < Device
+        # @see Base
+        def label
+          _("&Go")
+        end
+
+        # @see Base
+        def items
+          @items ||= [
+            Item(Id(:go_overview), "Device Overview"),
+            Item(Id(:go_partitions), "Partitions"),
+            Item(Id(:go_used_devices), "Used Devices"),
+            Item(Id(:go_lvs), "Logical Volumes"),
+            Item(Id(:go_pvs), "Physical Volumes")
+          ]
+        end
+
+        private
+
+        # @see Device
+        def disabled_for_device
+          disabled = []
+          disabled << :go_used_devices unless device.is?(:software_raid, :btrfs)
+          disabled << :go_pvs unless device.is?(:lvm_vg)
+          disabled << :go_partitions unless device.is?(:software_raid, :disk_device, :bcache)
+          disabled << :go_lvs unless device.is?(:lvm_vg)
+          disabled
+        end
+
+        # @see Base
+        def action_for(event)
+          tab = target_tab(event)
+          return nil unless tab
+
+          pager = UIState.instance.overview_tree_pager
+          Actions::GoToDeviceTab.new(device, pager, tab)
+        end
+
+        def target_tab(event)
+          # FIXME: makes more sense as a hash
+          case event
+          when :go_overview
+            _("&Overview")
+          when :go_partitions
+            _("&Partitions")
+          when :go_lvs
+            _("Log&ical Volumes")
+          when :go_used_devices
+            _("&Used Devices")
+          when :go_pvs
+            _("&Physical Volumes")
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/menus/modify.rb
+++ b/src/lib/y2partitioner/widgets/menus/modify.rb
@@ -1,0 +1,71 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/widgets/menus/device"
+require "y2partitioner/actions/delete_md"
+require "y2partitioner/actions/delete_partition"
+
+module Y2Partitioner
+  module Widgets
+    module Menus
+      # Class to represent the Modify/Edit menu
+      class Modify < Device
+        # @see Base
+        def label
+          _("Modify")
+        end
+
+        # @see Base
+        def items
+          @items ||= [
+            Item(Id(:menu_edit), _("&Edit...")),
+            Item(Id(:menu_delete), _("&Delete")),
+            Item(Id(:menu_resize), _("&Resize...")),
+            Item(Id(:menu_move), _("&Move..."))
+          ]
+        end
+
+        private
+
+        # @see Device
+        def disabled_for_device
+          items = []
+          items << :menu_edit if device.is?(:lvm_vg)
+          items << :menu_resize unless device.is?(:partition, :lvm_lv)
+          items << :menu_move unless device.is?(:partition)
+          items << :menu_delete if device.is?(:disk_device)
+          items
+        end
+
+        # @see Base
+        def action_for(event)
+          case event
+          when :menu_delete
+            if device.is?(:partition)
+              Actions::DeletePartition.new(device)
+            elsif device.is?(:md)
+              Actions::DeleteMd.new(device)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/menus/system.rb
+++ b/src/lib/y2partitioner/widgets/menus/system.rb
@@ -1,0 +1,85 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/execute_and_redraw"
+require "y2partitioner/dialogs/settings"
+require "y2partitioner/actions/rescan_devices"
+require "y2partitioner/actions/import_mount_points"
+
+module Y2Partitioner
+  module Widgets
+    module Menus
+      class System
+        Yast.import "Stage"
+        include Yast::I18n
+        include Yast::UIShortcuts
+        include ExecuteAndRedraw
+
+        def label
+          _("&System")         
+        end
+
+        def items
+          items = [Item(Id(:rescan_devices), _("R&escan Devices"))]
+          items << Item(Id(:import_mount_points), _("&Import Mount Points...")) if installation?
+          items += [
+            Item(Id(:settings), _("Se&ttings...")),
+            Item("---"),
+            Item(Id(:abort), _("Abo&rt (Abandon Changes)")),
+            Item("---"),
+            Item(Id(:next), _("&Finish (Save and Exit)"))
+          ]
+        end
+
+        def handle(event)
+          action = action_for(event)
+          if action
+            execute_and_redraw { action.run }
+          else
+            dialog = dialog_for(event)
+            dialog&.run
+            nil
+          end
+        end
+
+        private
+
+        # Check if we are running in the initial stage of an installation
+        def installation?
+          Yast::Stage.initial
+        end
+
+        def action_for(event)
+          if event == :rescan_devices
+            Actions::RescanDevices.new
+          elsif event == :import_mount_points
+            Actions::ImportMountPoints.new
+          end
+        end
+
+        def dialog_for(event)
+          if event == :settings
+            Dialogs::Settings.new
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/menus/view.rb
+++ b/src/lib/y2partitioner/widgets/menus/view.rb
@@ -1,0 +1,61 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/dialogs/summary_popup"
+require "y2partitioner/dialogs/device_graph"
+
+module Y2Partitioner
+  module Widgets
+    module Menus
+      class View
+        include Yast::I18n
+        include Yast::UIShortcuts
+
+        def label
+          _("&View")
+        end
+
+        def items
+          items = []
+          # TRANSLATORS: Menu items in the partitioner
+          items << Item(Id(:device_graphs), _("Device &Graphs...")) if Dialogs::DeviceGraph.supported?
+          items << Item(Id(:installation_summary), _("Installation &Summary..."))
+          items
+        end
+
+        def handle(event)
+          dialog_for(event)&.run
+          nil
+        end
+
+        private
+
+        def dialog_for(event)
+          case event
+          when :device_graphs
+            Dialogs::DeviceGraph.new
+          when :installation_summary
+            Dialogs::SummaryPopup.new
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/menus/view.rb
+++ b/src/lib/y2partitioner/widgets/menus/view.rb
@@ -18,41 +18,50 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "y2partitioner/widgets/menus/base"
 require "y2partitioner/dialogs/summary_popup"
 require "y2partitioner/dialogs/device_graph"
+require "y2partitioner/dialogs/settings"
 
 module Y2Partitioner
   module Widgets
     module Menus
-      class View
-        include Yast::I18n
-        include Yast::UIShortcuts
-
+      # Class to represent the View menu
+      class View < Base
+        # @see Base
         def label
           _("&View")
         end
 
+        # @see Base
         def items
-          items = []
-          # TRANSLATORS: Menu items in the partitioner
-          items << Item(Id(:device_graphs), _("Device &Graphs...")) if Dialogs::DeviceGraph.supported?
-          items << Item(Id(:installation_summary), _("Installation &Summary..."))
-          items
-        end
+          return @items if @items
 
-        def handle(event)
-          dialog_for(event)&.run
-          nil
+          @items =
+            if Dialogs::DeviceGraph.supported?
+              [Item(Id(:device_graphs), _("Device &Graphs..."))]
+            else
+              []
+            end
+
+          @items += [
+            Item(Id(:installation_summary), _("Installation &Summary...")),
+            Item(Id(:settings), _("Se&ttings...")),
+            Item(Id(:bcache_csets), _("Bcache Caching Sets..."))
+          ]
         end
 
         private
 
+        # @see Base
         def dialog_for(event)
           case event
           when :device_graphs
             Dialogs::DeviceGraph.new
           when :installation_summary
             Dialogs::SummaryPopup.new
+          when :settings
+            Dialogs::Settings.new
           end
         end
       end


### PR DESCRIPTION
## Problem

The previous version of the Partitioner menu bar was intentionally incomplete since it was just a proof of concept.

## Solution

After some meetings and discussions (see, for example, [this mail thread](https://lists.opensuse.org/yast-devel/2020-09/msg00004.html)) we have agreed on the general approach the menu should follow.

This pull request implements a first version of that menu, in which all possible Partitioner actions are represented in the most consistent way we have been able to come up with.

### Menus

#### System

With all the options that were below the system table, plus two extra entries to quit (with and without saving).
![system](https://user-images.githubusercontent.com/3638289/93387553-b7f89e80-f869-11ea-92ee-30ad85074b75.png)

#### Modify

With a few generic actions for the device currently selected in the table. We are considering to call it "Edit", since its a more common term for a menu. But "edit" has another historical meaning in the Partitioner and we would need to change that first.
![modify](https://user-images.githubusercontent.com/3638289/93387554-b8913500-f869-11ea-86f7-37d8580e8be3.png)

#### Add

For creating new devices. The first four actions are always possible. Creating partitions and LVs is only enabled when it makes sense for the selected device.
![add](https://user-images.githubusercontent.com/3638289/93387555-b929cb80-f869-11ea-8651-16cba4b03056.png)

#### View

With all the options that were (misplaced) in the left tree although they didn't correspond to devices in the system. In addition, the menu includes an entry to display the read-only list of csets that was available as a tab in the Bcache section.
![view](https://user-images.githubusercontent.com/3638289/93387560-b9c26200-f869-11ea-81ac-999f03a72ae8.png)

#### Go

To navigate through the interface. If the page currently open refers to a device, this switches among its tabs. If not (e.g. in the "System Overview" page), the menu entries can be used to go directly to the corresponding tab of the device that is selected in the table.
![go](https://user-images.githubusercontent.com/3638289/93387562-ba5af880-f869-11ea-951a-c1caaf805b49.png)

#### Actions

Options to modify the current device. In the "System Overview" page or any other of the first level pages, the action is performed on the device selected in the table. In a page corresponding to a device, the action is performed on that device.
![actions](https://user-images.githubusercontent.com/3638289/93387565-ba5af880-f869-11ea-871b-2aacc17605bc.png)

## Still pending

The goal of this pull request is not to provide a totally polished solution, but a checkpoint from which we can continue distributing the remaining work. For a full list of everything that is still pending, see the "Tasks" section of https://trello.com/c/NITXJRBE/2055-8-menu-driven-interface-finish-it

In summary:

  - Not all menu entries actually trigger the corresponding action. There are still some wires to connect.
  - Unit tests need to be adapted (and new tests created)
  - We currently have a menu called "Modify" that contains our historical "Edit" action. We should maybe find a better name for the action. Then we could rename the menu entry to the more common "Edit".
