### PR TITLE
AutoYaST: add tmpfs support

### DIFF
--- a/src/lib/y2storage/autoinst_profile/partitioning_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partitioning_section.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -137,6 +137,13 @@ module Y2Storage
       # @return [Array<DriveSection>]
       def btrfs_drives
         drives.select { |d| d.type == :CT_BTRFS }
+      end
+
+      # Drive sections with type :CT_TMPFS
+      #
+      # @return [Array<DriveSection>]
+      def tmpfs_drives
+        drives.select { |d| d.type == :CT_TMPFS }
       end
 
       # All drive sections generated from a given devicegraph

--- a/src/lib/y2storage/autoinst_proposal.rb
+++ b/src/lib/y2storage/autoinst_proposal.rb
@@ -40,7 +40,7 @@ module Y2Storage
   #   proposal.devices              # => Proposed layout
   #
   class AutoinstProposal < Proposal::Base
-    # @return [Hash] Partitioning layout from an AutoYaST profile
+    # @return [AutoinstProfile::PartitioningSection] Partitioning layout from an AutoYaST profile
     attr_reader :partitioning
 
     # @return [AutoinstIssues::List] List of found AutoYaST issues

--- a/src/lib/y2storage/planned/devices_collection.rb
+++ b/src/lib/y2storage/planned/devices_collection.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018-2019] SUSE LLC
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -162,6 +162,13 @@ module Y2Storage
       # @return [Array<Planned::Btrfs>]
       def btrfs_filesystems
         @btrfs_filesystems ||= devices.select { |d| d.is_a?(Planned::Btrfs) }
+      end
+
+      # Returns the list of planned Tmpfs filesystems
+      #
+      # @return [Array<Planned::Tmpfs>]
+      def tmpfs_filesystems
+        @tmpfs_filesystems ||= devices.select { |d| d.is_a?(Planned::Tmpfs) }
       end
 
       # Returns all devices, including nested ones

--- a/src/lib/y2storage/planned/tmpfs.rb
+++ b/src/lib/y2storage/planned/tmpfs.rb
@@ -1,0 +1,68 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage/planned/device"
+require "y2storage/planned/mixins"
+require "y2storage/match_volume_spec"
+require "y2storage/filesystems/type"
+
+module Y2Storage
+  module Planned
+    # Specification for a Y2Storage::Filesystems::Tmpfs object to be created during the AutoYaST proposal
+    #
+    # @see Device
+    class Tmpfs < Device
+      include Planned::CanBeMounted
+      include MatchVolumeSpec
+
+      # Constructor
+      #
+      # @param mount_point [String] mount path for this filesystem in the AutoYaST profile
+      # @param fstab_options [Array<String>] fstab options for this filesystem in the AutoYaST profile
+      def initialize(mount_point, fstab_options)
+        super()
+
+        initialize_can_be_mounted
+
+        self.mount_point = mount_point
+        self.fstab_options = fstab_options
+      end
+
+      # @return [Array<Symbol>]
+      def self.to_string_attrs
+        [:mount_point]
+      end
+
+      protected
+
+      # Values for volume specification matching
+      #
+      # @see MatchVolumeSpec
+      def volume_match_values
+        {
+          mount_point:  mount_point,
+          size:         nil,
+          fs_type:      Filesystems::Type::TMPFS,
+          partition_id: nil
+        }
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/autoinst_drives_map.rb
+++ b/src/lib/y2storage/proposal/autoinst_drives_map.rb
@@ -61,6 +61,7 @@ module Y2Storage
         add_mds(partitioning.md_drives)
         add_bcaches(partitioning.bcache_drives)
         add_btrfs_filesystems(partitioning.btrfs_drives)
+        add_tmpfs_filesystems(partitioning.tmpfs_drives)
         add_nfs_filesystems(partitioning.nfs_drives)
       end
 
@@ -201,6 +202,21 @@ module Y2Storage
       #   AutoYaST
       def add_btrfs_filesystems(btrfs_drives)
         btrfs_drives.each { |d| @drives[d.device] = d }
+      end
+
+      # Adds Tmpfs filesystems to the device map
+      #
+      # @param tmpfs_drives [Array<AutoinstProfile::DriveSection>] List of Tmpfs specifications from
+      #   AutoYaST
+      def add_tmpfs_filesystems(tmpfs_drives)
+        tmpfs_drives.each do |drive|
+          if drive.mount.nil? || drive.mount.empty?
+            issues_list.add(Y2Storage::AutoinstIssues::MissingValue, drive, :mount)
+            next
+          end
+
+          @drives[d.mount] = d
+        end
       end
 
       # Adds NFS filesystems to the device map

--- a/src/lib/y2storage/proposal/autoinst_tmpfs_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_tmpfs_planner.rb
@@ -1,0 +1,45 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/proposal/autoinst_drive_planner"
+require "y2storage/planned/tmpfs"
+
+module Y2Storage
+  module Proposal
+    # This class converts an AutoYaST specification into a Planned::Tmpfs
+    class AutoinstTmpfsPlanner < AutoinstDrivePlanner
+      # Returns a planned Tmpfs according to an AutoYaST specification
+      #
+      # @param drive_section [AutoinstProfile::DriveSection] drive section describing the Tmpfs
+      # @return [Array<Planned::Tmpfs>] Array containing the planned Tmpfs
+      def planned_devices(drive_section)
+        drive_section.partitions.map { |p| planned_tmpfs(p) }
+      end
+
+      private
+
+      # Generates a planned Tmpfs from a drive section
+      #
+      # @return [Planned::Tmpfs]
+      def planned_tmpfs(partition_section)
+        Planned::Tmpfs.new(partiton_section.mount, partition_section.fstab_options)
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/tmpfs_creator.rb
+++ b/src/lib/y2storage/proposal/tmpfs_creator.rb
@@ -1,0 +1,51 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/filesystems/tmpfs"
+require "y2storage/proposal/creator_result"
+
+module Y2Storage
+  module Proposal
+    # Class to create a Tmpfs filesystem according to a Planned::Tmpfs object
+    class TmpfsCreator
+      attr_reader :original_devicegraph
+
+      # Constructor
+      #
+      # @param original_devicegraph [Devicegraph] Initial devicegraph
+      def initialize(original_devicegraph)
+        @original_devicegraph = original_devicegraph
+      end
+
+      # Creates the Tmpfs filesystem
+      #
+      # @param planned_tmpfs  [Planned::Tmpfs] planned Tmpfs filesystem
+      # @return [CreatorResult] result containing the new Tmpfs filesystem
+      def create_nfs(planned_tmpfs)
+        new_graph = original_devicegraph.duplicate
+
+        nfs = Filesystems::Tmpfs.create(new_graph)
+        nfs.mount_path = planned_tmpfs.mount_point
+        nfs.mount_point.mount_options = planned_tmpfs.fstab_options
+
+        CreatorResult.new(new_graph, nfs.mount_path => planned_tmpfs)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

In SLE 12 (with old *yast2-storage*) AutoYaST was able to import/export tmpfs file systems. Such feature is missing in SLE 15.

* https://jira.suse.com/browse/SLE-16313
* PBI: https://trello.com/c/Cys7qIrF/2194-1-hibernation-storage-part-of-sle-15921
* See also: https://github.com/libyui/libyui-qt/pull/142

## Solution

WIP


## Testing

TODO

