### PR TITLE
Use the REMOVE view in remove_with_dependants

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 17 11:31:34 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed deletion of dependant devicegraph nodes (bsc#1179590)
+- 4.3.32
+
+-------------------------------------------------------------------
 Tue Dec 15 15:56:44 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - AutoYaST: added management of tmpfs file systems (jsc#SLE-11308).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.31
+Version:        4.3.32
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/devicegraph.rb
+++ b/src/lib/y2storage/devicegraph.rb
@@ -607,10 +607,10 @@ module Y2Storage
       raise(ArgumentError, "No device provided") if device.nil?
       raise(ArgumentError, "Device not found") unless device.exists_in_devicegraph?(self)
 
-      children = device.children
+      children = device.children(View::REMOVE)
       until children.empty?
         remove_with_dependants(children.first, keep: keep + [device])
-        children = device.children
+        children = device.children(View::REMOVE)
       end
 
       orphans = device.respond_to?(:potential_orphans) ? device.potential_orphans : []

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -809,6 +809,36 @@ describe Y2Storage::Devicegraph do
     end
   end
 
+  describe "#remove_btrfs_subvolume" do
+    subject(:devicegraph) { Y2Storage::StorageManager.instance.staging }
+
+    before do
+      fake_scenario("mixed_disks_btrfs")
+      btrfs.quota = true
+    end
+
+    let(:btrfs) { devicegraph.find_by_name("/dev/sda2").filesystem }
+
+    it "removes the given subvolume" do
+      subvol = btrfs.find_btrfs_subvolume_by_path("@/srv")
+      expect(subvol).to_not be_nil
+
+      devicegraph.remove_btrfs_subvolume(subvol)
+
+      subvol = btrfs.find_btrfs_subvolume_by_path("@/srv")
+      expect(subvol).to be_nil
+    end
+
+    it "removes the corresponding qgroup" do
+      subvol = btrfs.find_btrfs_subvolume_by_path("@/srv")
+      qgroups = btrfs.btrfs_qgroups.size
+
+      devicegraph.remove_btrfs_subvolume(subvol)
+
+      expect(btrfs.btrfs_qgroups.size).to eq(qgroups - 1)
+    end
+  end
+
   describe "#remove_md" do
     subject(:devicegraph) { Y2Storage::StorageManager.instance.staging }
 


### PR DESCRIPTION
## Problem

The problem described on [bsc#1179590](https://bugzilla.suse.com/show_bug.cgi?id=1179590) was caused because deleting a Btrfs subvolume in the devicegraph was not triggering the corresponding deletion of its qgroups.

That was fixed in libstorage-ng by adding the qgroups to the REMOVE view. See https://github.com/openSUSE/libstorage-ng/pull/787

But that didn't fix the problem in all possible situations because `Devicegraph#remove_with_dependants` was not honoring the REMOVE view.

## Solution

This PR fixes `remove_with_dependants` to use the REMOVE view when descending the hierarchy.

## Future improvements

Now that libstorage-ng has the concept of the REMOVE view, maybe we can get rid of `#remove_with_dependants` if we move some of its logic (eg. the fact that deleting a VG should invalidate all its PVs) to that view, instead of having extra code in the YaST side.

## Testing

- Added a new unit test
- I didn't check whether it actually solves 100% the situation described in [bsc#1179590](https://bugzilla.suse.com/show_bug.cgi?id=1179590), but it should.