### PR TITLE
Fix subvolumes prefix

### DIFF
--- a/src/lib/y2partitioner/actions/controllers/btrfs_subvolume.rb
+++ b/src/lib/y2partitioner/actions/controllers/btrfs_subvolume.rb
@@ -126,15 +126,11 @@ module Y2Partitioner
           !new?(subvolume)
         end
 
-        # Whether the filesystem already has a subvolume on disk with the given path
+        # Whether the filesystem already has a subvolume with the given path
         #
         # @return [Boolean]
         def exist_path?(path)
-          subvolume = filesystem.btrfs_subvolumes.find { |s| s.path == path }
-
-          return false unless subvolume
-
-          !new?(subvolume)
+          filesystem.btrfs_subvolumes.any? { |s| s.path == path }
         end
 
         # Whether quota support is enabled for the Btrfs filesystem

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -466,7 +466,7 @@ module Y2Partitioner
         def btrfs_subvolumes?
           return false unless btrfs?
 
-          filesystem.top_level_btrfs_subvolume.children.any?
+          filesystem.btrfs_subvolumes?
         end
 
         # Whether there is a list of default Btrfs subvolumes for the filesystem
@@ -593,9 +593,10 @@ module Y2Partitioner
         end
 
         # Deletes current subvolumes, except the top level one.
+        #
+        # @see Y2Storage::Filesystems::Btrfs_delete_btrfs_subvolume
         def delete_btrfs_subvolumes
-          subvolumes = filesystem.btrfs_subvolumes.reject(&:top_level?)
-          subvolumes.map(&:path).each { |p| filesystem.delete_btrfs_subvolume(p) }
+          filesystem.btrfs_subvolumes.map(&:path).each { |p| filesystem.delete_btrfs_subvolume(p) }
 
           # Auto deleted subvolumes are also discarded
           filesystem.auto_deleted_subvolumes = []

--- a/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
+++ b/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
@@ -181,8 +181,7 @@ module Y2Partitioner
         def uniqueness_error
           return nil unless controller.exist_path?(value)
 
-          # TRANSLATORS: error message, where %s is replaced by a path given by the user.
-          format(_("Subvolume name %s already exists."), value)
+          format(_("A subvolume already exists with this path."), value)
         end
 
         # Error when the given path is part of an already existing path

--- a/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
+++ b/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
@@ -181,7 +181,7 @@ module Y2Partitioner
         def uniqueness_error
           return nil unless controller.exist_path?(value)
 
-          format(_("A subvolume already exists with this path."), value)
+          format(_("There is already a subvolume with that path."), value)
         end
 
         # Error when the given path is part of an already existing path

--- a/src/lib/y2partitioner/widgets/device_table_entry.rb
+++ b/src/lib/y2partitioner/widgets/device_table_entry.rb
@@ -178,14 +178,14 @@ module Y2Partitioner
 
         # Btrfs subvolumes to show as children devices
         #
+        # Note that the top level subvolume and the prefix subvolume (typically @) are not included.
+        #
         # @param device [Y2Storage::Device]
         # @return [Array<Y2Storage::BtrfsSubvolume>]
         def btrfs_subvolumes(device)
           filesystem = device.is?(:filesystem) ? device : device.filesystem
 
-          # FIXME: the default subvolume is not shown, but maybe it should be included when pointing
-          #   to something different to @.
-          filesystem.btrfs_subvolumes.reject { |s| s.top_level? || s.default_btrfs_subvolume? }
+          filesystem.btrfs_subvolumes.reject { |s| s.top_level? || s.prefix? }
         end
       end
     end

--- a/src/lib/y2storage/btrfs_subvolume.rb
+++ b/src/lib/y2storage/btrfs_subvolume.rb
@@ -219,6 +219,13 @@ module Y2Storage
       userdata_value(:former_referenced_limit)
     end
 
+    # Whether the subvolume is used as prefix (typically @)
+    #
+    # @return [Boolean]
+    def prefix?
+      path == filesystem.subvolumes_prefix
+    end
+
     protected
 
     # Whether the subvolume requires a default mount point
@@ -250,13 +257,6 @@ module Y2Storage
     # @return [Boolean]
     def for_snapshots?
       path.match?(/.snapshots/)
-    end
-
-    # Whether the subvolume is the used as prefix (typically @)
-    #
-    # @return [Boolean]
-    def prefix?
-      path == filesystem.subvolumes_prefix
     end
 
     # Parent subvolume

--- a/src/lib/y2storage/btrfs_subvolume.rb
+++ b/src/lib/y2storage/btrfs_subvolume.rb
@@ -20,7 +20,6 @@
 require "y2storage/storage_class_wrapper"
 require "y2storage/btrfs_qgroup"
 require "y2storage/mountable"
-require "y2storage/volume_specification"
 
 module Y2Storage
   # A subvolume in a Btrfs filesystem
@@ -241,29 +240,23 @@ module Y2Storage
     # @return [Boolean]
     def require_default_mount_point?
       return false unless filesystem.root?
-      return false if top_level? || default_btrfs_subvolume? || snapshot?
+      return false if top_level? || default_btrfs_subvolume? || for_snapshots?
 
       parent_subvolume.top_level? || parent_subvolume.prefix?
     end
 
-    # Whether the subvolume is for snapshots
+    # Whether the subvolume is used for snapshots
     #
     # @return [Boolean]
-    def snapshot?
-      path.match?(/^.snapshots/)
+    def for_snapshots?
+      path.match?(/.snapshots/)
     end
 
     # Whether the subvolume is the used as prefix (typically @)
     #
     # @return [Boolean]
     def prefix?
-      return false unless filesystem.root?
-
-      spec = Y2Storage::VolumeSpecification.for("/")
-
-      return false unless spec&.btrfs_default_subvolume
-
-      spec.btrfs_default_subvolume == path
+      path == filesystem.subvolumes_prefix
     end
 
     # Parent subvolume

--- a/src/lib/y2storage/btrfs_subvolume.rb
+++ b/src/lib/y2storage/btrfs_subvolume.rb
@@ -256,7 +256,9 @@ module Y2Storage
     #
     # @return [Boolean]
     def for_snapshots?
-      path.match?(/.snapshots/)
+      snapshots_root = filesystem.snapshots_root
+
+      path == snapshots_root || path.start_with?(snapshots_root + "/")
     end
 
     # Parent subvolume

--- a/src/lib/y2storage/planned/can_be_formatted.rb
+++ b/src/lib/y2storage/planned/can_be_formatted.rb
@@ -1,8 +1,4 @@
-#!/usr/bin/env ruby
-#
-# encoding: utf-8
-
-# Copyright (c) [2015-2017] SUSE LLC
+# Copyright (c) [2015-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -226,9 +222,11 @@ module Y2Storage
         # If a default subvolume is configured (in control.xml), create it; if not,
         # use the toplevel subvolume that is implicitly created by mkfs.btrfs.
         filesystem.ensure_default_btrfs_subvolume(path: @default_subvolume)
-        return unless subvolumes?
 
-        filesystem.add_btrfs_subvolumes(subvolumes)
+        # Sets the subvolume prefix to create the rest of subvolumes as children of this one.
+        filesystem.subvolumes_prefix = @default_subvolume || ""
+
+        filesystem.add_btrfs_subvolumes(subvolumes) if subvolumes
       end
 
       def reuse_device!(device)

--- a/src/lib/y2storage/shadower.rb
+++ b/src/lib/y2storage/shadower.rb
@@ -163,11 +163,17 @@ module Y2Storage
 
     # Restores a previously auto deleted subvolume
     #
+    # If there already is a subvolume with the same path, the auto deleted subvolume is not restored.
+    #
     # @see #remove_auto_deleted
     #
     # @param filesystem [Filesystems::Btrfs] filesystem where to remove the subvolume as auto deleted
     # @param spec [SubvolSpecification] specification of the subvolume to restore
     def unshadow_btrfs_subvolume_spec(filesystem, spec)
+      subvolume_path = filesystem.btrfs_subvolume_path(spec.path)
+
+      return if filesystem.find_btrfs_subvolume_by_path(subvolume_path)
+
       subvolume = spec.create_btrfs_subvolume(filesystem)
       remove_auto_deleted(filesystem, subvolume)
     end

--- a/test/y2partitioner/actions/controllers/btrfs_subvolume_test.rb
+++ b/test/y2partitioner/actions/controllers/btrfs_subvolume_test.rb
@@ -209,17 +209,13 @@ describe Y2Partitioner::Actions::Controllers::BtrfsSubvolume do
   end
 
   describe "#exist_path?" do
-    context "when the filesystem already has a subvolume on disk with the given path" do
+    context "when the filesystem already has a subvolume with the given path" do
       it "returns true" do
         expect(subject.exist_path?("@/home")).to eq(true)
       end
     end
 
-    context "when the filesystem does not have a subvolume on disk with the given path" do
-      before do
-        filesystem.create_btrfs_subvolume("@/foo", false)
-      end
-
+    context "when the filesystem has not a subvolume with the given path" do
       it "returns false" do
         expect(subject.exist_path?("@/foo")).to eq(false)
       end

--- a/test/y2partitioner/actions/delete_btrfs_subvolume_test.rb
+++ b/test/y2partitioner/actions/delete_btrfs_subvolume_test.rb
@@ -25,6 +25,7 @@ require "y2partitioner/actions/delete_btrfs_subvolume"
 
 describe Y2Partitioner::Actions::DeleteBtrfsSubvolume do
   before do
+    allow(Y2Storage::VolumeSpecification).to receive(:for)
     allow(Y2Storage::VolumeSpecification).to receive(:for).with("/").and_return(root_spec)
 
     devicegraph_stub(scenario)

--- a/test/y2partitioner/dialogs/btrfs_subvolume_test.rb
+++ b/test/y2partitioner/dialogs/btrfs_subvolume_test.rb
@@ -144,7 +144,7 @@ describe Y2Partitioner::Dialogs::BtrfsSubvolume do
           let(:value) { "@/home" }
 
           it "shows an error message" do
-            expect(Yast2::Popup).to receive(:show).with(/already exists/, anything)
+            expect(Yast2::Popup).to receive(:show).with(/There is already a subvolume/, anything)
             subject.validate
           end
 

--- a/test/y2partitioner/widgets/device_table_entry_test.rb
+++ b/test/y2partitioner/widgets/device_table_entry_test.rb
@@ -33,7 +33,6 @@ describe Y2Partitioner::Widgets::DeviceTableEntry do
   let(:device) { current_graph.find_by_name(device_name) }
 
   describe ".new_with_children" do
-
     let(:entry) { described_class.new_with_children(device) }
 
     shared_examples "create entry" do
@@ -80,6 +79,14 @@ describe Y2Partitioner::Widgets::DeviceTableEntry do
         let(:device_name) { "/dev/sdb2" }
 
         include_examples "create subvolumes entries"
+
+        it "does not create a child entry for the prefix subvolume" do
+          device.filesystem.subvolumes_prefix = "@/home"
+
+          children_devices = entry.children.map(&:device)
+
+          expect(children_devices.map(&:path)).to_not include("@/home")
+        end
       end
 
       context "and the Btrfs is multidevice" do
@@ -101,6 +108,14 @@ describe Y2Partitioner::Widgets::DeviceTableEntry do
       include_examples "create entry"
 
       include_examples "create subvolumes entries"
+
+      it "does not create a child entry for the prefix subvolume" do
+        device.subvolumes_prefix = "@/home"
+
+        children_devices = entry.children.map(&:device)
+
+        expect(children_devices.map(&:path)).to_not include("@/home")
+      end
     end
 
     context "when the given device contains partitions" do

--- a/test/y2storage/btrfs_subvolume_test.rb
+++ b/test/y2storage/btrfs_subvolume_test.rb
@@ -148,10 +148,10 @@ describe Y2Storage::BtrfsSubvolume do
 
       context "and it is a snapshot subvolume" do
         before do
-          blk_device.filesystem.create_btrfs_subvolume(".snapshots/1/snapshot", true)
+          blk_device.filesystem.create_btrfs_subvolume("@/.snapshots/1/snapshot", true)
         end
 
-        let(:subvolume_path) { ".snapshots/1/snapshot" }
+        let(:subvolume_path) { "@/.snapshots/1/snapshot" }
 
         include_examples "default not required"
       end
@@ -169,18 +169,16 @@ describe Y2Storage::BtrfsSubvolume do
 
       context "and its parent is the top level subvolume" do
         before do
-          # FIXME: The filesystem is recreated because there is an error when calculting the subvolumes
-          #   prefix for an existing filesystem.
-          blk_device.delete_filesystem
-          blk_device.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
           blk_device.filesystem.mount_path = "/"
 
-          blk_device.filesystem.create_btrfs_subvolume("foo", true)
+          # Note that this subvolume is not considered a subvolume for working with snapshots because
+          # it is not under the subvolume prefix (does not start by @).
+          blk_device.filesystem.create_btrfs_subvolume(".snapshots", true)
         end
 
-        let(:subvolume_path) { "foo" }
+        let(:subvolume_path) { ".snapshots" }
 
-        include_examples "default required", "/foo"
+        include_examples "default required", "/.snapshots"
       end
 
       context "and its parent is the prefix subvolume" do

--- a/test/y2storage/btrfs_subvolume_test.rb
+++ b/test/y2storage/btrfs_subvolume_test.rb
@@ -444,4 +444,26 @@ describe Y2Storage::BtrfsSubvolume do
       end
     end
   end
+
+  describe "prefix?" do
+    before do
+      blk_device.filesystem.subvolumes_prefix = prefix
+    end
+
+    context "when the subvolume is used as prefix" do
+      let(:prefix) { subvolume_path }
+
+      it "returns true" do
+        expect(subject.prefix?).to eq(true)
+      end
+    end
+
+    context "when the subvolume is not used as prefix" do
+      let(:prefix) { "foo" }
+
+      it "returns false" do
+        expect(subject.prefix?).to eq(false)
+      end
+    end
+  end
 end

--- a/test/y2storage/shadower_test.rb
+++ b/test/y2storage/shadower_test.rb
@@ -26,6 +26,7 @@ require "y2storage/shadower"
 
 describe Y2Storage::Shadower do
   before do
+    allow(Y2Storage::VolumeSpecification).to receive(:for)
     allow(Y2Storage::VolumeSpecification).to receive(:for).with("/").and_return(root_spec)
 
     fake_scenario(scenario)


### PR DESCRIPTION
## Problem

This is a follow-up of https://github.com/yast/yast-storage-ng/pull/1160.

In SLE and openSUSE, a "@" Btrfs subvolume is used as kind of prefix for the rest of subvolumes in the root file system. All subvolumes proposed in the control file should be created as children of "@". Moreover, the path of all the subvolumes should start with "@/", for example:

~~~
top level
|-- @
  |-- @/home
  |-- @/var
  |-- @/.snapshots
      |-- @/.snapshots/1/snapshot
      |-- @/.snapshots/2/snapshot
~~~

This was designed so to make the snapshots rollback easier, see https://www.spinics.net/lists/linux-btrfs/msg44611.html (although having a prefix is not necessary at all. What really eases to rollback snapshots is the fact of having different subvolumes for root, home, etc).

The Expert Partitioner should be able to recognize a subvolume prefix to create the new Btrfs subvolumes accordingly. But there are some scenarios where the Partitioner is not working as expected:

* When the Btrfs exists on disk and has no subvolumes: it considers the first added subvolume as the prefix.
* When the Btrfs exists on disk and it is using snapshots: it does not recognize "@" as prefix.

Related links: 

* PBI: https://trello.com/c/Ei0AyUtc/2152-5-the-subvolume-prefix
* Bug: https://bugzilla.suse.com/show_bug.cgi?id=1067505
* See also: https://github.com/yast/yast-storage-ng/pull/1164


## Solution

The detection of the subvolumes prefix was improved. Now the prefix is inferred from the subvolumes hierarchy of the file system and the *btrfs_default_subvolume* indicated in the control file. So, given a subvolumes tree, the file system is supposed to be using a prefix when:

* The top level subvolume only has a child.
* The path of such subvolume is "@" or whatever the control file indicates in the *btrfs_default_subvolume* property for the current file system.
* All the children of such subvolume starts with its path.

This logic to infer the prefix is only applied when the subvolumes prefix has not been set yet for the file system. The prefix is directly set in some cases:

* When AutoYaST is creating the subvolumes for a file system (it sets the *subvolumes_prefix* option from the profile).
* When the Storage Proposal is creating the subvolumes for a file system (it sets the *btrfs_default_subvolume* option from the control file).
* When the Expert Partitioner is creating the default list of subvolumes for a file system (it also sets the *btrfs_default_subvolume* option from the control file).

When the prefix is neither directly set nor inferred, the new subvolumes will not use a prefix. 

Moreover, the shadowing process was improved. Now, the mount point is removed from user created subvolumes when the subvolume is shadowed.

And last but not least, now the tables do not show the prefix subvolume. Previously, the tables were hiding the default subvolume instead of the prefix. Note that in an running system with snapshots, @ subvolume is not the default subvolume. In that case, a snapshot is the default subvolume. 


## Testing

* Added unit tests
* Tested manually with the *partitioner_testing* client
* Tested during installation and in a running system
