### PR TITLE
Attempt to fix #1194

### DIFF
--- a/doc/boot-partition.md
+++ b/doc/boot-partition.md
@@ -28,7 +28,7 @@ Boot Partition Layout / Restrictions For Storage Proposal
 
 ### Grub2 and disk abstractions
 
-- Grub natively suppors lvm raid 0/1/4/5/6, encryption with or without lvm
+- Grub natively supports lvm raid 0/1/4/5/6, encryption with or without lvm
 - The problem with disk abstractions like lvm or raid is not exactly about
   booting. The system will boot fine but some features have an additional
   requirement - having a pre-boot environment block writable by grub-once.
@@ -65,7 +65,7 @@ Boot Partition Layout / Restrictions For Storage Proposal
  * generic boot loader installed into mbr
  * we have generic boot code for both dos/gpt partition table
  * stage1 installed into /boot or / partition (if possible, note: not on xfs)
- * **OR** separate grub boot partition for embdding stage1 (like prep on ppc)
+ * **OR** separate grub boot partition for embedding stage1 (like prep on ppc)
 
      > *[mchang]* gpt has bios_grub partition but only if you instruct grub2-install to
 install stage1 on mbr then it will search bios_grub to embed stage2

--- a/src/lib/y2storage/volume_specification_builder.rb
+++ b/src/lib/y2storage/volume_specification_builder.rb
@@ -107,7 +107,7 @@ module Y2Storage
         v.mount_point = "/boot/efi"
         v.fs_types = [Filesystems::Type::VFAT]
         v.fs_type = Filesystems::Type::VFAT
-        v.min_size = DiskSize.MiB(128)
+        v.min_size = DiskSize.MiB(100)
         v.desired_size = DiskSize.MiB(256)
         # Note 512MiB seems to be the threshold used by mkfs.vfat to
         # automatically use FAT32 if no FAT size is specified


### PR DESCRIPTION
By default, Windows 10 (20H2) demands and creates a 100 MiB EFI partition of its own. While it would be preferable to add some margin, reduce minimum size from 128 to 100 MiB in order to allow reusing an existing EFI partition, which should provide a better OOB installation experience in the common case. Windows 10 (20H2) occupies less than 30 MiB, and we're additionally using about 4 MiB for the time being.

I'm not sure to turn the right screw here, but I haven't found a better matching one.

Attempts to fix #1194 