### PR TITLE
Revisit the size and format of the proposed /boot/efi

### DIFF
--- a/doc/boot-requirements.md
+++ b/doc/boot-requirements.md
@@ -118,37 +118,45 @@
 				- **requires the /boot/efi partition to have id ESP (according to the EFI standard)**
 		- and the first partition contains no boot code or EFI files
 			- **requires only a new /boot/efi partition**
-			- **requires /boot/efi to be at the start of an MBR partition table, bumping any existing table if needed**
+			- **requires /boot/efi to be the first partition of the device**
+			- **requires /boot/efi to be in a MBR partition table, bumping any existing table if needed**
 			- **requires the /boot/efi partition to have id DOS32 (bootcode will be installed there)**
 		- and there are no partitions in the boot disk
 			- **requires only a new /boot/efi partition**
-			- **requires /boot/efi to be at the start of an MBR partition table, bumping any existing table if needed**
+			- **requires /boot/efi to be the first partition of the device**
+			- **requires /boot/efi to be in a MBR partition table, bumping any existing table if needed**
 			- **requires the /boot/efi partition to have id DOS32 (bootcode will be installed there)**
 	- and the first partition in the boot disk is a standard EFI with id ESP
 		- **requires only a new /boot/efi partition**
-		- **requires /boot/efi to be at the start of an MBR partition table, bumping any existing table if needed**
+		- **requires /boot/efi to be the first partition of the device**
+		- **requires /boot/efi to be in a MBR partition table, bumping any existing table if needed**
 		- **requires the /boot/efi partition to have id DOS32 (bootcode will be installed there)**
 - if the target boot disk initially contains a GPT partition table
 	- even if the first partition has id DOS32 and a FAT filesystem with an EFI system
 		- **requires only a new /boot/efi partition**
-		- **requires /boot/efi to be at the start of an MBR partition table, bumping any existing table if needed**
+		- **requires /boot/efi to be the first partition of the device**
+		- **requires /boot/efi to be in a MBR partition table, bumping any existing table if needed**
 		- **requires the /boot/efi partition to have id DOS32 (bootcode will be installed there)**
 	- if there are no partitions in the boot disk
 		- **requires only a new /boot/efi partition**
-		- **requires /boot/efi to be at the start of an MBR partition table, bumping any existing table if needed**
+		- **requires /boot/efi to be the first partition of the device**
+		- **requires /boot/efi to be in a MBR partition table, bumping any existing table if needed**
 		- **requires the /boot/efi partition to have id DOS32 (bootcode will be installed there)**
 - if the target boot disk contains no partition table initially
 	- **requires only a new /boot/efi partition**
-	- **requires /boot/efi to be at the start of an MBR partition table, bumping any existing table if needed**
+	- **requires /boot/efi to be the first partition of the device**
+	- **requires /boot/efi to be in a MBR partition table, bumping any existing table if needed**
 	- **requires the /boot/efi partition to have id DOS32 (bootcode will be installed there)**
 - when proposing a new EFI partition
 	- **requires /boot/efi to be on the boot disk**
 	- **requires /boot/efi to be a non-encrypted vfat partition**
 	- **requires /boot/efi to be close enough to the beginning of disk**
 	- when aiming for the recommended size
-		- **requires /boot/efi to be exactly 256 MiB large (always FAT32 min size)**
+		- **does not enforce FAT32 or 16 for /boot/efi (FAT size will be decided by mkfs.vfat)**
+		- **requires /boot/efi to be exactly 128 MiB large**
 	- when aiming for the minimal size
-		- **requires /boot/efi to be exactly 256 MiB large (always FAT32 min size)**
+		- **does not enforce FAT32 or 16 for /boot/efi (FAT size will be decided by mkfs.vfat)**
+		- **requires /boot/efi to be exactly 128 MiB large**
 
 ## needed partitions in a S/390 system
 - trying to install in a FBA DASD disk
@@ -302,7 +310,10 @@
 		- **requires /boot/efi to be a non-encrypted vfat partition**
 		- **requires /boot/efi to be close enough to the beginning of disk**
 		- when aiming for the recommended size
-			- **requires /boot/efi to be exactly 500 MiB large (enough for several operating systems)**
-		- when aiming for the minimal size
+			- **requires /boot/efi to use FAT32**
 			- **requires it to be at least 256 MiB (min size for FAT32 in drives with 4-KiB-per-sector)**
-			- **requires it to be at most 500 MiB (enough space for several operating systems)**
+			- **requires it to be at most 512 MiB (enough space for several operating systems)**
+		- when aiming for the minimal size
+			- **does not enforce FAT32 or 16 for /boot/efi (FAT size will be decided by mkfs.vfat)**
+			- **requires it to be at least 128 MiB (MS Windows requires 100 MiB for itself)**
+			- **requires it to be at most 512 MiB (enough space for several operating systems)**

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov  4 09:21:55 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Proposal: adjusted the size and format of the EFI partition
+  (bsc#1177358, bsc#1170625, bsc#1119318).
+- 4.3.18
+
+-------------------------------------------------------------------
 Fri Oct 30 11:58:50 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Partitioner: revamped user interface (related to jsc#PM-73,

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.17
+Version:        4.3.18
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/volume_specification_builder.rb
+++ b/src/lib/y2storage/volume_specification_builder.rb
@@ -107,9 +107,11 @@ module Y2Storage
         v.mount_point = "/boot/efi"
         v.fs_types = [Filesystems::Type::VFAT]
         v.fs_type = Filesystems::Type::VFAT
-        v.min_size = DiskSize.MiB(256)
-        v.desired_size = DiskSize.MiB(500)
-        v.max_size = DiskSize.MiB(500)
+        v.min_size = DiskSize.MiB(128)
+        v.desired_size = DiskSize.MiB(256)
+        # Note 512MiB seems to be the threshold used by mkfs.vfat to
+        # automatically use FAT32 if no FAT size is specified
+        v.max_size = DiskSize.MiB(512)
       end
     end
 

--- a/test/data/devicegraphs/output/raspi_empty.yml
+++ b/test/data/devicegraphs/output/raspi_empty.yml
@@ -5,7 +5,7 @@
     partition_table: ms-dos
     partitions:
     - partition:
-        size: 256 MiB
+        size: 128 MiB
         name: /dev/sda1
         type: primary
         id: dos32

--- a/test/data/devicegraphs/output/raspi_firmware.yml
+++ b/test/data/devicegraphs/output/raspi_firmware.yml
@@ -12,7 +12,7 @@
         file_system: vfat
         mount_point: /boot/vc
     - partition:
-        size: 256 MiB
+        size: 128 MiB
         name: /dev/sda2
         type: primary
         id: esp

--- a/test/support/proposed_partitions_examples.rb
+++ b/test/support/proposed_partitions_examples.rb
@@ -116,21 +116,34 @@ RSpec.shared_examples "flexible size EFI partition" do
   context "when aiming for the recommended size" do
     let(:target) { :desired }
 
-    it "requires /boot/efi to be exactly 500 MiB large (enough for several operating systems)" do
-      expect(efi_part.min_size).to eq 500.MiB
-      expect(efi_part.max_size).to eq 500.MiB
+    it "requires /boot/efi to use FAT32" do
+      expect(efi_part.mkfs_options).to include "-F32"
+    end
+
+    it "requires it to be at least 256 MiB (min size for FAT32 in drives with 4-KiB-per-sector)" do
+      expect(efi_part.min).to eq 256.MiB
+    end
+
+    it "requires it to be at most 512 MiB (enough space for several operating systems)" do
+      expect(efi_part.max).to eq 512.MiB
     end
   end
 
   context "when aiming for the minimal size" do
     let(:target) { :min }
 
-    it "requires it to be at least 256 MiB (min size for FAT32 in drives with 4-KiB-per-sector)" do
-      expect(efi_part.min).to eq 256.MiB
+    it "does not enforce FAT32 or 16 for /boot/efi (FAT size will be decided by mkfs.vfat)" do
+      expect(efi_part.mkfs_options).to be_nil
     end
 
-    it "requires it to be at most 500 MiB (enough space for several operating systems)" do
-      expect(efi_part.max).to eq 500.MiB
+    # See Windows requirements at
+    # https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/configure-uefigpt-based-hard-drive-partitions
+    it "requires it to be at least 128 MiB (MS Windows requires 100 MiB for itself)" do
+      expect(efi_part.min).to eq 128.MiB
+    end
+
+    it "requires it to be at most 512 MiB (enough space for several operating systems)" do
+      expect(efi_part.max).to eq 512.MiB
     end
   end
 end
@@ -141,18 +154,26 @@ RSpec.shared_examples "minimalistic EFI partition" do
   context "when aiming for the recommended size" do
     let(:target) { :desired }
 
-    it "requires /boot/efi to be exactly 256 MiB large (always FAT32 min size)" do
-      expect(efi_part.min_size).to eq 256.MiB
-      expect(efi_part.max_size).to eq 256.MiB
+    it "does not enforce FAT32 or 16 for /boot/efi (FAT size will be decided by mkfs.vfat)" do
+      expect(efi_part.mkfs_options).to be_nil
+    end
+
+    it "requires /boot/efi to be exactly 128 MiB large" do
+      expect(efi_part.min_size).to eq 128.MiB
+      expect(efi_part.max_size).to eq 128.MiB
     end
   end
 
   context "when aiming for the minimal size" do
     let(:target) { :min }
 
-    it "requires /boot/efi to be exactly 256 MiB large (always FAT32 min size)" do
-      expect(efi_part.min_size).to eq 256.MiB
-      expect(efi_part.max_size).to eq 256.MiB
+    it "does not enforce FAT32 or 16 for /boot/efi (FAT size will be decided by mkfs.vfat)" do
+      expect(efi_part.mkfs_options).to be_nil
+    end
+
+    it "requires /boot/efi to be exactly 128 MiB large" do
+      expect(efi_part.min_size).to eq 128.MiB
+      expect(efi_part.max_size).to eq 128.MiB
     end
   end
 end

--- a/test/y2storage/volume_specification_builder_test.rb
+++ b/test/y2storage/volume_specification_builder_test.rb
@@ -65,9 +65,9 @@ describe Y2Storage::VolumeSpecificationBuilder do
             mount_point:  "/boot/efi",
             fs_types:     [Y2Storage::Filesystems::Type::VFAT],
             fs_type:      Y2Storage::Filesystems::Type::VFAT,
-            min_size:     256.MiB,
-            desired_size: 500.MiB,
-            max_size:     500.MiB
+            min_size:     128.MiB,
+            desired_size: 256.MiB,
+            max_size:     512.MiB
           )
         end
       end


### PR DESCRIPTION
## Problem

The installer was proposing a `/boot/efi` partition in which both the size and FAT size were subject to improvement.

First of all, we were proposing a partition with a size between 256MiB and 500MiB. The reason for such minimum was that in Advanced Format 4K Native drives (4-KB-per-sector), a FAT32 file-system cannot work properly on smaller partitions.

But we were not enforcing the FAT size to 32. We were delegating the decision of the FAT size to `mkfs.vfat`. Turns out that, for whatever reason, that tool only uses FAT32 for partitions equal or bigger than 512MiB... which we were never creating by default.

As a result, our `/boot/efi` partition was always FAT16. The EFI standard recommends FAT32 when possible.

On the other hand, some people claim that 256 MiB is too big as a minimum size, specially in architectures like aarch64 in which sharing the computer with MS Windows or other operating systems is less common (although not impossible).

Related bug reports:

https://bugzilla.suse.com/show_bug.cgi?id=1177358
https://bugzilla.suse.com/show_bug.cgi?id=1170625
https://bugzilla.suse.com/show_bug.cgi?id=1119318

## Solution

Adjust the limits and enforce the FAT size when possible, as explained by the auto-generated documentation:

### When proposing a new /boot/efi in aarch64 (including Raspberry Pi)

  - when aiming for the recommended  or the minimal size (it doesn't make a difference)
    - **does not enforce FAT32 or 16 for /boot/efi (FAT size will be decided by mkfs.vfat)**
    - **requires /boot/efi to be exactly 128 MiB large**

### When proposing a new /boot/efi in x86

  - when aiming for the recommended size
    - **requires /boot/efi to use FAT32**
    - **requires it to be at least 256 MiB (min size for FAT32 in drives with 4-KiB-per-sector)**
    - **requires it to be at most 512 MiB (enough space for several operating systems)**
  - when aiming for the minimal size
    - **does not enforce FAT32 or 16 for /boot/efi (FAT size will be decided by mkfs.vfat)**
    - **requires it to be at least 128 MiB (MS Windows requires 100 MiB for itself)**
    - **requires it to be at most 512 MiB (enough space for several operating systems)**

## Testing

- Updated unit tests and documentation
- Tested manually, see screenshot below.

![small-efi](https://user-images.githubusercontent.com/3638289/98092656-3398c400-1e87-11eb-8531-f7d1a5728fac.png)
