### PR TITLE
Pre-generate uuid for swap (jsc#SLE-17081)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Dec 21 12:29:43 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Storage: pre-generates an UUID for every swap device the
+  installer plans to create (related to jsc#SLE-17081, bsc#1169874,
+  and bsc#1177926).
+- 4.3.34
+
+-------------------------------------------------------------------
 Fri Dec 18 12:35:39 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: setting the 'quotas' element to 'false' disables

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.33
+Version:        4.3.34
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -520,6 +520,7 @@ module Y2Partitioner
 
         def create_filesystem(type, label: nil)
           filesystem_parent.create_blk_filesystem(type)
+          filesystem.init_uuid
           filesystem.label = label unless label.nil?
         end
 

--- a/src/lib/y2storage/planned/can_be_formatted.rb
+++ b/src/lib/y2storage/planned/can_be_formatted.rb
@@ -171,7 +171,11 @@ module Y2Storage
       # @param filesystem [Filesystems::BlkFilesystem]
       def setup_filesystem(filesystem)
         filesystem.label = label if label
-        filesystem.uuid = uuid if uuid
+        if uuid.nil? || uuid.empty?
+          filesystem.init_uuid
+        else
+          filesystem.uuid = uuid
+        end
         filesystem.mkfs_options = mkfs_options if mkfs_options
         # Note that a good reason for this to be the last step is that the
         # previous properties can affect the suitable mount_by, so they must be


### PR DESCRIPTION
## Problem

As requested in [jsc#SLE-17081](https://jira.suse.com/browse/SLE-17081), it would be desirable that YaST bootloader sets the `resume=` kernel parameter following a similar convention to the one followed to reference devices in `/etc/fstab`. Very often, that convention is using the UUID of the swap device. 

The truth is that YaST bootloader already tries to honor that convention but, in many situation it simply cannot do it because the swap devices are not yet created at the point in time in which the YaST Bootloader proposal calculates the value of the `resume=` parameter. That means the UUID is still unknown. As a result, the proposal falls back to using another method other than the UUID to reference the swap device.

This has also been reported as [bug#1177926](https://bugzilla.suse.com/show_bug.cgi?id=1177926) and [bsc#1169874](https://bugzilla.suse.com/show_bug.cgi?id=1169874).

## Solution

This pre-generates an UUID for every swap device the installer plans to create and stores that UUID in the devicegraph. Thus, such information is already known before committing the changes to disk (ie. before actually creating the swap devices) and can be used by the bootloader proposal or any other part of YaST that is executed after configuring the partitioning but before performing the real installation.

## Testing

- Manually tested in all kind of manual installations (ie. no AutoYaST):
  - Proposal creating new swap devices
  - Proposal reusing previous swaps
  - Proposal creating new swap devices but reusing UUIDs from the deleted ones
  - Expert Partitioner creating new swap devices
  - Expert Partitioner reusing previous swaps
  - Expert Partitioner importing mount points
  - [Proposal (re)using encrypted swap](https://github.com/yast/yast-storage-ng/pull/1192#issuecomment-749433068)
- Manually with AutoYaST
  - [Proposal creating new swap devices](https://github.com/yast/yast-storage-ng/pull/1192#issuecomment-748948985) 
- Existing unit tests adapted.

## Screenshot

Screenshot including an excerpt of the YaST logs to prove the UUID used by the bootloader proposal is indeed the one pre-generated by the storage proposal.

![uuid](https://user-images.githubusercontent.com/3638289/102638321-986a5e00-4157-11eb-9fef-4311464f5a4e.png)
