### PR TITLE
Disable "Device" Menu Items for NFS Shares

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov  5 10:26:55 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Disable "Device" menu items for NFS shares
+  (related to jsc#PM-73, jsc#SLE-7742, jsc#SLE-15283)
+- 4.3.19
+
+-------------------------------------------------------------------
 Wed Nov  4 09:21:55 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Proposal: adjusted the size and format of the EFI partition

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.18
+Version:        4.3.19
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/widgets/menus/modify.rb
+++ b/src/lib/y2partitioner/widgets/menus/modify.rb
@@ -159,6 +159,10 @@ module Y2Partitioner
             [:menu_delete]
           elsif device.is?(:lvm_vg)
             [:menu_edit]
+          elsif device.is?(:nfs)
+            # For NFS we are using an embedded version of the NFS client module
+            # which relies on its own buttons; menu actions won't work there.
+            [:menu_edit, :menu_description, :menu_delete]
           else
             []
           end


### PR DESCRIPTION
## Trello

https://trello.com/c/MRJhR5x6/2080-1-partitioner-disable-menu-entries-from-device-and-add-when-an-nfs-device-is-selected

## Problem

The NFS page in the partitioner is really only an embedded version of the NFS client module. It does not fit into the scheme of thinge in the partitioner, in particular not how menus and menu actions work. That NFS client module/page uses its own buttons; it really only pretends to be a part of the partitioner.

## Fix

Disable menu actions that won't with NFS.

On the NFS page, all menu items that would cause trouble are already disabled.
That leaves the "All Devices" page where some actions in the "Device" menu were still enabled:

- Edit
- Show Details
- Delete

This PR disables them.

The user has to go to the NFS page to perform those actions via buttons in the embedded NFS client module.


## Show Details for NFS Shares?

While it might be possible to support at least "Show Details" even for NFS shares, AFAICS everything that we know about an NFS share is already displayed in the table; we don't seem to have any additional information that would warrant a separate pop-up for an NFS share.
