### PR TITLE
AutoYaST: disable quotas when <quotas> is set to false

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Dec 18 12:35:39 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: setting the 'quotas' element to 'false' disables
+  subvolumes quotas, no matter whether the 'referenced_limit'
+  was specified or not (related to jsc#SLE-7742).
+- 4.3.33
+
+-------------------------------------------------------------------
 Thu Dec 17 11:31:34 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Fixed deletion of dependant devicegraph nodes (bsc#1179590)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.32
+Version:        4.3.33
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/proposal/autoinst_drive_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_drive_planner.rb
@@ -245,18 +245,21 @@ module Y2Storage
 
       # Sets the Btrfs quotas according to the section and the subvolumes
       #
+      # If `section.quotas` is nil, it inspect whether quotas are needed for any
+      # of the subvolumes. In that case, it sets `device.quota` to true.
+      #
       # @param device  [Planned::Device] Planned device
       # @param section [AutoinstProfile::PartitionSection] AutoYaST specification
       def configure_btrfs_quotas(device, section)
-        if section.quotas
-          device.quota = true
+        if !section.quotas.nil?
+          device.quota = section.quotas
           return
         end
 
         subvols_with_quotas = device.subvolumes.select do |subvol|
           subvol.referenced_limit && !subvol.referenced_limit.unlimited?
         end
-        return if subvols_with_quotas.empty? || device.quota?
+        return if subvols_with_quotas.empty?
 
         device.quota = true
         issues_list.add(

--- a/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_disk_device_planner_test.rb
@@ -771,21 +771,13 @@ describe Y2Storage::Proposal::AutoinstDiskDevicePlanner do
           expect(planned_root.quota?).to eq(false)
         end
 
-        context "but a subvolume requires quotas" do
+        context "and a subvolume requires quotas" do
           let(:subvolumes) do
             [{ "path" => "@/tmp", "referenced_limit" => "1GiB" }]
           end
 
-          it "plans for quotas" do
-            expect(planned_root.quota?).to eq(true)
-          end
-
-          it "reports an issue" do
-            planner.planned_devices(drive)
-            issue = planner.issues_list.find do |i|
-              i.is_a?(Y2Storage::AutoinstIssues::MissingBtrfsQuotas)
-            end
-            expect(issue).to_not be_nil
+          it "does not plan for quotas" do
+            expect(planned_root.quota?).to eq(false)
           end
         end
       end


### PR DESCRIPTION
If `<quotas>` element is set to `false`, AutoYaST disables the quotas no matter whether the `referenced_limit` is specified for some subvolume.

Related to #1186.