### PR TITLE
Fix help

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 19 09:10:13 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- print properly help to avoid accidental opening of module by bash
+  completion (bsc#1172340) 
+- 4.3.21
+
+-------------------------------------------------------------------
 Wed Nov 11 14:44:26 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Untranslated error message in 'Edit Btrfs subvolumes'/

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.20
+Version:        4.3.21
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/clients/partitioner_testing.rb
+++ b/src/clients/partitioner_testing.rb
@@ -26,15 +26,21 @@ require "y2storage"
 # Comment next line and run the file with root privileges to test system lock
 Y2Storage::StorageManager.create_test_instance
 
-arg = Yast::WFM.Args.first
-case arg
-when /.ya?ml$/
-  Y2Storage::StorageManager.instance(mode: :rw).probe_from_yaml(arg)
-when /.xml$/
-  # note: support only xml device graph, not xml output of probing commands
-  Y2Storage::StorageManager.instance(mode: :rw).probe_from_xml(arg)
-else
-  raise "Invalid testing parameter #{arg}, expecting foo.yml or foo.xml."
+if Yast::WFM.Args.size == 1
+  arg = Yast::WFM.Args.first
+  case arg
+  when /.ya?ml$/
+    Y2Storage::StorageManager.instance(mode: :rw).probe_from_yaml(arg)
+  when /.xml$/
+    # note: support only xml device graph, not xml output of probing commands
+    Y2Storage::StorageManager.instance(mode: :rw).probe_from_xml(arg)
+  # rubocop:disable Lint/EmptyWhen
+  when /help/
+  # handled later by client
+  # rubocop:enable Lint/EmptyWhen
+  else
+    raise "Invalid testing parameter #{arg}, expecting foo.yml or foo.xml."
+  end
 end
 
 Y2Partitioner::Clients::Main.new.run(allow_commit: false)

--- a/src/lib/y2partitioner/clients/main.rb
+++ b/src/lib/y2partitioner/clients/main.rb
@@ -44,6 +44,7 @@ module Y2Partitioner
       #
       # @param allow_commit [Boolean] whether the changes can be stored on disk
       def run(allow_commit: true)
+        return nil if print_help(testing_client: !allow_commit)
         return nil if !run_partitioner?
 
         begin
@@ -70,6 +71,32 @@ module Y2Partitioner
       def run_partitioner?
         start_partitioner_warning == :yes &&
           setup_storage_manager
+      end
+
+      # Checks if help is needed to be printed
+      # @param [Boolean] if client is testing one or not
+      # @return [Boolean] true if help is printed and action should be stopped
+      def print_help(testing_client:)
+        args = Yast::WFM.Args
+        msg = if testing_client
+          return false if args.size == 1 && args[0] != "help"
+
+          _("Usage: `yast2 partitioner_testing <hw_setup.[xml|yaml]`")
+        else
+          return false if args.empty?
+
+          _("CLI is not supporter and also no arguments.")
+        end
+
+        cmdline_description = {
+          "id"   => "partitioner",
+          "help" => msg
+        }
+
+        Yast.import "CommandLine"
+        Yast::CommandLine.Run(cmdline_description)
+
+        true
       end
 
       # Tries to initialize the storage stack

--- a/src/lib/y2partitioner/clients/main.rb
+++ b/src/lib/y2partitioner/clients/main.rb
@@ -74,7 +74,7 @@ module Y2Partitioner
       end
 
       # Checks if help is needed to be printed
-      # @param [Boolean] if client is testing one or not
+      # @param testing_client [Boolean] if client is testing one or not
       # @return [Boolean] true if help is printed and action should be stopped
       def print_help(testing_client:)
         args = Yast::WFM.Args

--- a/test/y2partitioner/clients/main_test.rb
+++ b/test/y2partitioner/clients/main_test.rb
@@ -156,6 +156,10 @@ describe Y2Partitioner::Clients::Main do
           context "and it is not allowed to commit" do
             let(:allow_commit) { false }
 
+            before do
+              allow(Yast::WFM).to receive(:Args).and_return(["test.xml"])
+            end
+
             it "shows a message" do
               expect(Yast2::Popup).to receive(:show).with(/commit is not allowed/)
 


### PR DESCRIPTION
## Problem

double tab on CLI for partitioner opens a module.

- https://bugzilla.suse.com/show_bug.cgi?id=1172340
- https://trello.com/c/8G4FikEf/1988-ostumbleweed-p5-1172340-several-yast-modules-can-be-started-by-typing-yast2-module-tabtab

## Solution

Print properly that CLI is not supported. Also add built in help for partitioner_testing client.


## Testing

- *Tested manually*

