### PR TITLE
Add `#preferred_name` to BlkDevice and BlkFilesystem

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jan 12 12:59:07 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Added API methods to get the preferred name to reference a block
+  device or its filesystem (jsc#SLE-17081, also related to
+  bsc#1177926 and bsc#1169874).
+- 4.3.36
+
+-------------------------------------------------------------------
 Tue Dec 22 13:09:47 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Partitioner: do not allow to modify the path of Btrfs subvolumes

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.35
+Version:        4.3.36
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -321,6 +321,29 @@ module Y2Storage
         self.uuid = uuidgen
       end
 
+      # File path to reference the filesystem based on the current mount by option
+      #
+      # @see #mount_by
+      #
+      # @return [String, nil] nil if the name cannot be determined for the current mount by option
+      def mount_by_name
+        return nil unless mount_by
+
+        path_for_mount_by(mount_by)
+      end
+
+      # Name (full path) that can be used to reference the filesystem for the given mount by option
+      #
+      # @return [String, nil] nil if the name cannot be determined for the given mount by option
+      def path_for_mount_by(mount_by)
+        if mount_by.is?(:label, :uuid)
+          attr_value = public_send(mount_by.to_sym)
+          mount_by.udev_name(attr_value)
+        else
+          blk_devices.first.path_for_mount_by(mount_by)
+        end
+      end
+
       protected
 
       # Whether the network-related mount options (e.g. _netdev) should be part

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -321,6 +321,22 @@ module Y2Storage
         self.uuid = uuidgen
       end
 
+      # Most convenient file path to reference the filesystem
+      #
+      # If possible, the path is chosen based on the {#mount_by} attribute of the filesystem.
+      # If the filesystem is not mounted or the path for the specified mount_by cannot be
+      # calculated from the information present in the devicegraph, an alternative name
+      # based on {Filesystems::MountByType.best_for} (which already takes
+      # {Configuration#default_mount_by} into account) is calculated.
+      #
+      # This method always return a valid full-path filename that can be inferred from the
+      # information already available in the devicegraph
+      #
+      # @return [String]
+      def preferred_name
+        path_for_mount_by(preferred_mount_by)
+      end
+
       # File path to reference the filesystem based on the current mount by option
       #
       # @see #mount_by
@@ -368,6 +384,21 @@ module Y2Storage
         Yast::Execute.locally!(UUIDGEN, stdout: :capture).chomp
       rescue Cheetah::ExecutionFailed
         ""
+      end
+
+      # Most convenient mount_by option to reference the filesystem
+      #
+      # @see #preferred_name
+      #
+      # This method always returns an option that can be safely used by
+      # {#path_for_mount_by} to construct a valid filename.
+      #
+      # @return [Filesystems::MountByType]
+      def preferred_mount_by
+        mount_bys = with_mount_point { |mp| mp.suitable_mount_bys(assume_uuid: false) }
+        return mount_by if mount_bys.include?(mount_by)
+
+        Filesystems::MountByType.best_for(self, mount_bys)
       end
     end
   end

--- a/src/lib/y2storage/filesystems/mount_by_type.rb
+++ b/src/lib/y2storage/filesystems/mount_by_type.rb
@@ -77,6 +77,18 @@ module Y2Storage
         name.nil? ? to_s : _(name)
       end
 
+      # Full path of the udev by-* link for this type, given a value of the
+      # referenced attribute
+      #
+      # @param value [String, nil] label, uuid, path or id of the device to point to
+      # @return [String, nil] nil if it's not possible to build the path of an udev
+      #   link that points to the device
+      def udev_name(value)
+        return nil if value.nil? || value.empty? || is?(:device)
+
+        File.join("/dev", "disk", "by-#{to_sym}", value)
+      end
+
       class << self
         # Type corresponding to the given fstab spec
         #

--- a/src/lib/y2storage/luks.rb
+++ b/src/lib/y2storage/luks.rb
@@ -70,6 +70,17 @@ module Y2Storage
       super
     end
 
+    # @see BlkDevice#path_for_mount_by
+    def path_for_mount_by(mount_by)
+      # Unlike most block devices, LUKS devices have an UUID and can have a label
+      if mount_by.is?(:label, :uuid)
+        attr_value = public_send(mount_by.to_sym)
+        mount_by.udev_name(attr_value)
+      else
+        super
+      end
+    end
+
     protected
 
     # @see Device#is?

--- a/src/lib/y2storage/md.rb
+++ b/src/lib/y2storage/md.rb
@@ -308,6 +308,16 @@ module Y2Storage
       in_etc_mdadm?
     end
 
+    # @see BlkDevice#path_for_mount_by
+    def path_for_mount_by(mount_by)
+      # Unlike most block devices, MD RAIDs have an UUID
+      if mount_by.is?(:uuid)
+        mount_by.udev_name(uuid)
+      else
+        super
+      end
+    end
+
     protected
 
     # Holders connecting the MD Raid to its component block devices in the

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -445,7 +445,7 @@ module Y2Storage
       mount_point
     end
 
-    # @see #suitable_mount_by
+    # @see #suitable_mount_bys
     #
     # @param candidates [Array<Filesystems::MountByType>]
     # @param label [Boolean]

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -290,9 +290,16 @@ module Y2Storage
     # @param encryption [Boolean, nil] whether the filesystem sits on top of an
     #   encrypted device. Regarding the possible values (nil, true and false) it
     #   behaves like the label argument.
+    # @param assume_uuid [Boolean] whether it can be safely assumed that the
+    #   filesystem has a known UUID (as long as UUIDs are supported for that
+    #   filesystem type). True by default because most filesystems will get an
+    #   UUID assigned to them in the moment they are created in the real system,
+    #   even if that UUID is still not known by the devicegraph. If set to false,
+    #   mounting by UUID will only be considered suitable if the UUID is already
+    #   known in the devicegraph.
     #
     # @return [Array<Filesystems::MountByType>]
-    def suitable_mount_bys(label: nil, encryption: nil)
+    def suitable_mount_bys(label: nil, encryption: nil, assume_uuid: true)
       with_mount_point_for_suitable(encryption) do |mount_point|
         fs = mount_point.filesystem
 
@@ -308,7 +315,9 @@ module Y2Storage
         return candidates unless fs.is?(:blk_filesystem)
 
         label = (fs.label.size > 0) if label.nil?
-        candidates.delete(Filesystems::MountByType::LABEL) unless label
+        uuid = assume_uuid ? true : !fs.uuid.empty?
+
+        filter_mount_bys(candidates, label, uuid)
         candidates
       end
     end
@@ -434,6 +443,16 @@ module Y2Storage
       end
 
       mount_point
+    end
+
+    # @see #suitable_mount_by
+    #
+    # @param candidates [Array<Filesystems::MountByType>]
+    # @param label [Boolean]
+    # @param uuid [Boolean]
+    def filter_mount_bys(candidates, label, uuid)
+      candidates.delete(Filesystems::MountByType::LABEL) unless label
+      candidates.delete(Filesystems::MountByType::UUID) unless uuid
     end
   end
 end

--- a/src/lib/y2storage/mountable.rb
+++ b/src/lib/y2storage/mountable.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -174,6 +174,28 @@ module Y2Storage
     # @return [Array<String>]
     def extra_default_mount_options
       []
+    end
+
+    private
+
+    # Ensures a mount point before executing the given block
+    #
+    # A temporary mount point is created and removed when there is no mount point.
+    #
+    # @return [Object] block result
+    def with_mount_point(&block)
+      tmp_mount_point = false
+
+      if !mount_point
+        storage_create_mount_point("__fake_path__")
+        tmp_mount_point = true
+      end
+
+      result = block.call(mount_point)
+
+      storage_remove_mount_point if tmp_mount_point
+
+      result
     end
   end
 end

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -1464,4 +1464,21 @@ describe Y2Storage::BlkDevice do
       expect(subject.windows_suitable?).to eq(false)
     end
   end
+
+  describe "#preferred_name" do
+    let(:scenario) { "md-imsm1-devicegraph.xml" }
+    let(:device_name) { "/dev/sda1" }
+
+    let(:by_device) { Y2Storage::Filesystems::MountByType::DEVICE }
+    let(:by_path) { Y2Storage::Filesystems::MountByType::PATH }
+    let(:by_id) { Y2Storage::Filesystems::MountByType::ID }
+    let(:all_suitable) { [by_device, by_path, by_id] }
+
+    it "returns the best name from all the suitable ones" do
+      expect(Y2Storage::Filesystems::MountByType).to receive(:best_for)
+        .with(device, all_suitable).and_return(by_path)
+
+      expect(device.preferred_name).to eq "/dev/disk/by-path/pci-0000:00:1f.2-ata-1-part1"
+    end
+  end
 end

--- a/test/y2storage/filesystems/blk_filesystem_test.rb
+++ b/test/y2storage/filesystems/blk_filesystem_test.rb
@@ -455,4 +455,103 @@ describe Y2Storage::Filesystems::BlkFilesystem do
       expect(subject.name).to eq("Ext4 sda2")
     end
   end
+
+  describe "#mount_by_name" do
+    let(:dev_name) { "/dev/sda2" }
+    before { subject.mount_point.mount_by = mount_by }
+
+    context "when mounting by device" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::DEVICE }
+
+      it "returns the kernel name of the block device" do
+        expect(subject.mount_by_name).to eq(dev_name)
+      end
+    end
+
+    context "when mounting by UUID" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::UUID }
+
+      context "if the uuid of the filesystem is known already" do
+        before { subject.uuid = "111222333444" }
+
+        it "returns the by-uuid udev path" do
+          expect(subject.mount_by_name).to eq "/dev/disk/by-uuid/111222333444"
+        end
+      end
+
+      context "if the uuid is still not known" do
+        it "returns nil" do
+          expect(subject.mount_by_name).to be_nil
+        end
+      end
+    end
+
+    context "when mounting by label" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::LABEL }
+
+      context "if the filesystem has a label" do
+        it "returns the by-label udev path" do
+          expect(subject.mount_by_name).to eq "/dev/disk/by-label/root"
+        end
+      end
+
+      context "if the filesystem has no label" do
+        before { subject.label = "" }
+
+        it "returns nil" do
+          expect(subject.mount_by_name).to be_nil
+        end
+      end
+    end
+
+    context "when mounting by path" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::PATH }
+
+      before do
+        allow(subject).to receive(:blk_devices).and_return [blk_device]
+        allow(blk_device).to receive(:udev_full_paths).and_return(paths)
+      end
+
+      context "if the block device has by-path udev paths" do
+        let(:paths) { ["/dev/disk/by-path/pci1111-part2"] }
+
+        it "returns the first by-path udev path" do
+          expect(subject.mount_by_name).to eq(paths.first)
+        end
+      end
+
+      context "if the block device has no by-path udev paths" do
+        let(:paths) { [] }
+
+        it "returns nil" do
+          expect(subject.mount_by_name).to be_nil
+        end
+      end
+    end
+
+    context "when mounting by id" do
+      let(:mount_by) { Y2Storage::Filesystems::MountByType::ID }
+
+      before do
+        allow(subject).to receive(:blk_devices).and_return [blk_device]
+        allow(blk_device).to receive(:udev_full_ids).and_return(ids)
+      end
+
+      context "if the block device has by-id udev paths" do
+        let(:ids) { ["/dev/disk/by-id/id:pci:00"] }
+
+        it "returns the first by-id udev path" do
+          expect(subject.mount_by_name).to eq(ids.first)
+        end
+      end
+
+      context "if the block device has no by-id udev paths" do
+        let(:ids) { [] }
+
+        it "returns nil" do
+          expect(subject.mount_by_name).to be_nil
+        end
+      end
+    end
+  end
 end

--- a/test/y2storage/mount_point_test.rb
+++ b/test/y2storage/mount_point_test.rb
@@ -231,6 +231,50 @@ describe Y2Storage::MountPoint do
           expect(types).to_not include(Y2Storage::Filesystems::MountByType::PATH)
         end
       end
+
+      context "if we take the UUID for granted" do
+        let(:assume_uuid) { true }
+
+        context "and the UUID is already known" do
+          before { filesystem.uuid = "12345678-90ab-cdef-1234-567890abcdef" }
+
+          it "includes MountByType::UUID" do
+            expect(mount_point.suitable_mount_bys(assume_uuid: assume_uuid))
+              .to include(Y2Storage::Filesystems::MountByType::UUID)
+          end
+        end
+
+        context "and the filesystem has no UUID in the devicegraph" do
+          before { filesystem.uuid = "" }
+
+          it "includes MountByType::UUID" do
+            expect(mount_point.suitable_mount_bys(assume_uuid: assume_uuid))
+              .to include(Y2Storage::Filesystems::MountByType::UUID)
+          end
+        end
+      end
+
+      context "if we do not take the UUID for granted" do
+        let(:assume_uuid) { false }
+
+        context "and the UUID is already known" do
+          before { filesystem.uuid = "12345678-90ab-cdef-1234-567890abcdef" }
+
+          it "includes MountByType::UUID" do
+            expect(mount_point.suitable_mount_bys(assume_uuid: assume_uuid))
+              .to include(Y2Storage::Filesystems::MountByType::UUID)
+          end
+        end
+
+        context "and the filesystem has no UUID in the devicegraph" do
+          before { filesystem.uuid = "" }
+
+          it "does not include MountByType::UUID" do
+            expect(mount_point.suitable_mount_bys(assume_uuid: assume_uuid))
+              .to_not include(Y2Storage::Filesystems::MountByType::UUID)
+          end
+        end
+      end
     end
 
     context "for an encrypted device" do


### PR DESCRIPTION
## Problem

See [SLE-17081](https://jira.suse.com/browse/SLE-17081) (which is a follow-up of [bsc#1177926](https://bugzilla.suse.com/show_bug.cgi?id=1177926) and closely related to [bsc#1169874](https://bugzilla.suse.com/show_bug.cgi?id=1169874)).

Ideally, all components of the installer should use the same identification method (`uuid` vs `by-id` vs `by-path` vs...) to reference storage devices in different parts of the system like the bootloader parameters or the `/etc/fstab` file. But the bootloader setup (mostly `resume=` parameter) is not following the same identification method used for configuring the storage setup (mostly `fstab`).

That happens because the logic from yast2-storage-ng to determine which is the most convenient and stable device name is somehow duplicated in yast2-bootloader. Something that happens for historical reasons and also because so far yast2-storage-ng does not offer any proper public API to get the preferred mount_by option.

## Solution

This pull request extends the yast2-storage-ng API to offer:

- `BlkFilesystem#preferred_name` allows to get the best udev name to reference a filesystem. Based on the `mount_by` attribute of its mount point (if any), the global default `mount_by` and the logic contained in yast2-storage-ng to decide which name is more stable.
- `BlkDevice#preferred_name` allows to get the best udev name to reference a block device, regardless of its content, based on the global default `mount_by` and on the logic contained in yast2-storage-ng to decide which name is more stable. Useful for the bootloader when the device does not contain any filesystem (e.g. PReP).

The new API is then used from https://github.com/yast/yast-bootloader/pull/628 to effectively unify the logic.

## History

This in fact the third time we try to unify the logic in both modules.

- First attempt
  - https://github.com/yast/yast-bootloader/pull/591
  - https://github.com/yast/yast-storage-ng/pull/1050
- Second attempt on top of the first one
  - https://github.com/yast/yast-bootloader/pull/593
  - https://github.com/yast/yast-storage-ng/pull/1069
  - https://github.com/openSUSE/libstorage-ng/pull/713
- Reverting all the changes
  - https://github.com/yast/yast-bootloader/pull/595
  - https://github.com/yast/yast-storage-ng/pull/1071

This current attempt is done from scratch, taking the lessons learned and also some pieces of code from those previous attempts, but not trying to be a continuation or to keep the meaning of those original (and reverted) method names.

## Testing

- Added new unit tests to both pull requests
- Tested manually (with a dud including this, https://github.com/yast/yast-bootloader/pull/628 and the most recent libstorage-ng, and yast2.rpm)
  - Full installation of Tumbleweed with role XFCE and default settings (verified everything works and it includes the `resume=/dev/disk/by-uuid/xxyyzz` parameter)
  - Full installation of Tumbleweed with role XFCE changing default `mount_by` to path (verified everything works and it includes the `resume=/dev/disk/by-path/aa:bb-cc` parameter)
