### PR TITLE
Nested devices

### DIFF
--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -28,8 +28,8 @@ Source:         %{name}-%{version}.tar.bz2
 # UF_PMEM and UF_NVME
 BuildRequires:	libstorage-ng-ruby >= 4.3.30
 BuildRequires:  update-desktop-files
-# AutoYaST ElementPath class
-BuildRequires:  yast2 >= 4.3.20
+# CWM::TableItem
+BuildRequires:  yast2 >= 4.3.38
 BuildRequires:  yast2-devtools >= 4.2.2
 # for AbortException and handle direct abort
 BuildRequires:  yast2-ruby-bindings >= 4.0.6
@@ -49,8 +49,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 Requires:       findutils
 # UF_PMEM and UF_NVME
 Requires:       libstorage-ng-ruby >= 4.3.30
-# AutoYaST issue handling
-Requires:  yast2 >= 4.3.20
+# CWM::TableItem
+Requires:  yast2 >= 4.3.38
 
 # Y2Packager::Repository
 Requires:       yast2-packager >= 3.3.7

--- a/src/lib/y2partitioner/dialogs/bcache_csets.rb
+++ b/src/lib/y2partitioner/dialogs/bcache_csets.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "y2partitioner/dialogs/popup"
+require "y2partitioner/widgets/device_table_entry"
 require "y2partitioner/widgets/blk_devices_table"
 require "y2partitioner/widgets/columns"
 
@@ -58,13 +59,15 @@ module Y2Partitioner
 
       # Table for caching set devices
       class BcacheCsetsTable < Widgets::BlkDevicesTable
-        # Returns all caching set devices
+        # Returns entries for all caching set devices
         #
         # @see Widgets::BlkDevicesTable
         #
-        # @return [Array<Y2Storage::BcacheCset>]
-        def devices
-          DeviceGraphs.instance.current.bcache_csets
+        # @return [Array<DeviceTableEntry>]
+        def entries
+          DeviceGraphs.instance.current.bcache_csets.map do |dev|
+            Widgets::DeviceTableEntry.new(dev)
+          end
         end
 
         # Columns to show

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -42,12 +42,10 @@ module Y2Partitioner
       class DeviceTree
         attr_accessor :device
         attr_accessor :children
-        attr_accessor :status
 
-        def initialize(device, children: [], status: :open)
+        def initialize(device, children: [])
           @device = device
           @children = children
-          @status = status
         end
 
         def sid
@@ -98,16 +96,17 @@ module Y2Partitioner
       end
 
       def row_for(device)
-        d = device.is_a?(DeviceTree) ? device.device : device
-
-        row = [row_id(d)] + cols.map { |c| c.value_for(d) }
-
         if device.is_a?(DeviceTree)
-          row << device.children.map { |c| row_for(c) }
-          row << device.status
+          tree = device
+          device = device.device
+        else
+          tree = DeviceTree.new(device)
         end
 
-        row
+        values = cols.map { |c| c.value_for(device) }
+        children = tree.children.map { |c| row_for(c) }
+
+        item(row_id(device), values, children: children)
       end
 
       # LibYUI id to use for the row used to represent a device

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -64,7 +64,7 @@ module Y2Partitioner
 
       # Entry of the table that references the given sid or device, if any
       #
-      # @param device [Y2Storage::DevicePresenter, Integer] sid or a device presenter
+      # @param device [Y2Storage::Device, Integer] sid or a device presenter
       # @return [DeviceTableEntry, nil]
       def entry(device)
         return nil if device.nil?

--- a/src/lib/y2partitioner/widgets/columns/base.rb
+++ b/src/lib/y2partitioner/widgets/columns/base.rb
@@ -32,6 +32,10 @@ module Y2Partitioner
       #   * #title returning the column title.
       #   * #value_for(device) returning the content to display for the given device.
       #
+      # Additionally, if the subclass needs access to the information contained directly in the
+      # table entry, it can redefine {#entry_value} which in the base class is just a direct
+      # call to {#value_for} with the device of the entry as single argument.
+      #
       # @example
       #   class StorageId < Base
       #     def title
@@ -82,6 +86,14 @@ module Y2Partitioner
         #   @param device [Y2Storage::Device, Y2Storage::SimpleEtcFstabEntry]
         #   @return [String, Yast::Term]
         abstract_method :value_for
+
+        # The value to display for the given table entry
+        #
+        # @param entry [DeviceTableEntry]
+        # @return [String, Yast::Term]
+        def entry_value(entry)
+          value_for(entry.device)
+        end
 
         # Convenience method to internally identify the column
         #

--- a/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
@@ -34,13 +34,13 @@ module Y2Partitioner
 
       # Constructor
       #
-      # @param devices [Array<Y2Storage::Device>]
+      # @param entries [Array<DeviceTableEntry>]
       # @param pager [CWM::TreePager]
       # @param buttons_set [DeviceButtonsSet]
-      def initialize(devices, pager, buttons_set = nil)
+      def initialize(entries, pager, buttons_set = nil)
         textdomain "storage"
 
-        @devices = devices
+        @entries = entries
         @pager = pager
         @buttons_set = buttons_set
       end
@@ -58,7 +58,8 @@ module Y2Partitioner
 
         # if we do not have valid sid, then pick first available device.
         # Reason is to allow e.g. chain of delete like described in bsc#1076318
-        self.value = row_id(valid_sid?(initial_sid) ? initial_sid : devices.first)
+        entry = entry(initial_sid) || entries.first
+        self.value = entry.row_id
         handle_selected
       end
 
@@ -169,8 +170,8 @@ module Y2Partitioner
       #   partitioner
       attr_reader :pager
 
-      # @return [Array<Y2Storage::Device>] list of devices to display
-      attr_reader :devices
+      # @return [Array<DeviceTableEntry>] list of devices to display
+      attr_reader :entries
 
       DEFAULT_COLUMNS = [
         Columns::Device,

--- a/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
@@ -170,7 +170,7 @@ module Y2Partitioner
       #   partitioner
       attr_reader :pager
 
-      # @return [Array<DeviceTableEntry>] list of devices to display
+      # @return [Array<DeviceTableEntry>] list of device entries to display
       attr_reader :entries
 
       DEFAULT_COLUMNS = [

--- a/src/lib/y2partitioner/widgets/device_table_entry.rb
+++ b/src/lib/y2partitioner/widgets/device_table_entry.rb
@@ -1,0 +1,120 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+module Y2Partitioner
+  module Widgets
+    # Class to represent each entry of a table of devices, including the device
+    # itself and all the corresponding nested entries (like the partitions of a
+    # given disk).
+    class DeviceTableEntry
+      # Device represented in this entry
+      # @return [Y2Storage::Device, Y2Storage::SimpleEtcFstabEntry]
+      attr_accessor :device
+
+      # Nested entries
+      #
+      # @return [Array<DeviceTableEntry>]
+      attr_reader :children
+
+      # Whether the device should be represented in the table using the full name
+      #
+      # When this is false, the device may be represented with the full name or
+      # with a short version, depending on the circumstances.
+      #
+      # @return [Boolean] true to enforce the usage of full name
+      def full_name?
+        !!@full_name
+      end
+
+      # Constructor
+      #
+      # @param device [Y2Storage::Device, Y2Storage::SimpleEtcFstabEntry] see #device
+      # @param children [Array<Y2Storage::Device, DeviceTableEntry>] for children
+      #   specified as a device, a {DeviceTableEntry} will be created honoring full_names
+      # @param full_names [Boolean] If true, #full_name? will be enforced for this entry
+      #   and also for all the children entries without an existing DeviceTableEntry
+      def initialize(device, children: [], full_names: false)
+        @device = device
+        @full_name = full_names
+
+        @children = children.map do |child|
+          if child.is_a?(DeviceTableEntry)
+            child
+          else
+            DeviceTableEntry.new(child, full_names: full_names)
+          end
+        end
+      end
+
+      # Device identifier of the referenced device, if any
+      #
+      # @return [Integer, nil] nil if the device is not part of the devicegraph
+      #   (ie. it's a {Y2Storage::SimpleEtcFstabEntry})
+      def sid
+        return nil unless device.respond_to?(:sid)
+
+        device.sid
+      end
+
+      # LibYUI id of the table row
+      #
+      # @return [String] row id for given device
+      def row_id
+        "table:device:#{id}"
+      end
+
+      # CWM table item to represent this entry in the table
+      #
+      # @return [CWM::TableItem]
+      def table_item(cols)
+        values = cols.map { |c| c.entry_value(self) }
+        sub_items = children.map { |c| c.table_item(cols) }
+
+        CWM::TableItem.new(row_id, values, children: sub_items)
+      end
+
+      # Collection including this entry and all its descendants
+      #
+      # @return [Array<DeviceTableEntry>]
+      def all_entries
+        @all_entries ||= [self] + children.flat_map(&:all_entries)
+      end
+
+      # Collection including the devices referenced by this entry and by all its
+      # descendant entries
+      #
+      # @return [Array<Y2Storage::Device, Y2Storage::SimpleEtcFstabEntry>]
+      def all_devices
+        all_entries.map(&:device)
+      end
+
+      protected
+
+      # Identifier for the entry
+      #
+      # @return [Integer]
+      def id
+        # Y2Storage::SimpleEtcFstabEntry does not respond to #sid method
+        sid || device.object_id
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/devices_selection.rb
+++ b/src/lib/y2partitioner/widgets/devices_selection.rb
@@ -20,6 +20,7 @@
 require "yast"
 require "cwm/widget"
 require "cwm/table"
+require "y2partitioner/widgets/device_table_entry"
 require "y2partitioner/widgets/blk_devices_table"
 require "y2partitioner/widgets/columns"
 
@@ -249,8 +250,8 @@ module Y2Partitioner
 
       # Table part of the widget
       class DevicesTable < BlkDevicesTable
-        # @return [Array<Y2Storage::BlkDevice>] devices in the table
-        attr_accessor :devices
+        # @return [Array<DeviceTableEntry>] entries in the table
+        attr_accessor :entries
 
         # @return [String] id of the widget in Libyui
         attr_reader :widget_id
@@ -258,7 +259,12 @@ module Y2Partitioner
         def initialize(devices, widget_id)
           textdomain "storage"
           @widget_id = widget_id.to_s
-          @devices = devices
+          self.devices = devices
+        end
+
+        # @param devices [Array<Y2Storage::BlkDevice]
+        def devices=(devices)
+          @entries = devices.map { |dev| DeviceTableEntry.new(dev, full_names: true) }
         end
 
         # @macro seeAbstractWidget
@@ -274,11 +280,6 @@ module Y2Partitioner
             Columns::Encrypted,
             Columns::Type
           ]
-        end
-
-        # @see BlkDevicesTable
-        def row_id(device)
-          "#{widget_id}:device:#{device.sid}"
         end
 
         # Updates the table content ensuring the selected rows remain selected

--- a/src/lib/y2partitioner/widgets/fstab_selector.rb
+++ b/src/lib/y2partitioner/widgets/fstab_selector.rb
@@ -21,6 +21,7 @@ require "yast"
 require "cwm/widget"
 require "yast2/popup"
 require "y2partitioner/device_graphs"
+require "y2partitioner/widgets/device_table_entry"
 require "y2partitioner/widgets/blk_devices_table"
 require "y2partitioner/widgets/columns"
 
@@ -257,23 +258,14 @@ module Y2Partitioner
         # BTRFS subvolume entries are not taken into account
         # (see {Y2Storage::Fstab#filesystem_entries}).
         #
-        # @return [Array<Y2Storage::SimpleEtcFstabEntry>]
-        def devices
-          fstab.filesystem_entries
+        # @return [Array<DeviceTableEntry]
+        def entries
+          fstab.filesystem_entries.map { |e| DeviceTableEntry.new(e) }
         end
 
         # @return [Y2Storage::Devicegraph]
         def system_graph
           DeviceGraphs.instance.system
-        end
-
-        # This method is redefined to use #object_id instead of #sid
-        #
-        # {Widgets::BlkDevicesTable} expects to have a {Y2Storage::BlkDevice} for each row,
-        # but in this case it has a {Y2Storage::SimpleEtcFstabEntry}, which does not respond
-        # to #sid method.
-        def row_id(entry)
-          "table:device:#{entry.object_id}"
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/overview_tab.rb
+++ b/src/lib/y2partitioner/widgets/overview_tab.rb
@@ -69,7 +69,7 @@ module Y2Partitioner
       #
       # @return [Array<Y2Storage::Device>]
       def devices
-        [DeviceTableEntry.new(device)]
+        [DeviceTableEntry.new_with_children(device)]
       end
 
       # Widget of the bar graph to display above the table

--- a/src/lib/y2partitioner/widgets/overview_tab.rb
+++ b/src/lib/y2partitioner/widgets/overview_tab.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "cwm/widget"
+require "y2partitioner/widgets/device_table_entry"
 require "y2partitioner/widgets/configurable_blk_devices_table"
 require "y2partitioner/widgets/disk_bar_graph"
 require "y2partitioner/widgets/device_buttons_set"
@@ -68,7 +69,7 @@ module Y2Partitioner
       #
       # @return [Array<Y2Storage::Device>]
       def devices
-        [device]
+        [DeviceTableEntry.new(device)]
       end
 
       # Widget of the bar graph to display above the table

--- a/src/lib/y2partitioner/widgets/overview_tab.rb
+++ b/src/lib/y2partitioner/widgets/overview_tab.rb
@@ -67,7 +67,7 @@ module Y2Partitioner
       # All devices to show in the table, it should include the main device and
       # its relevant descendants
       #
-      # @return [Array<Y2Storage::Device>]
+      # @return [Array<DeviceTableEntry>]
       def devices
         [DeviceTableEntry.new_with_children(device)]
       end

--- a/src/lib/y2partitioner/widgets/pages/base.rb
+++ b/src/lib/y2partitioner/widgets/pages/base.rb
@@ -19,6 +19,7 @@
 
 require "cwm/page"
 require "cwm/tree_pager"
+require "y2partitioner/widgets/device_table_entry"
 
 module Y2Partitioner
   module Widgets

--- a/src/lib/y2partitioner/widgets/pages/bcache.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcache.rb
@@ -77,9 +77,7 @@ module Y2Partitioner
         private
 
         def devices
-          [
-            BlkDevicesTable::DeviceTree.new(device, children: device.partitions)
-          ]
+          [DeviceTableEntry.new(device, children: device.partitions)]
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/bcache.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcache.rb
@@ -77,7 +77,9 @@ module Y2Partitioner
         private
 
         def devices
-          [device] + device.partitions
+          [
+            BlkDevicesTable::DeviceTree.new(device, children: device.partitions)
+          ]
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/bcache.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcache.rb
@@ -56,7 +56,7 @@ module Y2Partitioner
             VBox(
               Left(
                 Tabs.new(
-                  BcacheTab.new(device, @pager),
+                  OverviewTab.new(device, @pager),
                   BcacheUsedDevicesTab.new(device, @pager)
                 )
               )
@@ -69,15 +69,6 @@ module Y2Partitioner
         # @return [String]
         def section
           Bcaches.label
-        end
-      end
-
-      # A Tab for a Bcache description and its buttons
-      class BcacheTab < OverviewTab
-        private
-
-        def devices
-          [DeviceTableEntry.new(device, children: device.partitions)]
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -105,9 +105,8 @@ module Y2Partitioner
         #
         # @return [Array<Y2Storage::BlkDevice>]
         def devices
-          bcaches.each_with_object([]) do |bcache, devices|
-            devices << bcache
-            devices.concat(bcache.partitions)
+          bcaches.map do |bcache|
+            BlkDevicesTable::DeviceTree.new(bcache, children: bcache.partitions)
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -106,7 +106,7 @@ module Y2Partitioner
         # @return [Array<Y2Storage::BlkDevice>]
         def devices
           bcaches.map do |bcache|
-            DeviceTableEntry.new(bcache, children: bcache.partitions)
+            DeviceTableEntry.new_with_children(bcache)
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -103,7 +103,7 @@ module Y2Partitioner
 
         # Returns all bcache devices and their partitions
         #
-        # @return [Array<Y2Storage::BlkDevice>]
+        # @return [Array<DeviceTableEntry>]
         def devices
           bcaches.map do |bcache|
             DeviceTableEntry.new_with_children(bcache)

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -106,7 +106,7 @@ module Y2Partitioner
         # @return [Array<Y2Storage::BlkDevice>]
         def devices
           bcaches.map do |bcache|
-            BlkDevicesTable::DeviceTree.new(bcache, children: bcache.partitions)
+            DeviceTableEntry.new(bcache, children: bcache.partitions)
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
@@ -69,7 +69,7 @@ module Y2Partitioner
 
         # @return [ConfigurableBlkDevicesTable]
         def table
-          @table ||= BtrfsFilesystemsTable.new(filesystems, pager, device_buttons)
+          @table ||= BtrfsFilesystemsTable.new(entries, pager, device_buttons)
         end
 
         # Widget with the dynamic set of buttons for the selected row
@@ -77,6 +77,10 @@ module Y2Partitioner
         # @return [DeviceButtonsSet]
         def device_buttons
           @device_buttons ||= DeviceButtonsSet.new(pager)
+        end
+
+        def entries
+          filesystems.map { |fs| DeviceTableEntry.new(fs) }
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
@@ -80,7 +80,7 @@ module Y2Partitioner
         end
 
         def entries
-          filesystems.map { |fs| DeviceTableEntry.new(fs) }
+          filesystems.map { |fs| DeviceTableEntry.new_with_children(fs) }
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
@@ -79,6 +79,7 @@ module Y2Partitioner
           @device_buttons ||= DeviceButtonsSet.new(pager)
         end
 
+        # @return [Array<DeviceTableEntry>]
         def entries
           filesystems.map { |fs| DeviceTableEntry.new_with_children(fs) }
         end

--- a/src/lib/y2partitioner/widgets/pages/disk.rb
+++ b/src/lib/y2partitioner/widgets/pages/disk.rb
@@ -27,7 +27,7 @@ module Y2Partitioner
     module Pages
       # Page for a disk device (Disk, Dasd, BIOS RAID or Multipath).
       #
-      # This page contains a {DiskTab} and, in case of Multipath or BIOS RAID,
+      # This page contains an {OverviewTab} and, in case of Multipath or BIOS RAID,
       # also a {DiskUsedDevicesTab}.
       class Disk < Base
         # @return [Y2Storage::BlkDevice] Disk device this page is about
@@ -74,7 +74,7 @@ module Y2Partitioner
         # @return [Tabs]
         def tabs
           tabs = [
-            DiskTab.new(disk, @pager)
+            OverviewTab.new(disk, @pager)
           ]
 
           tabs << DiskUsedDevicesTab.new(disk, @pager) if used_devices_tab?
@@ -87,15 +87,6 @@ module Y2Partitioner
         # @return [Boolean]
         def used_devices_tab?
           disk.is?(:multipath, :dm_raid, :md)
-        end
-      end
-
-      # A Tab for disk device description
-      class DiskTab < OverviewTab
-        private
-
-        def devices
-          [DeviceTableEntry.new(device, children: device.partitions)]
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/disk.rb
+++ b/src/lib/y2partitioner/widgets/pages/disk.rb
@@ -95,9 +95,7 @@ module Y2Partitioner
         private
 
         def devices
-          [
-            BlkDevicesTable::DeviceTree.new(device, children: device.partitions)
-          ]
+          [DeviceTableEntry.new(device, children: device.partitions)]
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/disk.rb
+++ b/src/lib/y2partitioner/widgets/pages/disk.rb
@@ -95,7 +95,9 @@ module Y2Partitioner
         private
 
         def devices
-          [device] + device.partitions
+          [
+            BlkDevicesTable::DeviceTree.new(device, children: device.partitions)
+          ]
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/disks.rb
+++ b/src/lib/y2partitioner/widgets/pages/disks.rb
@@ -49,7 +49,7 @@ module Y2Partitioner
 
         # Returns all disks and their partitions
         #
-        # @return [Array<Y2Storage::BlkDevice>]
+        # @return [Array<DeviceTableEntry>]
         def devices
           disks.map do |disk|
             DeviceTableEntry.new_with_children(disk)

--- a/src/lib/y2partitioner/widgets/pages/disks.rb
+++ b/src/lib/y2partitioner/widgets/pages/disks.rb
@@ -52,8 +52,9 @@ module Y2Partitioner
         # @return [Array<Y2Storage::BlkDevice>]
         def devices
           disks.each_with_object([]) do |disk, devices|
-            devices << disk
-            devices.concat(disk.partitions) if disk.respond_to?(:partitions)
+            tree = BlkDevicesTable::DeviceTree.new(disk)
+            tree.children = disk.partitions if disk.respond_to?(:partitions)
+            devices << tree
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/disks.rb
+++ b/src/lib/y2partitioner/widgets/pages/disks.rb
@@ -52,9 +52,8 @@ module Y2Partitioner
         # @return [Array<Y2Storage::BlkDevice>]
         def devices
           disks.each_with_object([]) do |disk, devices|
-            tree = BlkDevicesTable::DeviceTree.new(disk)
-            tree.children = disk.partitions if disk.respond_to?(:partitions)
-            devices << tree
+            children = disk.respond_to?(:partitions) ? disk.partitions : []
+            devices << DeviceTableEntry.new(disk, children: children)
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/disks.rb
+++ b/src/lib/y2partitioner/widgets/pages/disks.rb
@@ -51,9 +51,8 @@ module Y2Partitioner
         #
         # @return [Array<Y2Storage::BlkDevice>]
         def devices
-          disks.each_with_object([]) do |disk, devices|
-            children = disk.respond_to?(:partitions) ? disk.partitions : []
-            devices << DeviceTableEntry.new(disk, children: children)
+          disks.map do |disk|
+            DeviceTableEntry.new_with_children(disk)
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/lvm.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm.rb
@@ -69,7 +69,7 @@ module Y2Partitioner
         # @return [Array<Y2Storage::LvmVg, Y2Storage::LvmLv>]
         def devices
           device_graph.lvm_vgs.map do |vg|
-            BlkDevicesTable::DeviceTree.new(vg, children: vg.all_lvm_lvs)
+            DeviceTableEntry.new(vg, children: vg.all_lvm_lvs)
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/lvm.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm.rb
@@ -66,7 +66,7 @@ module Y2Partitioner
         #
         # @see Y2Storage::LvmVg#all_lvm_lvs
         #
-        # @return [Array<Y2Storage::LvmVg, Y2Storage::LvmLv>]
+        # @return [Array<DeviceTableEntry>]
         def devices
           device_graph.lvm_vgs.map do |vg|
             DeviceTableEntry.new_with_children(vg)

--- a/src/lib/y2partitioner/widgets/pages/lvm.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm.rb
@@ -69,7 +69,7 @@ module Y2Partitioner
         # @return [Array<Y2Storage::LvmVg, Y2Storage::LvmLv>]
         def devices
           device_graph.lvm_vgs.map do |vg|
-            DeviceTableEntry.new(vg, children: vg.all_lvm_lvs)
+            DeviceTableEntry.new_with_children(vg)
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/lvm.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm.rb
@@ -68,9 +68,8 @@ module Y2Partitioner
         #
         # @return [Array<Y2Storage::LvmVg, Y2Storage::LvmLv>]
         def devices
-          device_graph.lvm_vgs.reduce([]) do |devices, vg|
-            devices << vg
-            devices.concat(vg.all_lvm_lvs)
+          device_graph.lvm_vgs.map do |vg|
+            BlkDevicesTable::DeviceTree.new(vg, children: vg.all_lvm_lvs)
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
@@ -106,7 +106,9 @@ module Y2Partitioner
         #
         # @return [Array<Y2Storage::LvmVg, Y2Storage::LvmLv>]
         def devices
-          [device] + device.all_lvm_lvs
+          [
+            BlkDevicesTable::DeviceTree.new(device, children: device.all_lvm_lvs)
+          ]
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
@@ -98,16 +98,6 @@ module Y2Partitioner
         def bar_graph
           LvmVgBarGraph.new(device)
         end
-
-        # Returns all logical volumes of a volume group, including thin pools
-        # and thin volumes. Note that it also includes the Volume Group.
-        #
-        # @see Y2Storage::LvmVg#all_lvm_lvs
-        #
-        # @return [Array<Y2Storage::LvmVg, Y2Storage::LvmLv>]
-        def devices
-          [DeviceTableEntry.new(device, children: device.all_lvm_lvs)]
-        end
       end
 
       # A Tab for the LVM physical volumes of a volume group

--- a/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
@@ -106,9 +106,7 @@ module Y2Partitioner
         #
         # @return [Array<Y2Storage::LvmVg, Y2Storage::LvmLv>]
         def devices
-          [
-            BlkDevicesTable::DeviceTree.new(device, children: device.all_lvm_lvs)
-          ]
+          [DeviceTableEntry.new(device, children: device.all_lvm_lvs)]
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/md_raid.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raid.rb
@@ -79,9 +79,7 @@ module Y2Partitioner
         private
 
         def devices
-          [
-            BlkDevicesTable::DeviceTree.new(device, children: device.partitions)
-          ]
+          [DeviceTableEntry.new(device, children: device.partitions)]
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/md_raid.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raid.rb
@@ -28,7 +28,7 @@ require "y2partitioner/widgets/overview_tab"
 module Y2Partitioner
   module Widgets
     module Pages
-      # A Page for a md raid device: contains {MdTab} and {MdUsedDevicesTab}
+      # A Page for a md raid device: contains {OverviewTab} and {MdUsedDevicesTab}
       class MdRaid < Base
         # Constructor
         #
@@ -58,7 +58,7 @@ module Y2Partitioner
             VBox(
               Left(
                 Tabs.new(
-                  MdTab.new(@md, @pager, initial: true),
+                  OverviewTab.new(@md, @pager, initial: true),
                   MdUsedDevicesTab.new(@md, @pager)
                 )
               )
@@ -71,15 +71,6 @@ module Y2Partitioner
         # @return [String]
         def section
           MdRaids.label
-        end
-      end
-
-      # A Tab for a Software RAID description
-      class MdTab < OverviewTab
-        private
-
-        def devices
-          [DeviceTableEntry.new(device, children: device.partitions)]
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/md_raid.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raid.rb
@@ -79,7 +79,9 @@ module Y2Partitioner
         private
 
         def devices
-          [device] + device.partitions
+          [
+            BlkDevicesTable::DeviceTree.new(device, children: device.partitions)
+          ]
         end
       end
 

--- a/src/lib/y2partitioner/widgets/pages/md_raids.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raids.rb
@@ -63,7 +63,7 @@ module Y2Partitioner
 
         # Returns all Software RAIDs and its partitions
         #
-        # @return [Array<Y2Storage::Md>]
+        # @return [Array<DeviceTableEntry>]
         def devices
           devicegraph = DeviceGraphs.instance.current
           devicegraph.software_raids.map do |raid|

--- a/src/lib/y2partitioner/widgets/pages/md_raids.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raids.rb
@@ -66,9 +66,8 @@ module Y2Partitioner
         # @return [Array<Y2Storage::Md>]
         def devices
           devicegraph = DeviceGraphs.instance.current
-          devicegraph.software_raids.each_with_object([]) do |raid, devices|
-            devices << raid
-            devices.concat(raid.partitions)
+          devicegraph.software_raids.map do |raid|
+            BlkDevicesTable::DeviceTree.new(raid, children: raid.partitions)
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/md_raids.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raids.rb
@@ -67,7 +67,7 @@ module Y2Partitioner
         def devices
           devicegraph = DeviceGraphs.instance.current
           devicegraph.software_raids.map do |raid|
-            BlkDevicesTable::DeviceTree.new(raid, children: raid.partitions)
+            DeviceTableEntry.new(raid, children: raid.partitions)
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/md_raids.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raids.rb
@@ -67,7 +67,7 @@ module Y2Partitioner
         def devices
           devicegraph = DeviceGraphs.instance.current
           devicegraph.software_raids.map do |raid|
-            DeviceTableEntry.new(raid, children: raid.partitions)
+            DeviceTableEntry.new_with_children(raid)
           end
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -110,9 +110,8 @@ module Y2Partitioner
           # Since XEN virtual partitions are listed at the end of the "Hard
           # Disks" section, let's do the same in the general storage table
           all = device_graph.disk_devices + device_graph.stray_blk_devices
-          all.each_with_object([]) do |disk, devices|
-            children = disk.respond_to?(:partitions) ? disk.partitions : []
-            devices << DeviceTableEntry.new(disk, children: children)
+          all.map do |disk|
+            DeviceTableEntry.new_with_children(disk)
           end
         end
 
@@ -124,14 +123,14 @@ module Y2Partitioner
         # @return [Array<Y2Storage::LvmVg, Y2Storage::LvmLv>]
         def lvm_vgs
           device_graph.lvm_vgs.map do |vg|
-            DeviceTableEntry.new(vg, children: vg.all_lvm_lvs)
+            DeviceTableEntry.new_with_children(vg)
           end
         end
 
         # @return [Array<Y2Storage::Device>]
         def software_raids
           device_graph.software_raids.map do |raid|
-            DeviceTableEntry.new(raid, children: raid.partitions)
+            DeviceTableEntry.new_with_children(raid)
           end
         end
 
@@ -145,14 +144,14 @@ module Y2Partitioner
         # @return [Array<Y2Storage::Device>]
         def bcaches
           device_graph.bcaches.map do |bcache|
-            DeviceTableEntry.new(bcache, children: bcache.partitions)
+            DeviceTableEntry.new_with_children(bcache)
           end
         end
 
         # @return [Array<Y2Storage::Filesystems::Base>]
         def multidevice_filesystems
           device_graph.blk_filesystems.select(&:multidevice?).map do |fs|
-            DeviceTableEntry.new(fs)
+            DeviceTableEntry.new_with_children(fs)
           end
         end
 

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -105,7 +105,7 @@ module Y2Partitioner
           disk_devices + software_raids + lvm_vgs + nfs_devices + bcaches + multidevice_filesystems
         end
 
-        # @return [Array<Y2Storage::Device>]
+        # @return [Array<DeviceTableEntry>]
         def disk_devices
           # Since XEN virtual partitions are listed at the end of the "Hard
           # Disks" section, let's do the same in the general storage table
@@ -120,35 +120,35 @@ module Y2Partitioner
         #
         # @see Y2Storage::LvmVg#all_lvm_lvs
         #
-        # @return [Array<Y2Storage::LvmVg, Y2Storage::LvmLv>]
+        # @return [Array<DeviceTableEntry>]
         def lvm_vgs
           device_graph.lvm_vgs.map do |vg|
             DeviceTableEntry.new_with_children(vg)
           end
         end
 
-        # @return [Array<Y2Storage::Device>]
+        # @return [Array<DeviceTableEntry>]
         def software_raids
           device_graph.software_raids.map do |raid|
             DeviceTableEntry.new_with_children(raid)
           end
         end
 
-        # @return [Array<Y2Storage::Device>]
+        # @return [Array<DeviceTableEntry>]
         def nfs_devices
           device_graph.nfs_mounts.map do |nfs|
             DeviceTableEntry.new(nfs)
           end
         end
 
-        # @return [Array<Y2Storage::Device>]
+        # @return [Array<DeviceTableEntry>]
         def bcaches
           device_graph.bcaches.map do |bcache|
             DeviceTableEntry.new_with_children(bcache)
           end
         end
 
-        # @return [Array<Y2Storage::Filesystems::Base>]
+        # @return [Array<DeviceTableEntry>]
         def multidevice_filesystems
           device_graph.blk_filesystems.select(&:multidevice?).map do |fs|
             DeviceTableEntry.new_with_children(fs)

--- a/src/lib/y2partitioner/widgets/used_devices_tab.rb
+++ b/src/lib/y2partitioner/widgets/used_devices_tab.rb
@@ -19,6 +19,7 @@
 
 require "cwm/widget"
 require "y2partitioner/widgets/configurable_blk_devices_table"
+require "y2partitioner/widgets/device_table_entry"
 require "y2partitioner/widgets/columns"
 
 module Y2Partitioner
@@ -66,7 +67,7 @@ module Y2Partitioner
       def table
         return @table unless @table.nil?
 
-        @table = ConfigurableBlkDevicesTable.new(devices, @pager)
+        @table = ConfigurableBlkDevicesTable.new(entries, @pager)
         @table.show_columns(*columns)
         @table
       end
@@ -81,11 +82,12 @@ module Y2Partitioner
         ]
       end
 
-      # Devices to show in the table. It includes the device and all its used devices.
+      # Entries to show in the table. Typically one for the device with its used
+      # devices as children entries.
       #
-      # @return [Array<Device>]
-      def devices
-        [device] + used_devices
+      # @return [Array<DeviceTableEntry>]
+      def entries
+        [DeviceTableEntry.new(device, children: used_devices, full_names: true)]
       end
 
       # Devices considered as used by the device

--- a/test/y2partitioner/dialogs/bcache_csets_test.rb
+++ b/test/y2partitioner/dialogs/bcache_csets_test.rb
@@ -61,7 +61,7 @@ describe Y2Partitioner::Dialogs::BcacheCsets do
 
     describe "#items" do
       it "contains all the Bcache Caching Sets" do
-        devices = subject.items.map { |i| i[1] }
+        devices = column_values(subject, 0)
 
         expect(devices).to contain_exactly("/dev/vdb", "/dev/vda1")
       end

--- a/test/y2partitioner/test_helper.rb
+++ b/test/y2partitioner/test_helper.rb
@@ -43,3 +43,30 @@ def remove_sort_keys(value)
 
   value
 end
+
+# Content of the given table, with each row represented as an array of values
+#
+# @param table [CWM::Table]
+# @return [Array<Array>]
+def table_values(table)
+  table.items.flat_map { |i| table_item_values(i) }
+end
+
+# All values for the given column of a table
+#
+# @param table [CWM::Table]
+# @param index [Integer] position of the column in the table
+# @return [Array]
+def column_values(table, index)
+  table_values(table).map { |p| p[index] }
+end
+
+# @see #table_values
+def table_item_values(item)
+  return [remove_sort_keys(item)] if item.is_a?(Array)
+
+  [
+    remove_sort_keys(item.values),
+    *item.children.flat_map { |i| table_item_values(i) }
+  ]
+end

--- a/test/y2partitioner/widgets/btrfs_devices_selector_test.rb
+++ b/test/y2partitioner/widgets/btrfs_devices_selector_test.rb
@@ -45,8 +45,8 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
     available_devices_names - selected_devices_names
   end
 
-  let(:selected_items) { selected_table.items }
-  let(:unselected_items) { unselected_table.items }
+  let(:selected_items) { table_values(selected_table) }
+  let(:unselected_items) { table_values(unselected_table) }
   let(:expected_selected_items) { selected_devices_names.map { |device_name| "^#{device_name}$" } }
   let(:expected_unselected_items) { unselected_devices_names.map { |device_name| "^#{device_name}$" } }
 
@@ -63,11 +63,11 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
   context "right after initialization" do
     describe "#contents" do
       it "displays all the unselected devices in the corresponding table" do
-        expect(rows_match?(remove_sort_keys(unselected_items), *expected_unselected_items)).to eq true
+        expect(rows_match?(unselected_items, *expected_unselected_items)).to eq true
       end
 
       it "displays all the selected devices in the corresponding table" do
-        expect(rows_match?(remove_sort_keys(selected_items), *expected_selected_items)).to eq true
+        expect(rows_match?(selected_items, *expected_selected_items)).to eq true
       end
     end
   end
@@ -91,7 +91,7 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
 
     describe "#contents" do
       it "displays all the selected devices in the corresponding table" do
-        expect(rows_match?(remove_sort_keys(selected_items), *expected_selected_items)).to eq true
+        expect(rows_match?(selected_items, *expected_selected_items)).to eq true
       end
 
       it "displays none device as unselected" do
@@ -126,11 +126,11 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
         end
 
         it "displays all the selected devices in the corresponding table" do
-          expect(rows_match?(remove_sort_keys(selected_items), *expected_selected_items)).to eq true
+          expect(rows_match?(selected_items, *expected_selected_items)).to eq true
         end
 
         it "displays all the available devices in the corresponding table" do
-          expect(rows_match?(remove_sort_keys(unselected_items), *expected_unselected_items)).to eq true
+          expect(rows_match?(unselected_items, *expected_unselected_items)).to eq true
         end
       end
     end
@@ -159,7 +159,7 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
       end
 
       it "displays all the available devices as unselected" do
-        expect(rows_match?(remove_sort_keys(unselected_items), *expected_unselected_items)).to eq true
+        expect(rows_match?(unselected_items, *expected_unselected_items)).to eq true
       end
     end
   end
@@ -190,11 +190,11 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
         end
 
         it "displays all the selected devices in the corresponding table and order" do
-          expect(rows_match?(remove_sort_keys(selected_items), *expected_selected_items)).to eq true
+          expect(rows_match?(selected_items, *expected_selected_items)).to eq true
         end
 
         it "displays all the available devices in the corresponding table and order" do
-          expect(rows_match?(remove_sort_keys(unselected_items), *expected_unselected_items)).to eq true
+          expect(rows_match?(unselected_items, *expected_unselected_items)).to eq true
         end
       end
     end
@@ -222,13 +222,13 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
         it "displays all the selected devices in the corresponding table" do
           expected_items = expected_selected_items.reject { |item| item.include?(device_name) }
 
-          expect(rows_match?(remove_sort_keys(selected_items), *expected_items)).to eq true
+          expect(rows_match?(selected_items, *expected_items)).to eq true
         end
 
         it "displays all the available devices in the corresponding" do
           expected_items = expected_unselected_items.append("#{device_name}$")
 
-          expect(rows_match?(remove_sort_keys(unselected_items), *expected_items)).to eq true
+          expect(rows_match?(unselected_items, *expected_items)).to eq true
         end
       end
     end

--- a/test/y2partitioner/widgets/btrfs_filesystems_table_test.rb
+++ b/test/y2partitioner/widgets/btrfs_filesystems_table_test.rb
@@ -21,6 +21,7 @@
 require_relative "../test_helper"
 
 require "cwm/rspec"
+require "y2partitioner/widgets/device_table_entry"
 require "y2partitioner/widgets/btrfs_filesystems_table"
 
 describe Y2Partitioner::Widgets::BtrfsFilesystemsTable do
@@ -30,9 +31,10 @@ describe Y2Partitioner::Widgets::BtrfsFilesystemsTable do
 
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
 
-  subject { described_class.new(filesystems, pager) }
+  subject { described_class.new(entries, pager) }
 
   let(:filesystems) { device_graph.btrfs_filesystems }
+  let(:entries) { filesystems.map { |fs| Y2Partitioner::Widgets::DeviceTableEntry.new(fs) } }
 
   let(:pager) { double("Pager") }
 

--- a/test/y2partitioner/widgets/lvm_devices_table_test.rb
+++ b/test/y2partitioner/widgets/lvm_devices_table_test.rb
@@ -21,6 +21,7 @@
 require_relative "../test_helper"
 
 require "cwm/rspec"
+require "y2partitioner/widgets/device_table_entry"
 require "y2partitioner/widgets/lvm_devices_table"
 
 describe Y2Partitioner::Widgets::LvmDevicesTable do
@@ -30,9 +31,12 @@ describe Y2Partitioner::Widgets::LvmDevicesTable do
 
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
 
-  subject { described_class.new(devices, pager) }
+  subject { described_class.new(entries, pager) }
 
   let(:devices) { device_graph.lvm_vgs }
+  let(:entries) do
+    devices.map { |d| Y2Partitioner::Widgets::DeviceTableEntry.new_with_children(d) }
+  end
 
   let(:pager) { double("Pager") }
 
@@ -46,9 +50,9 @@ describe Y2Partitioner::Widgets::LvmDevicesTable do
   end
 
   describe "#items" do
-    it "returns array of arrays" do
+    it "returns array of CWM table items" do
       expect(subject.items).to be_a(::Array)
-      expect(subject.items.first).to be_a(::Array)
+      expect(subject.items.first).to be_a(CWM::TableItem)
     end
   end
 end

--- a/test/y2partitioner/widgets/lvm_vg_devices_selector_test.rb
+++ b/test/y2partitioner/widgets/lvm_vg_devices_selector_test.rb
@@ -52,16 +52,16 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
   context "right after initialization" do
     describe "#contents" do
       it "displays all the unselected devices in the corresponding table" do
-        items = unselected_table.items
+        items = table_values(unselected_table)
         expect(items.size).to eq(4)
         names = ["^/dev/sdb$", "^/dev/sda3$", "^/dev/sda4$", "^/dev/sde3$"]
-        expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
+        expect(rows_match?(items, *names)).to eq(true)
       end
 
       it "displays all the selected devices in the corresponding table and order" do
-        items = selected_table.items
+        items = table_values(selected_table)
         expect(items.size).to eq(2)
-        expect(rows_match?(remove_sort_keys(items), "^/dev/sdc$", "^/dev/sda2$")).to eq(true)
+        expect(rows_match?(items, "^/dev/sdc$", "^/dev/sda2$")).to eq(true)
       end
     end
   end
@@ -87,7 +87,7 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
       before { widget.handle(event) }
 
       it "displays all the selected devices in the corresponding table" do
-        items = selected_table.items
+        items = table_values(selected_table)
         expect(items.size).to eq(6)
         names = ["/dev/sdb$", "/dev/sdc$", "/dev/sda2$", "/dev/sda3$", "/dev/sda4$", "/dev/sde3$"]
         expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
@@ -124,14 +124,14 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
         before { widget.handle(event) }
 
         it "displays all the selected devices in the corresponding table" do
-          items = selected_table.items
+          items = table_values(selected_table)
           expect(items.size).to eq(2)
           names = ["/dev/sdc$", "/dev/sda2$"]
           expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
         end
 
         it "displays all the available devices in the corresponding table" do
-          items = unselected_table.items
+          items = table_values(unselected_table)
           expect(items.size).to eq(4)
           names = ["/dev/sdb$", "/dev/sda3$", "/dev/sda4$", "/dev/sde3$"]
           expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
@@ -160,14 +160,14 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
         before { widget.handle(event) }
 
         it "displays all the selected devices in the corresponding table" do
-          items = selected_table.items
+          items = table_values(selected_table)
           expect(items.size).to eq(3)
           names = ["/dev/sdc$", "/dev/sda2$", "/dev/sda3$"]
           expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
         end
 
         it "displays all the available devices in the corresponding table" do
-          items = unselected_table.items
+          items = table_values(unselected_table)
           expect(items.size).to eq(3)
           names = ["/dev/sdb$", "/dev/sda4$", "/dev/sde3$"]
           expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
@@ -227,14 +227,14 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
       let(:vg) { Y2Storage::LvmVg.find_by_vg_name(current_graph, "vg0") }
 
       it "does not display the removed devices in the 'selected' table" do
-        items = selected_table.items
+        items = table_values(selected_table)
         expect(items.size).to eq(2)
         names = ["/dev/sdd$", "/dev/sde1$"]
         expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
       end
 
       it "displays all the available devices in the 'unselected' table" do
-        items = unselected_table.items
+        items = table_values(unselected_table)
         expect(items.size).to eq 6
         names = ["/dev/sdb$", "/dev/sdc$", "/dev/sda2$", "/dev/sda3$", "/dev/sda4$", "/dev/sde3$"]
         expect(rows_match?(remove_sort_keys(items), *names)).to eq true
@@ -266,14 +266,14 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
         before { widget.handle(event) }
 
         it "displays all the selected devices in the corresponding table" do
-          items = selected_table.items
+          items = table_values(selected_table)
           expect(items.size).to eq(2)
           names = ["/dev/sdc$", "/dev/sda2$"]
           expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
         end
 
         it "displays all the available devices in the corresponding table" do
-          items = unselected_table.items
+          items = table_values(unselected_table)
           expect(items.size).to eq(4)
           names = ["/dev/sdb$", "/dev/sda3$", "/dev/sda4$", "/dev/sde3$"]
           expect(rows_match?(remove_sort_keys(items), *names)).to eq(true)
@@ -307,14 +307,14 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
           before { widget.handle(event) }
 
           it "displays all the selected devices in the corresponding table" do
-            items = selected_table.items
+            items = table_values(selected_table)
             expect(items.size).to eq(3)
             names = ["/dev/sdc$", "/dev/sdd$", "/dev/sde1$"]
             expect(rows_match?(remove_sort_keys(items), *names)).to eq true
           end
 
           it "displays all the available devices in the corresponding table" do
-            items = unselected_table.items
+            items = table_values(unselected_table)
             expect(items.size).to eq(5)
             names = ["/dev/sdb$", "/dev/sda2$", "/dev/sda3$", "/dev/sda4$", "/dev/sde3$"]
             expect(rows_match?(remove_sort_keys(items), *names)).to eq true
@@ -348,14 +348,14 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
           before { widget.handle(event) }
 
           it "displays all the selected devices in the corresponding table" do
-            items = selected_table.items
+            items = table_values(selected_table)
             expect(items.size).to eq(4)
             names = ["/dev/sda2$", "/dev/sdc$", "/dev/sdd$", "/dev/sde1$"]
             expect(rows_match?(remove_sort_keys(items), *names)).to eq true
           end
 
           it "displays all the available devices in the corresponding table" do
-            items = unselected_table.items
+            items = table_values(unselected_table)
             expect(items.size).to eq(4)
             names = ["/dev/sdb$", "/dev/sda3$", "/dev/sda4$", "/dev/sde3$"]
             expect(rows_match?(remove_sort_keys(items), *names)).to eq true

--- a/test/y2partitioner/widgets/md_devices_selector_test.rb
+++ b/test/y2partitioner/widgets/md_devices_selector_test.rb
@@ -44,14 +44,14 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
   context "right after initialization" do
     describe "#contents" do
       it "displays all the unselected devices in the corresponding table" do
-        items = unselected_table.items
-        expect(rows_match?(remove_sort_keys(items), "^/dev/sda2$", "^/dev/sda4$", "^/dev/sdb$",
+        items = table_values(unselected_table)
+        expect(rows_match?(items, "^/dev/sda2$", "^/dev/sda4$", "^/dev/sdb$",
           "^/dev/sdc$")).to eq true
       end
 
       it "displays all the selected devices in the corresponding table and order" do
-        items = selected_table.items
-        expect(rows_match?(remove_sort_keys(items), "^/dev/sde3$", "^/dev/sda3$")).to eq true
+        items = table_values(selected_table)
+        expect(rows_match?(items, "^/dev/sde3$", "^/dev/sda3$")).to eq true
       end
     end
   end
@@ -77,14 +77,14 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
       before { widget.handle(event) }
 
       it "displays all the selected devices in the corresponding table" do
-        items = selected_table.items
+        items = table_values(selected_table)
         expect(items.size).to eq 6
         names = ["/dev/sde3$", "/dev/sda3$", "/dev/sda2$", "/dev/sda4$", "/dev/sdb$", "/dev/sdc$"]
-        expect(rows_match?(remove_sort_keys(items), *names)).to eq true
+        expect(rows_match?(items, *names)).to eq true
       end
 
       it "displays no unselected devices" do
-        items = unselected_table.items
+        items = table_values(unselected_table)
         expect(items).to be_empty
       end
     end
@@ -113,13 +113,13 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
         before { widget.handle(event) }
 
         it "displays all the selected devices in the corresponding table and order" do
-          items = selected_table.items
-          expect(rows_match?(remove_sort_keys(items), "/dev/sde3$", "/dev/sda3$")).to eq true
+          items = table_values(selected_table)
+          expect(rows_match?(items, "/dev/sde3$", "/dev/sda3$")).to eq true
         end
 
         it "displays all the available devices in the corresponding table and order" do
-          items = unselected_table.items
-          expect(rows_match?(remove_sort_keys(items), "/dev/sda2$", "/dev/sda4$", "/dev/sdb$",
+          items = table_values(unselected_table)
+          expect(rows_match?(items, "/dev/sda2$", "/dev/sda4$", "/dev/sdb$",
             "/dev/sdc$")).to eq true
         end
       end
@@ -146,16 +146,16 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
         before { widget.handle(event) }
 
         it "displays all the selected devices in the corresponding table and order" do
-          items = selected_table.items
+          items = table_values(selected_table)
           expect(items.size).to eq 3
-          expect(rows_match?(remove_sort_keys(items), "/dev/sde3$", "/dev/sda3$",
+          expect(rows_match?(items, "/dev/sde3$", "/dev/sda3$",
             "/dev/sda2$")).to eq true
         end
 
         it "displays all the available devices in the corresponding table" do
-          items = unselected_table.items
+          items = table_values(unselected_table)
           expect(items.size).to eq 3
-          expect(rows_match?(remove_sort_keys(items), "/dev/sda4$", "/dev/sdb", "/dev/sdc")).to eq true
+          expect(rows_match?(items, "/dev/sda4$", "/dev/sdb", "/dev/sdc")).to eq true
         end
       end
     end
@@ -182,15 +182,15 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
       before { widget.handle(event) }
 
       it "displays no selected devices" do
-        items = selected_table.items
+        items = table_values(selected_table)
         expect(items).to be_empty
       end
 
       it "displays all the available devices in the corresponding table and order" do
-        items = unselected_table.items
+        items = table_values(unselected_table)
         expect(items.size).to eq 6
         names = ["/dev/sda2$", "/dev/sda3$", "/dev/sda4$", "/dev/sdb$", "/dev/sdc$", "/dev/sde3$"]
-        expect(rows_match?(remove_sort_keys(items), *names)).to eq true
+        expect(rows_match?(items, *names)).to eq true
       end
     end
   end
@@ -218,13 +218,13 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
         before { widget.handle(event) }
 
         it "displays all the selected devices in the corresponding table and order" do
-          items = selected_table.items
-          expect(rows_match?(remove_sort_keys(items), "/dev/sde3$", "/dev/sda3$")).to eq true
+          items = table_values(selected_table)
+          expect(rows_match?(items, "/dev/sde3$", "/dev/sda3$")).to eq true
         end
 
         it "displays all the available devices in the corresponding table and order" do
-          items = unselected_table.items
-          expect(rows_match?(remove_sort_keys(items), "/dev/sda2$", "/dev/sda4$", "/dev/sdb$",
+          items = table_values(unselected_table)
+          expect(rows_match?(items, "/dev/sda2$", "/dev/sda4$", "/dev/sdb$",
             "/dev/sdc$")).to eq true
         end
       end
@@ -251,13 +251,13 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
         before { widget.handle(event) }
 
         it "displays all the selected devices in the corresponding table" do
-          items = selected_table.items
-          expect(rows_match?(remove_sort_keys(items), "/dev/sde3$")).to eq true
+          items = table_values(selected_table)
+          expect(rows_match?(items, "/dev/sde3$")).to eq true
         end
 
         it "displays all the available devices in the corresponding table and order" do
-          items = unselected_table.items
-          expect(rows_match?(remove_sort_keys(items), "/dev/sda2$", "/dev/sda3$",
+          items = table_values(unselected_table)
+          expect(rows_match?(items, "/dev/sda2$", "/dev/sda3$",
             "/dev/sda4$")).to eq true
         end
       end
@@ -296,7 +296,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "keeps displaying all the selected devices in the corresponding table and order" do
             names = ["/dev/sde3$", "/dev/sda3$", "/dev/sda2$", "/dev/sda4$"]
-            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
+            expect(rows_match?(table_values(selected_table), *names)).to eq true
           end
         end
       end
@@ -320,7 +320,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "displays all the selected devices in the corresponding table and order" do
             names = ["/dev/sda3$", "/dev/sde3$", "/dev/sda4$", "/dev/sda2$"]
-            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
+            expect(rows_match?(table_values(selected_table), *names)).to eq true
           end
         end
       end
@@ -348,7 +348,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "keeps displaying all the selected devices in the corresponding table and order" do
             names = ["/dev/sde3$", "/dev/sda3$", "/dev/sda2$", "/dev/sda4$"]
-            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
+            expect(rows_match?(table_values(selected_table), *names)).to eq true
           end
         end
       end
@@ -370,7 +370,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "displays all the selected devices in the corresponding table and order" do
             names = ["/dev/sde3$", "/dev/sda2$", "/dev/sda3$", "/dev/sda4$"]
-            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
+            expect(rows_match?(table_values(selected_table), *names)).to eq true
           end
         end
       end
@@ -398,7 +398,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "keeps displaying all the selected devices in the corresponding table and order" do
             names = ["/dev/sde3$", "/dev/sda3$", "/dev/sda2$", "/dev/sda4$"]
-            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
+            expect(rows_match?(table_values(selected_table), *names)).to eq true
           end
         end
       end
@@ -422,7 +422,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "displays all the selected devices in the corresponding table and order" do
             names = ["/dev/sda3$", "/dev/sda4$", "/dev/sde3$", "/dev/sda2$"]
-            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
+            expect(rows_match?(table_values(selected_table), *names)).to eq true
           end
         end
       end
@@ -450,7 +450,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "keeps displaying all the selected devices in the corresponding table and order" do
             names = ["/dev/sde3$", "/dev/sda3$", "/dev/sda2$", "/dev/sda4$"]
-            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
+            expect(rows_match?(table_values(selected_table), *names)).to eq true
           end
         end
       end
@@ -472,7 +472,7 @@ describe Y2Partitioner::Widgets::MdDevicesSelector do
 
           it "displays all the selected devices in the corresponding table and order" do
             names = ["/dev/sda3$", "/dev/sda2$", "/dev/sda4$", "/dev/sde3$"]
-            expect(rows_match?(remove_sort_keys(selected_table.items), *names)).to eq true
+            expect(rows_match?(table_values(selected_table), *names)).to eq true
           end
         end
       end

--- a/test/y2partitioner/widgets/md_raids_table_test.rb
+++ b/test/y2partitioner/widgets/md_raids_table_test.rb
@@ -22,6 +22,7 @@
 require_relative "../test_helper"
 
 require "cwm/rspec"
+require "y2partitioner/widgets/device_table_entry"
 require "y2partitioner/widgets/md_raids_table"
 
 describe Y2Partitioner::Widgets::MdRaidsTable do
@@ -31,9 +32,12 @@ describe Y2Partitioner::Widgets::MdRaidsTable do
 
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
 
-  subject { described_class.new(devices, pager) }
+  subject { described_class.new(entries, pager) }
 
   let(:devices) { device_graph.md_raids }
+  let(:entries) do
+    devices.map { |d| Y2Partitioner::Widgets::DeviceTableEntry.new_with_children(d) }
+  end
 
   let(:pager) { double("Pager") }
 
@@ -47,9 +51,9 @@ describe Y2Partitioner::Widgets::MdRaidsTable do
   end
 
   describe "#items" do
-    it "returns array of arrays" do
+    it "returns array of CWM table items" do
       expect(subject.items).to be_a(::Array)
-      expect(subject.items.first).to be_a(::Array)
+      expect(subject.items.first).to be_a(CWM::TableItem)
     end
   end
 end

--- a/test/y2partitioner/widgets/overview_tab_test.rb
+++ b/test/y2partitioner/widgets/overview_tab_test.rb
@@ -1,0 +1,150 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/overview_tab"
+
+describe Y2Partitioner::Widgets::OverviewTab do
+  before { devicegraph_stub(scenario) }
+
+  let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+  let(:device) { current_graph.find_by_name(device_name) }
+  let(:pager) { double("Pager") }
+
+  subject { described_class.new(device, pager) }
+
+  describe "#contents" do
+    let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
+    let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::ConfigurableBlkDevicesTable) } }
+    let(:items) { column_values(table, 0) }
+
+    # Device names for the children items of the given item
+    def children_names(item)
+      item.children.map { |child| remove_sort_key(child.values.first) }
+    end
+
+    RSpec.shared_examples "overview tab without partitions" do
+      it "contains a graph bar" do
+        bar = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::DiskBarGraph) }
+        expect(bar).to_not be_nil
+      end
+
+      it "shows a table containing only the device" do
+        expect(table).to_not be_nil
+
+        expect(items).to eq [device_name]
+        expect(table.items.first.children).to be_empty
+      end
+    end
+
+    RSpec.shared_examples "overview tab with partitions" do
+      it "contains a graph bar" do
+        bar = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::DiskBarGraph) }
+        expect(bar).to_not be_nil
+      end
+
+      it "shows a table with the device and its partitions as nested items" do
+        expect(table).to_not be_nil
+
+        part_names = device.partitions.map(&:basename)
+        expect(items).to contain_exactly(device_name, *part_names)
+
+        expect(table.items.size).to eq 1
+        item = table.items.first
+        expect(children_names(item)).to contain_exactly(*part_names)
+      end
+    end
+
+    context "for a disk" do
+      let(:scenario) { "mixed_disks" }
+      let(:device_name) { "/dev/sdc" }
+
+      include_examples "CWM::Tab"
+
+      context "when the disk contains no partitions" do
+        include_examples "overview tab without partitions"
+      end
+
+      context "when the disk is partitioned" do
+        let(:device_name) { "/dev/sda" }
+
+        include_examples "overview tab with partitions"
+      end
+
+      context "when the disks contains logical partitions" do
+        let(:device_name) { "/dev/sdb" }
+        let(:primary) { ["sdb1", "sdb2", "sdb3"] }
+        let(:extended) { "sdb4" }
+        let(:logical) { ["sdb5", "sdb6", "sdb7"] }
+
+        it "shows a table with the device and its partitions correctly nested" do
+          part_names = primary + [extended] + logical
+          expect(items).to contain_exactly(device_name, *part_names)
+
+          expect(table.items.size).to eq 1
+
+          first_item = table.items.first
+          expect(children_names(first_item)).to contain_exactly(*primary, extended)
+
+          ext_item = first_item.children.find do |item|
+            remove_sort_key(item.values.first) == extended
+          end
+          expect(children_names(ext_item)).to contain_exactly(*logical)
+        end
+      end
+    end
+
+    context "for an MD RAID" do
+      let(:scenario) { "md_raid" }
+      let(:device_name) { "/dev/md/md0" }
+
+      include_examples "CWM::Tab"
+
+      context "when the RAID contains no partitions" do
+        include_examples "overview tab without partitions"
+      end
+
+      context "when the RAID is partitioned" do
+        let(:scenario) { "partitioned_md_raid.xml" }
+
+        include_examples "overview tab with partitions"
+      end
+    end
+
+    context "for a bcache device" do
+      let(:scenario) { "bcache2.xml" }
+      let(:device_name) { "/dev/bcache0" }
+
+      include_examples "CWM::Tab"
+
+      context "when the bcache device contains no partitions" do
+        include_examples "overview tab without partitions"
+      end
+
+      context "when the bcache device is partitioned" do
+        let(:device_name) { "/dev/bcache1" }
+
+        include_examples "overview tab with partitions"
+      end
+    end
+  end
+end

--- a/test/y2partitioner/widgets/pages/bcache_test.rb
+++ b/test/y2partitioner/widgets/pages/bcache_test.rb
@@ -39,52 +39,19 @@ describe Y2Partitioner::Widgets::Pages::Bcache do
 
   let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
   let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::ConfigurableBlkDevicesTable) } }
-  let(:items) { table.items.map { |i| i[1] } }
+  let(:items) { column_values(table, 0) }
 
   include_examples "CWM::Page"
 
   describe "#contents" do
     it "shows a bcache overview tab" do
-      expect(Y2Partitioner::Widgets::Pages::BcacheTab).to receive(:new)
+      expect(Y2Partitioner::Widgets::OverviewTab).to receive(:new)
       subject.contents
     end
 
     it "shows an used devices tab" do
       expect(Y2Partitioner::Widgets::Pages::BcacheUsedDevicesTab).to receive(:new)
       subject.contents
-    end
-  end
-
-  describe Y2Partitioner::Widgets::Pages::BcacheTab do
-    subject { described_class.new(bcache, pager) }
-
-    include_examples "CWM::Tab"
-
-    describe "#contents" do
-      it "contains a graph bar" do
-        bar = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::DiskBarGraph) }
-        expect(bar).to_not be_nil
-      end
-
-      context "when the bcache device contains no partitions" do
-        it "shows a table containing only the bcache" do
-          expect(table).to_not be_nil
-
-          expect(remove_sort_keys(items)).to eq ["/dev/bcache0"]
-        end
-      end
-
-      context "when the bcache device is partitioned" do
-        let(:device_name) { "/dev/bcache1" }
-
-        it "shows a table with the bcache and its partitions" do
-          expect(table).to_not be_nil
-
-          expect(remove_sort_keys(items)).to contain_exactly(
-            "/dev/bcache1", "/dev/bcache1p1", "/dev/bcache1p2"
-          )
-        end
-      end
     end
   end
 

--- a/test/y2partitioner/widgets/pages/bcaches_test.rb
+++ b/test/y2partitioner/widgets/pages/bcaches_test.rb
@@ -47,10 +47,10 @@ describe Y2Partitioner::Widgets::Pages::Bcaches do
 
       expect(table).to_not be_nil
 
-      devices = table.items.map { |i| i[1] }
+      devices = column_values(table, 0)
 
       expect(remove_sort_keys(devices)).to contain_exactly("/dev/bcache0", "/dev/bcache1",
-        "/dev/bcache2", "/dev/bcache0p1", "/dev/bcache2p1")
+        "/dev/bcache2", "bcache0p1", "bcache2p1")
     end
   end
 end

--- a/test/y2partitioner/widgets/pages/btrfs_filesystems_test.rb
+++ b/test/y2partitioner/widgets/pages/btrfs_filesystems_test.rb
@@ -47,7 +47,7 @@ describe Y2Partitioner::Widgets::Pages::BtrfsFilesystems do
       expect(table).to_not be_nil
 
       id_values = btrfs_filesystems.map(&:blk_device_basename)
-      first_column = table.items.map { |i| i[1] }
+      first_column = column_values(table, 0)
 
       expect(first_column).to contain_exactly(*id_values)
     end

--- a/test/y2partitioner/widgets/pages/btrfs_test.rb
+++ b/test/y2partitioner/widgets/pages/btrfs_test.rb
@@ -41,7 +41,7 @@ describe Y2Partitioner::Widgets::Pages::Btrfs do
 
   let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
   let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::ConfigurableBlkDevicesTable) } }
-  let(:items) { table.items.map { |i| i[1] } }
+  let(:items) { column_values(table, 0) }
 
   include_examples "CWM::Page"
 

--- a/test/y2partitioner/widgets/pages/disk_test.rb
+++ b/test/y2partitioner/widgets/pages/disk_test.rb
@@ -38,14 +38,13 @@ describe Y2Partitioner::Widgets::Pages::Disk do
 
   let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
   let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::ConfigurableBlkDevicesTable) } }
-  let(:items) { table.items.map { |i| i[1] } }
 
   include_examples "CWM::Page"
 
   describe "#contents" do
     context "when the device is neither BIOS RAID nor multipath" do
       it "shows a disk overview tab" do
-        expect(Y2Partitioner::Widgets::Pages::DiskTab).to receive(:new)
+        expect(Y2Partitioner::Widgets::OverviewTab).to receive(:new)
         subject.contents
       end
 
@@ -60,7 +59,7 @@ describe Y2Partitioner::Widgets::Pages::Disk do
       let(:disk) { current_graph.bios_raids.first }
 
       it "shows a disk overview tab" do
-        expect(Y2Partitioner::Widgets::Pages::DiskTab).to receive(:new)
+        expect(Y2Partitioner::Widgets::OverviewTab).to receive(:new)
         subject.contents
       end
 
@@ -75,48 +74,13 @@ describe Y2Partitioner::Widgets::Pages::Disk do
       let(:disk) { current_graph.multipaths.first }
 
       it "shows a disk overview tab" do
-        expect(Y2Partitioner::Widgets::Pages::DiskTab).to receive(:new)
+        expect(Y2Partitioner::Widgets::OverviewTab).to receive(:new)
         subject.contents
       end
 
       it "shows a used devices tab" do
         expect(Y2Partitioner::Widgets::UsedDevicesTab).to receive(:new)
         subject.contents
-      end
-    end
-  end
-
-  describe Y2Partitioner::Widgets::Pages::DiskTab do
-    subject { described_class.new(disk, pager) }
-
-    include_examples "CWM::Tab"
-
-    describe "#contents" do
-      let(:scenario) { "mixed_disks" }
-
-      it "contains a graph bar" do
-        bar = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::DiskBarGraph) }
-        expect(bar).to_not be_nil
-      end
-
-      context "when the disk contains no partitions" do
-        let(:disk) { current_graph.find_by_name("/dev/sdc") }
-
-        it "shows a table containing only the disk" do
-          expect(table).to_not be_nil
-
-          expect(remove_sort_keys(items)).to eq ["/dev/sdc"]
-        end
-      end
-
-      context "when the disk is partitioned" do
-        it "shows a table with the disk and its partitions" do
-          expect(table).to_not be_nil
-
-          expect(remove_sort_keys(items)).to contain_exactly(
-            "/dev/sda", "/dev/sda1", "/dev/sda2"
-          )
-        end
       end
     end
   end
@@ -130,6 +94,8 @@ describe Y2Partitioner::Widgets::Pages::Disk do
     include_examples "CWM::Tab"
 
     describe "#contents" do
+      let(:items) { column_values(table, 0) }
+
       context "when the device is a BIOS RAID" do
         let(:scenario) { "empty-dm_raids.xml" }
 

--- a/test/y2partitioner/widgets/pages/disks_test.rb
+++ b/test/y2partitioner/widgets/pages/disks_test.rb
@@ -37,6 +37,11 @@ describe Y2Partitioner::Widgets::Pages::Disks do
 
   include_examples "CWM::Page"
 
+  # Name that is expected to be used for each device
+  def disk_dev_name(device)
+    device.is?(:lvm_lv, :partition) ? device.basename : device.name
+  end
+
   describe "#contents" do
     let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
     let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDevicesTable) } }
@@ -47,8 +52,8 @@ describe Y2Partitioner::Widgets::Pages::Disks do
     it "shows a table with the disk devices and their partitions" do
       expect(table).to_not be_nil
 
-      devices_name = disks_and_parts.map(&:name)
-      items_name = table.items.map { |i| i[1] }
+      devices_name = disks_and_parts.map { |d| disk_dev_name(d) }
+      items_name = column_values(table, 0)
 
       expect(remove_sort_keys(items_name.sort)).to eq(devices_name.sort)
     end
@@ -61,8 +66,8 @@ describe Y2Partitioner::Widgets::Pages::Disks do
 
       it "shows a table with the disk devices, their partitions and the Xen virtual partitions" do
         devices = disks_and_parts + device_graph.stray_blk_devices
-        devices_name = devices.map(&:name)
-        items_name = table.items.map { |i| i[1] }
+        devices_name = devices.map { |d| disk_dev_name(d) }
+        items_name = column_values(table, 0)
 
         expect(remove_sort_keys(items_name.sort)).to eq(devices_name.sort)
       end

--- a/test/y2partitioner/widgets/pages/lvm_test.rb
+++ b/test/y2partitioner/widgets/pages/lvm_test.rb
@@ -44,7 +44,7 @@ describe Y2Partitioner::Widgets::Pages::Lvm do
 
     let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::LvmDevicesTable) } }
 
-    let(:items) { table.items.map { |i| i[1] } }
+    let(:items) { column_values(table, 0) }
 
     before do
       vg = Y2Storage::LvmVg.find_by_vg_name(current_graph, "vg0")
@@ -56,15 +56,15 @@ describe Y2Partitioner::Widgets::Pages::Lvm do
 
       expect(remove_sort_keys(items)).to contain_exactly(
         "/dev/vg0",
-        "/dev/vg0/lv1",
-        "/dev/vg0/lv2",
-        "/dev/vg0/pool1",
-        "/dev/vg0/thin1",
-        "/dev/vg0/thin2",
-        "/dev/vg0/pool2",
-        "/dev/vg0/thin3",
+        "lv1",
+        "lv2",
+        "pool1",
+        "thin1",
+        "thin2",
+        "pool2",
+        "thin3",
         "/dev/vg1",
-        "/dev/vg1/lv1"
+        "lv1"
       )
     end
 

--- a/test/y2partitioner/widgets/pages/lvm_vg_test.rb
+++ b/test/y2partitioner/widgets/pages/lvm_vg_test.rb
@@ -37,7 +37,7 @@ describe Y2Partitioner::Widgets::Pages::LvmVg do
 
   let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
   let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::LvmDevicesTable) } }
-  let(:items) { table.items.map { |i| i[1] } }
+  let(:items) { column_values(table, 0) }
 
   describe "#contents" do
     it "shows a vg tab" do
@@ -69,15 +69,15 @@ describe Y2Partitioner::Widgets::Pages::LvmVg do
       it "shows a table with the vg and its lvs (including thin volumes)" do
         expect(table).to_not be_nil
 
-        expect(remove_sort_keys(items)).to contain_exactly(
+        expect(items).to contain_exactly(
           "/dev/vg0",
-          "/dev/vg0/lv1",
-          "/dev/vg0/lv2",
-          "/dev/vg0/pool1",
-          "/dev/vg0/thin1",
-          "/dev/vg0/thin2",
-          "/dev/vg0/pool2",
-          "/dev/vg0/thin3"
+          "lv1",
+          "lv2",
+          "pool1",
+          "thin1",
+          "thin2",
+          "pool2",
+          "thin3"
         )
       end
     end
@@ -93,7 +93,7 @@ describe Y2Partitioner::Widgets::Pages::LvmVg do
 
       let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::ConfigurableBlkDevicesTable) } }
 
-      let(:items) { table.items.map { |i| i[1] } }
+      let(:items) { column_values(table, 0) }
 
       it "shows a table with the vg and its pvs" do
         expect(table).to_not be_nil

--- a/test/y2partitioner/widgets/pages/md_raid_test.rb
+++ b/test/y2partitioner/widgets/pages/md_raid_test.rb
@@ -36,52 +36,19 @@ describe Y2Partitioner::Widgets::Pages::MdRaid do
 
   let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
   let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::ConfigurableBlkDevicesTable) } }
-  let(:items) { table.items.map { |i| i[1] } }
+  let(:items) { column_values(table, 0) }
 
   include_examples "CWM::Page"
 
   describe "#contents" do
     it "shows a MD tab" do
-      expect(Y2Partitioner::Widgets::Pages::MdTab).to receive(:new).with(md, pager, anything)
+      expect(Y2Partitioner::Widgets::OverviewTab).to receive(:new).with(md, pager, anything)
       subject.contents
     end
 
     it "shows a used devices tab" do
       expect(Y2Partitioner::Widgets::UsedDevicesTab).to receive(:new).with(md, pager)
       subject.contents
-    end
-  end
-
-  describe Y2Partitioner::Widgets::Pages::MdTab do
-    subject { described_class.new(md, pager) }
-
-    include_examples "CWM::Tab"
-
-    describe "#contents" do
-      it "contains a graph bar" do
-        bar = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::DiskBarGraph) }
-        expect(bar).to_not be_nil
-      end
-
-      context "when the MD contains no partitions" do
-        it "shows a table containing only the RAID" do
-          expect(table).to_not be_nil
-
-          expect(remove_sort_keys(items)).to eq ["/dev/md/md0"]
-        end
-      end
-
-      context "when the MD is partitioned" do
-        let(:scenario) { "partitioned_md_raid.xml" }
-
-        it "shows a table with the RAID and its partitions" do
-          expect(table).to_not be_nil
-
-          expect(remove_sort_keys(items)).to contain_exactly(
-            "/dev/md/md0", "/dev/md/md0p1"
-          )
-        end
-      end
     end
   end
 

--- a/test/y2partitioner/widgets/pages/md_raids_test.rb
+++ b/test/y2partitioner/widgets/pages/md_raids_test.rb
@@ -45,7 +45,7 @@ describe Y2Partitioner::Widgets::Pages::MdRaids do
     let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDevicesTable) } }
     let(:buttons_set) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::DeviceButtonsSet) } }
 
-    let(:items) { table.items.map { |i| i[1] } }
+    let(:items) { column_values(table, 0) }
 
     it "shows a button to add a raid" do
       button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::MdAddButton) }
@@ -61,10 +61,10 @@ describe Y2Partitioner::Widgets::Pages::MdRaids do
 
       raids = current_graph.software_raids
       parts = raids.map(&:partitions).flatten.compact
-      devices_name = (raids + parts).map(&:name)
-      items_name = table.items.map { |i| i[1] }
+      devices_name = raids.map(&:name) + parts.map(&:basename)
+      items_name = column_values(table, 0)
 
-      expect(remove_sort_keys(items_name.sort)).to eq(devices_name.sort)
+      expect(items_name.sort).to eq(devices_name.sort)
     end
 
     it "associates the table and the set of buttons" do
@@ -81,7 +81,7 @@ describe Y2Partitioner::Widgets::Pages::MdRaids do
       end
 
       it "contains all Software RAIDs" do
-        expect(remove_sort_keys(items)).to include(
+        expect(items).to include(
           "/dev/md/md0",
           "/dev/md1"
         )
@@ -92,8 +92,7 @@ describe Y2Partitioner::Widgets::Pages::MdRaids do
       let(:scenario) { "nested_md_raids" }
 
       it "contains all software RAIDs and its partitions" do
-        expect(remove_sort_keys(items)).to include("/dev/md0", "/dev/md0p1", "/dev/md0p2", "/dev/md1",
-          "/dev/md2")
+        expect(items).to include("/dev/md0", "md0p1", "md0p2", "/dev/md1", "/dev/md2")
       end
     end
 

--- a/test/y2partitioner/widgets/pages/stray_blk_device_test.rb
+++ b/test/y2partitioner/widgets/pages/stray_blk_device_test.rb
@@ -34,7 +34,7 @@ describe Y2Partitioner::Widgets::Pages::StrayBlkDevice do
 
   let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
   let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::ConfigurableBlkDevicesTable) } }
-  let(:items) { table.items.map { |i| i[1] } }
+  let(:items) { column_values(table, 0) }
 
   include_examples "CWM::Page"
 
@@ -54,7 +54,7 @@ describe Y2Partitioner::Widgets::Pages::StrayBlkDevice do
       it "shows a table containing only the device" do
         expect(table).to_not be_nil
 
-        expect(remove_sort_keys(items)).to eq ["/dev/xvda1"]
+        expect(items).to eq ["/dev/xvda1"]
       end
     end
   end

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -48,7 +48,7 @@ describe Y2Partitioner::Widgets::Pages::System do
 
     # Names from the devices in the list
     def row_names(table)
-      table.items.map { |i| i[1].params.first }
+      column_values(table, 0)
     end
 
     let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
@@ -66,18 +66,9 @@ describe Y2Partitioner::Widgets::Pages::System do
       let(:scenario) { "mixed_disks.yml" }
 
       it "contains all disks and their partitions" do
-        expect(remove_sort_keys(items)).to contain_exactly(
-          "/dev/sda",
-          "/dev/sda1",
-          "/dev/sda2",
-          "/dev/sdb",
-          "/dev/sdb1",
-          "/dev/sdb2",
-          "/dev/sdb3",
-          "/dev/sdb4",
-          "/dev/sdb5",
-          "/dev/sdb6",
-          "/dev/sdb7",
+        expect(items).to contain_exactly(
+          "/dev/sda", "sda1", "sda2",
+          "/dev/sdb", "sdb1", "sdb2", "sdb3", "sdb4", "sdb5", "sdb6", "sdb7",
           "/dev/sdc"
         )
       end
@@ -87,9 +78,8 @@ describe Y2Partitioner::Widgets::Pages::System do
       let(:scenario) { "dasd_50GiB.yml" }
 
       it "contains all DASDs and their partitions" do
-        expect(remove_sort_keys(items)).to contain_exactly(
-          "/dev/dasda",
-          "/dev/dasda1"
+        expect(items).to contain_exactly(
+          "/dev/dasda", "dasda1"
         )
       end
     end
@@ -98,24 +88,22 @@ describe Y2Partitioner::Widgets::Pages::System do
       let(:scenario) { "empty-dm_raids.xml" }
 
       it "contains all DM RAIDs" do
-        expect(remove_sort_keys(items)).to include(
+        expect(items).to include(
           "/dev/mapper/isw_ddgdcbibhd_test1",
           "/dev/mapper/isw_ddgdcbibhd_test2"
         )
       end
 
       it "does not contain devices belonging to DM RAIDs" do
-        expect(remove_sort_keys(items)).to_not include(
+        expect(items).to_not include(
           "/dev/sdb",
           "/dev/sdc"
         )
       end
 
       it "contains devices that does not belong to DM RAIDs" do
-        expect(remove_sort_keys(items)).to include(
-          "/dev/sda",
-          "/dev/sda1",
-          "/dev/sda2"
+        expect(items).to include(
+          "/dev/sda", "sda1", "sda2"
         )
       end
     end
@@ -124,14 +112,14 @@ describe Y2Partitioner::Widgets::Pages::System do
       let(:scenario) { "md-imsm1-devicegraph.xml" }
 
       it "contains all BIOS MD RAIDs" do
-        expect(remove_sort_keys(items)).to include(
+        expect(items).to include(
           "/dev/md/a",
           "/dev/md/b"
         )
       end
 
       it "does not contain devices belonging to BIOS DM RAIDs" do
-        expect(remove_sort_keys(items)).to_not include(
+        expect(items).to_not include(
           "/dev/sdb",
           "/dev/sdc",
           "/dev/sdd"
@@ -139,10 +127,8 @@ describe Y2Partitioner::Widgets::Pages::System do
       end
 
       it "contains devices that does not belong to BIOS DM RAIDs" do
-        expect(remove_sort_keys(items)).to include(
-          "/dev/sda",
-          "/dev/sda1",
-          "/dev/sda2"
+        expect(items).to include(
+          "/dev/sda", "sda1", "sda2"
         )
       end
     end
@@ -155,14 +141,14 @@ describe Y2Partitioner::Widgets::Pages::System do
       end
 
       it "contains all Software RAIDs" do
-        expect(remove_sort_keys(items)).to include(
+        expect(items).to include(
           "/dev/md/md0",
           "/dev/md1"
         )
       end
 
       it "contains devices belonging to Software RAIDs" do
-        expect(remove_sort_keys(items)).to include(
+        expect(items).to include(
           "/dev/sda"
         )
       end
@@ -177,25 +163,15 @@ describe Y2Partitioner::Widgets::Pages::System do
       end
 
       it "contains all Volume Groups and their logical volumes (including thin volumes)" do
-        expect(remove_sort_keys(items)).to include(
-          "/dev/vg0",
-          "/dev/vg0/lv1",
-          "/dev/vg0/lv2",
-          "/dev/vg0/pool1",
-          "/dev/vg0/thin1",
-          "/dev/vg0/thin2",
-          "/dev/vg0/pool2",
-          "/dev/vg0/thin3",
-          "/dev/vg1",
-          "/dev/vg1/lv1"
+        expect(items).to include(
+          "/dev/vg0", "lv1", "lv2", "pool1", "thin1", "thin2", "pool2", "thin3",
+          "/dev/vg1", "lv1"
         )
       end
 
       it "contains devices belonging to Volume Groups" do
-        expect(remove_sort_keys(items)).to include(
-          "/dev/sda5",
-          "/dev/sda7",
-          "/dev/sda9"
+        expect(items).to include(
+          "sda5", "sda7", "sda9"
         )
       end
     end
@@ -212,7 +188,7 @@ describe Y2Partitioner::Widgets::Pages::System do
       let(:scenario) { "bcache1.xml" }
 
       it "contains all bcache devices" do
-        expect(remove_sort_keys(items)).to include("/dev/bcache0", "/dev/bcache1", "/dev/bcache2")
+        expect(items).to include("/dev/bcache0", "/dev/bcache1", "/dev/bcache2")
       end
     end
 


### PR DESCRIPTION
This replaces #1132 

## Goal

In order to implement the interface described in [doc/partitioner_ui.md](https://github.com/yast/yast-storage-ng/blob/master/doc/partitioner_ui.md), we want to represent nesting of devices in several tables.

But we were using plain arrays to represent the rows of a table, instead of the `CWM::TableItem` class introduced at https://github.com/yast/yast-yast2/pull/1111

## Solution

Introduce a new `Y2Partitioner::Widgets::DeviceTableEntry` class to represent each entry of a table of devices, including the device itself and all the corresponding nested entries (like the partitions of a given disk). For each entry it's possible to specify if full names of devices must be enforced (useful for the tables at the "Used Devices" tab).

## Screenshots

![nested1b](https://user-images.githubusercontent.com/3638289/96441713-3f8b5180-120a-11eb-848e-e4f6a0090b17.png)

![nested2b](https://user-images.githubusercontent.com/3638289/96441709-3ef2bb00-120a-11eb-9e9f-15f4f2114f5e.png)

![nested3](https://user-images.githubusercontent.com/3638289/96287167-ce695580-0fe1-11eb-95f3-3757ff7e590d.png)

## Testing

- Unit tests adapted.
- Manually tested in the installed system
- Missing: manual test during installation (can likely be postponed until we merge everything to master)