### PR TITLE
Partial fix for bug#176140

### DIFF
--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -644,6 +644,13 @@ module Y2Storage
       false
     end
 
+    # Whether this device contains, directly or indirectly, the root mount point
+    #
+    # @return [Boolean]
+    def contain_root?
+      ([self] + descendants).any? { |desc| desc.is_a?(MountPoint) && desc.root? }
+    end
+
     # Whether the block device fulfills conditions to be used for a Windows system
     #
     # Note that only partitions can be used for installing Windows.

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -265,7 +265,7 @@ module Y2Storage
       def needs_network_mount_options?
         # Adding "_netdev" and similar options in fstab for / should not be necessary
         # and it confuses (or used to confuse) systemd. See bsc#1165937.
-        in_network? && !root?
+        in_network? && !root_disk?
       end
 
       # @see Device#is?

--- a/src/lib/y2storage/mountable.rb
+++ b/src/lib/y2storage/mountable.rb
@@ -110,6 +110,16 @@ module Y2Storage
       mount_point.root?
     end
 
+    # Whether the device is mounted as root or based in the same disk than the
+    # device mounted as root
+    #
+    # @return [Boolean]
+    def root_disk?
+      return true if root?
+
+      ([self] + ancestors).any? { |dev| dev.is_a?(BlkDevice) && dev.contain_root? }
+    end
+
     # Creates a mount point object for the device
     #
     # @param path [String]


### PR DESCRIPTION
## Problem

The logic for adding _netdev needs to be refined... once again!

Now we have been told that `_netdev` should be skipped not only for "/" and all its subvolumes, but also for all the mount points that are based on the same disk than "/".

See https://bugzilla.suse.com/show_bug.cgi?id=1176140

## Partial Solution

This expands the logic of `#set_default_mount_options` to honor the new proposed (and approved) logic described here:
https://gist.github.com/ancorgs/435328f6f16920a17b0b8cca7500526e#proposed-rspec-output-for-y2storagemountpoint

Unfortunately, this is only a solution if the root mount point is the first to be created. For example, imagine we create a mount point for "/var" in sda2. In that moment, `#set_default_mount_options` will add _netdev to it since there is no evidence of that partition being in the root disk. If at a later point, sda3 is created and mounted as "/", the mount options of sda2 will not be re-adjusted (so far, we have never needed to adjust the options of one mount point based on the presence of another one, so we have no such mechanism).

## Testing

- Added a new unit test

## Do not merge

We need a definitive solution.