### PR TITLE
Improved Error Handling for Mounting efivars

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Nov 18 16:30:03 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Improved error handling for mounting /sys/firmware/efi/efivars
+  (bsc#1174029):
+  - Also check in /proc/filesystems if efivarfs is supported
+  - Don't throw exception if a mount fails, just display a warning
+- 4.3.21
+
+-------------------------------------------------------------------
 Wed Nov 11 14:44:26 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Untranslated error message in 'Edit Btrfs subvolumes'/

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.20
+Version:        4.3.21
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -90,7 +90,7 @@ module Y2Storage
 
         if !SCR.Execute(path(".target.mount"), [device, target_path], options)
           # TRANSLATORS: %s is the path of a system mount like "/dev", "/proc", "/sys"
-          Yast::Report.Warning(_("Could not mount %s") % path )
+          Yast::Report.Warning(_("Could not mount %s") % path)
         end
 
         nil
@@ -113,12 +113,10 @@ module Y2Storage
       #
       # @return [Boolean] true if efivarfs is supported
       def efivarfs_support?
-        begin
-          File.readlines("/proc/filesystems").any? { |line| line =~ /efivarfs/ }
-        rescue Errno::ENOENT => err
-          log.error("Can't check efivarfss support: #{err}")
-          false
-        end
+        File.readlines("/proc/filesystems").any? { |line| line =~ /efivarfs/ }
+      rescue Errno::ENOENT => e
+        log.error("Can't check efivarfss support: #{e}")
+        false
       end
 
       def manager

--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -106,7 +106,12 @@ module Y2Storage
       #
       # @return [Boolean] true if efivarfs is supported
       def efivarfs_support?
-        File.readlines("/proc/filesystems").any? { |line| line =~ /efivarfs/ }
+        begin
+          File.readlines("/proc/filesystems").any? { |line| line =~ /efivarfs/ }
+        rescue Errno::ENOENT => err
+          log.error("Can't check efivarfss support: #{err}")
+          false
+        end
       end
 
       def manager

--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -28,6 +28,7 @@ Yast.import "SlideShow"
 Yast.import "Installation"
 Yast.import "FileUtils"
 Yast.import "Mode"
+Yast.import "Report"
 
 module Y2Storage
   module Clients
@@ -36,9 +37,14 @@ module Y2Storage
     # target system and any other action handled by libstorage.
     class InstPrepdisk
       include Yast
+      include Yast::I18n
       include Yast::Logger
 
       EFIVARS_PATH = "/sys/firmware/efi/efivars".freeze
+
+      def initialize
+        textdomain "storage"
+      end
 
       def run
         return :auto if Mode.update
@@ -83,7 +89,8 @@ module Y2Storage
         log.info "Cmd: mount #{options} #{device} #{target_path}"
 
         if !SCR.Execute(path(".target.mount"), [device, target_path], options)
-          raise ".target.mount failed"
+          # TRANSLATORS: %s is the path of a system mount like "/dev", "/proc", "/sys"
+          Yast::Report.Warning(_("Could not mount %s") % path )
         end
 
         nil


### PR DESCRIPTION
## Trello

https://trello.com/c/fhCSVHzi/2149-2-tw-1174029-yast2-depends-on-efi-vars

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1174029

## Problem

When we are done creating parititons and filesystems during installation, we mount system mounts such as `/dev`, `/proc`, `/sys`, `/run` to the newly created target system so it can later be used correctly in a `chroot` environment.

On EFI systems, that also includes the EFI variables in `/sys/firmware/efi/efivars` (a separate filesystem / kernel table).

On some platforms (arm64) that is only half-implemented, however: They do use EFI, but there is no support (yet) for the special _efivarfs_ filesystem that is used to read and write EFI variables directly via that system mount.

So attempting to mount that  `/sys/firmware/efi/efivars` filesystem fails, an exception is (intentionally!) thrown, and with that the whole installation fails.


## Fix

- Check not only if `/sys/firmware/efi/efivars` exists (i.e. if the current system uses EFI), but also if the _efivarfs_ filesystem type is supported by the current kernel, i.e. if that filesystem type is in the list of supported filesystems in `/proc/filesystems`.

- More graceful error handling: If any of those mounts fails, don't just throw a hard exception (so the installation fails), but report the problem in a warning pop-up.
