### PR TITLE
Fix Jira references in changelog

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Fri Oct 30 11:58:50 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
-- Partitioner: revamped user interface (related to jsd#PM-73,
-  jsd#SLE-7742, jsd#SLE-15283).
+- Partitioner: revamped user interface (related to jsc#PM-73,
+  jsc#SLE-7742, jsc#SLE-15283).
 - 4.3.17
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## Problem

#1157 is failing in Jenkins because `jsd#XXX` is not recognized as a reference to Jira anymore.

## Solution

Use `jsc#XXXX` instead.
