### PR TITLE
Fix md page

### DIFF
--- a/src/lib/y2partitioner/widgets/pages/md_raid.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raid.rb
@@ -58,7 +58,7 @@ module Y2Partitioner
             VBox(
               Left(
                 Tabs.new(
-                  MdTab.new(@md, initial: true),
+                  MdTab.new(@md, @pager, initial: true),
                   MdUsedDevicesTab.new(@md, @pager)
                 )
               )

--- a/test/y2partitioner/widgets/pages/md_raid_test.rb
+++ b/test/y2partitioner/widgets/pages/md_raid_test.rb
@@ -42,12 +42,12 @@ describe Y2Partitioner::Widgets::Pages::MdRaid do
 
   describe "#contents" do
     it "shows a MD tab" do
-      expect(Y2Partitioner::Widgets::Pages::MdTab).to receive(:new)
+      expect(Y2Partitioner::Widgets::Pages::MdTab).to receive(:new).with(md, pager, anything)
       subject.contents
     end
 
     it "shows a used devices tab" do
-      expect(Y2Partitioner::Widgets::UsedDevicesTab).to receive(:new)
+      expect(Y2Partitioner::Widgets::UsedDevicesTab).to receive(:new).with(md, pager)
       subject.contents
     end
   end


### PR DESCRIPTION
## Problem

The page of a MD RAID is creating the Overview tab with a wrong pager, making it to fail when double-clicking over a device to open the popup with the description.

Part of: https://trello.com/c/NITXJRBE/2055-8-menu-driven-interface-finish-it.

## Solution

Create the overview tab with the correct page.

## Testing

* Adapted unit tests
