### PR TITLE
Add Btrfs quotas to the Partitioner UI

### DIFF
--- a/src/lib/y2partitioner/actions/controllers/btrfs_subvolume.rb
+++ b/src/lib/y2partitioner/actions/controllers/btrfs_subvolume.rb
@@ -156,7 +156,7 @@ module Y2Partitioner
         #
         # @return [DiskSize]
         def fallback_referenced_limit
-          subvolume&.former_referenced_limit || filesystem.blk_devices.first.size
+          subvolume&.former_referenced_limit || filesystem.blk_devices.map(&:size).min
         end
 
         private

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -390,7 +390,7 @@ module Y2Partitioner
         #
         # @param value [Boolean]
         def btrfs_quota=(value)
-          return if filesystem.nil? || !filesystem.is?(:btrfs)
+          return unless btrfs?
 
           filesystem.quota = value
         end
@@ -401,7 +401,7 @@ module Y2Partitioner
         #
         # @return [Boolean]
         def btrfs_quota?
-          return false if filesystem.nil? || !filesystem.is?(:btrfs)
+          return false unless btrfs?
 
           filesystem.quota?
         end

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -384,6 +384,28 @@ module Y2Partitioner
           filesystem.configure_snapper
         end
 
+        # Sets quota support for the filesystem if it makes sense
+        #
+        # @see Y2Storage::Filesystems::Btrfs.quota=
+        #
+        # @param value [Boolean]
+        def btrfs_quota=(value)
+          return if filesystem.nil? || !filesystem.is?(:btrfs)
+
+          filesystem.quota = value
+        end
+
+        # Status of the quota support for the Btrfs filesystem
+        #
+        # @see Y2Storage::Filesystems::Btrfs.quota?
+        #
+        # @return [Boolean]
+        def btrfs_quota?
+          return false if filesystem.nil? || !filesystem.is?(:btrfs)
+
+          filesystem.quota?
+        end
+
         # Paths that are mounted in the current device graph, excluding
         # subvolumes
         #

--- a/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
+++ b/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
@@ -295,9 +295,11 @@ module Y2Partitioner
         def help
           _(
             "<p><b>Limit Size</b> allows to set a quota on the referenced space of the " \
-            "subvolume. This is only possible if Btrfs quotas are enabled for this file " \
-            "system. Btrfs quotas can be enabled or disabled editing the file system " \
-            "from the Btrfs section of the Partitioner.</p>"
+            "subvolume. The referenced space is the total size of the data contained " \
+            "in the subvolume, including the data that is shared with other subvolumes. " \
+            "Setting a limit is only possible if Btrfs quotas are active in this file " \
+            "system. Btrfs quotas can be enabled or disabled editing the file system from " \
+            "the Btrfs section of the Partitioner.</p>"
           )
         end
 

--- a/src/lib/y2partitioner/widgets/btrfs_filesystems_table.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_filesystems_table.rb
@@ -45,8 +45,9 @@ module Y2Partitioner
       def fs_columns
         [
           Columns::Device,
-          Columns::Type,
-          Columns::FilesystemLabel,
+          Columns::BtrfsRferLimit,
+          Columns::BtrfsReferenced,
+          Columns::BtrfsExclusive,
           Columns::MountPoint
         ]
       end

--- a/src/lib/y2partitioner/widgets/btrfs_options.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_options.rb
@@ -19,6 +19,7 @@
 
 require "y2partitioner/widgets/filesystem_options"
 require "y2partitioner/widgets/format_and_mount"
+require "y2partitioner/widgets/btrfs_quota"
 
 module Y2Partitioner
   module Widgets
@@ -29,7 +30,9 @@ module Y2Partitioner
         VBox(
           mount_options_widget,
           VSpacing(0.5),
-          snapshots_widget
+          Left(snapshots_widget),
+          VSpacing(0.5),
+          Left(quota_widget)
         )
       end
 
@@ -63,6 +66,10 @@ module Y2Partitioner
       # @return [Widgets::Snapshots]
       def snapshots_widget
         @snapshots_widget ||= Widgets::Snapshots.new(controller)
+      end
+
+      def quota_widget
+        @quota_widget ||= Widgets::BtrfsQuota.new(controller)
       end
 
       # Refreshes the snapshots widget

--- a/src/lib/y2partitioner/widgets/btrfs_quota.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_quota.rb
@@ -1,0 +1,78 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "cwm"
+
+module Y2Partitioner
+  module Widgets
+    # Widget to enable or disable quota support in the Btrfs filesystem
+    class BtrfsQuota < CWM::CheckBox
+      # Constructor
+      #
+      # @param controller [Actions::Controllers::Filesystem]
+      def initialize(controller)
+        textdomain "storage"
+        @controller = controller
+      end
+
+      # @macro seeAbstractWidget
+      def label
+        _("Enable Subvolume Quotas")
+      end
+
+      # @macro seeAbstractWidget
+      def help
+        format(
+          # TRANSLATORS: help text for the widget to enable subvolume quotas,
+          # where %{label} is the label of the widget
+          _("<p><b>%{label}</b> can be used to turn on and off the quota support " \
+            "for this Btrfs file system. When quotas are enabled, the exact space " \
+            "used and referenced by each subvolume is constantly accounted and can " \
+            "be limited. In that case, the max referenced space for each subvolume " \
+            "can be set while creating or editing that subvolume.</p>" \
+            "<p>Enabling quotas also makes possible to know exactly how much space " \
+            "would be freed by deleting a given snapshot or subvolume (the so-called " \
+            "exclusive space).</p>" \
+            "<p>When quotas are activated, they affect all operations in the file " \
+            "system, which takes a performance hit. Activation of quotas is not " \
+            "recommended unless the user intends to actually use them. Moreover, " \
+            "Btrfs quotas have been reported to produce system instability and to " \
+            "present incorrect space accounting in some cases. The situation is " \
+            "gradually improving as the issues are being found and fixed.</p>"), label: label
+        )
+      end
+
+      # @macro seeAbstractWidget
+      def opt
+        [:notify]
+      end
+
+      # Synchronizes the widget with the information from the controller
+      def init
+        self.value = @controller.btrfs_quota?
+      end
+
+      # @macro seeAbstractWidget
+      def handle(event)
+        @controller.btrfs_quota = value if event["ID"] == widget_id
+        nil
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/columns.rb
+++ b/src/lib/y2partitioner/widgets/columns.rb
@@ -25,6 +25,9 @@ module Y2Partitioner
   end
 end
 
+require "y2partitioner/widgets/columns/btrfs_exclusive"
+require "y2partitioner/widgets/columns/btrfs_referenced"
+require "y2partitioner/widgets/columns/btrfs_rfer_limit"
 require "y2partitioner/widgets/columns/caching_device"
 require "y2partitioner/widgets/columns/chunk_size"
 require "y2partitioner/widgets/columns/device"

--- a/src/lib/y2partitioner/widgets/columns/btrfs_exclusive.rb
+++ b/src/lib/y2partitioner/widgets/columns/btrfs_exclusive.rb
@@ -1,0 +1,53 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2partitioner/widgets/columns/disk_size"
+
+module Y2Partitioner
+  module Widgets
+    module Columns
+      # Widget for displaying the `Exclusive Size` column
+      class BtrfsExclusive < DiskSize
+        # Constructor
+        def initialize
+          textdomain "storage"
+        end
+
+        # @see Columns::Base#title
+        def title
+          # TRANSLATORS: table header (so try to keep it short) - Size of the exclusive space
+          # of a Btrfs subvolume
+          Right(_("Excl. Size"))
+        end
+
+        private
+
+        # Returns the size of exclusive space for the given device, if possible
+        #
+        # @param device [Y2Storage::Device]
+        # @return [Y2Stoorage::DiskSize, nil] a disk size object when possible; nil otherwise
+        def device_size(device)
+          return nil unless device.respond_to?(:exclusive)
+
+          device.exclusive
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/columns/btrfs_referenced.rb
+++ b/src/lib/y2partitioner/widgets/columns/btrfs_referenced.rb
@@ -1,0 +1,53 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2partitioner/widgets/columns/disk_size"
+
+module Y2Partitioner
+  module Widgets
+    module Columns
+      # Widget for displaying the `Referenced Size` column
+      class BtrfsReferenced < DiskSize
+        # Constructor
+        def initialize
+          textdomain "storage"
+        end
+
+        # @see Columns::Base#title
+        def title
+          # TRANSLATORS: table header (so try to keep it short) - Size of the referenced space
+          # of a Btrfs subvolume
+          Right(_("Ref. Size"))
+        end
+
+        private
+
+        # Returns the size of the referenced space for the given device, if possible
+        #
+        # @param device [Y2Storage::Device]
+        # @return [Y2Stoorage::DiskSize, nil] a disk size object when possible; nil otherwise
+        def device_size(device)
+          return nil unless device.respond_to?(:referenced)
+
+          device.referenced
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/columns/btrfs_rfer_limit.rb
+++ b/src/lib/y2partitioner/widgets/columns/btrfs_rfer_limit.rb
@@ -1,0 +1,55 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/widgets/columns/disk_size"
+
+module Y2Partitioner
+  module Widgets
+    module Columns
+      # Widget for displaying the `Referenced Size Limit` column
+      class BtrfsRferLimit < DiskSize
+        # Constructor
+        def initialize
+          textdomain "storage"
+        end
+
+        # @see Columns::Base#title
+        def title
+          # TRANSLATORS: table header - Max size of the referenced space
+          # of a subvolume
+          Right(_("Size Limit"))
+        end
+
+        private
+
+        # Returns the limit of the referenced space for the given device, if possible
+        #
+        # @param device [Y2Storage::Device]
+        # @return [Y2Stoorage::DiskSize, nil] a disk size object when possible; nil otherwise
+        def device_size(device)
+          return nil unless device.respond_to?(:referenced_limit)
+          return nil if device.referenced_limit.unlimited?
+
+          device.referenced_limit
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/columns/disk_size.rb
+++ b/src/lib/y2partitioner/widgets/columns/disk_size.rb
@@ -1,0 +1,48 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/widgets/columns/base"
+
+module Y2Partitioner
+  module Widgets
+    module Columns
+      # Base class for all the columns that need to display a DiskSize
+      class DiskSize < Base
+        # @!method device_size(device)
+        #   Size to be used in {#value_for}
+        #
+        #   This abstract method must be implemented by the descending classes
+        #
+        #   @param device [Y2Storage::Device, Y2Storage::SimpleEtcFstabEntry] see {#value_for}
+        #   @return [Y2Storage::DiskSize, nil] size to display or nil for a blank cell
+        abstract_method :device_size
+
+        # @see Columns::Base#value_for
+        def value_for(device)
+          size = device_size(device)
+
+          return "" unless size
+
+          cell(size.to_human_string, sort_key(size.to_i.to_s))
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/columns/disk_size.rb
+++ b/src/lib/y2partitioner/widgets/columns/disk_size.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "y2partitioner/widgets/columns/base"
+require "abstract_method"
 
 module Y2Partitioner
   module Widgets

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -555,6 +555,7 @@ module Y2Partitioner
         @controller = controller
       end
 
+      # @macro seeAbstractWidget
       def label
         _("Enable Snapshots")
       end
@@ -573,6 +574,17 @@ module Y2Partitioner
       def handle(event)
         @controller.configure_snapper = value if event["ID"] == widget_id
         nil
+      end
+
+      # @macro seeAbstractWidget
+      def help
+        format(
+          # TRANSLATORS: help text, where %{label} is the label of the explained widget
+          _("<p><b>%{label}</b> configures Snapper and the subvolumes of the root file " \
+            "system in a way that makes possible to take snapshots of the system. That " \
+            "allows to boot to any of those former snapshots, rolling back any change " \
+            "done to the system and restoring its previous state.</p>"), label: label
+        )
       end
     end
 

--- a/src/lib/y2partitioner/widgets/help.rb
+++ b/src/lib/y2partitioner/widgets/help.rb
@@ -41,13 +41,13 @@ module Y2Partitioner
                                       "of the BtrFS subvolume. This is the space that would be\n" \
                                       "freed by deleting the subvolume. Known and displayed only\n" \
                                       "if quotas were active for the corresponding BtrFS file\n" \
-                                      "system during the hardware probing."),
+                                      "system during the hardware detection."),
 
         btrfs_referenced:          N_("<b>Ref. Size</b> shows the size of the referenced space\n" \
                                       "of the BtrFS subvolume. This is the total size of all files\n" \
                                       "in the subvolume. Known and displayed only if quotas were\n" \
                                       "active for the corresponding BtrFS file system during the\n" \
-                                      "hardware probing."),
+                                      "hardware detection."),
 
         btrfs_rfer_limit:          N_("<b>Size Limit</b> shows the max size of the referenced\n" \
                                       "space for the BtrFS subvolume, if BtrFS quotas are active in\n" \

--- a/src/lib/y2partitioner/widgets/help.rb
+++ b/src/lib/y2partitioner/widgets/help.rb
@@ -37,6 +37,22 @@ module Y2Partitioner
         bios_id:                   N_("<b>BIOS ID</b> shows the BIOS ID of the hard\n" \
                                       "disk. This field can be empty."),
 
+        btrfs_exclusive:           N_("<b>Excl. Size</b> shows the size of the exclusive space\n" \
+                                      "of the BtrFS subvolume. This is the space that would be\n" \
+                                      "freed by deleting the subvolume. Known and displayed only\n" \
+                                      "if quotas were active for the corresponding BtrFS file\n" \
+                                      "system during the hardware probing."),
+
+        btrfs_referenced:          N_("<b>Ref. Size</b> shows the size of the referenced space\n" \
+                                      "of the BtrFS subvolume. This is the total size of all files\n" \
+                                      "in the subvolume. Known and displayed only if quotas were\n" \
+                                      "active for the corresponding BtrFS file system during the\n" \
+                                      "hardware probing."),
+
+        btrfs_rfer_limit:          N_("<b>Size Limit</b> shows the max size of the referenced\n" \
+                                      "space for the BtrFS subvolume, if BtrFS quotas are active in\n" \
+                                      "the corresponding BtrFS file system."),
+
         bus:                       N_("<b>Bus</b> shows how the device is connected to\n" \
                                       "the system. This field can be empty, e.g. for multipath disks."),
 

--- a/src/lib/y2storage/btrfs_subvolume.rb
+++ b/src/lib/y2storage/btrfs_subvolume.rb
@@ -193,6 +193,9 @@ module Y2Storage
     def referenced_limit=(limit)
       return unless create_missing_qgroup
 
+      if referenced_limit && !referenced_limit.unlimited?
+        save_userdata(:former_referenced_limit, referenced_limit)
+      end
       btrfs_qgroup.referenced_limit = limit
     end
 
@@ -205,6 +208,16 @@ module Y2Storage
       return unless create_missing_qgroup
 
       btrfs_qgroup.exclusive_limit = limit
+    end
+
+    # Previous significant (ie. not unlimited) value of {#referenced_limit}
+    #
+    # Used by the Partitioner to restore the value of the corresponding widget if the
+    # user re-enables the limit, which improves the sense of continuity.
+    #
+    # @return [DiskSize, nil] nil if the limit has never changed
+    def former_referenced_limit
+      userdata_value(:former_referenced_limit)
     end
 
     protected

--- a/test/y2partitioner/actions/controllers/filesystem_test.rb
+++ b/test/y2partitioner/actions/controllers/filesystem_test.rb
@@ -242,6 +242,46 @@ describe Y2Partitioner::Actions::Controllers::Filesystem do
     end
   end
 
+  describe "#btrfs_quota?" do
+    context "when the currently editing device has a Btrfs filesystem" do
+      let(:dev_name) { "/dev/sda2" }
+
+      it "returns the filesystem value for #quota?" do
+        expect(controller.btrfs_quota?).to eq false
+        device.filesystem.quota = true
+        expect(controller.btrfs_quota?).to eq true
+      end
+    end
+
+    context "when the currently editing device has a no-Btrfs filesystem" do
+      let(:dev_name) { "/dev/sdb6" }
+
+      it "returns false" do
+        expect(controller.btrfs_quota?).to eq false
+      end
+    end
+
+    context "when the currently editing device has no filesystem" do
+      let(:dev_name) { "/dev/sdb7" }
+
+      it "returns false" do
+        expect(controller.btrfs_quota?).to eq false
+      end
+    end
+  end
+
+  describe "#btrfs_quota=" do
+    let(:dev_name) { "/dev/sda2" }
+
+    it "sets #quota? for the current Btrfs filesystem" do
+      expect(device.filesystem.quota?).to eq false
+      controller.btrfs_quota = true
+      expect(device.filesystem.quota?).to eq true
+      controller.btrfs_quota = false
+      expect(device.filesystem.quota?).to eq false
+    end
+  end
+
   describe "#apply_role" do
     before do
       subject.role_id = role

--- a/test/y2partitioner/widgets/btrfs_filesystems_table_test.rb
+++ b/test/y2partitioner/widgets/btrfs_filesystems_table_test.rb
@@ -38,5 +38,21 @@ describe Y2Partitioner::Widgets::BtrfsFilesystemsTable do
 
   let(:pager) { double("Pager") }
 
-  include_examples "CWM::Table"
+  # FIXME: default tests check that all column headers are strings, but they also can be a Yast::Term
+  # include_examples "CWM::Table"
+
+  describe "#header" do
+    it "returns an array including the quota and the subvolume sizes" do
+      expect(subject.header).to be_a(::Array)
+      titles = subject.header.map { |col| col.is_a?(Yast::Term) ? col.params.first : col }
+      expect(titles).to include("Ref. Size", "Excl. Size", "Size Limit")
+    end
+  end
+
+  describe "#items" do
+    it "returns array of CWM table items" do
+      expect(subject.items).to be_a(::Array)
+      expect(subject.items.first).to be_a(CWM::TableItem)
+    end
+  end
 end

--- a/test/y2partitioner/widgets/btrfs_options_test.rb
+++ b/test/y2partitioner/widgets/btrfs_options_test.rb
@@ -57,6 +57,12 @@ describe Y2Partitioner::Widgets::BtrfsOptions do
     expect(widget).to_not be_nil
   end
 
+  it "includes a widget to configure BtrFS quotas" do
+    widget = subject.contents.nested_find { |i| i.is_a?(Y2Partitioner::Widgets::BtrfsQuota) }
+
+    expect(widget).to_not be_nil
+  end
+
   describe "#validate" do
     before do
       allow(subject).to receive(:filesystem_errors).and_return(warnings)

--- a/test/y2partitioner/widgets/btrfs_quota_test.rb
+++ b/test/y2partitioner/widgets/btrfs_quota_test.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/btrfs_quota"
+require "y2partitioner/actions/controllers"
+
+describe Y2Partitioner::Widgets::BtrfsQuota do
+  before { devicegraph_stub(scenario) }
+
+  let(:scenario) { "btrfs_simple_quotas.xml" }
+  let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+  let(:blk_device) { current_graph.find_by_name("/dev/vda2") }
+
+  let(:controller) do
+    Y2Partitioner::Actions::Controllers::Filesystem.new(blk_device, "")
+  end
+
+  subject { described_class.new(controller) }
+
+  include_examples "CWM::AbstractWidget"
+end

--- a/test/y2partitioner/widgets/columns/btrfs_exclusive_test.rb
+++ b/test/y2partitioner/widgets/columns/btrfs_exclusive_test.rb
@@ -1,0 +1,98 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require_relative "./shared_examples"
+
+require "y2partitioner/widgets/columns/btrfs_exclusive"
+
+describe Y2Partitioner::Widgets::Columns::BtrfsExclusive do
+  using Y2Storage::Refinements::SizeCasts
+
+  subject { described_class.new }
+
+  include_examples "Y2Partitioner::Widgets::Column"
+
+  let(:scenario) { "btrfs_simple_quotas.xml" }
+  let(:devicegraph) { Y2Partitioner::DeviceGraphs.instance.current }
+  let(:blk_device) { Y2Storage::BlkDevice.find_by_name(devicegraph, device_name) }
+  let(:device) { blk_device }
+
+  let(:device_name) { "/dev/vda2" }
+
+  before do
+    devicegraph_stub(scenario)
+  end
+
+  describe "#value_for" do
+    context "when no device is given" do
+      let(:device_name) { "unknonw" }
+
+      it "returns an empty string" do
+        expect(subject.value_for(device)).to eq("")
+      end
+    end
+
+    context "when the device is a partition" do
+      it "returns an empty string" do
+        expect(subject.value_for(device)).to eq("")
+      end
+    end
+
+    context "when the device is a btrfs filesystem" do
+      let(:device) { blk_device.filesystem }
+
+      it "returns an empty string" do
+        expect(subject.value_for(device)).to eq("")
+      end
+    end
+
+    context "when the device is a btrfs subvolume" do
+      let(:device) { blk_device.filesystem.find_btrfs_subvolume_by_path("@/home") }
+
+      context "and quotas are not enabled" do
+        before do
+          blk_device.filesystem.quota = false
+        end
+
+        it "returns empty string" do
+          expect(subject.value_for(device)).to eq("")
+        end
+      end
+
+      context "and quotas are active" do
+        it "contains the human readable representation of the exclusive size" do
+          value = subject.value_for(device)
+          size = value.params[0]
+
+          expect(size).to eq("48.00 KiB")
+        end
+
+        it "contains a sort key for the device exclusive size" do
+          value = subject.value_for(device)
+          sort_key = value.params.find { |param| param.is_a?(Yast::Term) && param.value == :sortKey }
+
+          expect(sort_key).to_not be_nil
+          expect(sort_key.params).to include("49152")
+        end
+      end
+    end
+  end
+end

--- a/test/y2partitioner/widgets/columns/btrfs_referenced_test.rb
+++ b/test/y2partitioner/widgets/columns/btrfs_referenced_test.rb
@@ -1,0 +1,98 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require_relative "./shared_examples"
+
+require "y2partitioner/widgets/columns/btrfs_referenced"
+
+describe Y2Partitioner::Widgets::Columns::BtrfsReferenced do
+  using Y2Storage::Refinements::SizeCasts
+
+  subject { described_class.new }
+
+  include_examples "Y2Partitioner::Widgets::Column"
+
+  let(:scenario) { "btrfs_simple_quotas.xml" }
+  let(:devicegraph) { Y2Partitioner::DeviceGraphs.instance.current }
+  let(:blk_device) { Y2Storage::BlkDevice.find_by_name(devicegraph, device_name) }
+  let(:device) { blk_device }
+
+  let(:device_name) { "/dev/vda2" }
+
+  before do
+    devicegraph_stub(scenario)
+  end
+
+  describe "#value_for" do
+    context "when no device is given" do
+      let(:device_name) { "unknonw" }
+
+      it "returns an empty string" do
+        expect(subject.value_for(device)).to eq("")
+      end
+    end
+
+    context "when the device is a partition" do
+      it "returns an empty string" do
+        expect(subject.value_for(device)).to eq("")
+      end
+    end
+
+    context "when the device is a btrfs filesystem" do
+      let(:device) { blk_device.filesystem }
+
+      it "returns an empty string" do
+        expect(subject.value_for(device)).to eq("")
+      end
+    end
+
+    context "when the device is a btrfs subvolume" do
+      let(:device) { blk_device.filesystem.find_btrfs_subvolume_by_path("@/home") }
+
+      context "and quotas are not enabled" do
+        before do
+          blk_device.filesystem.quota = false
+        end
+
+        it "returns empty string" do
+          expect(subject.value_for(device)).to eq("")
+        end
+      end
+
+      context "and quotas are active" do
+        it "contains the human readable representation of the referenced size" do
+          value = subject.value_for(device)
+          size = value.params[0]
+
+          expect(size).to eq("48.00 KiB")
+        end
+
+        it "contains a sort key for the device referenced size" do
+          value = subject.value_for(device)
+          sort_key = value.params.find { |param| param.is_a?(Yast::Term) && param.value == :sortKey }
+
+          expect(sort_key).to_not be_nil
+          expect(sort_key.params).to include("49152")
+        end
+      end
+    end
+  end
+end

--- a/test/y2partitioner/widgets/columns/btrfs_rfer_limit_test.rb
+++ b/test/y2partitioner/widgets/columns/btrfs_rfer_limit_test.rb
@@ -1,0 +1,100 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require_relative "./shared_examples"
+
+require "y2partitioner/widgets/columns/btrfs_rfer_limit"
+
+describe Y2Partitioner::Widgets::Columns::BtrfsRferLimit do
+  using Y2Storage::Refinements::SizeCasts
+
+  subject { described_class.new }
+
+  include_examples "Y2Partitioner::Widgets::Column"
+
+  let(:scenario) { "btrfs_simple_quotas.xml" }
+  let(:devicegraph) { Y2Partitioner::DeviceGraphs.instance.current }
+  let(:blk_device) { Y2Storage::BlkDevice.find_by_name(devicegraph, device_name) }
+  let(:device) { blk_device }
+
+  let(:device_name) { "/dev/vda2" }
+
+  before do
+    devicegraph_stub(scenario)
+  end
+
+  describe "#value_for" do
+    context "when no device is given" do
+      let(:device_name) { "unknonw" }
+
+      it "returns an empty string" do
+        expect(subject.value_for(device)).to eq("")
+      end
+    end
+
+    context "when the device is a partition" do
+      it "returns an empty string" do
+        expect(subject.value_for(device)).to eq("")
+      end
+    end
+
+    context "when the device is a btrfs partition" do
+      let(:device) { blk_device.filesystem }
+
+      it "returns an empty string" do
+        expect(subject.value_for(device)).to eq("")
+      end
+    end
+
+    context "when the device is a btrfs subvolume" do
+      let(:device) { blk_device.filesystem.find_btrfs_subvolume_by_path("@/opt") }
+
+      before { device.referenced_limit = limit }
+
+      context "if the subvolume has no quota" do
+        let(:limit) { Y2Storage::DiskSize.unlimited }
+
+        it "returns empty string" do
+          expect(subject.value_for(device)).to eq("")
+        end
+      end
+
+      context "if the subvolume has a quota" do
+        let(:limit) { 512.MiB }
+
+        it "contains the human readable representation of the device referenced limit" do
+          value = subject.value_for(device)
+          size = value.params[0]
+
+          expect(size).to eq("0.50 GiB")
+        end
+
+        it "contains a sort key for the device referenced limit" do
+          value = subject.value_for(device)
+          sort_key = value.params.find { |param| param.is_a?(Yast::Term) && param.value == :sortKey }
+
+          expect(sort_key).to_not be_nil
+          expect(sort_key.params).to include("536870912")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

We want to add support for Btrfs quotas to the Partitioner. See [Jira entry SLE-7742](https://jira.suse.com/browse/SLE-7742)

This is the second part of https://trello.com/c/Ypt6X2VA/2118-3-partitioner-support-for-btrfs-quotas (the first part was #1163).

## Solution

- In the form to edit a Btrfs file system (not to be confused with the form to edit a block device), a new "Enable Subvolumes Quota" is added. <details><summary>Click here to see two screenshots about it</summary>![quota1](https://user-images.githubusercontent.com/3638289/99694671-f8a0ae00-2a8c-11eb-9ca2-c27e5c0779ef.png)
![quota2](https://user-images.githubusercontent.com/3638289/99694678-f9394480-2a8c-11eb-8e12-e1894b945eac.png)
</details>

- In the form to edit a Btrfs subvolume, a "Limit Size" widget is added. <details><summary>Click here to see two screenshots about it</summary>![quota3](https://user-images.githubusercontent.com/3638289/99694682-f9d1db00-2a8c-11eb-95fe-57a661bda4a5.png)
![quota4](https://user-images.githubusercontent.com/3638289/99694684-fa6a7180-2a8c-11eb-8406-481f83f59819.png)
**Note:** the help text was extended in 167bcff 
</details>

- The columns in the Btrfs section of the Partitioner are reorganized to show that limit and also, if known, the space used by each subvolume. <details><summary>Click here to see two screenshots about it</summary>![quota5](https://user-images.githubusercontent.com/3638289/99699549-597eb500-2a92-11eb-8d26-b3df702170a4.png)
![quota6b](https://user-images.githubusercontent.com/3638289/99715166-c8660900-2aa6-11eb-8f9e-b96540ec7eaa.png)
**Note:** the help texts were slightly modified in 167bcff 
</details>

- As a bonus, when subvolumes with a quota are displayed in a general table with more devices, the size limit is displayed in the column "Size".

## Testing

- Manually tested
- Added unit tests