### PR TITLE
Partitioner: remove tab state

### DIFF
--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -140,7 +140,18 @@ module Y2Partitioner
     # The current status
     #
     # @return [PageStatus]
-    attr_accessor :current_status
+    attr_reader :current_status
+
+    # Sets the current status
+    #
+    # Note that the active tab is not stored when switching to the status of another page.
+    #
+    # @param status [PageStatus]
+    def current_status=(status)
+      current_status.active_tab = nil if current_status && current_status != status
+
+      @current_status = status
+    end
 
     # Returns the status representation for a page
     #

--- a/src/lib/y2partitioner/widgets/blk_device_edit_button.rb
+++ b/src/lib/y2partitioner/widgets/blk_device_edit_button.rb
@@ -25,8 +25,8 @@ module Y2Partitioner
   module Widgets
     # Device button for modifying a {Y2Storage::BlkDevice}
     class BlkDeviceEditButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/src/lib/y2partitioner/widgets/partition_add_button.rb
+++ b/src/lib/y2partitioner/widgets/partition_add_button.rb
@@ -25,8 +25,8 @@ module Y2Partitioner
   module Widgets
     # Button for adding a partition
     class PartitionAddButton < DeviceButton
-      def initialize(*args)
-        super
+      def initialize(args = {})
+        super(**args)
         textdomain "storage"
       end
 

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -326,8 +326,8 @@ describe Y2Partitioner::UIState do
             ui_state.select_page(vg_page.tree_path)
           end
 
-          it "selects the last active tab in the page" do
-            expect(ui_state.active_tab).to eq lvs_tab.label
+          it "returns nil" do
+            expect(ui_state.active_tab).to be_nil
           end
         end
       end
@@ -408,8 +408,24 @@ describe Y2Partitioner::UIState do
           ui_state.select_page(disk_page.tree_path)
         end
 
-        it "returns the sid of last selected device in the page" do
-          expect(ui_state.row_id).to eq(device.sid)
+        context "and to the same tab" do
+          before do
+            ui_state.switch_to_tab(partitions_tab)
+          end
+
+          it "returns the sid of last selected device in the page" do
+            expect(ui_state.row_id).to eq(device.sid)
+          end
+        end
+
+        context "but to a different tab" do
+          before do
+            ui_state.switch_to_tab(overview_tab)
+          end
+
+          it "returns nil" do
+            expect(ui_state.row_id).to be_nil
+          end
         end
       end
     end


### PR DESCRIPTION
This is part of the on-going process to reorganize the Partitioner UI into the branch *partitioner-ui-02*.

This PR modifies `UIState` avoiding it to memorize the latest tab when we go back to a previous visited page. With new UI, the first tab will be always the default one. For example, a MD RAID will have two tabs: *Overview Device* and *Used Devices*. *Overview Device* will always be the landing tab when go to the page of a specific MD. The *Used Devices* tab will only be automatically open when we are managing the used devices.
