### PR TITLE
Remove heading from partitioner dialog

### DIFF
--- a/src/lib/y2partitioner/dialogs/main.rb
+++ b/src/lib/y2partitioner/dialogs/main.rb
@@ -51,10 +51,6 @@ module Y2Partitioner
         DeviceGraphs.create_instance(system, initial)
       end
 
-      def title
-        _("Expert Partitioner")
-      end
-
       def contents
         # NOTE: Since this method is used as first parameter of {Yast::CWM.show} every time that
         # {#run} calls `super`, a new {OverviewTreePager} will be created in every dialog redraw.


### PR DESCRIPTION
## Problem

The `Expert Partitioner` title does not allow to put the recently added menu bar at the very top.

* Part of https://trello.com/c/dT7X5aC1/2045-menu-layout-rendering-improvements

## Solution

Do not display the `Expert Partitioner` heading anymore.

## Testing

- *Tested manually*

## Screenshots

| Installer | Running System |
|-|-|
|  ![Screenshot_tw_2020-09-16_17:10:04](https://user-images.githubusercontent.com/1691872/93364866-faf24c00-f840-11ea-84b7-fb577f4ce936.png) |  ![93351630-dd69b600-f831-11ea-9300-a2248e153047](https://user-images.githubusercontent.com/1691872/93364951-18271a80-f841-11ea-88b7-78d701536cc8.png) |

## Related PRs

Some adjustments were necessary in order to not keep reserving space for the Wizard heading. See below PRs for more details 

* https://github.com/yast/yast-yast2/pull/1098
* https://github.com/libyui/libyui-qt/pull/133

