### PR TITLE
Partitioner: only show summary when needed

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 10 08:45:09 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: do not show summary when there are no actions to
+  perform (bsc#1179829).
+- 4.3.28
+
+-------------------------------------------------------------------
 Fri Dec  4 08:57:17 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Fix unit tests (related to jsc#SLE-11308).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.27
+Version:        4.3.28
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/quit_partitioner.rb
+++ b/src/lib/y2partitioner/actions/quit_partitioner.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -65,7 +65,7 @@ module Y2Partitioner
       #
       # @return [Boolean]
       def system_edited?
-        DeviceGraphs.instance.devices_edited?
+        DeviceGraphs.instance.actions?
       end
 
       # Confirmation popup before quitting the Expert Partitioner

--- a/src/lib/y2partitioner/device_graphs.rb
+++ b/src/lib/y2partitioner/device_graphs.rb
@@ -142,11 +142,11 @@ module Y2Partitioner
       @checkpoints[device.sid]
     end
 
-    # Whether initial devices have been modified
+    # Whether there are actions to perform during the commit phase
     #
     # @return [Boolean]
-    def devices_edited?
-      current != initial
+    def actions?
+      !current.actiongraph.empty?
     end
 
     private

--- a/src/lib/y2partitioner/dialogs/main.rb
+++ b/src/lib/y2partitioner/dialogs/main.rb
@@ -175,7 +175,7 @@ module Y2Partitioner
       #
       # @return [Boolean]
       def system_edited?
-        DeviceGraphs.instance.devices_edited?
+        DeviceGraphs.instance.actions?
       end
 
       # Current devicegraph with all the modifications

--- a/test/y2partitioner/actions/quit_partitioner_test.rb
+++ b/test/y2partitioner/actions/quit_partitioner_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2018] SUSE LLC
+
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -27,18 +28,18 @@ describe Y2Partitioner::Actions::QuitPartitioner do
     devicegraph_stub("mixed_disks")
 
     devicegraphs = Y2Partitioner::DeviceGraphs.instance
-    allow(devicegraphs).to receive(:devices_edited?).and_return(devices_edited)
+    allow(devicegraphs).to receive(:actions?).and_return(actions)
 
     allow(Y2Partitioner::DeviceGraphs).to receive(:instance).and_return(devicegraphs)
   end
 
-  let(:devices_edited) { false }
+  let(:actions) { false }
 
   subject { described_class.new }
 
   describe "#run" do
     context "when no devices have been modified" do
-      let(:devices_edited) { false }
+      let(:actions) { false }
 
       it "does not show a confirmation popup" do
         expect(Yast2::Popup).to_not receive(:show)
@@ -52,7 +53,7 @@ describe Y2Partitioner::Actions::QuitPartitioner do
     end
 
     context "when some devices have been modified" do
-      let(:devices_edited) { true }
+      let(:actions) { true }
 
       before do
         allow(Yast2::Popup).to receive(:show).and_return(accept)
@@ -86,7 +87,7 @@ describe Y2Partitioner::Actions::QuitPartitioner do
 
   describe "#quit?" do
     context "when no devices have been modified" do
-      let(:devices_edited) { false }
+      let(:actions) { false }
 
       it "returns true" do
         expect(subject.quit?).to eq(true)
@@ -94,7 +95,7 @@ describe Y2Partitioner::Actions::QuitPartitioner do
     end
 
     context "when some devices have been modified" do
-      let(:devices_edited) { true }
+      let(:actions) { true }
 
       before do
         allow(Yast2::Popup).to receive(:show).and_return(accept)

--- a/test/y2partitioner/device_graphs_test.rb
+++ b/test/y2partitioner/device_graphs_test.rb
@@ -69,21 +69,28 @@ describe Y2Partitioner::DeviceGraphs do
     end
   end
 
-  describe "#devices_edited?" do
-    context "when no devices have been modified in the current graph" do
+  describe "#actions?" do
+    context "when there are no actions to perform in the current graph" do
+      before do
+        # Note that adding userdata makes devicegraphs to be not equal when comparing them.
+        # Regression for bsc#1179829.
+        sdb2 = subject.current.find_by_name("/dev/sdb2")
+        sdb2.filesystem.subvolumes_prefix = "@"
+      end
+
       it "returns false" do
-        expect(subject.devices_edited?).to eq(false)
+        expect(subject.actions?).to eq(false)
       end
     end
 
-    context "when some devices have been modified in the current graph" do
+    context "when there are actions to perform in the current graph" do
       before do
         sda2 = subject.current.find_by_name("/dev/sda2")
         sda2.delete_filesystem
       end
 
       it "returns true" do
-        expect(subject.devices_edited?).to eq(true)
+        expect(subject.actions?).to eq(true)
       end
     end
   end

--- a/test/y2partitioner/dialogs/main_test.rb
+++ b/test/y2partitioner/dialogs/main_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2018] SUSE LLC
+
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -30,14 +31,14 @@ describe Y2Partitioner::Dialogs::Main do
     allow(Yast::Mode).to receive(:installation).and_return(installation)
 
     devicegraphs = Y2Partitioner::DeviceGraphs.instance
-    allow(devicegraphs).to receive(:devices_edited?).and_return(devices_edited)
+    allow(devicegraphs).to receive(:actions?).and_return(actions)
 
     allow(Y2Partitioner::DeviceGraphs).to receive(:instance).and_return(devicegraphs)
   end
 
   let(:installation) { true }
 
-  let(:devices_edited) { false }
+  let(:actions) { false }
 
   let(:system_graph) { Y2Partitioner::DeviceGraphs.instance.system }
 
@@ -91,7 +92,7 @@ describe Y2Partitioner::Dialogs::Main do
       end
 
       context "and there are no changes" do
-        let(:devices_edited) { false }
+        let(:actions) { false }
 
         context "and the user accepts the dialog (next)" do
           let(:dialog_result) { :next }
@@ -101,7 +102,7 @@ describe Y2Partitioner::Dialogs::Main do
       end
 
       context "and there are changes" do
-        let(:devices_edited) { true }
+        let(:actions) { true }
 
         context "and the user accepts the dialog (next)" do
           let(:dialog_result) { :next }
@@ -123,7 +124,7 @@ describe Y2Partitioner::Dialogs::Main do
       end
 
       context "and there are no changes" do
-        let(:devices_edited) { false }
+        let(:actions) { false }
 
         context "and the user accepts the dialog (next)" do
           let(:dialog_result) { :next }
@@ -133,7 +134,7 @@ describe Y2Partitioner::Dialogs::Main do
       end
 
       context "and there are changes" do
-        let(:devices_edited) { true }
+        let(:actions) { true }
 
         before do
           allow(Y2Partitioner::Dialogs::Summary).to receive(:run).and_return(summary_result)
@@ -198,7 +199,7 @@ describe Y2Partitioner::Dialogs::Main do
       let(:installation) { false }
 
       context "and there are no changes" do
-        let(:devices_edited) { false }
+        let(:actions) { false }
 
         it "returns 'Finish' label" do
           expect(subject.next_button).to eq(Yast::Label.FinishButton)
@@ -206,7 +207,7 @@ describe Y2Partitioner::Dialogs::Main do
       end
 
       context "and there are changes" do
-        let(:devices_edited) { true }
+        let(:actions) { true }
 
         it "returns 'Next' label" do
           expect(subject.next_button).to eq(Yast::Label.NextButton)
@@ -217,7 +218,7 @@ describe Y2Partitioner::Dialogs::Main do
 
   shared_examples "quiting partitioner" do
     context "when there are no changes" do
-      let(:devices_edited) { false }
+      let(:actions) { false }
 
       it "does not show a confirmation popup" do
         expect(Yast2::Popup).to_not receive(:show)
@@ -231,7 +232,7 @@ describe Y2Partitioner::Dialogs::Main do
     end
 
     context "when there are changes" do
-      let(:devices_edited) { true }
+      let(:actions) { true }
 
       before do
         allow(Yast2::Popup).to receive(:show).and_return(accept)

--- a/test/y2partitioner/dialogs/summary_test.rb
+++ b/test/y2partitioner/dialogs/summary_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2018] SUSE LLC
+
+# Copyright (c) [2018-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -43,7 +44,7 @@ describe Y2Partitioner::Dialogs::Summary do
   describe "#abort_handler" do
     before do
       devicegraphs = Y2Partitioner::DeviceGraphs.instance
-      allow(devicegraphs).to receive(:devices_edited?).and_return(true)
+      allow(devicegraphs).to receive(:actions?).and_return(true)
 
       allow(Y2Partitioner::DeviceGraphs).to receive(:instance).and_return(devicegraphs)
 


### PR DESCRIPTION
## Problem

In some cases, the Expert Partitioner is showing the "Summary" step even though nothing was modified.

* https://bugzilla.suse.com/show_bug.cgi?id=1179829


## Solution

There was a problem with the condition to decide whether to show the "Summary". The idea was to show the Summary only if any device was edited. To decide that, a devicegraph comparison was used (`initial != current`). But such comparison takes into account the userdata. So, two devicegraphs with the same devices but different user data would be different.

Because that, when a devicegrah has Btrfs subvolumes, the userdata of Btrfs is filled in the *current* devicegraph to save its `subvolumes_prefix`. This was making *current* to be different to *initial*.

Now on, the Summary is shown only if there is any action to perform during the commit phase.


## Testing

- Added unit test
- Tested manually with the *partitioner_testing* client
