### PR TITLE
L3 Veritas Volume Manager: Allow to Ignore Probe Errors

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 20 15:36:03 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added $LIBSTORAGE_IGNORE_PROBE_ERRORS environment variable
+  to ignore storage probing errors (bsc#1177332)
+- 4.1.97
+
+-------------------------------------------------------------------
 Mon Aug 17 12:37:24 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not append a suffix to LVM Volume Group names unless it

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.1.96
+Version:        4.1.97
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/callbacks/probe.rb
+++ b/src/lib/y2storage/callbacks/probe.rb
@@ -26,6 +26,31 @@ module Y2Storage
     # Class to implement callbacks used during libstorage-ng probe
     class Probe < Storage::ProbeCallbacks
       include LibstorageCallback
+
+      # Callback for libstorage-ng to report an error to the user.
+      #
+      # If the $LIBSTORAGE_IGNORE_PROBE_ERRORS environment variable is set,
+      # this just returns 'true', i.e. the error is ignored.
+      #
+      # Otherwise, this displays the error and prompts the user if the error
+      # should be ignored.
+      #
+      # @note If the user rejects to continue, the method will return false
+      # which implies libstorage-ng will raise the corresponding exception for
+      # the error.
+      #
+      # See Storage::Callbacks#error in libstorage-ng
+      #
+      # @param message [String] error title coming from libstorage-ng
+      #   (in the ASCII-8BIT encoding! see https://sourceforge.net/p/swig/feature-requests/89/)
+      # @param what [String] details coming from libstorage-ng (in the ASCII-8BIT encoding!)
+      # @return [Boolean] true will make libstorage-ng ignore the error, false
+      #   will result in a libstorage-ng exception
+      def error(message, what)
+        return true if StorageEnv.instance.ignore_probe_errors?
+
+        super(message, what)
+      end
     end
   end
 end

--- a/src/lib/y2storage/storage_env.rb
+++ b/src/lib/y2storage/storage_env.rb
@@ -34,7 +34,10 @@ module Y2Storage
 
     ENV_ACTIVATE_LUKS = "YAST_ACTIVATE_LUKS".freeze
 
+    ENV_LIBSTORAGE_IGNORE_PROBE_ERRORS = "LIBSTORAGE_IGNORE_PROBE_ERRORS".freeze
+
     private_constant :ENV_MULTIPATH, :ENV_BIOS_RAID, :ENV_ACTIVATE_LUKS
+    private_constant :ENV_LIBSTORAGE_IGNORE_PROBE_ERRORS
 
     def initialize
       @active_cache = {}
@@ -67,6 +70,21 @@ module Y2Storage
     #
     def activate_luks?
       active?(ENV_ACTIVATE_LUKS, true)
+    end
+
+    # Whether errors during libstorage probing should be ignored.
+    #
+    # See bsc#1177332:
+    #
+    # Some storage technologies like Veritas Volume Manager use disk labels
+    # like "sun" that we don't support in libstorage / storage-ng. Setting the
+    # LIBSTORAGE_IGNORE_PROBE_ERRORS env var gives the admin a chance to use
+    # the YaST partitioner despite that. Those disks will show up like empty
+    # disks and not cause an error pop-up for each one.
+    def ignore_probe_errors?
+      result = active?(ENV_LIBSTORAGE_IGNORE_PROBE_ERRORS)
+      log.info("Ignoring libstorage probe errors") if result
+      result
     end
 
   private

--- a/test/y2storage/callbacks/probe_test.rb
+++ b/test/y2storage/callbacks/probe_test.rb
@@ -30,5 +30,24 @@ describe Y2Storage::Callbacks::Probe do
   describe "#error" do
     include_examples "general #error examples"
     include_examples "default #error true examples"
+
+    context "without LIBSTORAGE_IGNORE_PROBE_ERRORS" do
+      before { mock_env(env_vars) }
+      let(:env_vars) { {} }
+      it "it displays an error pop-up" do
+        expect(Yast::Report).to receive(:yesno_popup)
+        subject.error("probing failed", "")
+      end
+    end
+
+    context "with LIBSTORAGE_IGNORE_PROBE_ERRORS set" do
+      before { mock_env(env_vars) }
+      after { mock_env({}) } # clean up for future tests
+      let(:env_vars) { { "LIBSTORAGE_IGNORE_PROBE_ERRORS" => "1" } }
+      it "does not display an error pop-up and returns true" do
+        expect(Yast::Report).not_to receive(:yesno_popup)
+        expect(subject.error("probing failed", "")).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1177332

**This is the PR against SLE-15-SP1**

## Trello

https://trello.com/c/rjFULQ97/

## Problem

Some third-party storage software like the Veritas Volume Manager use a disk label (partitioning scheme) that we don't support in libstorage-ng and yast-storage-ng. In this particular case, they use a Sun disk label for disks below 2 TB, and GPT above that size.

When starting the YaST partitioner, libstorage-ng detects the unsupported disk label and reports it as an error. That error is displayed in an error pop-up dialog, and the user can choose to continue anyway (in which case that disk is treated as if it were empty, i.e. no partitions are shown).

In this particular case, the customer had 29 disks and found the sheer number of reported errors overwhelming. They wanted to have a mechanism to speed this up; even more so since this happens every time the YaST partitioner is started.

## Solution

This PR introduces a new environment variable `$LIBSTORAGE_IGNORE_PROBE_ERRORS`. If set, all errors found during probing are suppressed and treated as if the user had chosen "Continue" in the error pop-up. No error pop-up is shown.

## Usage

```shell
xhost +
sudo LIBSTORAGE_IGNORE_PROBE_ERRORS=1 yast2 disk
```

or

```
export LIBSTORAGE_IGNORE_PROBE_ERRORS=1
sudo yast2 disk
```



# Test

## Unit Test

```
cd yast-storage-ng/src/test/lib/callbacks
rspec probe_test.rb
cd ../../..
rake test:unit
```

## Manual Test

- In the VM manager, add a new virtual disk
- Start the VM
- Log in
- Create a Sun disk label on that disk:

      sudo parted /dev/sdb mklabel sun

- Start the YaST partitioner normally; it will complain about that disk.

      xhost +
      sudo yast2 disk

- Start it with the new environment variable; it will not complain:

      sudo LIBSTORAGE_IGNORE_PROBE_ERRORS=1 yast2 disk

# Related PRs

- Original: SLE-15 SP1: This PR
- Port to SLE-15 SP2:
- Port to _master_:  https://github.com/yast/yast-storage-ng/pull/1152