### PR TITLE
Improve installation of packages

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Dec 15 13:34:29 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Do not enforce installation of packages that are not strictly
+  needed (bsc#1065588).
+- Partitioner: improved calculation of which packages need to be
+  installed in the running system (bsc#1168077).
+
+-------------------------------------------------------------------
 Thu Dec 10 16:45:41 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: add support for Btrfs quotas (jsc#SLE-7742).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.29
+Version:        4.3.30
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -214,7 +214,7 @@ module Y2Partitioner
       def packages_installed?
         return true if Yast::Mode.installation
 
-        pkgs = device_graph.used_features.pkg_list
+        pkgs = device_graph.actiongraph.used_features.pkg_list
         Y2Storage::PackageHandler.new(pkgs).install
       end
 

--- a/src/lib/y2partitioner/widgets/summary_text.rb
+++ b/src/lib/y2partitioner/widgets/summary_text.rb
@@ -100,6 +100,10 @@ module Y2Partitioner
 
       # Updates the value of {#packages}
       def calculate_packages
+        # This is only used during installation (the summary in a installed system does not
+        # include the packages to be installed because they are interactively installed right
+        # away), so we use Devicegraph#used_features (without arguments) to display all packages
+        # that are added to the software proposal, both optional and required.
         @packages = current_graph.used_features.pkg_list
       end
 

--- a/src/lib/y2partitioner/widgets/summary_text.rb
+++ b/src/lib/y2partitioner/widgets/summary_text.rb
@@ -100,7 +100,7 @@ module Y2Partitioner
 
       # Updates the value of {#packages}
       def calculate_packages
-        # This is only used during installation (the summary in a installed system does not
+        # This is only used during installation (the summary in an installed system does not
         # include the packages to be installed because they are interactively installed right
         # away), so we use Devicegraph#used_features (without arguments) to display all packages
         # that are added to the software proposal, both optional and required.

--- a/src/lib/y2storage/actiongraph.rb
+++ b/src/lib/y2storage/actiongraph.rb
@@ -48,6 +48,11 @@ module Y2Storage
     storage_forward :storage_compound_actions, to: :compound_actions, as: "CompoundAction"
     private :storage_compound_actions
 
+    # @!method storage_used_features
+    #   @return [Integer] bit-field with the used features of the actiongraph
+    storage_forward :storage_used_features, to: :used_features
+    private :storage_used_features
+
     # List of compound actions of the actiongraph.
     #
     # @note This is different from ::Storage#compound_actions because this
@@ -60,6 +65,13 @@ module Y2Storage
     def compound_actions
       to_storage_value.generate_compound_actions unless generated_compound_actions?
       storage_compound_actions
+    end
+
+    # List of storage features used by the actiongraph
+    #
+    # @return [StorageFeaturesList]
+    def used_features
+      StorageFeaturesList.from_bitfield(storage_used_features)
     end
 
     private

--- a/src/lib/y2storage/devicegraph.rb
+++ b/src/lib/y2storage/devicegraph.rb
@@ -81,7 +81,8 @@ module Y2Storage
     #     (like, for example, a duplicated id)
     storage_forward :check
 
-    # @!method storage_used_features
+    # @!method storage_used_features(dependency_type)
+    #   @param dependency_type [Integer] value of Storage::UsedFeaturesDependencyType
     #   @return [Integer] bit-field with the used features of the devicegraph
     storage_forward :storage_used_features, to: :used_features
     private :storage_used_features
@@ -552,9 +553,22 @@ module Y2Storage
 
     # List of storage features used by the devicegraph
     #
+    # By default, it returns the features associated to all devices and filesystems
+    # in the devicegraph. The required_only argument can be used to limit the result
+    # by excluding features associated to those filesystems that have no mount point.
+    #
+    # @param required_only [Boolean] whether the result should only include those
+    #   features that are mandatory (ie. associated to devices with a mount point)
     # @return [StorageFeaturesList]
-    def used_features
-      StorageFeaturesList.from_bitfield(storage_used_features)
+    def used_features(required_only: false)
+      type =
+        if required_only
+          Storage::UsedFeaturesDependencyType_REQUIRED
+        else
+          Storage::UsedFeaturesDependencyType_SUGGESTED
+        end
+
+      StorageFeaturesList.from_bitfield(storage_used_features(type))
     end
 
     private

--- a/src/lib/y2storage/package_handler.rb
+++ b/src/lib/y2storage/package_handler.rb
@@ -52,8 +52,10 @@ module Y2Storage
     # Constructor
     #
     # @param packages [Array<String>] packages to be added to {#pkg_list}
-    def initialize(packages)
+    # @param optional [Boolean] see {#optional}
+    def initialize(packages, optional: false)
       textdomain("storage")
+      @optional = optional
       @pkg_list = []
       add_packages(packages)
     end
@@ -102,8 +104,10 @@ module Y2Storage
     def set_proposal_packages
       return true if @pkg_list.empty?
 
-      log.info("Marking #{pkg_list} for installation")
-      success = Yast::PackagesProposal.SetResolvables(PROPOSAL_ID, :package, @pkg_list)
+      log.info("Marking #{pkg_list} for installation (optional: #{optional})")
+      success = Yast::PackagesProposal.SetResolvables(
+        PROPOSAL_ID, :package, @pkg_list, optional: optional
+      )
       if !success
         log.error("PackagesProposal::SetResolvables() for #{pkg_list} failed")
         set_resolvables_error_popup
@@ -114,6 +118,14 @@ module Y2Storage
     end
 
     private
+
+    # Whether the packages should be considered as optional when adding them to the
+    # installation proposal.
+    #
+    # Obviously, this is relevant for {#set_proposal_packages} but not for {#install}.
+    #
+    # @return [Boolean]
+    attr_reader :optional
 
     # Add a number of packages to the list of packages to be installed
     #

--- a/test/y2storage/actiongraph_test.rb
+++ b/test/y2storage/actiongraph_test.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+describe Y2Storage::Actiongraph do
+  describe "#used_features" do
+    let(:scenario) { "mixed_disks" }
+    let(:staging) { Y2Storage::StorageManager.instance.staging }
+
+    before do
+      fake_scenario(scenario)
+      ntfs = staging.filesystems.find { |fs| fs.type.is?(:ntfs) }
+      ntfs.mount_path = "/mnt"
+    end
+
+    it "returns the expected set of storage features" do
+      features = staging.actiongraph.used_features
+      expect(features).to be_a Y2Storage::StorageFeaturesList
+      expect(features.size).to eq 1
+      expect(features.first.id).to eq :UF_NTFS
+    end
+  end
+end

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -1162,6 +1162,13 @@ describe Y2Storage::Devicegraph do
         expect(features.map(&:id))
           .to contain_exactly(:UF_BTRFS, :UF_EXT4, :UF_NTFS, :UF_XFS, :UF_SWAP)
       end
+
+      it "returns only the features for mounted filesystems if required_only is given" do
+        features = fake_devicegraph.used_features(required_only: true)
+        expect(features).to be_a Y2Storage::StorageFeaturesList
+        expect(features.map(&:id))
+          .to contain_exactly(:UF_BTRFS, :UF_XFS, :UF_SWAP)
+      end
     end
 
     context "with unformatted DASD and FC devices" do


### PR DESCRIPTION
## Problem

Sometimes yast2-storage-ng decides that some packages need to be installed. But there was room for improvement at least in two situations:

- [bsc#1065588](https://bugzilla.suse.com/show_bug.cgi?id=1065588): During installation, all potentially needed packages were added to the software proposal as mandatory ones, which implies the users cannot install the system if they decide to deselect the packages for installation at a later point (ie. in the "Software" section of the installation summary).

- [bsc#1168077](https://bugzilla.suse.com/show_bug.cgi?id=1168077): In an already installed system, the Partitioner calculated the packages to install based on the content of the system after performing all the changes, instead of calculating that based on the actions the Partitioner was going to actually perform. For example, if the system contained an NTFS filesystem that was not going to be modified in any way, the Partitioner always insisted in installing `ntfs-3g` and `ntfsprogs`.

The described behavior was the best yast2-storage-ng could do based on the old functionality provided by libstorage-ng, that offered no way to distinguish optional and required packages and no way to check which features were needed for a concrete set of actions.

Internal Trello card: https://trello.com/c/SresnvEB/1826-3-osdistribution-p5-1065588-these-packages-need-to-be-selected-to-install-ntfs-3g-ntfsprogs

## Solution

This [pull request](https://github.com/openSUSE/libstorage-ng/pull/774) extended libstorage-ng API, so now it can provide all the information needed by yast2-storage-ng. So the current pull request improves package handling in yast2-storage-ng in several ways.

During installation, some packages are added to the software proposal as required but others are added as optional, which means the user can de-select them without blocking the whole system installation. For example, if the system contains a filesystem that is NOT going to be mounted by default (let's say, a NTFS or JFS partition from another operating system), the user can deselect the corresponding packages and finish the installation without them.

In a running system, the Partitioner will only try to install the packages it needs to perform the requested operations, ignoring devices that are not involved in the changes.

As a nice side effect of the latter change, the Partitioner will cause way fewer repository refreshes. Turns out the Partitioner sometimes triggered unwanted `zypper refresh` operations when it considered that some of these packages could need to be installed (no matter whether they were actually installed or not): "ntfs-3g", "ntfsprogs", "exfat-utils", "f2fs-tools", "jfsutils". Now that will only happen if a NTFS/ExFAT/JFS/f2fs filesystem is indeed going to be created or modified, which is a very minimal subset of all the situations that used to trigger the repository refresh in the past.

## Testing

- Both scenarios tested manually
- Unit tests extended
