### PR TITLE
Adapt the draft of the menus to partitioner-ui-03

### DIFF
--- a/src/lib/y2partitioner/widgets/main_menu_bar.rb
+++ b/src/lib/y2partitioner/widgets/main_menu_bar.rb
@@ -124,11 +124,9 @@ module Y2Partitioner
       def calculate_menus
         [
           Menus::System.new,
-          Menus::Modify.new(device || page_device),
-          Menus::Add.new(device || page_device),
-          Menus::View.new,
-          Menus::Go.new(page_device || device),
-          Menus::Extra.new(page_device || device)
+          Menus::Add.new(device),
+          Menus::Modify.new(device),
+          Menus::View.new
         ]
       end
 


### PR DESCRIPTION
This is part of the prototype we are building in the `partitioner-ui-03` branch. A couple of images is worth a thousand words (well, or at least a hundred).

![menu-03-raid](https://user-images.githubusercontent.com/3638289/93595138-7e35ae00-f9b7-11ea-96e4-034db634b8a0.png)

![menu-03-vg](https://user-images.githubusercontent.com/3638289/93595141-7ece4480-f9b7-11ea-8191-b1d4c13754d1.png)
