### PR TITLE
Partitioner: do not allow to modify the path of Btrfs subvolumes (bsc#1180182)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 22 13:09:47 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Partitioner: do not allow to modify the path of Btrfs subvolumes
+  (bsc#1180182)
+- 4.3.35
+
+-------------------------------------------------------------------
 Mon Dec 21 12:29:43 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Storage: pre-generates an UUID for every swap device the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.34
+Version:        4.3.35
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/btrfs_subvolume.rb
+++ b/src/lib/y2partitioner/actions/controllers/btrfs_subvolume.rb
@@ -78,11 +78,6 @@ module Y2Partitioner
         def update_subvolume
           return unless subvolume
 
-          if !exist_subvolume?
-            filesystem.delete_btrfs_subvolume(subvolume.path)
-            create_subvolume(subvolume_path)
-          end
-
           subvolume.nocow = subvolume_nocow
           subvolume.referenced_limit = subvolume_referenced_limit
         end

--- a/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
+++ b/src/lib/y2partitioner/dialogs/btrfs_subvolume.rb
@@ -80,16 +80,20 @@ module Y2Partitioner
           @controller = controller
         end
 
+        # @macro seeAbstractWidget
         def label
           _("Path")
         end
 
+        # @macro seeAbstractWidget
         def store
           controller.subvolume_path = value
         end
 
+        # @macro seeAbstractWidget
         def init
-          controller.exist_subvolume? ? disable : focus
+          # The path must not be modified once the subvolume is in the devicegraph (bsc#1180182)
+          controller.subvolume ? disable : focus
 
           self.value = controller.subvolume_path
         end
@@ -138,6 +142,7 @@ module Y2Partitioner
         # @return [Actions::Controllers::BtrfsSubvolume]
         attr_reader :controller
 
+        # Sets the input focus on this widget
         def focus
           Yast::UI.SetFocus(Id(widget_id))
         end

--- a/test/y2partitioner/actions/edit_btrfs_subvolume_test.rb
+++ b/test/y2partitioner/actions/edit_btrfs_subvolume_test.rb
@@ -42,7 +42,6 @@ describe Y2Partitioner::Actions::EditBtrfsSubvolume do
 
       allow(Y2Partitioner::Actions::Controllers::BtrfsSubvolume).to receive(:new).and_return(controller)
 
-      controller.subvolume_path = "@/bar"
       controller.subvolume_nocow = false
     end
 
@@ -72,7 +71,7 @@ describe Y2Partitioner::Actions::EditBtrfsSubvolume do
       it "modifies the Btrfs subvolume with the given attributes" do
         subject.run
 
-        subvolume = filesystem.btrfs_subvolumes.find { |s| s.path == "@/bar" }
+        subvolume = filesystem.btrfs_subvolumes.find { |s| s.path == "@/foo" }
         expect(subvolume.nocow?).to eq(false)
       end
 

--- a/test/y2partitioner/dialogs/btrfs_subvolume_test.rb
+++ b/test/y2partitioner/dialogs/btrfs_subvolume_test.rb
@@ -78,6 +78,38 @@ describe Y2Partitioner::Dialogs::BtrfsSubvolume do
 
     include_examples "CWM::AbstractWidget"
 
+    describe "#init" do
+      context "when creating a subvolume" do
+        it "does not disable the widget" do
+          allow(Yast::UI).to receive(:SetFocus)
+          expect(subject).to_not receive(:disable)
+          subject.init
+        end
+      end
+
+      context "when editing a subvolume" do
+        context "that exists on disk" do
+          let(:subvolume) { filesystem.btrfs_subvolumes.first }
+
+          # See bsc#1180182
+          it "disables the widget" do
+            expect(subject).to receive(:disable)
+            subject.init
+          end
+        end
+
+        context "that does not exist on disk yet" do
+          let(:subvolume) { filesystem.create_btrfs_subvolume("@/foo", false) }
+
+          # See bsc#1180182
+          it "disables the widget" do
+            expect(subject).to receive(:disable)
+            subject.init
+          end
+        end
+      end
+    end
+
     describe "#store" do
       let(:value) { "@/foo" }
 


### PR DESCRIPTION
## Problem

The YaST Partitioner didn't allow the users to modify the path of those subvolumes that already existed on the disk.

But it allowed to modify the path of those subvolumes that existed only in the devicegraph so far. In order to make that possible, the corresponding subvolume was deleted from the devicegraph and re-created.

That had undesired effects, like causing the removal of all the children subvolumes every time a subvolume was modified (even if the path was not altered). That's described in [bsc#1180182](https://bugzilla.suse.com/show_bug.cgi?id=1180182) (which is a spin-off of [bsc#1179590](https://bugzilla.suse.com/show_bug.cgi?id=1179590)).

## Solution

Simply, do not allow to modify the path of a subvolume that already exists in the devicegraph. libstorage-ng doesn't offer a safe way of doing such change and recreating the whole thing doesn't look like a good idea either (more similar problems would likely arise, since we are risking to confuse libstorage-ng).

## Testing

- Improved/added unit tests
- Tested manually with `partitioner_testing`