### PR TITLE
Remove titles and add nesting in used devices

### DIFF
--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -45,7 +45,7 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def label
-        _("Devices")
+        ""
       end
 
       attr_reader :items

--- a/src/lib/y2partitioner/widgets/pages/bcache.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcache.rb
@@ -53,13 +53,6 @@ module Y2Partitioner
           Top(
             VBox(
               Left(
-                HBox(
-                  Image(Icons::BCACHE, ""),
-                  # TRANSLATORS: Heading. String followed by a device name like /dev/bcache0
-                  Heading(format(_("Bcache: %s"), device.name))
-                )
-              ),
-              Left(
                 Tabs.new(
                   BcacheTab.new(device, @pager),
                   BcacheDevicesTab.new(device, @pager)

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -65,12 +65,6 @@ module Y2Partitioner
           @contents ||= Top(
             VBox(
               Left(
-                HBox(
-                  Image(icon, ""),
-                  Heading(label)
-                )
-              ),
-              Left(
                 VBox(
                   table,
                   Left(device_buttons),

--- a/src/lib/y2partitioner/widgets/pages/btrfs.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs.rb
@@ -62,12 +62,6 @@ module Y2Partitioner
         def contents
           Top(
             VBox(
-              Left(
-                HBox(
-                  Image(icon, ""),
-                  Heading(title)
-                )
-              ),
               Left(tabs)
             )
           )
@@ -83,15 +77,6 @@ module Y2Partitioner
         # @return [String]
         def icon
           Icons::BTRFS
-        end
-
-        # Page title
-        #
-        # @return [String]
-        def title
-          # TRANSLATORS: BTRFS page title, where %{basename} is replaced by the device
-          # basename (e.g., sda1).
-          format(_("Btrfs %{basename}"), basename: filesystem.blk_device_basename)
         end
 
         # Tabs to show the filesystem data

--- a/src/lib/y2partitioner/widgets/pages/btrfs.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs.rb
@@ -129,7 +129,9 @@ module Y2Partitioner
         #
         # @return [Array<Y2Storage::BlkDevice>]
         def devices
-          filesystem.plain_blk_devices
+          [
+            BlkDevicesTable::DeviceTree.new(filesystem, children: filesystem.plain_blk_devices)
+          ]
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/pages/devices_table.rb
+++ b/src/lib/y2partitioner/widgets/pages/devices_table.rb
@@ -46,12 +46,6 @@ module Y2Partitioner
           return @contents if @contents
 
           @contents = VBox(
-            Left(
-              HBox(
-                Image(icon, ""),
-                Heading(heading)
-              )
-            ),
             table,
             Left(device_buttons),
             Right(table_buttons)
@@ -86,15 +80,6 @@ module Y2Partitioner
         # @return [Yast::UI::Term, CWM::AbstractWidget]
         def table_buttons
           Empty()
-        end
-
-        # Heading of the table
-        #
-        # By default, is the same than {#label}
-        #
-        # @return [String]
-        def heading
-          label
         end
 
         # Table to display

--- a/src/lib/y2partitioner/widgets/pages/disk.rb
+++ b/src/lib/y2partitioner/widgets/pages/disk.rb
@@ -80,7 +80,7 @@ module Y2Partitioner
             DiskTab.new(disk, @pager)
           ]
 
-          tabs << UsedDevicesTab.new(used_devices, @pager) if used_devices_tab?
+          tabs << UsedDevicesTab.new(devices, @pager) if used_devices_tab?
 
           Tabs.new(*tabs)
         end
@@ -90,6 +90,12 @@ module Y2Partitioner
         # @return [Boolean]
         def used_devices_tab?
           disk.is?(:multipath, :dm_raid, :md)
+        end
+
+        def devices
+          [
+            BlkDevicesTable::DeviceTree.new(disk, children: used_devices)
+          ]
         end
 
         # Devices used by the RAID or Multipath

--- a/src/lib/y2partitioner/widgets/pages/disk.rb
+++ b/src/lib/y2partitioner/widgets/pages/disk.rb
@@ -60,13 +60,6 @@ module Y2Partitioner
           Top(
             VBox(
               Left(
-                HBox(
-                  Image(Icons::HD, ""),
-                  # TRANSLATORS: Heading. String followed by device name of hard disk
-                  Heading(format(_("Hard Disk: %s"), disk.name))
-                )
-              ),
-              Left(
                 tabs
               )
             )

--- a/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
@@ -60,12 +60,6 @@ module Y2Partitioner
           Top(
             VBox(
               Left(
-                HBox(
-                  Image(Icons::LVM, ""),
-                  Heading(format(_("Volume Group: %s"), @lvm_vg.name))
-                )
-              ),
-              Left(
                 Tabs.new(
                   LvmVgTab.new(@lvm_vg, @pager),
                   LvmPvTab.new(@lvm_vg, @pager)

--- a/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
@@ -170,7 +170,9 @@ module Y2Partitioner
         end
 
         def devices
-          @lvm_vg.lvm_pvs.map(&:plain_blk_device)
+          [
+            BlkDevicesTable::DeviceTree.new(@lvm_vg, children: @lvm_vg.lvm_pvs.map(&:plain_blk_device))
+          ]
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/pages/md_raid.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raid.rb
@@ -57,12 +57,6 @@ module Y2Partitioner
           Top(
             VBox(
               Left(
-                HBox(
-                  Image(Icons::RAID, ""),
-                  Heading(format(_("RAID: %s"), @md.name))
-                )
-              ),
-              Left(
                 Tabs.new(
                   MdTab.new(@md, initial: true),
                   MdDevicesTab.new(@md, @pager)

--- a/src/lib/y2partitioner/widgets/pages/md_raid.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raid.rb
@@ -95,7 +95,9 @@ module Y2Partitioner
         def initialize(md, pager, initial: false)
           textdomain "storage"
 
-          super(md.devices, pager)
+          devices = [BlkDevicesTable::DeviceTree.new(md, children: md.devices)]
+
+          super(devices, pager)
           @md = md
           @initial = initial
         end

--- a/src/lib/y2partitioner/widgets/pages/nfs_mounts.rb
+++ b/src/lib/y2partitioner/widgets/pages/nfs_mounts.rb
@@ -55,13 +55,6 @@ module Y2Partitioner
           return @contents if @contents
 
           @contents = VBox(
-            Left(
-              HBox(
-                Image(Icons::NFS, ""),
-                # TRANSLATORS: Heading for the expert partitioner page
-                Heading(_("Network File System (NFS)"))
-              )
-            ),
             nfs_client.init_ui || fallback_ui
           )
         end

--- a/src/lib/y2partitioner/widgets/pages/stray_blk_device.rb
+++ b/src/lib/y2partitioner/widgets/pages/stray_blk_device.rb
@@ -51,14 +51,6 @@ module Y2Partitioner
           return @contents if @contents
 
           @contents = VBox(
-            Left(
-              HBox(
-                Image(Icons::DEFAULT_DEVICE, ""),
-                # TRANSLATORS: Heading for a generic storage device
-                # TRANSLATORS: String followed by name of the storage device
-                Heading(format(_("Device: %s"), device.name))
-              )
-            ),
             StrayBlkDeviceDescription.new(device),
             Left(
               HBox(

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -56,7 +56,6 @@ module Y2Partitioner
           return @contents if @contents
 
           @contents = VBox(
-            Left(header),
             table,
             Left(device_buttons)
           )
@@ -77,17 +76,6 @@ module Y2Partitioner
 
           @contents = nil
           @table = nil
-        end
-
-        # Page header
-        #
-        # @return [Yast::UI::Term]
-        def header
-          HBox(
-            Image(Icons::ALL, ""),
-            # TRANSLATORS: Heading. String followed by the hostname
-            Heading(format(_("Available Storage on %s"), hostname))
-          )
         end
 
         # The table contains all storage devices, including Software RAIDs and LVM Vgs


### PR DESCRIPTION
Part of the dirty prototype at `partitioner-ui-03`: remove titles from list pages and add nesting in used devices/physical volumes.

The "Used Devices" tab for Bcache is not using nesting because it is not clear how to do it. Right now, this tab is showing both: caching and backing device. 

![Screenshot from 2020-09-18 23-16-16](https://user-images.githubusercontent.com/1112304/93650102-86b4d580-fa05-11ea-8b12-06e32f1a1805.png)

![Screenshot from 2020-09-19 00-03-41](https://user-images.githubusercontent.com/1112304/93652077-a6e79300-fa0b-11ea-8d32-8302939d892b.png)
