### PR TITLE
Partitioner: improvements

### DIFF
--- a/src/lib/y2partitioner/widgets/columns/type.rb
+++ b/src/lib/y2partitioner/widgets/columns/type.rb
@@ -189,7 +189,7 @@ module Y2Partitioner
           elsif device.md
             part_of_label(device.md)
           elsif device.bcache
-            part_of_label(device.bcache)
+            bcache_backing_label(device.bcache)
           elsif device.in_bcache_cset
             bcache_cset_label
           else
@@ -260,12 +260,20 @@ module Y2Partitioner
           )
         end
 
-        # Label when the device is used as caching device in a bcache
+        # Label when the device is used as backing device of a Bcache
+        #
+        # @param [Y2Storage::Device] device
+        def bcache_backing_label(device)
+          # TRANSLATORS: %{bcache} is replaced by a device name (e.g., bcache0).
+          format(_("Backing of %{bcache}"), bcache: device.basename)
+        end
+
+        # Label when the device is used as caching device in a Bcache
         #
         # @return [String]
         def bcache_cset_label
           # TRANSLATORS: an special type of device
-          _("Bcache cache")
+          _("Bcache caching")
         end
 
         # Label when the device is part of another one, like Bcache or RAID

--- a/src/lib/y2partitioner/widgets/menus/add.rb
+++ b/src/lib/y2partitioner/widgets/menus/add.rb
@@ -66,37 +66,36 @@ module Y2Partitioner
 
         private
 
-        # @see Base
-        # rubocop:disable Metrics/CyclomaticComplexity
-        # Is this a complex method actually?
-        def action_for(event)
-          case event
-          when :menu_add_md
-            Actions::AddMd.new
-          when :menu_add_vg
-            Actions::AddLvmVg.new
-          when :menu_add_btrfs
-            Actions::AddBtrfs.new
-          when :menu_add_bcache
-            Actions::AddBcache.new
-          when :menu_add_partition
-            add_partition_action
-          when :menu_add_lv
-            add_lv_action
-          end
+        # @see Device#action_for
+        def menu_add_md_action
+          Actions::AddMd.new
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
-        # @see #action_for
-        def add_partition_action
+        # @see Device#action_for
+        def menu_add_vg_action
+          Actions::AddLvmVg.new
+        end
+
+        # @see Device#action_for
+        def menu_add_btrfs_action
+          Actions::AddBtrfs.new
+        end
+
+        # @see Device#action_for
+        def menu_add_bcache_action
+          Actions::AddBcache.new
+        end
+
+        # @see Device#action_for
+        def menu_add_partition_action
           return unless support_add_partition?
 
           dev = device.is?(:partition) ? device.partitionable : device
           Actions::AddPartition.new(dev)
         end
 
-        # @see #action_for
-        def add_lv_action
+        # @see Device#action_for
+        def menu_add_lv_action
           return unless support_add_lv?
 
           vg = device.is?(:lvm_lv) ? device.lvm_vg : device

--- a/src/lib/y2partitioner/widgets/menus/device.rb
+++ b/src/lib/y2partitioner/widgets/menus/device.rb
@@ -48,6 +48,13 @@ module Y2Partitioner
         # @return [Integer] device sid
         attr_reader :device_sid
 
+        # @see Base
+        def action_for(event)
+          action = "#{event}_action"
+
+          send(action) if respond_to?(action, true)
+        end
+
         # Items to disable if {#device} is not nil
         # @see #disabled_items
         #

--- a/test/y2partitioner/widgets/columns/type_test.rb
+++ b/test/y2partitioner/widgets/columns/type_test.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env rspec
+
 # Copyright (c) [2020] SUSE LLC
 #
 # All Rights Reserved.
@@ -192,8 +193,8 @@ describe Y2Partitioner::Widgets::Columns::Type do
         let(:scenario) { "bcache1.xml" }
         let(:device_name) { "/dev/vdc" }
 
-        it "includes 'Part of'" do
-          expect(label).to include("Part of")
+        it "includes 'Backing of'" do
+          expect(label).to include("Backing of")
         end
 
         it "includes the bcache name" do
@@ -206,7 +207,7 @@ describe Y2Partitioner::Widgets::Columns::Type do
         let(:device_name) { "/dev/vdb" }
 
         it "returns 'Bcache cache'" do
-          expect(label).to include("Bcache cache")
+          expect(label).to include("Bcache caching")
         end
       end
     end

--- a/test/y2partitioner/widgets/menus/modify_test.rb
+++ b/test/y2partitioner/widgets/menus/modify_test.rb
@@ -233,6 +233,58 @@ describe Y2Partitioner::Widgets::Menus::Modify do
         end
       end
 
+      context "and the selected device is a LVM Volume Group" do
+        let(:scenario) { "trivial_lvm.yml" }
+
+        let(:device_name) { "/dev/vg0" }
+
+        it "calls an action to delete the Volume Group" do
+          expect(Y2Partitioner::Actions::DeleteLvmVg).to receive(:new).with(device)
+
+          subject.handle(event)
+        end
+      end
+
+      context "and the selected device is a LVM Logical Volume" do
+        let(:scenario) { "trivial_lvm.yml" }
+
+        let(:device_name) { "/dev/vg0/lv1" }
+
+        it "calls an action to delete the Logical Volume" do
+          expect(Y2Partitioner::Actions::DeleteLvmLv).to receive(:new).with(device)
+
+          subject.handle(event)
+        end
+      end
+
+      context "and the selected device is a Bcache" do
+        let(:scenario) { "bcache1.xml" }
+
+        let(:device_name) { "/dev/bcache0" }
+
+        it "calls an action to delete the Bcache" do
+          expect(Y2Partitioner::Actions::DeleteBcache).to receive(:new).with(device)
+
+          subject.handle(event)
+        end
+      end
+
+      context "and the selected device is a Btrfs" do
+        let(:scenario) { "trivial_btrfs.yml" }
+
+        let(:device_name) { "/dev/sda1" }
+
+        let(:btrfs) { device.blk_filesystem }
+
+        subject { described_class.new(btrfs) }
+
+        it "calls an action to delete the Btrfs" do
+          expect(Y2Partitioner::Actions::DeleteBtrfs).to receive(:new).with(btrfs)
+
+          subject.handle(event)
+        end
+      end
+
       include_examples "no action", "mixed_disks.yml", "/dev/sda"
     end
 


### PR DESCRIPTION
This is part of the on-going process to reorganize the Partitioner UI into the branch *partitioner-ui-02*.

This PR:

* Avoids some rubocop complaints by using metaprogramming.
* Adds some missing actions to the *Device->Delete* menu. 
* Uses a better wording in the Type column for the Bcache caching and backing devices.

![Screenshot from 2020-09-24 13-39-30](https://user-images.githubusercontent.com/1112304/94146115-5fc62b80-fe6b-11ea-9d58-a3f39dc61e72.png)
