### PR TITLE
Adapt UIState to changes in the partitioner-ui-02 branch

### DIFF
--- a/src/lib/y2partitioner/actions/add_btrfs.rb
+++ b/src/lib/y2partitioner/actions/add_btrfs.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "yast2/popup"
+require "y2partitioner/ui_state"
 require "y2partitioner/actions/transaction_wizard"
 require "y2partitioner/actions/controllers/filesystem"
 require "y2partitioner/actions/controllers/btrfs_devices"
@@ -51,6 +52,7 @@ module Y2Partitioner
       def options
         fs_controller = Controllers::Filesystem.new(controller.filesystem, title)
 
+        UIState.instance.select_row(controller.filesystem.sid)
         Dialogs::BtrfsOptions.run(fs_controller)
       end
 

--- a/src/lib/y2partitioner/actions/base.rb
+++ b/src/lib/y2partitioner/actions/base.rb
@@ -20,7 +20,7 @@
 require "yast"
 require "yast/i18n"
 require "yast2/popup"
-
+require "y2partitioner/ui_state"
 require "abstract_method"
 
 module Y2Partitioner
@@ -42,6 +42,7 @@ module Y2Partitioner
       def run
         return :back unless run?
 
+        UIState.instance.save_extra_info
         action_result = perform_action
 
         result(action_result)

--- a/src/lib/y2partitioner/actions/delete_lvm_lv.rb
+++ b/src/lib/y2partitioner/actions/delete_lvm_lv.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "y2partitioner/ui_state"
 require "y2partitioner/actions/delete_device"
 
 module Y2Partitioner
@@ -41,6 +42,7 @@ module Y2Partitioner
         log.info "deleting logical volume #{device}"
         vg = device.lvm_vg
         vg.delete_lvm_lv(device)
+        UIState.instance.select_row(vg.sid)
       end
 
       # Confirmation before performing the delete action

--- a/src/lib/y2partitioner/actions/transaction_wizard.rb
+++ b/src/lib/y2partitioner/actions/transaction_wizard.rb
@@ -20,6 +20,7 @@
 require "yast"
 require "ui/sequence"
 require "y2partitioner/device_graphs"
+require "y2partitioner/ui_state"
 
 Yast.import "Wizard"
 
@@ -44,6 +45,7 @@ module Y2Partitioner
 
           sym =
             if run?
+              UIState.instance.save_extra_info
               wizard_next_back do
                 super(sequence: sequence_hash)
               end

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -83,7 +83,9 @@ module Y2Partitioner
     #
     # It records the decision, so the last active tab is displayed when the page will be redraw.
     #
-    # @param label [String]
+    # If the selected tab is the default one of the page, nil must be passed as argument
+    #
+    # @param label [String, nil] nil if switching to the default tab, no matter the label
     def switch_to_tab(label)
       current_status&.active_tab = label
     end
@@ -192,7 +194,8 @@ module Y2Partitioner
     #   * selected row
     #   * candidates pages
     class PageStatus
-      # The key to reference the selected row for a table not wrapped in a tab
+      # The key to reference the default tab of a page or to use when the page contains
+      # no known tabs
       FALLBACK_TAB = "root".freeze
       private_constant :FALLBACK_TAB
 

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -90,6 +90,31 @@ module Y2Partitioner
       current_status&.active_tab = label
     end
 
+    # Additional state information for the active tab of the current page
+    #
+    # @return [Object, nil]
+    def extra
+      current_status&.extra
+    end
+
+    # Sets the additional state information for the active page and tab
+    #
+    # @param info [Object, nil]
+    def extra=(info)
+      current_status.extra = info
+    end
+
+    # Stores the information of the active tab of the current page
+    #
+    # @see #extra
+    # @see #extra=
+    def save_extra_info
+      page = overview_tree_pager&.current_page
+      return unless page&.respond_to?(:state_info)
+
+      self.extra = page.state_info
+    end
+
     # Returns the id of the last selected row in the active tab of current page
     #
     # @return [Integer, nil]
@@ -233,6 +258,7 @@ module Y2Partitioner
         @page_id = page_id
         @candidate_pages = candidate_pages_ids
         @selected_rows = { FALLBACK_TAB => nil }
+        @extras = {}
       end
 
       # Returns the last selected row for the active tab
@@ -253,6 +279,24 @@ module Y2Partitioner
         selected_rows[tab] = sid
       end
 
+      # Returns the extra information previously stored for the active tab
+      #
+      # If the node has no tabs a fallback reference will be used. See #selected_rows
+      #
+      # @return [Object, nil]
+      def extra
+        extras[tab]
+      end
+
+      # Stores the extra information for the active tab
+      #
+      # If the node has no tabs a fallback reference will be used. See #selected_rows
+      #
+      # @param info [Object, nil]
+      def extra=(info)
+        extras[tab] = info
+      end
+
       private
 
       # A collection to keep the selected rows per tab
@@ -263,6 +307,13 @@ module Y2Partitioner
       #
       # @return [Hash{String => Integer}]
       attr_reader :selected_rows
+
+      # A collection to keep the additional information for each page and tab
+      #
+      # As in {#selected_rows}, FALLBACK_TAB is used as key in some cases.
+      #
+      # @return [Hash{String => Object}]
+      attr_reader :extras
 
       # Returns the active tab or the fallback when none
       #

--- a/src/lib/y2partitioner/ui_state.rb
+++ b/src/lib/y2partitioner/ui_state.rb
@@ -92,6 +92,10 @@ module Y2Partitioner
 
     # Additional state information for the active tab of the current page
     #
+    # FIXME: in the mid-term, it would be nice to turn this into a proper API to
+    # store and fetch the status of each individual widget within the page, instead
+    # of this generic container for the state of the full tab/page.
+    #
     # @return [Object, nil]
     def extra
       current_status&.extra
@@ -108,6 +112,11 @@ module Y2Partitioner
     #
     # @see #extra
     # @see #extra=
+    #
+    # FIXME: see the comment in #extra. At some point, the #state_info method
+    # should be moved to each widget needing to store its information and the
+    # page itself would offer a method to make possible to iterate through all
+    # those widgets (e.g. #widgets_with_state_info).
     def save_extra_info
       page = overview_tree_pager&.current_page
       return unless page&.respond_to?(:state_info)

--- a/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
@@ -55,6 +55,7 @@ module Y2Partitioner
         return @contents if @contents
 
         # Before calculating the content, ensure consistency of #open_items
+        # FIXME: the API to fetch the stored state may change, see the comment in UIState#extra
         self.open_items = UIState.instance.extra&.fetch(widget_id, nil) || {}
         @contents = super
       end

--- a/src/lib/y2partitioner/widgets/device_table_entry.rb
+++ b/src/lib/y2partitioner/widgets/device_table_entry.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "cwm/table"
 
 module Y2Partitioner
   module Widgets
@@ -87,12 +88,16 @@ module Y2Partitioner
 
       # CWM table item to represent this entry in the table
       #
+      # @param cols [Array<Columns::Base>] columns to display
+      # @param open_items [Hash{String => Boolean}] hash listing whether items
+      #   should be expanded or collapsed. See {BlkDevicesTable#open_items}.
       # @return [CWM::TableItem]
-      def table_item(cols)
+      def table_item(cols, open_items)
         values = cols.map { |c| c.entry_value(self) }
-        sub_items = children.map { |c| c.table_item(cols) }
+        sub_items = children.map { |c| c.table_item(cols, open_items) }
+        open = open_items.fetch(row_id, true)
 
-        CWM::TableItem.new(row_id, values, children: sub_items)
+        CWM::TableItem.new(row_id, values, children: sub_items, open: open)
       end
 
       # Collection including this entry and all its descendants

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -24,6 +24,7 @@ require "y2storage/mountable"
 require "y2storage/btrfs_subvolume"
 require "y2partitioner/filesystems"
 require "y2partitioner/widgets/fstab_options"
+require "y2partitioner/dialogs/mkfs_options"
 require "y2partitioner/dialogs/btrfs_subvolumes"
 
 Yast.import "Popup"

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -114,10 +114,12 @@ module Y2Partitioner
         ].compact
       end
 
-      # Overrides default behavior of TreePager to register the new state with
-      # {UIState} before jumping to the tree node
+      # Overrides default behavior of TreePager to register with {UIState} the status
+      # of the current page and the new destination, before jumping to the tree node
       def switch_page(page)
-        UIState.instance.select_page(page.tree_path)
+        state = UIState.instance
+        state.save_extra_info
+        state.select_page(page.tree_path)
         super
       end
 
@@ -273,7 +275,7 @@ module Y2Partitioner
 
       # @return [CWM::PagerTreeItem]
       def stray_blk_device_item(device)
-        page = Pages::StrayBlkDevice.new(device)
+        page = Pages::StrayBlkDevice.new(device, self)
         device_item(page)
       end
 
@@ -296,7 +298,7 @@ module Y2Partitioner
         return nil unless Y2Storage::Bcache.supported?
 
         devices = device_graph.bcaches
-        page = Pages::Bcaches.new(devices, self)
+        page = Pages::Bcaches.new(self)
         children = devices.map { |v| disk_items(v, Pages::Bcache) }
         section_item(page, Icons::BCACHE, children: children)
       end

--- a/src/lib/y2partitioner/widgets/pages/base.rb
+++ b/src/lib/y2partitioner/widgets/pages/base.rb
@@ -62,6 +62,7 @@ module Y2Partitioner
         # It represents the current state of the widgets, so they can be initialized to the
         # same state next time the page is redrawn.
         #
+        # FIXME: the API to query the UI state may change, see comment in UIState#save_extra_info
         # @return [Object, nil] it returns nil in the base class
         def state_info
           nil

--- a/src/lib/y2partitioner/widgets/pages/base.rb
+++ b/src/lib/y2partitioner/widgets/pages/base.rb
@@ -56,6 +56,17 @@ module Y2Partitioner
           [parent, id].compact
         end
 
+        # State information of the page, for those pages that need to restore that state
+        # on each render
+        #
+        # It represents the current state of the widgets, so they can be initialized to the
+        # same state next time the page is redrawn.
+        #
+        # @return [Object, nil] it returns nil in the base class
+        def state_info
+          nil
+        end
+
         private
 
         # The parent page

--- a/src/lib/y2partitioner/widgets/pages/bcache.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcache.rb
@@ -17,9 +17,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2partitioner/widgets/tabs"
 require "y2partitioner/widgets/overview_tab"
-require "y2partitioner/widgets/pages/base"
+require "y2partitioner/widgets/pages/tabbed"
 require "y2partitioner/widgets/pages/bcaches"
 require "y2partitioner/widgets/used_devices_tab"
 require "y2partitioner/widgets/bcache_edit_button"
@@ -28,7 +27,7 @@ module Y2Partitioner
   module Widgets
     module Pages
       # A Page for a bcache device
-      class Bcache < Base
+      class Bcache < Tabbed
         # @return [Y2Storage::Bcache] Device this page is about
         attr_reader :bcache
         alias_method :device, :bcache
@@ -50,21 +49,15 @@ module Y2Partitioner
           device.basename
         end
 
-        # @macro seeCustomWidget
-        def contents
-          Top(
-            VBox(
-              Left(
-                Tabs.new(
-                  OverviewTab.new(device, @pager),
-                  BcacheUsedDevicesTab.new(device, @pager)
-                )
-              )
-            )
-          )
-        end
-
         private
+
+        # @see Tabbed
+        def calculate_tabs
+          [
+            OverviewTab.new(device, @pager),
+            BcacheUsedDevicesTab.new(device, @pager)
+          ]
+        end
 
         # @return [String]
         def section

--- a/src/lib/y2partitioner/widgets/pages/bcaches.rb
+++ b/src/lib/y2partitioner/widgets/pages/bcaches.rb
@@ -17,19 +17,16 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2partitioner/widgets/pages/base"
+require "y2partitioner/widgets/pages/devices_table"
 require "y2partitioner/widgets/bcache_add_button"
-require "y2partitioner/widgets/device_buttons_set"
-require "y2partitioner/widgets/configurable_blk_devices_table"
 
 module Y2Partitioner
   module Widgets
     module Pages
       # A Page for bcache devices
       #
-      # It contains two tabs: one tab with a list of bcache devices and another
-      # tab with the list of caching sets.
-      class Bcaches < Base
+      # It contains a table with a list of all bcache devices
+      class Bcaches < DevicesTable
         extend Yast::I18n
 
         textdomain "storage"
@@ -43,69 +40,24 @@ module Y2Partitioner
           _("Bcache Devices")
         end
 
-        # Constructor
-        #
-        # @param bcaches [Array<Y2Storage::Bcache>]
-        # @param pager [CWM::TreePager]
-        def initialize(bcaches, pager)
-          textdomain "storage"
-
-          @bcaches = bcaches
-          @pager = pager
-        end
-
         # @macro seeAbstractWidget
         def label
           self.class.label
         end
 
-        # @macro seeCustomWidget
-        def contents
-          @contents ||= Top(
-            VBox(
-              Left(
-                VBox(
-                  table,
-                  Left(device_buttons),
-                  Right(table_buttons)
-                )
-              )
-            )
-          )
-        end
-
         private
-
-        # @return [Array<Y2Storage::Bcache>]
-        attr_reader :bcaches
-
-        # @return [CWM::TreePager]
-        attr_reader :pager
-
-        # Table to list all bcache devices and their partitions
-        #
-        # @return [Widgets::ConfigurableBlkDevicesTable]
-        def table
-          @table ||= ConfigurableBlkDevicesTable.new(devices, pager, device_buttons)
-        end
-
-        # Widget with the dynamic set of buttons for the selected row
-        #
-        # @return [DeviceButtonsSet]
-        def device_buttons
-          @device_buttons ||= DeviceButtonsSet.new(pager)
-        end
 
         # @see DevicesTable
         def table_buttons
           BcacheAddButton.new
         end
 
-        # Returns all bcache devices and their partitions
+        # Entries for all bcache devices and their partitions
         #
         # @return [Array<DeviceTableEntry>]
         def devices
-          bcaches.map do |bcache|
+          devicegraph = DeviceGraphs.instance.current
+          devicegraph.bcaches.map do |bcache|
             DeviceTableEntry.new_with_children(bcache)
           end
         end

--- a/src/lib/y2partitioner/widgets/pages/btrfs.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs.rb
@@ -17,8 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2partitioner/widgets/tabs"
-require "y2partitioner/widgets/pages/base"
+require "y2partitioner/widgets/pages/tabbed"
 require "y2partitioner/widgets/pages/btrfs_filesystems"
 require "y2partitioner/widgets/overview_tab"
 require "y2partitioner/widgets/btrfs_filesystems_table"
@@ -31,7 +30,7 @@ module Y2Partitioner
       # Page for a BTRFS filesystem
       #
       # This page contains a {FilesystemTab} and a {BtrfsUsedDevicesTab}.
-      class Btrfs < Base
+      class Btrfs < Tabbed
         # @return [Y2Storage::Filesystems::Btrfs]
         attr_reader :filesystem
 
@@ -56,15 +55,6 @@ module Y2Partitioner
           filesystem.blk_device_basename
         end
 
-        # @macro seeCustomWidget
-        def contents
-          Top(
-            VBox(
-              Left(tabs)
-            )
-          )
-        end
-
         private
 
         # @return [CWM::TreePager]
@@ -75,14 +65,12 @@ module Y2Partitioner
         # There are two tabs: one for the filesystem info and another one with the devices
         # used by the filesystem.
         #
-        # @return [Tabs]
-        def tabs
-          tabs = [
+        # @return [Array<CWM::Tab>]
+        def calculate_tabs
+          [
             FilesystemTab.new(filesystem, pager),
             BtrfsUsedDevicesTab.new(filesystem, pager)
           ]
-
-          Tabs.new(*tabs)
         end
 
         # @return [String]
@@ -96,7 +84,7 @@ module Y2Partitioner
         private
 
         # @return [BtrfsFilesystemsTable]
-        def table(buttons_set)
+        def calculate_table(buttons_set)
           BtrfsFilesystemsTable.new(devices, @pager, buttons_set)
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
+++ b/src/lib/y2partitioner/widgets/pages/btrfs_filesystems.rb
@@ -68,8 +68,8 @@ module Y2Partitioner
         end
 
         # @return [ConfigurableBlkDevicesTable]
-        def table
-          @table ||= BtrfsFilesystemsTable.new(entries, pager, device_buttons)
+        def calculate_table
+          BtrfsFilesystemsTable.new(entries, pager, device_buttons)
         end
 
         # Widget with the dynamic set of buttons for the selected row

--- a/src/lib/y2partitioner/widgets/pages/devices_table.rb
+++ b/src/lib/y2partitioner/widgets/pages/devices_table.rb
@@ -20,6 +20,7 @@
 require "y2partitioner/device_graphs"
 require "y2partitioner/widgets/pages/base"
 require "y2partitioner/widgets/device_buttons_set"
+require "abstract_method"
 
 module Y2Partitioner
   module Widgets
@@ -44,6 +45,7 @@ module Y2Partitioner
         def contents
           return @contents if @contents
 
+          @table = calculate_table
           @contents = VBox(
             table,
             Left(device_buttons),
@@ -54,6 +56,11 @@ module Y2Partitioner
         # @macro seeAbstractWidget
         abstract_method :label
 
+        # @see Base
+        def state_info
+          { table.widget_id => table.ui_open_items }
+        end
+
         private
 
         # @return [CWM::TreePager]
@@ -63,6 +70,11 @@ module Y2Partitioner
         #
         # @return [Array<Y2Storage::Device>]
         abstract_method :devices
+
+        # Table to display
+        #
+        # @return [Widgets::ConfigurableBlkDevicesTable]
+        attr_reader :table
 
         # Widget representing the fixed buttons (those that do not change
         # every time the user selects a new row) displayed at the bottom of the
@@ -75,11 +87,11 @@ module Y2Partitioner
           Empty()
         end
 
-        # Table to display
+        # @see #table
         #
         # @return [Widgets::ConfigurableBlkDevicesTable]
-        def table
-          @table ||= ConfigurableBlkDevicesTable.new(devices, pager, device_buttons)
+        def calculate_table
+          ConfigurableBlkDevicesTable.new(devices, pager, device_buttons)
         end
 
         # Widget with the dynamic set of buttons for the selected row

--- a/src/lib/y2partitioner/widgets/pages/disk.rb
+++ b/src/lib/y2partitioner/widgets/pages/disk.rb
@@ -17,8 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2partitioner/widgets/tabs"
-require "y2partitioner/widgets/pages/base"
+require "y2partitioner/widgets/pages/tabbed"
 require "y2partitioner/widgets/used_devices_tab"
 require "y2partitioner/widgets/overview_tab"
 
@@ -29,7 +28,7 @@ module Y2Partitioner
       #
       # This page contains an {OverviewTab} and, in case of Multipath or BIOS RAID,
       # also a {DiskUsedDevicesTab}.
-      class Disk < Base
+      class Disk < Tabbed
         # @return [Y2Storage::BlkDevice] Disk device this page is about
         attr_reader :disk
         alias_method :device, :disk
@@ -52,17 +51,6 @@ module Y2Partitioner
           disk.basename
         end
 
-        # @macro seeCustomWidget
-        def contents
-          Top(
-            VBox(
-              Left(
-                tabs
-              )
-            )
-          )
-        end
-
         private
 
         # Tabs to show device data
@@ -71,15 +59,12 @@ module Y2Partitioner
         # another one with the device partitions. When the device is a  BIOS RAID or
         # Multipath, a third tab is used to show the disks that belong to the device.
         #
-        # @return [Tabs]
-        def tabs
-          tabs = [
-            OverviewTab.new(disk, @pager)
-          ]
-
+        # @return [Array<CWM::Tab>]
+        def calculate_tabs
+          tabs = [OverviewTab.new(disk, @pager)]
           tabs << DiskUsedDevicesTab.new(disk, @pager) if used_devices_tab?
 
-          Tabs.new(*tabs)
+          tabs
         end
 
         # Whether a extra tab for used devices is necessary

--- a/src/lib/y2partitioner/widgets/pages/lvm.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm.rb
@@ -57,8 +57,8 @@ module Y2Partitioner
         end
 
         # @see DevicesTable
-        def table
-          @table ||= LvmDevicesTable.new(devices, pager, device_buttons)
+        def calculate_table
+          LvmDevicesTable.new(devices, pager, device_buttons)
         end
 
         # Returns all volume groups and their logical volumes, including thin pools

--- a/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
+++ b/src/lib/y2partitioner/widgets/pages/lvm_vg.rb
@@ -17,9 +17,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2partitioner/widgets/tabs"
 require "y2partitioner/widgets/overview_tab"
-require "y2partitioner/widgets/pages/base"
+require "y2partitioner/widgets/pages/tabbed"
 require "y2partitioner/widgets/pages/lvm"
 require "y2partitioner/widgets/lvm_devices_table"
 require "y2partitioner/widgets/lvm_vg_bar_graph"
@@ -32,7 +31,7 @@ module Y2Partitioner
   module Widgets
     module Pages
       # A Page for a LVM Volume Group. It contains several tabs.
-      class LvmVg < Base
+      class LvmVg < Tabbed
         # Constructor
         #
         # @param lvm_vg [Y2Storage::Lvm_vg]
@@ -55,21 +54,15 @@ module Y2Partitioner
           @lvm_vg.vg_name
         end
 
-        # @macro seeCustomWidget
-        def contents
-          Top(
-            VBox(
-              Left(
-                Tabs.new(
-                  LvmVgTab.new(@lvm_vg, @pager),
-                  LvmPvTab.new(@lvm_vg, @pager)
-                )
-              )
-            )
-          )
-        end
-
         private
+
+        # @see Tabbed
+        def calculate_tabs
+          [
+            LvmVgTab.new(@lvm_vg, @pager),
+            LvmPvTab.new(@lvm_vg, @pager)
+          ]
+        end
 
         # @return [String]
         def section
@@ -88,14 +81,14 @@ module Y2Partitioner
         #
         # @param buttons_set [DeviceButtonsSet]
         # @return [LvmDevicesTable]
-        def table(buttons_set)
+        def calculate_table(buttons_set)
           LvmDevicesTable.new(devices, @pager, buttons_set)
         end
 
         # Bar graph representing the volume group
         #
         # @return [LvmBarGraph]
-        def bar_graph
+        def calculate_bar_graph
           LvmVgBarGraph.new(device)
         end
       end

--- a/src/lib/y2partitioner/widgets/pages/md_raid.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raid.rb
@@ -17,9 +17,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2partitioner/widgets/tabs"
 require "y2partitioner/device_graphs"
-require "y2partitioner/widgets/pages/base"
+require "y2partitioner/widgets/pages/tabbed"
 require "y2partitioner/widgets/pages/md_raids"
 require "y2partitioner/widgets/used_devices_tab"
 require "y2partitioner/widgets/used_devices_edit_button"
@@ -29,7 +28,7 @@ module Y2Partitioner
   module Widgets
     module Pages
       # A Page for a md raid device: contains {OverviewTab} and {MdUsedDevicesTab}
-      class MdRaid < Base
+      class MdRaid < Tabbed
         # Constructor
         #
         # @param md [Y2Storage::Md]
@@ -52,21 +51,15 @@ module Y2Partitioner
           @md.basename
         end
 
-        # @macro seeCustomWidget
-        def contents
-          Top(
-            VBox(
-              Left(
-                Tabs.new(
-                  OverviewTab.new(@md, @pager, initial: true),
-                  MdUsedDevicesTab.new(@md, @pager)
-                )
-              )
-            )
-          )
-        end
-
         private
+
+        # @see Tabbed
+        def calculate_tabs
+          [
+            OverviewTab.new(@md, @pager, initial: true),
+            MdUsedDevicesTab.new(@md, @pager)
+          ]
+        end
 
         # @return [String]
         def section

--- a/src/lib/y2partitioner/widgets/pages/md_raids.rb
+++ b/src/lib/y2partitioner/widgets/pages/md_raids.rb
@@ -57,8 +57,8 @@ module Y2Partitioner
         end
 
         # @see DevicesTable
-        def table
-          @table ||= MdRaidsTable.new(devices, pager, device_buttons)
+        def calculate_table
+          MdRaidsTable.new(devices, pager, device_buttons)
         end
 
         # Returns all Software RAIDs and its partitions

--- a/src/lib/y2partitioner/widgets/pages/stray_blk_device.rb
+++ b/src/lib/y2partitioner/widgets/pages/stray_blk_device.rb
@@ -17,25 +17,26 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2partitioner/widgets/tabs"
-require "y2partitioner/widgets/pages/base"
+require "y2partitioner/widgets/pages/tabbed"
 require "y2partitioner/widgets/overview_tab"
 
 module Y2Partitioner
   module Widgets
     module Pages
       # A Page for a StrayBlkDevice (basically a XEN virtual partition)
-      class StrayBlkDevice < Base
+      class StrayBlkDevice < Tabbed
         # @return [Y2Storage::StrayBlkDevice] device the page is about
         attr_reader :device
 
         # Constructor
         #
         # @param [Y2Storage::StrayBlkDevice] device
-        def initialize(device)
+        # @param pager [CWM::TreePager]
+        def initialize(device, pager)
           textdomain "storage"
 
           @device = device
+          @pager = pager
           self.widget_id = "stray_blk_device:" + device.name
         end
 
@@ -44,16 +45,11 @@ module Y2Partitioner
           device.basename
         end
 
-        # @macro seeCustomWidget
-        def contents
-          @contents ||=
-            Top(
-              VBox(
-                Left(
-                  OverviewTab.new(device, @pager)
-                )
-              )
-            )
+        private
+
+        # @see Tabbed
+        def calculate_tabs
+          [OverviewTab.new(device, @pager)]
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/pages/system.rb
+++ b/src/lib/y2partitioner/widgets/pages/system.rb
@@ -52,13 +52,17 @@ module Y2Partitioner
 
         # @macro seeCustomWidget
         def contents
-          invalidate_cached_content
-          return @contents if @contents
+          invalidate_cached_widgets
 
-          @contents = VBox(
+          VBox(
             table,
             Left(device_buttons)
           )
+        end
+
+        # @see Base
+        def state_info
+          { table.widget_id => table.ui_open_items }
         end
 
         private
@@ -71,10 +75,9 @@ module Y2Partitioner
 
         # Invalidates cached content if needed according to
         # {OverviewTreePager#invalidated_views}
-        def invalidate_cached_content
+        def invalidate_cached_widgets
           return unless pager.invalidated_pages.delete(:system)
 
-          @contents = nil
           @table = nil
         end
 

--- a/src/lib/y2partitioner/widgets/pages/tabbed.rb
+++ b/src/lib/y2partitioner/widgets/pages/tabbed.rb
@@ -1,0 +1,71 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2partitioner/widgets/tabs"
+require "y2partitioner/widgets/pages/base"
+require "abstract_method"
+
+module Y2Partitioner
+  module Widgets
+    module Pages
+      # Base class for pages containing several tabs, typically used to
+      # represent a given device
+      class Tabbed < Base
+        # @see Base
+        #
+        # @return [Hash]
+        def state_info
+          tabs.current_page.state_info
+        end
+
+        # @macro seeCustomWidget
+        def contents
+          return @contents if @contents
+
+          @tabs = Tabs.new(*calculate_tabs)
+          @contents =
+            Top(
+              VBox(
+                Left(
+                  tabs
+                )
+              )
+            )
+        end
+
+        def init
+          # Invalidate the memoized content so it gets recalculated in the next UI draw
+          @contents = nil
+        end
+
+        private
+
+        # Set of tabs of the page
+        #
+        # @return [Tabs]
+        attr_reader :tabs
+
+        # @see #tabs
+        #
+        # @return [Array<CWM::Tab>] All tabs must be able to respond to #state_info
+        abstract_method :calculate_tabs
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/tabs.rb
+++ b/src/lib/y2partitioner/widgets/tabs.rb
@@ -11,7 +11,8 @@ module Y2Partitioner
       # Overrides default behavior of tabs to register the new state before
       # doing the real switch
       def switch_page(page)
-        UIState.instance.switch_to_tab(page.label)
+        target = (page == default_page) ? nil : page.label
+        UIState.instance.switch_to_tab(target)
         super
       end
 
@@ -43,11 +44,13 @@ module Y2Partitioner
 
     # @see Tabs
     class DumbTabPager < CWM::DumbTabPager
+      alias_method :default_page, :initial_page
       include TabsWithState
     end
 
     # @see Tabs
     class PushButtonTabPager < CWM::PushButtonTabPager
+      alias_method :default_page, :initial_page
       include TabsWithState
     end
   end

--- a/src/lib/y2partitioner/widgets/tabs.rb
+++ b/src/lib/y2partitioner/widgets/tabs.rb
@@ -8,11 +8,16 @@ module Y2Partitioner
   module Widgets
     # Mixin for the different Tab subclasses to interact with {UIState}
     module TabsWithState
-      # Overrides default behavior of tabs to register the new state before
-      # doing the real switch
+      # Overrides default behavior of tabs to register the status of the current
+      # page and the set the new one in {UIState} before doing the real switch
       def switch_page(page)
+        state = UIState.instance
+
+        state.save_extra_info
+
         target = (page == default_page) ? nil : page.label
-        UIState.instance.switch_to_tab(target)
+        state.switch_to_tab(target)
+
         super
       end
 

--- a/src/lib/y2partitioner/widgets/used_devices_tab.rb
+++ b/src/lib/y2partitioner/widgets/used_devices_tab.rb
@@ -44,7 +44,16 @@ module Y2Partitioner
 
       # @macro seeCustomWidget
       def contents
-        @contents ||= VBox(table, buttons)
+        VBox(table, buttons)
+      end
+
+      # State information of the tab
+      #
+      # See {Widgets::Pages::Base#state_info}
+      #
+      # @return [Hash]
+      def state_info
+        { table.widget_id => table.ui_open_items }
       end
 
       private
@@ -58,7 +67,7 @@ module Y2Partitioner
       #
       # @return [Yast::Term]
       def buttons
-        Empty()
+        @buttons ||= Empty()
       end
 
       # Returns a table with all devices used by the container device

--- a/test/y2partitioner/actions/add_btrfs_test.rb
+++ b/test/y2partitioner/actions/add_btrfs_test.rb
@@ -32,11 +32,33 @@ describe Y2Partitioner::Actions::AddBtrfs do
   end
 
   subject(:sequence) { described_class.new }
-  let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+
+  # Number of Btrfs filesystems in the current devicegraph
+  #
+  # Using "let" wouldn't be an option here. To test the real transaction we always want to
+  # check in the devicegraph that is current in the precise moment we ask, with no caching.
+  def btrfs_count
+    Y2Partitioner::DeviceGraphs.instance.current.btrfs_filesystems.size
+  end
 
   describe "#run" do
+    let(:controller) { Y2Partitioner::Actions::Controllers::BtrfsDevices.new }
+
     before do
       allow(Yast2::Popup).to receive(:show)
+
+      allow(Y2Partitioner::Actions::Controllers::Filesystem).to receive(:new)
+
+      allow(Y2Partitioner::Actions::Controllers::BtrfsDevices).to receive(:new)
+        .and_return(controller)
+
+      allow(Y2Partitioner::Dialogs::BtrfsDevices).to receive(:run) do
+        # If this dialog returns :next, it has for sure added at least one device
+        device = Y2Partitioner::DeviceGraphs.instance.current.find_by_name("/dev/sda3")
+        controller.add_device(device)
+
+        :next
+      end
     end
 
     context "when there are not enough available devices" do
@@ -57,13 +79,7 @@ describe Y2Partitioner::Actions::AddBtrfs do
       let(:devicegraph) { "complex-lvm-encrypt.yml" }
 
       context "if the user goes forward through all the dialogs" do
-        let(:controller) { Y2Partitioner::Actions::Controllers::BtrfsDevices.new }
-
         before do
-          allow(Y2Partitioner::Actions::Controllers::Filesystem).to receive(:new)
-          allow_any_instance_of(Y2Partitioner::Actions::Controllers::BtrfsDevices).to receive(:new)
-            .and_return(controller)
-          allow(Y2Partitioner::Dialogs::BtrfsDevices).to receive(:run).and_return :next
           allow(Y2Partitioner::Dialogs::BtrfsOptions).to receive(:run).and_return :next
         end
 
@@ -72,20 +88,14 @@ describe Y2Partitioner::Actions::AddBtrfs do
         end
 
         it "creates a new Btrfs filesytem" do
-          expect(current_graph.btrfs_filesystems.size).to eq 0
-
-          device = current_graph.find_by_name("/dev/sda3")
-          controller.add_device(device)
+          expect(btrfs_count).to eq 0
           sequence.run
-
-          expect(current_graph.btrfs_filesystems.size).to eq 1
+          expect(btrfs_count).to eq 1
         end
       end
 
       context "if the user aborts the process at some point" do
         before do
-          allow(Y2Partitioner::Actions::Controllers::Filesystem).to receive(:new)
-          allow(Y2Partitioner::Dialogs::BtrfsDevices).to receive(:run).and_return :next
           allow(Y2Partitioner::Dialogs::BtrfsOptions).to receive(:run).and_return :abort
         end
 
@@ -94,7 +104,9 @@ describe Y2Partitioner::Actions::AddBtrfs do
         end
 
         it "does not create a new Btrfs filesystem in the devicegraph" do
-          expect { sequence.run }.to_not(change { current_graph.btrfs_filesystems })
+          expect(btrfs_count).to eq 0
+          sequence.run
+          expect(btrfs_count).to eq 0
         end
       end
     end

--- a/test/y2partitioner/ui_state_test.rb
+++ b/test/y2partitioner/ui_state_test.rb
@@ -43,7 +43,7 @@ describe Y2Partitioner::UIState do
   let(:disks_page) { Y2Partitioner::Widgets::Pages::Disks.new(disks, pager) }
   let(:md_raids_page) { Y2Partitioner::Widgets::Pages::MdRaids.new(pager) }
   let(:lvm_page) { Y2Partitioner::Widgets::Pages::Lvm.new(pager) }
-  let(:bcaches_page) { Y2Partitioner::Widgets::Pages::Bcaches.new([], pager) }
+  let(:bcaches_page) { Y2Partitioner::Widgets::Pages::Bcaches.new(pager) }
   let(:btrfs_filesystems_page) { Y2Partitioner::Widgets::Pages::BtrfsFilesystems.new([], pager) }
 
   describe ".new" do

--- a/test/y2partitioner/widgets/pages/bcache_test.rb
+++ b/test/y2partitioner/widgets/pages/bcache_test.rb
@@ -19,9 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com
 
-require_relative "../../test_helper"
-
-require "cwm/rspec"
+require_relative "device_page"
 require "y2partitioner/widgets/pages/bcache"
 
 describe Y2Partitioner::Widgets::Pages::Bcache do
@@ -42,6 +40,12 @@ describe Y2Partitioner::Widgets::Pages::Bcache do
   let(:items) { column_values(table, 0) }
 
   include_examples "CWM::Page"
+
+  include_examples(
+    "device page",
+    "Y2Partitioner::Widgets::OverviewTab",
+    "Y2Partitioner::Widgets::Pages::BcacheUsedDevicesTab"
+  )
 
   describe "#contents" do
     it "shows a bcache overview tab" do

--- a/test/y2partitioner/widgets/pages/bcaches_test.rb
+++ b/test/y2partitioner/widgets/pages/bcaches_test.rb
@@ -37,18 +37,26 @@ describe Y2Partitioner::Widgets::Pages::Bcaches do
 
   include_examples "CWM::Page"
 
+  let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
+  let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDevicesTable) } }
+
   describe "#contents" do
-    let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
-
     it "shows a table with the bcache devices and their partitions" do
-      table = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDevicesTable) }
-
       expect(table).to_not be_nil
 
       devices = column_values(table, 0)
 
       expect(remove_sort_keys(devices)).to contain_exactly("/dev/bcache0", "/dev/bcache1",
         "/dev/bcache2", "bcache0p1", "bcache2p1")
+    end
+  end
+
+  describe "#state_info" do
+    let(:open) { { "id1" => true, "id2" => false } }
+
+    it "returns a hash with the id of the devices table and its corresponding open items" do
+      expect(table).to receive(:ui_open_items).and_return open
+      expect(subject.state_info).to eq(table.widget_id => open)
     end
   end
 end

--- a/test/y2partitioner/widgets/pages/bcaches_test.rb
+++ b/test/y2partitioner/widgets/pages/bcaches_test.rb
@@ -31,9 +31,7 @@ describe Y2Partitioner::Widgets::Pages::Bcaches do
 
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }
 
-  subject { described_class.new(bcaches, pager) }
-
-  let(:bcaches) { device_graph.bcaches }
+  subject { described_class.new(pager) }
 
   let(:pager) { double("OverviewTreePager") }
 

--- a/test/y2partitioner/widgets/pages/device_page.rb
+++ b/test/y2partitioner/widgets/pages/device_page.rb
@@ -1,0 +1,82 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com
+
+require_relative "../../test_helper"
+
+require "cwm/rspec"
+
+RSpec.shared_examples "device page" do |overview_tab_id, devices_tab_id|
+  let(:tabs_widget) do
+    subject.contents.nested_find { |e| e.is_a?(CWM::PushButtonTabPager) }
+  end
+
+  let(:overview_tab) { tabs_widget.send(:page_for_id, overview_tab_id) }
+  let(:devices_tab) { tabs_widget.send(:page_for_id, devices_tab_id) }
+  let(:ui_state) { Y2Partitioner::UIState.instance }
+
+  describe "switching between tabs" do
+    before do
+      # Mock the query to check the selected item in the table
+      allow(Yast::UI).to receive(:QueryWidget).with(anything, :SelectedItems).and_return []
+    end
+
+    it "saves the state information of the tab" do
+      expect(ui_state).to receive(:save_extra_info)
+      tabs_widget.switch_page(devices_tab)
+    end
+
+    it "correctly updates the page in UIState" do
+      expect(ui_state).to receive(:switch_to_tab).with(devices_tab.label).ordered
+      expect(ui_state).to receive(:switch_to_tab).with(nil).ordered
+
+      tabs_widget.switch_page(devices_tab)
+      tabs_widget.switch_page(overview_tab)
+    end
+  end
+
+  describe "#state_info" do
+    before do
+      allow(tabs_widget).to receive(:current_page).and_return tab
+    end
+
+    let(:tab_content) { Yast::CWM.widgets_in_contents([tab]) }
+    let(:table) { tab_content.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDevicesTable) } }
+    let(:open) { { "id1" => true, "id2" => false } }
+
+    context "if the overview tab is currently selected" do
+      let(:tab) { overview_tab }
+
+      it "returns a hash with the id of the overview table and its corresponding open items" do
+        expect(table).to receive(:ui_open_items).and_return open
+        expect(subject.state_info).to eq(table.widget_id => open)
+      end
+    end
+
+    context "if the used devices tab is currently selected" do
+      let(:tab) { devices_tab }
+
+      it "returns a hash with the id of the used devices table and its corresponding open items" do
+        expect(table).to receive(:ui_open_items).and_return open
+        expect(subject.state_info).to eq(table.widget_id => open)
+      end
+    end
+  end
+end

--- a/test/y2partitioner/widgets/pages/disk_test.rb
+++ b/test/y2partitioner/widgets/pages/disk_test.rb
@@ -19,9 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com
 
-require_relative "../../test_helper"
-
-require "cwm/rspec"
+require_relative "device_page"
 require "y2partitioner/widgets/pages/disk"
 
 describe Y2Partitioner::Widgets::Pages::Disk do
@@ -67,6 +65,12 @@ describe Y2Partitioner::Widgets::Pages::Disk do
         expect(Y2Partitioner::Widgets::UsedDevicesTab).to receive(:new)
         subject.contents
       end
+
+      include_examples(
+        "device page",
+        "Y2Partitioner::Widgets::OverviewTab",
+        "Y2Partitioner::Widgets::Pages::DiskUsedDevicesTab"
+      )
     end
 
     context "when the device is a multipath" do
@@ -82,6 +86,12 @@ describe Y2Partitioner::Widgets::Pages::Disk do
         expect(Y2Partitioner::Widgets::UsedDevicesTab).to receive(:new)
         subject.contents
       end
+
+      include_examples(
+        "device page",
+        "Y2Partitioner::Widgets::OverviewTab",
+        "Y2Partitioner::Widgets::Pages::DiskUsedDevicesTab"
+      )
     end
   end
 

--- a/test/y2partitioner/widgets/pages/disks_test.rb
+++ b/test/y2partitioner/widgets/pages/disks_test.rb
@@ -42,9 +42,10 @@ describe Y2Partitioner::Widgets::Pages::Disks do
     device.is?(:lvm_lv, :partition) ? device.basename : device.name
   end
 
+  let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
+  let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDevicesTable) } }
+
   describe "#contents" do
-    let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
-    let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDevicesTable) } }
     let(:disks_and_parts) do
       (device_graph.disks + device_graph.disks.map(&:partitions)).flatten.compact
     end
@@ -71,6 +72,15 @@ describe Y2Partitioner::Widgets::Pages::Disks do
 
         expect(remove_sort_keys(items_name.sort)).to eq(devices_name.sort)
       end
+    end
+  end
+
+  describe "#state_info" do
+    let(:open) { { "id1" => true, "id2" => false } }
+
+    it "returns a hash with the id of the devices table and its corresponding open items" do
+      expect(table).to receive(:ui_open_items).and_return open
+      expect(subject.state_info).to eq(table.widget_id => open)
     end
   end
 end

--- a/test/y2partitioner/widgets/pages/lvm_test.rb
+++ b/test/y2partitioner/widgets/pages/lvm_test.rb
@@ -39,11 +39,10 @@ describe Y2Partitioner::Widgets::Pages::Lvm do
 
   include_examples "CWM::Page"
 
+  let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
+  let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::LvmDevicesTable) } }
+
   describe "#contents" do
-    let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
-
-    let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::LvmDevicesTable) } }
-
     let(:items) { column_values(table, 0) }
 
     before do
@@ -71,6 +70,15 @@ describe Y2Partitioner::Widgets::Pages::Lvm do
     it "shows a menu button to create a new VG" do
       button = widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::LvmVgAddButton) }
       expect(button).to_not be_nil
+    end
+  end
+
+  describe "#state_info" do
+    let(:open) { { "id1" => true, "id2" => false } }
+
+    it "returns a hash with the id of the devices table and its corresponding open items" do
+      expect(table).to receive(:ui_open_items).and_return open
+      expect(subject.state_info).to eq(table.widget_id => open)
     end
   end
 end

--- a/test/y2partitioner/widgets/pages/lvm_vg_test.rb
+++ b/test/y2partitioner/widgets/pages/lvm_vg_test.rb
@@ -19,9 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require_relative "../../test_helper"
-
-require "cwm/rspec"
+require_relative "device_page"
 require "y2partitioner/widgets/pages/lvm_vg"
 
 describe Y2Partitioner::Widgets::Pages::LvmVg do
@@ -34,6 +32,12 @@ describe Y2Partitioner::Widgets::Pages::LvmVg do
   let(:pager) { double("Pager") }
 
   include_examples "CWM::Page"
+
+  include_examples(
+    "device page",
+    "Y2Partitioner::Widgets::Pages::LvmVgTab",
+    "Y2Partitioner::Widgets::Pages::LvmPvTab"
+  )
 
   let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
   let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::LvmDevicesTable) } }

--- a/test/y2partitioner/widgets/pages/md_raid_test.rb
+++ b/test/y2partitioner/widgets/pages/md_raid_test.rb
@@ -19,9 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require_relative "../../test_helper"
-
-require "cwm/rspec"
+require_relative "device_page"
 require "y2partitioner/widgets/pages/md_raid"
 
 describe Y2Partitioner::Widgets::Pages::MdRaid do
@@ -51,6 +49,12 @@ describe Y2Partitioner::Widgets::Pages::MdRaid do
       subject.contents
     end
   end
+
+  include_examples(
+    "device page",
+    "Y2Partitioner::Widgets::OverviewTab",
+    "Y2Partitioner::Widgets::Pages::MdUsedDevicesTab"
+  )
 
   describe Y2Partitioner::Widgets::Pages::MdUsedDevicesTab do
     subject { described_class.new(md, pager) }

--- a/test/y2partitioner/widgets/pages/stray_blk_device_test.rb
+++ b/test/y2partitioner/widgets/pages/stray_blk_device_test.rb
@@ -30,7 +30,7 @@ describe Y2Partitioner::Widgets::Pages::StrayBlkDevice do
   let(:device) { current_graph.stray_blk_devices.first }
   let(:pager) { double("Pager") }
 
-  subject { described_class.new(device) }
+  subject { described_class.new(device, pager) }
 
   let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
   let(:table) { widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::ConfigurableBlkDevicesTable) } }

--- a/test/y2partitioner/widgets/pages/system_test.rb
+++ b/test/y2partitioner/widgets/pages/system_test.rb
@@ -40,17 +40,17 @@ describe Y2Partitioner::Widgets::Pages::System do
 
   include_examples "CWM::Page"
 
+  # Widget with the list of devices
+  def find_table(widgets)
+    widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDevicesTable) }
+  end
+
+  # Names from the devices in the list
+  def row_names(table)
+    column_values(table, 0)
+  end
+
   describe "#contents" do
-    # Widget with the list of devices
-    def find_table(widgets)
-      widgets.detect { |i| i.is_a?(Y2Partitioner::Widgets::BlkDevicesTable) }
-    end
-
-    # Names from the devices in the list
-    def row_names(table)
-      column_values(table, 0)
-    end
-
     let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
 
     let(:table) { find_table(widgets) }
@@ -236,6 +236,17 @@ describe Y2Partitioner::Widgets::Pages::System do
         # Still cached
         expect(remove_sort_keys(rows)).to eq ["/dev/sda", "new:/device"]
       end
+    end
+  end
+
+  describe "#state_info" do
+    let(:widgets) { Yast::CWM.widgets_in_contents([subject]) }
+    let(:table) { find_table(widgets) }
+    let(:open) { { "id1" => true, "id2" => false } }
+
+    it "returns a hash with the id of the devices table and its corresponding open items" do
+      expect(table).to receive(:ui_open_items).and_return open
+      expect(subject.state_info).to eq(table.widget_id => open)
     end
   end
 end


### PR DESCRIPTION
## Problem

On one hand, after all the recent changes in the the `partitioner-ui-02` branch, the correct row of each table was not always properly selected in the UI:

- After deleting a LV in the "All Devices" table or in the "LVM Volume Groups" one, the corresponding VG was not being selected.
- After creating a new multi-device Btrfs filesystem, that new device was not selected.
- After creating a single (not multi-device) Btrfs filesystem through the "Add -> Btrfs" menu option, in a table containing the block device being formatted, such device was not selected.
- When moving to the "Used Devices" tab of a device and then back to the "Overview" one without performing any chance, the selection was always changed to the first row.

On the other hand, now that all tables in the Partitioner contain nested elements, it's necessary to remember which parts of each table has being collapsed by the user and ensure they remain collapsed in subsequent redraws of the same table.

## Solution

First of all, this pull request contains fixes for all the mentioned problems.

It also includes a mechanism to store into `UIState` the state information of the current page (and tab) and uses that mechanism to ensure collapsed/expanded table sections are properly kept (the table state is stored before switching to another page or tab and before executing any action) and displayed (the initial value of `TableItem#open` for each item is set based on the stored state).

Bonus: this also adds a non-related missing "require" found during some manual testing. Apparently it was not needed in the `master` branch, but its absence was producing a crash in the `partitioner-ui-02` branch.

## Testing

- Tested manually, so far.
- Added unit tests for the new parts.

## Review

It's probably easier to review commit by commit, since each of them addresses a different issue.