### PR TITLE
WIP: Disable 'Add' menu actions on NFS page

### DIFF
--- a/src/lib/y2partitioner/widgets/menus/add.rb
+++ b/src/lib/y2partitioner/widgets/menus/add.rb
@@ -60,6 +60,8 @@ module Y2Partitioner
 
         # @see Device
         def disabled_for_device
+          return all_item_ids if disable_all?
+
           items = []
           items << :menu_add_partition unless support_add_partition?
           items << :menu_add_lv unless support_add_lv?
@@ -68,6 +70,8 @@ module Y2Partitioner
 
         # @see Device
         def disabled_without_device
+          return all_item_ids if disable_all?
+
           [:menu_add_partition, :menu_add_lv]
         end
 
@@ -121,6 +125,27 @@ module Y2Partitioner
           return false unless device
 
           device.is?(:lvm_vg, :lvm_lv)
+        end
+
+        # Whether all actions in this menus should be disabled.
+        #
+        # For NFS, we are embedding a separate YaST module (yast-nfs-client)
+        # That doesn't fit very well into the partitioner's menu structure;
+        # so we have to disable all actions in this menu and rely on buttons
+        # that the embedded module adds below the devices table.
+        #
+        # @return [Boolean]
+        def disable_all?
+          nfs_page?
+        end
+
+        # Whether the current page in the partitioner is the NFS page.
+        #
+        # @return [Boolean]
+        def nfs_page?
+          # FIXME: This is ugly. We need a better way to check what the current page is.
+          page = Yast::UI.QueryWidget(Id("Y2Partitioner::Widgets::OverviewTree"), :Value)
+          page.end_with?("NfsMounts")
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/menus/base.rb
+++ b/src/lib/y2partitioner/widgets/menus/base.rb
@@ -58,6 +58,13 @@ module Y2Partitioner
           end
         end
 
+        # Return a list of the IDs of all items in this menu.
+        #
+        # @return [Array<Symbol>] ids of the menu items
+        def all_item_ids
+          items.map { |item| item_id(item) }.compact
+        end
+
         private
 
         # Dialog that should be opened for the given UI event
@@ -74,6 +81,19 @@ module Y2Partitioner
         # @return [Actions::Base, nil] nil if the event does not correspond to any action
         def action_for(_event)
           nil
+        end
+
+        # Return the ID of a menu item.
+        #
+        # @return Symbol|String|nil
+        def item_id(item)
+          return nil if item.nil? || !item.is_a?(Yast::Term)
+
+          id_term = item.first
+          return nil if id_term.nil? || !id_term.is_a?(Yast::Term)
+          return nil unless id_term.value == :id
+
+          id_term.first
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -53,7 +53,7 @@ module Y2Partitioner
 
     # Widget representing partitioner overview pager with tree on left side and rest on right side.
     #
-    # It has replace point where it displays more details about selected element in partitioning.
+    # It has a replace point where it displays more details about selected element in partitioning.
     class OverviewTreePager < CWM::TreePager
       # Pages whose cached content should be considered outdated
       #


### PR DESCRIPTION
## Trello

https://trello.com/c/MRJhR5x6/2080-1-partitioner-disable-menu-entries-from-device-and-add-when-an-nfs-device-is-selected

## Problem

The NFS page in the partitioner is really only an embedded version of the NFS client module. It does not fit into the scheme of thing in the partitioner, in particular not how menus and menu actions work. That NFS client module/page uses its own buttons; it really only pretends to be a part of the partitioner.

## Fix

Disable menu actions that won't work on that page.


### "Device" Menu

All actions are disabled anyway since no appropriate device can be selected on this page; no matter if an NFS mount is the current device or nothing.

### "Add" Menu

All items are disabled.

## Implementation

**This is an ugly hack** since there is (so far) no way for the menus to find out what page is currently selected.

What this does is to query the tree pager widget what its current value is and check that value against the well-known item ID of the NFS page in that tree. This uses UI calls directly, completely bypassing the entire object structure in the partitioner.

I tried to find an official way, but the partitioner practices information hiding way too much: There is no connection between the menu classes and the pager or the view. We need to fix that.