### PR TITLE
Partitioner: actions to add and edit tmpfs

### DIFF
--- a/src/lib/y2partitioner/actions/add_tmpfs.rb
+++ b/src/lib/y2partitioner/actions/add_tmpfs.rb
@@ -71,7 +71,7 @@ module Y2Partitioner
       # @return [String]
       def title
         # TRANSLATORS: wizard title when creating a new Tmpfs filesystem.
-        _("Add tmpfs")
+        _("Add Tmpfs")
       end
     end
   end

--- a/src/lib/y2partitioner/actions/add_tmpfs.rb
+++ b/src/lib/y2partitioner/actions/add_tmpfs.rb
@@ -1,0 +1,78 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/ui_state"
+require "y2partitioner/actions/transaction_wizard"
+require "y2partitioner/actions/controllers/filesystem"
+require "y2partitioner/dialogs/tmpfs"
+
+module Y2Partitioner
+  module Actions
+    # Action for creating a new Tmpfs filesystem
+    class AddTmpfs < TransactionWizard
+      # Constructor
+      def initialize
+        super
+        textdomain "storage"
+      end
+
+      # Only step of the wizard
+      #
+      # @see Dialogs::Tmpfs
+      #
+      # @return [Symbol] :finish when the dialog successes
+      def add_tmpfs
+        result = Dialogs::Tmpfs.run(fs_controller)
+        return result if result != :next
+
+        fs_controller.finish
+        UIState.instance.select_row(tmpfs.sid)
+        :finish
+      end
+
+      protected
+
+      # @see TransactionWizard
+      def sequence_hash
+        {
+          "ws_start"  => "add_tmpfs",
+          "add_tmpfs" => { finish: :finish }
+        }
+      end
+
+      # The tmpfs object must be created within the transaction
+      def tmpfs
+        @tmpfs ||= Y2Storage::Filesystems::Tmpfs.create(DeviceGraphs.instance.current)
+      end
+
+      def fs_controller
+        @fs_controller ||= Controllers::Filesystem.new(tmpfs, title)
+      end
+
+      # Wizard title
+      #
+      # @return [String]
+      def title
+        # TRANSLATORS: wizard title when creating a new Tmpfs filesystem.
+        _("Add tmpfs")
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/actions/edit_tmpfs.rb
+++ b/src/lib/y2partitioner/actions/edit_tmpfs.rb
@@ -1,0 +1,78 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2partitioner/ui_state"
+require "y2partitioner/actions/transaction_wizard"
+require "y2partitioner/actions/controllers/filesystem"
+require "y2partitioner/dialogs/tmpfs"
+
+module Y2Partitioner
+  module Actions
+    # Action for creating a new Tmpfs filesystem
+    class EditTmpfs < TransactionWizard
+      # Constructor
+      #
+      # @param filesystem [Y2Storage::Filesystems::Tmpfs]
+      def initialize(filesystem)
+        super()
+        textdomain "storage"
+
+        @device_sid = filesystem.sid
+        UIState.instance.select_row(filesystem.sid)
+      end
+
+      # Only step of the wizard
+      #
+      # @see Dialogs::Tmpfs
+      #
+      # @return [Symbol] :finish when the dialog successes
+      def edit_tmpfs
+        result = Dialogs::Tmpfs.run(fs_controller, edit: true)
+        return result if result != :next
+
+        fs_controller.finish
+        :finish
+      end
+
+      protected
+
+      # @see TransactionWizard
+      def sequence_hash
+        {
+          "ws_start"   => "edit_tmpfs",
+          "edit_tmpfs" => { finish: :finish }
+        }
+      end
+
+      def fs_controller
+        @fs_controller ||= Controllers::Filesystem.new(device, title)
+      end
+
+      # Wizard title
+      #
+      # @return [String]
+      def title
+        # TRANSLATORS: wizard title when editing a tmpfs filesystem, where %s is
+        # replaced by the path where tmpfs is mounted
+        format(_("Edit tmpfs at %s"), device.mount_path)
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/actions/edit_tmpfs.rb
+++ b/src/lib/y2partitioner/actions/edit_tmpfs.rb
@@ -71,7 +71,7 @@ module Y2Partitioner
       def title
         # TRANSLATORS: wizard title when editing a tmpfs filesystem, where %s is
         # replaced by the path where tmpfs is mounted
-        format(_("Edit tmpfs at %s"), device.mount_path)
+        format(_("Edit Tmpfs at %s"), device.mount_path)
       end
     end
   end

--- a/src/lib/y2partitioner/dialogs/tmpfs.rb
+++ b/src/lib/y2partitioner/dialogs/tmpfs.rb
@@ -1,0 +1,60 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2partitioner/dialogs/base"
+require "y2partitioner/widgets/tmpfs_options"
+
+module Y2Partitioner
+  module Dialogs
+    # Dialog to create and edit a tmpfs filesystem
+    class Tmpfs < Base
+      # @param controller [Actions::Controllers::Filesystem]
+      def initialize(controller, edit: false)
+        super()
+
+        textdomain "storage"
+
+        @controller = controller
+        @edit = edit
+      end
+
+      # @macro seeDialog
+      def title
+        @controller.wizard_title
+      end
+
+      # @macro seeDialog
+      def contents
+        HVSquash(widget)
+      end
+
+      private
+
+      # @return [Actions::Controllers::Filesystem]
+      attr_reader :controller
+
+      # Widget for Tmpfs options
+      #
+      # @return [Widgets::TmpfsOptions]
+      def widget
+        @widget ||= Widgets::TmpfsOptions.new(controller, @edit)
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -208,8 +208,7 @@ module Y2Partitioner
           VBox(
             Left(MountBy.new(@controller)),
             VSpacing(1),
-            Left(VolumeLabel.new(@controller, self)),
-            VSpacing(1),
+            * ui_term_with_vspace(VolumeLabel.new(@controller, self)),
             Left(GeneralOptions.new(@controller)),
             Left(FilesystemsOptions.new(@controller)),
             * ui_term_with_vspace(JournalOptions.new(@controller)),
@@ -254,6 +253,15 @@ module Y2Partitioner
         super(controller)
 
         @parent_widget = parent_widget
+      end
+
+      # @see FstabCommon::supported_by_filesystem?
+      #
+      # @return [Boolean]
+      def supported_by_filesystem?
+        return false unless filesystem.supports_label?
+
+        super
       end
 
       # @macro seeAbstractWidget

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -799,6 +799,7 @@ module Y2Partitioner
       def widgets
         [
           SwapPriority.new(@controller),
+          TmpfsSize.new(@controller),
           IOCharset.new(@controller),
           Codepage.new(@controller)
         ]
@@ -831,6 +832,55 @@ module Y2Partitioner
       def help
         _("<p><b>Swap Priority:</b>\nEnter the swap priority. " \
         "Higher numbers mean higher priority.</p>\n")
+      end
+    end
+
+    # Size for tmpfs
+    class TmpfsSize < CWM::InputField
+      include FstabCommon
+
+      # Possible values of the widget
+      VALUES = ["size="].freeze
+      # Format of the option
+      REGEXP  = /^size=/
+      # Default value of the widget
+      DEFAULT = "".freeze
+      # Regular expression to validate the content of #value
+      VALUE_REGEXP = /^\d+(k|m|g|%)?$/i
+
+      # @macro seeAbstractWidget
+      def label
+        _("Max Size")
+      end
+
+      # @macro seeAbstractWidget
+      def store
+        delete_fstab_option!(REGEXP)
+        add_fstab_option("size=#{value}") if value && !value.empty?
+      end
+
+      # @macro seeAbstractWidget
+      def validate
+        return true if value.nil? || value.empty?
+        return true if value =~ VALUE_REGEXP
+
+        Yast::Popup.Error(
+          _(
+            "The size must be a number,\n" \
+            "optionally followed by a unit (k, m or g) or by a percent sign (%)."
+          )
+        )
+        focus
+        false
+      end
+
+      # @macro seeAbstractWidget
+      def help
+        _("<p><b>Max Size:</b>\nUpper limit on the size of the file system. " \
+        "The size is given in bytes by default, optionally followed by a <b>k</b>, <b>m</b> " \
+        "or <b>g</b> suffix to specify KiB, MiB or GiB. The size may also have a <b>% </b> " \
+        "suffix to limit this instance to a percentage of physical RAM. " \
+        "The default, when neither this option nor nr_blocks is specified, is 50%.</p>\n")
       end
     end
 

--- a/src/lib/y2partitioner/widgets/menus/add.rb
+++ b/src/lib/y2partitioner/widgets/menus/add.rb
@@ -26,6 +26,7 @@ require "y2partitioner/actions/add_bcache"
 require "y2partitioner/actions/add_partition"
 require "y2partitioner/actions/add_lvm_lv"
 require "y2partitioner/actions/add_btrfs_subvolume"
+require "y2partitioner/actions/add_tmpfs"
 
 module Y2Partitioner
   module Widgets
@@ -51,6 +52,7 @@ module Y2Partitioner
             Item(Id(:menu_add_vg), _("LVM &Volume Group...")),
             Item(Id(:menu_add_btrfs), _("&Btrfs...")),
             Item(Id(:menu_add_bcache), _("B&cache...")),
+            Item(Id(:menu_add_tmpfs), _("&Tmpfs...")),
             Item("---"),
             Item(Id(:menu_add_partition), _("&Partition...")),
             Item(Id(:menu_add_lv), _("&Logical Volume...")),
@@ -92,6 +94,11 @@ module Y2Partitioner
         # @see Device#action_for
         def menu_add_bcache_action
           Actions::AddBcache.new
+        end
+
+        # @see Device#action_for
+        def menu_add_tmpfs_action
+          Actions::AddTmpfs.new
         end
 
         # @see Device#action_for

--- a/src/lib/y2partitioner/widgets/menus/modify.rb
+++ b/src/lib/y2partitioner/widgets/menus/modify.rb
@@ -26,6 +26,7 @@ require "y2partitioner/actions/delete_lvm_lv"
 require "y2partitioner/actions/delete_bcache"
 require "y2partitioner/actions/delete_btrfs"
 require "y2partitioner/actions/delete_btrfs_subvolume"
+require "y2partitioner/actions/delete_tmpfs"
 require "y2partitioner/actions/edit_md_devices"
 require "y2partitioner/actions/edit_btrfs_devices"
 require "y2partitioner/actions/edit_bcache"
@@ -33,6 +34,7 @@ require "y2partitioner/actions/resize_lvm_vg"
 require "y2partitioner/actions/edit_blk_device"
 require "y2partitioner/actions/edit_btrfs"
 require "y2partitioner/actions/edit_btrfs_subvolume"
+require "y2partitioner/actions/edit_tmpfs"
 require "y2partitioner/actions/resize_blk_device"
 require "y2partitioner/actions/move_partition"
 require "y2partitioner/actions/create_partition_table"
@@ -101,6 +103,8 @@ module Y2Partitioner
             Actions::EditBtrfs.new(device)
           elsif device.is?(:btrfs_subvolume)
             Actions::EditBtrfsSubvolume.new(device)
+          elsif device.is?(:tmpfs)
+            Actions::EditTmpfs.new(device)
           end
         end
 

--- a/src/lib/y2partitioner/widgets/tmpfs_buttons.rb
+++ b/src/lib/y2partitioner/widgets/tmpfs_buttons.rb
@@ -20,6 +20,8 @@
 require "y2partitioner/widgets/action_button"
 require "y2partitioner/widgets/device_edit_button"
 require "y2partitioner/widgets/device_delete_button"
+require "y2partitioner/actions/add_tmpfs"
+require "y2partitioner/actions/edit_tmpfs"
 require "y2partitioner/actions/delete_tmpfs"
 
 module Y2Partitioner
@@ -36,7 +38,7 @@ module Y2Partitioner
 
       # @see ActionButton#action
       def action
-        # TODO
+        Actions::AddTmpfs.new
       end
     end
 
@@ -44,7 +46,7 @@ module Y2Partitioner
     class TmpfsEditButton < DeviceEditButton
       # @see ActionButton#action
       def action
-        # TODO
+        Actions::EditTmpfs.new(device)
       end
     end
 

--- a/src/lib/y2partitioner/widgets/tmpfs_options.rb
+++ b/src/lib/y2partitioner/widgets/tmpfs_options.rb
@@ -1,0 +1,70 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "cwm"
+require "yast2/popup"
+require "y2partitioner/widgets/format_and_mount"
+
+module Y2Partitioner
+  module Widgets
+    # Widget to set tmpfs options
+    class TmpfsOptions < MountOptions
+      def initialize(controller, edit)
+        textdomain "storage"
+
+        @edit = edit
+        super(controller, nil)
+      end
+
+      # @macro seeAbstractWidget
+      def contents
+        VBox(
+          Left(@mount_point_widget),
+          VSpacing(0.5),
+          Left(@fstab_options_widget)
+        )
+      end
+
+      # @see MountOptions
+      def refresh
+        @mount_point_widget.refresh
+        @mount_point_widget.disable if @edit
+        mount_point_change
+      end
+
+      # @macro seeAbstractWidget
+      def handle(event)
+        mount_point_change if event["ID"] == @mount_point_widget.widget_id
+
+        nil
+      end
+
+      def help
+        _(
+          "<p>The tmpfs facility allows the creation of very fast file systems whose contents " \
+          "reside in virtual memory. The file system is automatically created in the moment of " \
+          "mounting it and the contents are lost when the file system is unmounted.</p>" \
+          "<p>Although the file system consumes only as much memory as required by its current " \
+          "contents, its max size is limited automatically by the system based on the total " \
+          "amount of RAM. That max limit can be customized with the appropriate fstab option.</p>"
+        )
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/tmpfs_options.rb
+++ b/src/lib/y2partitioner/widgets/tmpfs_options.rb
@@ -65,6 +65,17 @@ module Y2Partitioner
           "amount of RAM. That max limit can be customized with the appropriate fstab option.</p>"
         )
       end
+
+      def validate
+        return false unless super
+        return true unless controller.mount_point&.root?
+
+        Yast::Popup.Error(
+          _("Installing into a temporary file system is not supported.")
+        )
+        @mount_point_widget.focus
+        false
+      end
     end
   end
 end

--- a/src/lib/y2partitioner/widgets/tmpfs_options.rb
+++ b/src/lib/y2partitioner/widgets/tmpfs_options.rb
@@ -25,6 +25,11 @@ module Y2Partitioner
   module Widgets
     # Widget to set tmpfs options
     class TmpfsOptions < MountOptions
+      # Constructor
+      #
+      # @param controller [Actions::Controllers::Filesystem]
+      # @param edit [Boolean] whether the tmpfs is being edited. False if the widget
+      #   is being used to create a new tmpfs object
       def initialize(controller, edit)
         textdomain "storage"
 

--- a/src/lib/y2storage/filesystems/base.rb
+++ b/src/lib/y2storage/filesystems/base.rb
@@ -82,6 +82,20 @@ module Y2Storage
         false
       end
 
+      # Checks whether the filesystem has the capability of hosting Btrfs subvolumes
+      #
+      # @return [Boolean] it only should be true for Btrfs.
+      def supports_btrfs_subvolumes?
+        false
+      end
+
+      # Whether the filesystem supports having a label
+      #
+      # @return [Boolean]
+      def supports_label?
+        false
+      end
+
       # @see Mountable#extra_default_mount_options
       #
       # @return [Array<String>]

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -202,13 +202,6 @@ module Y2Storage
         blk_devices.find(&:journal?)
       end
 
-      # Checks whether the filesystem has the capability of hosting Btrfs subvolumes
-      #
-      # It only should be true for Btrfs.
-      def supports_btrfs_subvolumes?
-        false
-      end
-
       # @return [Boolean]
       def in_network?
         blk_devices.any?(&:in_network?)

--- a/test/y2partitioner/actions/add_tmpfs_test.rb
+++ b/test/y2partitioner/actions/add_tmpfs_test.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2partitioner/device_graphs"
+require "y2partitioner/actions/add_tmpfs"
+
+describe Y2Partitioner::Actions::AddTmpfs do
+  before do
+    devicegraph_stub("tmpfs1-devicegraph.xml")
+  end
+
+  subject { described_class.new }
+
+  describe "#run" do
+    context "if the user goes forward in the dialog" do
+      before do
+        allow(Y2Partitioner::Dialogs::Tmpfs).to receive(:run).and_return(:next)
+      end
+
+      it "returns :finish" do
+        expect(subject.run).to eq(:finish)
+      end
+
+      it "creates a new tmpfs" do
+        before = Y2Partitioner::DeviceGraphs.instance.current.tmp_filesystems.size
+        subject.run
+        after = Y2Partitioner::DeviceGraphs.instance.current.tmp_filesystems.size
+        expect(after).to eq(before + 1)
+      end
+    end
+
+    context "if the user aborts the process" do
+      before do
+        allow(Y2Partitioner::Dialogs::Tmpfs).to receive(:run).and_return(:abort)
+      end
+
+      it "returns :abort" do
+        expect(subject.run).to eq(:abort)
+      end
+    end
+  end
+end

--- a/test/y2partitioner/actions/edit_tmpfs_test.rb
+++ b/test/y2partitioner/actions/edit_tmpfs_test.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2partitioner/device_graphs"
+require "y2partitioner/actions/edit_tmpfs"
+
+describe Y2Partitioner::Actions::EditTmpfs do
+  before do
+    devicegraph_stub("tmpfs1-devicegraph.xml")
+  end
+
+  subject { described_class.new(filesystem) }
+  let(:filesystem) { Y2Partitioner::DeviceGraphs.instance.current.tmp_filesystems.first }
+
+  describe "#run" do
+    context "if the user goes forward in the dialog" do
+      before do
+        allow(Y2Partitioner::Dialogs::Tmpfs).to receive(:run).and_return(:next)
+      end
+
+      it "returns :finish" do
+        expect(subject.run).to eq(:finish)
+      end
+    end
+
+    context "if the user aborts the process" do
+      before do
+        allow(Y2Partitioner::Dialogs::Tmpfs).to receive(:run).and_return(:abort)
+      end
+
+      it "returns :abort" do
+        expect(subject.run).to eq(:abort)
+      end
+    end
+  end
+end

--- a/test/y2partitioner/dialogs/tmpfs_test.rb
+++ b/test/y2partitioner/dialogs/tmpfs_test.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2storage"
+require "y2partitioner/dialogs/tmpfs"
+require "y2partitioner/actions/controllers"
+
+describe Y2Partitioner::Dialogs::Tmpfs do
+  before { devicegraph_stub("tmpfs1-devicegraph.xml") }
+
+  let(:filesystem) { fake_devicegraph.tmp_filesystems.first }
+  let(:controller) do
+    Y2Partitioner::Actions::Controllers::Filesystem.new(filesystem, "")
+  end
+
+  subject { described_class.new(controller) }
+
+  include_examples "CWM::Dialog"
+end

--- a/test/y2partitioner/widgets/fstab_options_test.rb
+++ b/test/y2partitioner/widgets/fstab_options_test.rb
@@ -287,6 +287,61 @@ describe Y2Partitioner::Widgets do
     include_examples "InputField"
   end
 
+  describe Y2Partitioner::Widgets::TmpfsSize do
+    include_examples "InputField"
+
+    describe "#validate" do
+      before do
+        allow(subject).to receive(:value).and_return value
+      end
+
+      context "if the value is an empty string" do
+        let(:value) { "" }
+
+        it "returns true and displays no popup" do
+          expect(Yast::Popup).to_not receive(:Error)
+          expect(subject.validate).to eq true
+        end
+      end
+
+      context "if the value is numeric" do
+        let(:value) { "128" }
+
+        it "returns true and displays no popup" do
+          expect(Yast::Popup).to_not receive(:Error)
+          expect(subject.validate).to eq true
+        end
+      end
+
+      context "if the value is a number followed by k, m or g" do
+        let(:value) { "256m" }
+
+        it "returns true and displays no popup" do
+          expect(Yast::Popup).to_not receive(:Error)
+          expect(subject.validate).to eq true
+        end
+      end
+
+      context "if the value is a percentage" do
+        let(:value) { "25%" }
+
+        it "returns true and displays no popup" do
+          expect(Yast::Popup).to_not receive(:Error)
+          expect(subject.validate).to eq true
+        end
+      end
+
+      context "if the value is invalid" do
+        let(:value) { "m" }
+
+        it "shows and error popup and returns false" do
+          expect(Yast::Popup).to receive(:Error)
+          expect(subject.validate).to eq(false)
+        end
+      end
+    end
+  end
+
   describe Y2Partitioner::Widgets::IOCharset do
     include_examples "CWM::ComboBox"
     include_examples "CWM::AbstractWidget#init#store"

--- a/test/y2partitioner/widgets/menus/add_test.rb
+++ b/test/y2partitioner/widgets/menus/add_test.rb
@@ -59,6 +59,10 @@ describe Y2Partitioner::Widgets::Menus::Add do
       expect(subject.items).to include(item_with_id(:menu_add_bcache))
     end
 
+    it "includes 'Tmpfs'" do
+      expect(subject.items).to include(item_with_id(:menu_add_tmpfs))
+    end
+
     it "includes 'Partition'" do
       expect(subject.items).to include(item_with_id(:menu_add_partition))
     end
@@ -253,6 +257,16 @@ describe Y2Partitioner::Widgets::Menus::Add do
 
       it "calls an action to add a Btrfs" do
         expect(Y2Partitioner::Actions::AddBtrfs).to receive(:new)
+
+        subject.handle(event)
+      end
+    end
+
+    context "when 'Tmpfs' is selected" do
+      let(:event) { :menu_add_tmpfs }
+
+      it "calls an action to add a Tmpfs" do
+        expect(Y2Partitioner::Actions::AddTmpfs).to receive(:new)
 
         subject.handle(event)
       end

--- a/test/y2partitioner/widgets/menus/modify_test.rb
+++ b/test/y2partitioner/widgets/menus/modify_test.rb
@@ -241,6 +241,20 @@ describe Y2Partitioner::Widgets::Menus::Modify do
         end
       end
 
+      context "and the selected device is a tmpfs" do
+        let(:scenario) { "tmpfs1-devicegraph.xml" }
+
+        let(:device) { current_graph.tmp_filesystems.last }
+
+        subject { described_class.new(device) }
+
+        it "calls an action to edit the Tmpfs" do
+          expect(Y2Partitioner::Actions::EditTmpfs).to receive(:new).with(device)
+
+          subject.handle(event)
+        end
+      end
+
       context "and the selected device is a Btrfs subvolume" do
         let(:scenario) { "mixed_disks_btrfs.yml" }
 

--- a/test/y2partitioner/widgets/tmpfs_buttons_test.rb
+++ b/test/y2partitioner/widgets/tmpfs_buttons_test.rb
@@ -23,11 +23,21 @@ require_relative "button_examples"
 require "y2partitioner/widgets/tmpfs_buttons"
 
 describe Y2Partitioner::Widgets::TmpfsAddButton do
-  # TODO
+  let(:action) { Y2Partitioner::Actions::AddTmpfs }
+
+  let(:scenario) { "one-empty-disk" }
+
+  include_examples "add button"
 end
 
 describe Y2Partitioner::Widgets::TmpfsEditButton do
-  # TODO
+  let(:action) { Y2Partitioner::Actions::EditTmpfs }
+
+  let(:scenario) { "tmpfs1-devicegraph.xml" }
+
+  let(:device) { devicegraph.tmp_filesystems.last }
+
+  include_examples "button"
 end
 
 describe Y2Partitioner::Widgets::TmpfsDeleteButton do

--- a/test/y2partitioner/widgets/tmpfs_options_test.rb
+++ b/test/y2partitioner/widgets/tmpfs_options_test.rb
@@ -1,0 +1,82 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/tmpfs_options"
+require "y2partitioner/actions/controllers"
+
+describe Y2Partitioner::Widgets do
+  before do
+    devicegraph_stub(scenario)
+    allow(Yast::UI).to receive(:ChangeWidget)
+  end
+
+  let(:scenario) { "tmpfs1-devicegraph.xml" }
+  let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
+  let(:filesystem) { current_graph.tmp_filesystems.first }
+
+  let(:controller) do
+    Y2Partitioner::Actions::Controllers::Filesystem.new(filesystem, "")
+  end
+
+  describe Y2Partitioner::Widgets::TmpfsOptions do
+    subject { described_class.new(controller, edit) }
+
+    context "when editing an existing tmpfs" do
+      let(:edit) { true }
+
+      include_examples "CWM::CustomWidget"
+
+      describe "#init" do
+        it "disables the widget to modify the mount path" do
+          expect(Yast::UI).to receive(:ChangeWidget)
+            .with(Id("Y2Partitioner::Widgets::MountPoint"), :Enabled, false)
+
+          subject.init
+        end
+
+        it "initializes the widget for the mount path with the correct value" do
+          expect(Yast::UI).to receive(:ChangeWidget)
+            .with(Id("Y2Partitioner::Widgets::MountPoint"), :Value, filesystem.mount_path)
+
+          subject.init
+        end
+      end
+    end
+
+    context "when creating a new tmpfs" do
+      let(:edit) { false }
+
+      include_examples "CWM::CustomWidget"
+
+      describe "#init" do
+        it "does not disable the widget to modify the mount path" do
+          expect(Yast::UI).to_not receive(:ChangeWidget)
+            .with(Id("Y2Partitioner::Widgets::MountPoint"), :Enabled, false)
+
+          subject.init
+        end
+      end
+    end
+  end
+end

--- a/test/y2partitioner/widgets/tmpfs_options_test.rb
+++ b/test/y2partitioner/widgets/tmpfs_options_test.rb
@@ -77,6 +77,19 @@ describe Y2Partitioner::Widgets do
           subject.init
         end
       end
+
+      describe "#validate" do
+        it "silently returns true if the filesystem has a reasonable mount path" do
+          expect(Yast::Popup).to_not receive(:Error)
+          expect(subject.validate).to eq true
+        end
+
+        it "opens an error popup and returns false if filesystem is mounted at '/'" do
+          filesystem.mount_path = "/"
+          expect(Yast::Popup).to receive(:Error)
+          expect(subject.validate).to eq false
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This replaces #1176 

## Problem

In SLE 12 (with old yast2-storage) AutoYaST was able to import/export tmpfs file systems. Moreover, the Expert Partitioner included a section for the tmpfs file systems. Both features are missing in SLE 15.

- https://jira.suse.com/browse/SLE-16313
- PBI: https://trello.com/c/JRECcir9/2134-5-tmpfs-in-the-partitioner-and-autoyast

## Solution

As a follow-up to #1179, this pull request adds the possibility to create tmp filesystem and to edit the existing ones.

See screenshots below.

## Testing

- Added unit tests.
- Tested manually with the `partitioner_testing` client.

## Screenshots

![tmpfs_add](https://user-images.githubusercontent.com/3638289/100892610-ce061a80-34ba-11eb-8773-d07acd9b92d4.png)

![tmpfs_options](https://user-images.githubusercontent.com/3638289/100892607-cd6d8400-34ba-11eb-93f7-d20459ec60a9.png)

![tmpfs_edit](https://user-images.githubusercontent.com/3638289/100892604-ccd4ed80-34ba-11eb-9739-71e3e9e72b97.png)

![tmpfs_noroot](https://user-images.githubusercontent.com/3638289/100895728-2b4f9b00-34be-11eb-8541-d6658b298a19.png)
