### PR TITLE
Partitioner: tests for the menus System and View

### DIFF
--- a/test/y2partitioner/widgets/main_menu_bar_test.rb
+++ b/test/y2partitioner/widgets/main_menu_bar_test.rb
@@ -1,0 +1,119 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/main_menu_bar"
+
+describe Y2Partitioner::Widgets::MainMenuBar do
+  before do
+    devicegraph_stub("complex-lvm-encrypt")
+  end
+
+  let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+  let(:device) { device_graph.disks.first }
+
+  subject(:widget) { described_class.new }
+
+  include_examples "CWM::CustomWidget"
+
+  describe "#contents" do
+    context "if no device has been selected yet" do
+      # FIXME: this behavior is actually a bug
+      it "contains no menus" do
+        menus = widget.contents.params[1]
+        expect(menus).to eq []
+      end
+    end
+
+    context "if a device has been selected" do
+      before { widget.select_row(device.sid) }
+
+      it "contains menus for System, Add, Modify and View" do
+        menus = widget.contents.params[1]
+        expect(menus.map(&:value)).to all(eq :menu)
+        titles = menus.map { |m| m.params[0] }
+        expect(titles).to eq ["&System", "&Add", "&Device", "&View"]
+      end
+    end
+  end
+
+  describe "#handle" do
+    let(:system_menu) { Y2Partitioner::Widgets::Menus::System.new }
+    let(:add_menu) { Y2Partitioner::Widgets::Menus::Add.new(device) }
+    let(:modify_menu) { Y2Partitioner::Widgets::Menus::Modify.new(device) }
+    let(:view_menu) { Y2Partitioner::Widgets::Menus::View.new }
+
+    before do
+      allow(Y2Partitioner::Widgets::Menus::System).to receive(:new).and_return system_menu
+      allow(Y2Partitioner::Widgets::Menus::Add).to receive(:new).and_return add_menu
+      allow(Y2Partitioner::Widgets::Menus::Modify).to receive(:new).and_return modify_menu
+      allow(Y2Partitioner::Widgets::Menus::View).to receive(:new).and_return view_menu
+      widget.select_row(device.sid)
+    end
+
+    context "for a MenuEvent" do
+      let(:event) { { "EventType" => "MenuEvent", "ID" => "example_id" } }
+
+      context "if any of the menus can respond to the event" do
+        before do
+          allow(system_menu).to receive(:handle).and_return nil
+          allow(add_menu).to receive(:handle).and_return :result
+        end
+
+        it "delegates to that menu and returns the result" do
+          expect(system_menu).to receive(:handle).with("example_id")
+          expect(add_menu).to receive(:handle).with("example_id")
+          expect(widget.handle(event)).to eq :result
+        end
+      end
+
+      context "if none of the menus can respond to the event" do
+        before do
+          allow(system_menu).to receive(:handle).and_return nil
+          allow(add_menu).to receive(:handle).and_return nil
+          allow(modify_menu).to receive(:handle).and_return nil
+          allow(view_menu).to receive(:handle).and_return nil
+        end
+
+        it "returns nil after trying to delegate to all the menus" do
+          expect(system_menu).to receive(:handle).with("example_id")
+          expect(add_menu).to receive(:handle).with("example_id")
+          expect(modify_menu).to receive(:handle).with("example_id")
+          expect(view_menu).to receive(:handle).with("example_id")
+          expect(widget.handle(event)).to be_nil
+        end
+      end
+    end
+
+    context "for an event that is not a MenuEvent" do
+      let(:event) { { "EventType" => "Whatever", "ID" => "example_id" } }
+
+      it "returns nil without trying to delegate on the menus" do
+        expect(system_menu).to_not receive(:handle)
+        expect(add_menu).to_not receive(:handle)
+        expect(modify_menu).to_not receive(:handle)
+        expect(view_menu).to_not receive(:handle)
+        expect(widget.handle(event)).to be_nil
+      end
+    end
+  end
+end

--- a/test/y2partitioner/widgets/menus/examples.rb
+++ b/test/y2partitioner/widgets/menus/examples.rb
@@ -31,15 +31,15 @@ shared_examples "Y2Partitioner::Widgets::Menus" do
     it "produces an array of Items" do
       expect(subject.items).to be_an Array
 
-      expect(subject.items).to all(be_item)
+      expect(subject.items).to all(be_item.or(be_menu))
     end
   end
 
   describe "#disabled_items" do
-    it "produces an array of Items" do
-      expect(subject.items).to be_an Array
+    it "produces an array with symbols" do
+      expect(subject.disabled_items).to be_an Array
 
-      expect(subject.items).to all(be_item)
+      expect(subject.disabled_items).to all(be_a Symbol)
     end
   end
 

--- a/test/y2partitioner/widgets/menus/matchers.rb
+++ b/test/y2partitioner/widgets/menus/matchers.rb
@@ -26,6 +26,12 @@ RSpec::Matchers.define :be_item do
   end
 end
 
+RSpec::Matchers.define :be_menu do
+  match do |element|
+    element.is_a?(Yast::Term) && element.value == :menu
+  end
+end
+
 RSpec::Matchers.define :item_with_id do |expected_id|
   match do |item|
     return false unless be_item(item)

--- a/test/y2partitioner/widgets/menus/system_test.rb
+++ b/test/y2partitioner/widgets/menus/system_test.rb
@@ -123,7 +123,7 @@ describe Y2Partitioner::Widgets::Menus::System do
       before { allow_any_instance_of(action_class).to receive(:run).and_return action_result }
       let(:action_result) { :whatever }
 
-      it "calls the correspondig action (#{action_class})" do
+      it "calls the corresponding action (#{action_class})" do
         expect_any_instance_of(action_class).to receive(:run)
         menu.handle(id)
       end

--- a/test/y2partitioner/widgets/menus/system_test.rb
+++ b/test/y2partitioner/widgets/menus/system_test.rb
@@ -1,0 +1,188 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require_relative "examples"
+require_relative "matchers"
+
+require "y2partitioner/widgets/menus/system"
+
+describe Y2Partitioner::Widgets::Menus::System do
+  before do
+    allow(Yast::Stage).to receive(:initial).and_return(install)
+  end
+
+  subject(:menu) { described_class.new }
+
+  let(:install) { false }
+
+  def find_menu(menu, label)
+    menu.items.find { |i| i.is_a?(Yast::Term) && i.value == :menu && i.params[0] == label }
+  end
+
+  include_examples "Y2Partitioner::Widgets::Menus"
+
+  describe "#items" do
+    it "includes entries for exiting with and without saving the changes" do
+      expect(subject.items).to include(item_with_id(:abort))
+      expect(subject.items).to include(item_with_id(:next))
+    end
+
+    it "includes and entry for rescaning devices" do
+      expect(subject.items).to include(item_with_id(:rescan_devices))
+    end
+
+    context "during installation" do
+      let(:install) { true }
+
+      it "includes the entry Import Mount Points" do
+        expect(subject.items).to include(item_with_id(:import_mount_points))
+      end
+    end
+
+    context "in an already installed system" do
+      let(:install) { false }
+
+      it "does not include the entry Import Mount Points" do
+        expect(subject.items).to_not include(item_with_id(:import_mount_points))
+      end
+    end
+
+    # All the following tests about the entries available in the configure menu are a bit
+    # redundant with the tests for Actions::ConfigureAction, but we can live with that
+
+    it "contains a Configure menu with entries for encryption, iSCSI and FCoE" do
+      configure = find_menu(subject, "&Configure")
+      expect(configure).to_not be_nil
+
+      items = configure.params[1]
+      expect(items).to include(item_with_id(:provide_crypt_passwords))
+      expect(items).to include(item_with_id(:configure_iscsi))
+      expect(items).to include(item_with_id(:configure_fcoe))
+    end
+
+    context "in a s390 system" do
+      let(:architecture) { :s390 }
+
+      it "contains entries for DASD, zFCP and XPRAM in the configure menu" do
+        configure = find_menu(subject, "&Configure")
+        items = configure.params[1]
+
+        expect(items).to include(item_with_id(:configure_dasd))
+        expect(items).to include(item_with_id(:configure_zfcp))
+        expect(items).to include(item_with_id(:configure_xpram))
+      end
+    end
+
+    context "in a non-s390 system" do
+      let(:architecture) { :x86_64 }
+
+      it "contains no entries for DASD, zFCP or XPRAM in the configure menu" do
+        configure = find_menu(subject, "&Configure")
+        items = configure.params[1]
+
+        expect(items).to_not include(item_with_id(:configure_dasd))
+        expect(items).to_not include(item_with_id(:configure_zfcp))
+        expect(items).to_not include(item_with_id(:configure_xpram))
+      end
+    end
+  end
+
+  describe "#disabled_items" do
+    it "returns an empty array, since all present entries are always enabled" do
+      expect(menu.disabled_items).to eq []
+    end
+  end
+
+  describe "#handle" do
+    let(:architecture) { :s390 }
+
+    RSpec.shared_examples "handle action" do |action_class|
+      # Using here something like this
+      #   allow(action_class).to receive(:new).and_return a_double
+      # turned to be pretty hard because action classes are memoized.
+      # So this looks like a legitimate usage of allow_any_instance.
+      before { allow_any_instance_of(action_class).to receive(:run).and_return action_result }
+      let(:action_result) { :whatever }
+
+      it "calls the correspondig action (#{action_class})" do
+        expect_any_instance_of(action_class).to receive(:run)
+        menu.handle(id)
+      end
+
+      context "if the action returns :finish" do
+        let(:action_result) { :finish }
+
+        it "returns :redraw" do
+          expect(menu.handle(id)).to eq :redraw
+        end
+      end
+
+      context "if the action returns any different result" do
+        let(:action_result) { :next }
+
+        it "returns nil" do
+          expect(menu.handle(id)).to be_nil
+        end
+      end
+    end
+
+    context "when :rescan_devices was selected" do
+      let(:id) { :rescan_devices }
+      include_examples "handle action", Y2Partitioner::Actions::RescanDevices
+    end
+
+    context "when :import_mount_points was selected" do
+      let(:id) { :import_mount_points }
+      include_examples "handle action", Y2Partitioner::Actions::ImportMountPoints
+    end
+
+    context "when :provide_crypt_passwords was selected" do
+      let(:id) { :provide_crypt_passwords }
+      include_examples "handle action", Y2Partitioner::Actions::ProvideCryptPasswords
+    end
+
+    context "when :configure_iscsi was selected" do
+      let(:id) { :configure_iscsi }
+      include_examples "handle action", Y2Partitioner::Actions::ConfigureIscsi
+    end
+
+    context "when :configure_fcoe was selected" do
+      let(:id) { :configure_fcoe }
+      include_examples "handle action", Y2Partitioner::Actions::ConfigureFcoe
+    end
+
+    context "when :configure_dasd was selected" do
+      let(:id) { :configure_dasd }
+      include_examples "handle action", Y2Partitioner::Actions::ConfigureDasd
+    end
+
+    context "when :configure_zfcp was selected" do
+      let(:id) { :configure_zfcp }
+      include_examples "handle action", Y2Partitioner::Actions::ConfigureZfcp
+    end
+
+    context "when :configure_xpram was selected" do
+      let(:id) { :configure_xpram }
+      include_examples "handle action", Y2Partitioner::Actions::ConfigureXpram
+    end
+  end
+end

--- a/test/y2partitioner/widgets/menus/view_test.rb
+++ b/test/y2partitioner/widgets/menus/view_test.rb
@@ -1,0 +1,126 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require_relative "examples"
+require_relative "matchers"
+
+require "y2partitioner/widgets/menus/view"
+
+describe Y2Partitioner::Widgets::Menus::View do
+  before do
+    allow(Y2Partitioner::Dialogs::DeviceGraph).to receive(:supported?).and_return(graphical)
+  end
+
+  subject(:menu) { described_class.new }
+
+  let(:graphical) { true }
+
+  include_examples "Y2Partitioner::Widgets::Menus"
+
+  describe "#items" do
+    it "includes entries for installation summary, settings and csets" do
+      expect(subject.items).to include(item_with_id(:installation_summary))
+      expect(subject.items).to include(item_with_id(:settings))
+      expect(subject.items).to include(item_with_id(:bcache_csets))
+    end
+
+    context "in graphical mode" do
+      let(:graphical) { true }
+
+      it "includes the entry to display the Device Graphs" do
+        expect(subject.items).to include(item_with_id(:device_graphs))
+      end
+    end
+
+    context "in an already installed system" do
+      let(:graphical) { false }
+
+      it "does not include the entry to display de Device Graphs" do
+        expect(subject.items).to_not include(item_with_id(:device_graphs))
+      end
+    end
+  end
+
+  describe "#disabled_items" do
+    it "returns an empty array, since all present entries are always enabled" do
+      expect(menu.disabled_items).to eq []
+    end
+  end
+
+  describe "#handle" do
+    RSpec.shared_examples "handle dialog" do |dialog_class|
+      let(:dialog) { double("Dialog", run: dialog_result) }
+      let(:dialog_result) { :whatever }
+      before { allow(dialog_class).to receive(:new).and_return dialog }
+
+      it "opens the corresponding dialog (#{dialog_class})" do
+        expect(dialog_class).to receive(:new)
+        expect(dialog).to receive(:run)
+        menu.handle(id)
+      end
+
+      context "if the dialog returns :finish" do
+        let(:dialog_result) { :finish }
+
+        it "returns nil" do
+          expect(menu.handle(id)).to be_nil
+        end
+      end
+
+      context "if the dialog returns :next" do
+        let(:dialog_result) { :next }
+
+        it "returns nil" do
+          expect(menu.handle(id)).to be_nil
+        end
+      end
+
+      context "if the dialog returns any different result" do
+        let(:dialog_result) { nil }
+
+        it "returns nil" do
+          expect(menu.handle(id)).to be_nil
+        end
+      end
+    end
+
+    context "when :device_graphs was selected" do
+      let(:id) { :device_graphs }
+      include_examples "handle dialog", Y2Partitioner::Dialogs::DeviceGraph
+    end
+
+    context "when :installation_summary was selected" do
+      let(:id) { :installation_summary }
+      include_examples "handle dialog", Y2Partitioner::Dialogs::SummaryPopup
+    end
+
+    context "when :settings was selected" do
+      let(:id) { :settings }
+      include_examples "handle dialog", Y2Partitioner::Dialogs::Settings
+    end
+
+    context "when :bcache_csets was selected" do
+      let(:id) { :bcache_csets }
+      include_examples "handle dialog", Y2Partitioner::Dialogs::BcacheCsets
+    end
+  end
+end


### PR DESCRIPTION
This is part of the on-going process to reorganize the Partitioner UI into the branch `partitioner-ui-02`.

This PR adds some missing unit tests.