### PR TITLE
Do not use the ESP minimal size to discard partitions

### DIFF
--- a/doc/boot-partition.md
+++ b/doc/boot-partition.md
@@ -28,7 +28,7 @@ Boot Partition Layout / Restrictions For Storage Proposal
 
 ### Grub2 and disk abstractions
 
-- Grub natively suppors lvm raid 0/1/4/5/6, encryption with or without lvm
+- Grub natively supports lvm raid 0/1/4/5/6, encryption with or without lvm
 - The problem with disk abstractions like lvm or raid is not exactly about
   booting. The system will boot fine but some features have an additional
   requirement - having a pre-boot environment block writable by grub-once.
@@ -65,7 +65,7 @@ Boot Partition Layout / Restrictions For Storage Proposal
  * generic boot loader installed into mbr
  * we have generic boot code for both dos/gpt partition table
  * stage1 installed into /boot or / partition (if possible, note: not on xfs)
- * **OR** separate grub boot partition for embdding stage1 (like prep on ppc)
+ * **OR** separate grub boot partition for embedding stage1 (like prep on ppc)
 
      > *[mchang]* gpt has bios_grub partition but only if you instruct grub2-install to
 install stage1 on mbr then it will search bios_grub to embed stage2

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan 14 13:40:54 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Partitioner: removed warning for too small EFI system partition.
+- Proposal: reuse pre-existing EFI partition even if it's small
+- Related to bsc#1177358, bsc#1170625 and bsc#1119318.
+- 4.3.37
+
+-------------------------------------------------------------------
 Tue Jan 12 12:59:07 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Added API methods to get the preferred name to reference a block

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.36
+Version:        4.3.37
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -203,9 +203,10 @@ module Y2Storage
       # Whether there is no partition that matches the volume
       #
       # @param volume [VolumeSpecification]
+      # @param exclude [Array<Symbol>, Symbol] see {MatchVolumeSpec#match_volume?}
       # @return [Boolean] true if there is no partition; false otherwise.
-      def missing_partition_for?(volume)
-        Partition.all(devicegraph).none? { |p| p.match_volume?(volume) }
+      def missing_partition_for?(volume, exclude: [])
+        Partition.all(devicegraph).none? { |p| p.match_volume?(volume, exclude: exclude) }
       end
 
       # Specific error when the boot disk cannot be detected

--- a/src/lib/y2storage/boot_requirements_strategies/uefi.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/uefi.rb
@@ -59,7 +59,7 @@ module Y2Storage
 
         # Missing EFI does not need to be a fatal (e.g. when boot from network).
         # User just has to not select grub2-efi bootloader.
-        res_new << esp_missing_warning if res_new.empty? && missing_partition_for?(efi_volume)
+        res_new << esp_missing_warning if res_new.empty? && !valid_esp_configured?
 
         res + res_new
       end
@@ -88,12 +88,27 @@ module Y2Storage
         SetupError.new(message: msg)
       end
 
+      # Error about missing EFI system partition
+      #
+      # @return [SetupError]
       def esp_missing_warning
         SetupError.new(missing_volume: efi_volume)
       end
 
       def efi_missing?
         free_mountpoint?("/boot/efi")
+      end
+
+      # Whether the devicegraph contains a partition mounted at /boot/efi and
+      # that looks like a valid EFI system partition
+      #
+      # @return [boolean]
+      def valid_esp_configured?
+        # The user may have configured an ESP that is smaller than the one the proposal
+        # would have suggested, so let's exclude the size from the check (a user who sets
+        # the correct partition id, filesystem and mount point deserves some trust).
+        # https://github.com/yast/yast-storage-ng/issues/1194#issuecomment-756165860
+        !missing_partition_for?(efi_volume, exclude: :size)
       end
 
       # @return [VolumeSpecification]

--- a/test/y2storage/boot_requirements_errors_test.rb
+++ b/test/y2storage/boot_requirements_errors_test.rb
@@ -302,7 +302,21 @@ describe Y2Storage::BootRequirementsChecker do
       context "when there is a /boot/efi partition in the system" do
         let(:scenario) { "efi" }
 
-        include_examples("no warnings")
+        context "and the partition is as big as the ones the proposal suggests" do
+          include_examples("no warnings")
+        end
+
+        context "but the partition is smaller than the proposal would have suggested" do
+          before do
+            esp = fake_devicegraph.find_by_name("/dev/sda1")
+            allow(esp).to receive(:resize_info).and_return(
+              double("ResizeInfo", resize_ok?: true, min_size: 1.MiB, max_size: 8.GiB)
+            )
+            esp.resize(16.MiB)
+          end
+
+          include_examples("no warnings")
+        end
       end
     end
 

--- a/test/y2storage/reusing_efi_test.rb
+++ b/test/y2storage/reusing_efi_test.rb
@@ -128,7 +128,17 @@ describe Y2Storage::BootRequirementsChecker do
     context "and it is smaller than the proposal min" do
       let(:size) { 32.MiB }
 
-      include_examples "not_reuse_partition_id"
+      context "and the id is ESP" do
+        let(:partition_id) { Y2Storage::PartitionId::ESP }
+
+        include_examples "reuse_efi"
+      end
+
+      context "and the id is not ESP" do
+        let(:partition_id) { Y2Storage::PartitionId::LINUX }
+
+        include_examples "not_reuse_efi"
+      end
     end
 
     context "and it is bigger than the proposal max" do


### PR DESCRIPTION
## Problem

The automatic partitioning proposal never creates an EFI system partition (ESP) that is smaller than a certain size (128 MiB) at the time of writing. That's fine so far.

But there are two other situations in which the same minimal size is applied and that's causing problems to some users:

- When the automatic partitioning proposal is deciding whether a pre-existing ESP should be reused instead of proposing a brand new one.
- If the Expert Partitioner was used to create a custom ESP.

So the min size is ok for brand new EFI partitions suggested by the installer, but it should not be used to discard partitions in other scenarios.

See the detailed discussion here: #1194. 

See also (restricted access): https://trello.com/c/eAdUReCf/2236-2-do-not-use-the-efi-minimal-size-to-discard-partitions

## Solution

Stop using the proposal min ESP size to discard partitions.

This pull request replaces #1195. As discussed there, this solution is preferred to lowering the min size used by the proposal.

## Testing

- Adapted the unit tests.
- Manually tested:
  - Verified the proposal indeed reuses a small ESP (before this, it used to propose the creation of a second EFI partition).
  - Verified the guided setup does not longer show the warning pop-up if a small (but correct otherwise) ESP is manually created.