### PR TITLE
More robust menus

### DIFF
--- a/src/lib/y2partitioner/actions/add_lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/add_lvm_vg.rb
@@ -21,6 +21,7 @@ require "yast"
 require "y2partitioner/actions/transaction_wizard"
 require "y2partitioner/actions/controllers/lvm_vg"
 require "y2partitioner/dialogs/lvm_vg"
+require "y2partitioner/ui_state"
 
 module Y2Partitioner
   module Actions
@@ -42,6 +43,7 @@ module Y2Partitioner
         return result if result != :next
 
         controller.apply_values
+        UIState.instance.select_row(controller.vg.sid)
         :finish
       end
 

--- a/src/lib/y2partitioner/actions/add_md.rb
+++ b/src/lib/y2partitioner/actions/add_md.rb
@@ -22,6 +22,7 @@ require "y2partitioner/actions/transaction_wizard"
 require "y2partitioner/actions/controllers/md"
 require "y2partitioner/dialogs/md"
 require "y2partitioner/dialogs/md_options"
+require "y2partitioner/ui_state"
 
 Yast.import "Popup"
 
@@ -42,8 +43,10 @@ module Y2Partitioner
 
       def md_options
         result = Dialogs::MdOptions.run(controller)
+        return result unless result == :next
 
-        (result == :next) ? :finish : result
+        UIState.instance.select_row(controller.md.sid)
+        :finish
       end
 
       protected

--- a/src/lib/y2partitioner/actions/controllers/add_partition.rb
+++ b/src/lib/y2partitioner/actions/controllers/add_partition.rb
@@ -20,7 +20,6 @@
 require "yast"
 require "y2storage"
 require "y2partitioner/actions/controllers/base"
-require "y2partitioner/ui_state"
 
 module Y2Partitioner
   module Actions
@@ -125,7 +124,6 @@ module Y2Partitioner
           slot = slot_for(region)
           aligned = align(region, slot, ptable)
           @partition = ptable.create_partition(slot.name, aligned, type)
-          UIState.instance.select_row(@partition.sid)
         end
 
         # Removes the previously created partition from the device

--- a/src/lib/y2partitioner/actions/controllers/btrfs_devices.rb
+++ b/src/lib/y2partitioner/actions/controllers/btrfs_devices.rb
@@ -19,7 +19,6 @@
 
 require "yast"
 require "y2storage"
-require "y2partitioner/ui_state"
 require "y2partitioner/blk_device_restorer"
 require "y2partitioner/actions/controllers/base"
 require "y2partitioner/actions/controllers/available_devices"
@@ -55,8 +54,6 @@ module Y2Partitioner
 
           @metadata_raid_level = Y2Storage::BtrfsRaidLevel::DEFAULT
           @data_raid_level = Y2Storage::BtrfsRaidLevel::DEFAULT
-
-          UIState.instance.select_row(filesystem.sid) if filesystem
         end
 
         # Metadata RAID level for the filesystem
@@ -224,8 +221,6 @@ module Y2Partitioner
           filesystem = device.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
           filesystem.metadata_raid_level = @metadata_raid_level
           filesystem.data_raid_level = @data_raid_level
-
-          UIState.instance.select_row(filesystem.sid)
 
           @filesystem = filesystem
         end

--- a/src/lib/y2partitioner/actions/controllers/lvm_lv.rb
+++ b/src/lib/y2partitioner/actions/controllers/lvm_lv.rb
@@ -19,7 +19,6 @@
 
 require "yast"
 require "y2storage"
-require "y2partitioner/ui_state"
 require "y2partitioner/actions/controllers/base"
 
 module Y2Partitioner
@@ -95,7 +94,6 @@ module Y2Partitioner
         # Creates the LV in the VG according to the controller attributes
         def create_lv
           @lv = lv_type.is?(:thin) ? create_thin_lv : create_normal_or_pool_lv
-          UIState.instance.select_row(@lv.sid)
         end
 
         # Removes the previously created logical volume

--- a/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
@@ -20,7 +20,6 @@
 require "yast"
 require "y2storage"
 require "y2partitioner/size_parser"
-require "y2partitioner/ui_state"
 require "y2partitioner/blk_device_restorer"
 require "y2partitioner/actions/controllers/base"
 require "y2partitioner/actions/controllers/available_devices"
@@ -223,8 +222,6 @@ module Y2Partitioner
           when :resize
             initialize_for_resize(current_vg)
           end
-
-          UIState.instance.select_row(vg.sid) unless vg.nil?
         end
 
         # Detects current action

--- a/src/lib/y2partitioner/actions/controllers/md.rb
+++ b/src/lib/y2partitioner/actions/controllers/md.rb
@@ -20,7 +20,6 @@
 require "yast"
 require "y2storage"
 require "y2partitioner/actions/controllers/base"
-require "y2partitioner/ui_state"
 require "y2partitioner/blk_device_restorer"
 require "y2partitioner/actions/controllers/available_devices"
 
@@ -57,7 +56,6 @@ module Y2Partitioner
 
           @md_sid = md.sid
           @initial_name = md.name
-          UIState.instance.select_row(md.sid)
         end
 
         # MD RAID being modified

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -76,6 +76,7 @@ module Y2Partitioner
     # @param pages_ids [Array<String, Integer>] the path to the selected page
     def select_page(pages_ids)
       self.current_status = status_for(pages_ids)
+      menu_bar&.select_page
     end
 
     # Method to be called when the user switches to a tab within a page

--- a/src/lib/y2partitioner/widgets/main_menu_bar.rb
+++ b/src/lib/y2partitioner/widgets/main_menu_bar.rb
@@ -48,6 +48,12 @@ module Y2Partitioner
         refresh
       end
 
+      # @see UIState#select_page
+      def select_page
+        @device = nil
+        refresh
+      end
+
       # @macro seeAbstractWidget
       def id
         :menu_bar
@@ -106,18 +112,33 @@ module Y2Partitioner
       #
       # @return [Array<Menus::Base>]
       def calculate_menus
-        [
-          Menus::System.new,
-          Menus::Add.new(device),
-          Menus::Modify.new(device),
-          Menus::View.new
-        ]
+        [system_menu, add_menu, modify_menu, view_menu]
       end
 
       # Disable all items with the specified IDs
       def disable_menu_items(*ids)
         disabled_hash = ids.each_with_object({}) { |id, h| h[id] = false }
         Yast::UI.ChangeWidget(Id(id), :EnabledItems, disabled_hash)
+      end
+
+      # @see #calculate_menus
+      def system_menu
+        @system_menu ||= Menus::System.new
+      end
+
+      # @see #calculate_menus
+      def view_menu
+        @view_menu ||= Menus::View.new
+      end
+
+      # @see #calculate_menus
+      def add_menu
+        Menus::Add.new(device)
+      end
+
+      # @see #calculate_menus
+      def modify_menu
+        Menus::Modify.new(device)
       end
 
       # @return [Y2Storage::Devicegraph]

--- a/src/lib/y2partitioner/widgets/menus/add.rb
+++ b/src/lib/y2partitioner/widgets/menus/add.rb
@@ -56,6 +56,8 @@ module Y2Partitioner
           ]
         end
 
+        private
+
         # @see Device
         def disabled_for_device
           items = []
@@ -64,7 +66,10 @@ module Y2Partitioner
           items
         end
 
-        private
+        # @see Device
+        def disabled_without_device
+          [:menu_add_partition, :menu_add_lv]
+        end
 
         # @see Device#action_for
         def menu_add_md_action

--- a/src/lib/y2partitioner/widgets/menus/add.rb
+++ b/src/lib/y2partitioner/widgets/menus/add.rb
@@ -111,11 +111,15 @@ module Y2Partitioner
         #
         # @return [Boolean]
         def support_add_partition?
+          return false unless device
+
           partitionable? || device.is?(:partition)
         end
 
         # Whether the action to add a LVM Logical Volume can be called with the current device
         def support_add_lv?
+          return false unless device
+
           device.is?(:lvm_vg, :lvm_lv)
         end
       end

--- a/src/lib/y2partitioner/widgets/menus/device.rb
+++ b/src/lib/y2partitioner/widgets/menus/device.rb
@@ -40,7 +40,7 @@ module Y2Partitioner
         #
         # @return [Array<Symbol>]
         def disabled_items
-          @disabled_items ||= device ? disabled_for_device : []
+          @disabled_items ||= device ? disabled_for_device : disabled_without_device
         end
 
         private
@@ -61,6 +61,17 @@ module Y2Partitioner
         # @return [Array<Symbol>]
         def disabled_for_device
           []
+        end
+
+        # Items to disable if {#device} is nil
+        # @see #disabled_items
+        #
+        # @return [Array<Symbol>]
+        def disabled_without_device
+          items_with_id = items.select do |i|
+            i.value == :item && i.params[0].is_a?(Yast::Term) && i.params[0].value == :id
+          end
+          items_with_id.map { |i| i.params[0].params[0] }
         end
 
         # Current devicegraph

--- a/src/lib/y2partitioner/widgets/menus/device.rb
+++ b/src/lib/y2partitioner/widgets/menus/device.rb
@@ -66,6 +66,9 @@ module Y2Partitioner
         # Items to disable if {#device} is nil
         # @see #disabled_items
         #
+        # Unless redefined in a descendant class, all items of the menu are
+        # disabled when the device is nil
+        #
         # @return [Array<Symbol>]
         def disabled_without_device
           items_with_id = items.select do |i|

--- a/src/lib/y2partitioner/widgets/menus/modify.rb
+++ b/src/lib/y2partitioner/widgets/menus/modify.rb
@@ -84,6 +84,13 @@ module Y2Partitioner
           items
         end
 
+        # @see Device
+        def action_for(*args)
+          return nil unless device
+
+          super
+        end
+
         # @see Device#action_for
         def menu_edit_action
           if device.is?(:blk_device) && device.usable_as_blk_device?
@@ -141,6 +148,7 @@ module Y2Partitioner
         # @see Base
         def dialog_for(event)
           return nil unless event == :menu_description
+          return nil unless device
 
           Dialogs::DeviceDescription.new(device)
         end

--- a/test/y2partitioner/actions/controllers/lvm_lv_test.rb
+++ b/test/y2partitioner/actions/controllers/lvm_lv_test.rb
@@ -97,14 +97,6 @@ describe Y2Partitioner::Actions::Controllers::LvmLv do
       expect(controller.lv.lvm_vg).to eq(controller.vg)
     end
 
-    it "select the table row corresponding to the new lv" do
-      expect(Y2Partitioner::UIState.instance).to receive(:select_row) do |lv|
-        expect(lv).to eq(controller.lv.sid)
-      end
-
-      controller.create_lv
-    end
-
     context "when the stored lv type is thin" do
       let(:lv_type) { Y2Storage::LvType::THIN }
 

--- a/test/y2partitioner/widgets/main_menu_bar_test.rb
+++ b/test/y2partitioner/widgets/main_menu_bar_test.rb
@@ -35,12 +35,28 @@ describe Y2Partitioner::Widgets::MainMenuBar do
 
   include_examples "CWM::CustomWidget"
 
+  # Just to shorten
+  let(:system) { Y2Partitioner::Widgets::Menus::System }
+  let(:add) { Y2Partitioner::Widgets::Menus::Add }
+  let(:modify) { Y2Partitioner::Widgets::Menus::Modify }
+  let(:view) { Y2Partitioner::Widgets::Menus::View }
+
   describe "#contents" do
-    context "if no device has been selected yet" do
-      # FIXME: this behavior is actually a bug
+    context "if no device or page has been selected yet" do
       it "contains no menus" do
         menus = widget.contents.params[1]
         expect(menus).to eq []
+      end
+    end
+
+    context "if a page with no devices has been selected" do
+      before { widget.select_page }
+
+      it "contains menus for System, Add, Modify and View" do
+        menus = widget.contents.params[1]
+        expect(menus.map(&:value)).to all(eq :menu)
+        titles = menus.map { |m| m.params[0] }
+        expect(titles).to eq ["&System", "&Add", "&Device", "&View"]
       end
     end
 
@@ -56,17 +72,33 @@ describe Y2Partitioner::Widgets::MainMenuBar do
     end
   end
 
+  describe "#select_page" do
+    it "initializes the Add and Modify menus with no device" do
+      expect(add).to receive(:new).with(nil).and_call_original
+      expect(modify).to receive(:new).with(nil).and_call_original
+      widget.select_page
+    end
+  end
+
+  describe "#select_row" do
+    it "initializes the Add and Modify menus with the corresponding device" do
+      expect(add).to receive(:new).with(device).and_call_original
+      expect(modify).to receive(:new).with(device).and_call_original
+      widget.select_row(device.sid)
+    end
+  end
+
   describe "#handle" do
-    let(:system_menu) { Y2Partitioner::Widgets::Menus::System.new }
-    let(:add_menu) { Y2Partitioner::Widgets::Menus::Add.new(device) }
-    let(:modify_menu) { Y2Partitioner::Widgets::Menus::Modify.new(device) }
-    let(:view_menu) { Y2Partitioner::Widgets::Menus::View.new }
+    let(:system_menu) { system.new }
+    let(:add_menu) { add.new(device) }
+    let(:modify_menu) { modify.new(device) }
+    let(:view_menu) { view.new }
 
     before do
-      allow(Y2Partitioner::Widgets::Menus::System).to receive(:new).and_return system_menu
-      allow(Y2Partitioner::Widgets::Menus::Add).to receive(:new).and_return add_menu
-      allow(Y2Partitioner::Widgets::Menus::Modify).to receive(:new).and_return modify_menu
-      allow(Y2Partitioner::Widgets::Menus::View).to receive(:new).and_return view_menu
+      allow(system).to receive(:new).and_return system_menu
+      allow(add).to receive(:new).and_return add_menu
+      allow(modify).to receive(:new).and_return modify_menu
+      allow(view).to receive(:new).and_return view_menu
       widget.select_row(device.sid)
     end
 

--- a/test/y2partitioner/widgets/menus/add_test.rb
+++ b/test/y2partitioner/widgets/menus/add_test.rb
@@ -69,6 +69,15 @@ describe Y2Partitioner::Widgets::Menus::Add do
   end
 
   describe "#disabled_items" do
+    context "when there is no device" do
+      let(:device) { nil }
+
+      it "contains 'Partition' and 'Logical Volume'" do
+        items = [:menu_add_partition, :menu_add_lv]
+        expect(subject.disabled_items).to contain_exactly(*items)
+      end
+    end
+
     context "when the device is a disk device (Hard Disk, BIOS RAID, Multipath, DASD)" do
       let(:scenario) { "one-empty-disk.yml" }
 
@@ -231,6 +240,15 @@ describe Y2Partitioner::Widgets::Menus::Add do
         end
       end
 
+      context "but no device is selected" do
+        let(:device) { nil }
+
+        it "calls no action" do
+          expect(Y2Partitioner::Actions::AddPartition).to_not receive(:new)
+          subject.handle(event)
+        end
+      end
+
       include_examples "no action", "trivial_lvm.yml", "/dev/vg0"
     end
 
@@ -257,6 +275,15 @@ describe Y2Partitioner::Widgets::Menus::Add do
         it "calls an action to add a Logical Volume in the Volume Group of the selected device" do
           expect(Y2Partitioner::Actions::AddLvmLv).to receive(:new).with(device.lvm_vg)
 
+          subject.handle(event)
+        end
+      end
+
+      context "but no device is selected" do
+        let(:device) { nil }
+
+        it "calls no action" do
+          expect(Y2Partitioner::Actions::AddLvmLv).to_not receive(:new)
           subject.handle(event)
         end
       end

--- a/test/y2partitioner/widgets/menus/modify_test.rb
+++ b/test/y2partitioner/widgets/menus/modify_test.rb
@@ -77,6 +77,18 @@ describe Y2Partitioner::Widgets::Menus::Modify do
   end
 
   describe "#disabled_items" do
+    context "when there is no device" do
+      let(:device) { nil }
+
+      it "contains all the entries" do
+        items = [
+          :menu_edit, :menu_description, :menu_delete, :menu_resize, :menu_move,
+          :menu_change_devs, :menu_create_ptable, :menu_clone_ptable
+        ]
+        expect(subject.disabled_items).to contain_exactly(*items)
+      end
+    end
+
     context "when the device is a disk device (Hard Disk, BIOS RAID, Multipath, DASD)" do
       let(:scenario) { "one-empty-disk.yml" }
 
@@ -172,6 +184,17 @@ describe Y2Partitioner::Widgets::Menus::Modify do
       end
     end
 
+    shared_examples "no device" do
+      context "but no device is selected" do
+        let(:device) { nil }
+
+        it "calls no action" do
+          expect(Y2Partitioner::Actions::Base).to_not receive(:new)
+          subject.handle(event)
+        end
+      end
+    end
+
     context "when 'Edit' is selected" do
       let(:event) { :menu_edit }
 
@@ -204,6 +227,8 @@ describe Y2Partitioner::Widgets::Menus::Modify do
       end
 
       include_examples "no action", "trivial_lvm.yml", "/dev/vg0"
+
+      include_examples "no device"
     end
 
     context "when 'Delete' is selected" do
@@ -286,6 +311,8 @@ describe Y2Partitioner::Widgets::Menus::Modify do
       end
 
       include_examples "no action", "mixed_disks.yml", "/dev/sda"
+
+      include_examples "no device"
     end
 
     context "when 'Resize' is selected" do
@@ -316,6 +343,8 @@ describe Y2Partitioner::Widgets::Menus::Modify do
       end
 
       include_examples "no action", "mixed_disks.yml", "/dev/sda"
+
+      include_examples "no device"
     end
 
     context "when 'Move' is selected" do
@@ -334,6 +363,8 @@ describe Y2Partitioner::Widgets::Menus::Modify do
       end
 
       include_examples "no action", "mixed_disks.yml", "/dev/sda"
+
+      include_examples "no device"
     end
 
     context "when 'Change Used Devices' is selected" do
@@ -392,6 +423,8 @@ describe Y2Partitioner::Widgets::Menus::Modify do
       end
 
       include_examples "no action", "mixed_disks.yml", "/dev/sda"
+
+      include_examples "no device"
     end
 
     context "when 'Create Partition Table' is selected" do
@@ -410,6 +443,8 @@ describe Y2Partitioner::Widgets::Menus::Modify do
       end
 
       include_examples "no action", "mixed_disks.yml", "/dev/sda1"
+
+      include_examples "no device"
     end
 
     context "when 'Clone Partitions' is selected" do
@@ -428,6 +463,8 @@ describe Y2Partitioner::Widgets::Menus::Modify do
       end
 
       include_examples "no action", "mixed_disks.yml", "/dev/sda1"
+
+      include_examples "no device"
     end
 
     context "when 'Show Details' is selected" do
@@ -438,6 +475,8 @@ describe Y2Partitioner::Widgets::Menus::Modify do
 
         subject.handle(event)
       end
+
+      include_examples "no device"
     end
   end
 end


### PR DESCRIPTION
This is part of the on-going process to reorganize the Partitioner UI into the branch `partitioner-ui-02`.

## Problem

The "Add" and "Device" menus act on the device currently selected in the table. But it was failing in several situations:

- With a completely empty devicegraph, no device is ever selected and the menu bar was always empty.
- When clicking in a section with no elements (eg. clicking "RAID") there is no selected device (empty table), so the menu still referenced to the selected device in the previous table.
- When the process of adding a new device was canceled, the temporary new device (that didn't exist anymore after cancelling) was considered as the current one. Producing a crash when any action was selected in the menu.
- When managing NFS, all the menu entries were always enabled. Selecting any action that refers to a concrete device produced a crash.

## Solution

This fixes the first three problems.

To mitigate the fourth problem, now the menus simply ignore actions executed on unknown devices instead of crashing. Due to the nature of NFS management (with another client being embedded inside the Partitioner), the main problem is still not solved and all actions are still enabled.

## Testing

- Tested manually
- Updated and extended unit tests
