### PR TITLE
Use short names

### DIFF
--- a/src/lib/y2partitioner/widgets/columns/device.rb
+++ b/src/lib/y2partitioner/widgets/columns/device.rb
@@ -51,8 +51,12 @@ module Y2Partitioner
         # @return [String]
         def device_name(device)
           return fstab_device_name(device) if fstab_entry?(device)
-          return device.display_name unless device.is?(:blk_filesystem)
+          return filesystem_name(device) if device.is?(:blk_filesystem)
 
+          device.is?(:disk_device, :raid, :lvm_vg, :bcache) ? device.display_name : device.basename
+        end
+
+        def filesystem_name(device)
           dev_name = device.blk_device_basename
           dev_name = "(#{dev_name})" unless device.multidevice?
 


### PR DESCRIPTION
Part of the dirty prototype at `partitioner-ui-03`: use basenames for nested devices.

![Screenshot from 2020-09-18 17-26-10](https://user-images.githubusercontent.com/1112304/93621829-0a55ce80-f9d4-11ea-9773-d51caa54ae97.png)
