### PR TITLE
Use the driver to decide whether _netdev is needed

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 20 07:26:55 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Improved mechanism to detect whether _netdev is needed for a
+  given disk: use its driver as extra criterion (bsc#1176140).
+- 4.2.115
+
+-------------------------------------------------------------------
 Tue Oct 20 15:36:03 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added $LIBSTORAGE_IGNORE_PROBE_ERRORS environment variable

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.114
+Version:        4.2.115
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -611,6 +611,17 @@ module Y2Storage
       hwinfo.bus
     end
 
+    # Kernel drivers used by this device
+    #
+    # @see #hwinfo
+    #
+    # @return [Array<String>] empty if the driver is unknown
+    def driver
+      return [] if hwinfo.nil?
+
+      hwinfo.driver || []
+    end
+
     # Size of the space that could be theoretically reclaimed by shrinking the
     # device
     #
@@ -642,6 +653,19 @@ module Y2Storage
     # @return [Boolean] true if this is a network-based disk or depends on one
     def in_network?
       false
+    end
+
+    # Whether the block device must be considered remote regarding how and when
+    # things are mounted during the systemd boot process
+    #
+    # Remote mount units have dependencies on some systemd targets like
+    # remote-fs-pre, remote-fs, network and network-online.
+    #
+    # See bsc#1176140
+    #
+    # @return [Boolean]
+    def systemd_remote?
+      in_network?
     end
 
     # Whether the block device fulfills conditions to be used for a Windows system

--- a/src/lib/y2storage/disk.rb
+++ b/src/lib/y2storage/disk.rb
@@ -76,6 +76,25 @@ module Y2Storage
       transport.network?
     end
 
+    # @see #systemd_remote?
+    SYSTEMD_REMOTE_DRIVERS = ["iscsi-tcp", "bnx2i", "qedi", "fcoe", "bnx2fc", "qedf"].freeze
+    private_constant :SYSTEMD_REMOTE_DRIVERS
+
+    # @see BlkDevice#systemd_remote?
+    def systemd_remote?
+      # For local devices we don't need to check the driver from the hwinfo data
+      return false unless in_network?
+
+      # Some iSCSI and FCoE disk are accessible to systemd without any need to wait for systemd
+      # to initialize the network. For example, those using drivers like qla4xxx, be2iscsi, cxgbi,
+      # fnic and csiostor keep all the configuration within the HBA NVRAM and will start
+      # presenting devices once the driver is loaded. Thus, this method only returns true if the
+      # disk uses a driver that is known to require a daemon to be started in order to make the
+      # device available. See bsc#1176140.
+      log.info "systemd_remote? for #{name}: checking driver - #{driver}"
+      (SYSTEMD_REMOTE_DRIVERS & driver).any?
+    end
+
     # Default partition table type for newly created partition tables
     # @see Partitionable#default_ptable_type
     #

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -334,6 +334,11 @@ module Y2Storage
       blk_device.in_network?
     end
 
+    # @see BlkDevice#systemd_remote?
+    def systemd_remote?
+      blk_device.systemd_remote?
+    end
+
     # Options that must be propagated from the fstab entries of the mount points
     # to the crypttab entries of the corresponding device
     OPTIONS_TO_PROPAGATE = ["_netdev", "noauto", "nofail"]

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -170,6 +170,13 @@ module Y2Storage
         blk_devices.any?(&:in_network?)
       end
 
+      # @see BlkDevice#systemd_remote?
+      #
+      # @return [Boolean]
+      def systemd_remote?
+        blk_devices.any?(&:systemd_remote?)
+      end
+
       # Option used in the fstab file for devices that require network
       NETWORK_OPTION = "_netdev".freeze
       private_constant :NETWORK_OPTION
@@ -265,7 +272,7 @@ module Y2Storage
       def needs_network_mount_options?
         # Adding "_netdev" and similar options in fstab for / should not be necessary
         # and it confuses (or used to confuse) systemd. See bsc#1165937.
-        in_network? && !root?
+        systemd_remote? && !root?
       end
 
       # @see Device#is?

--- a/src/lib/y2storage/lvm_lv.rb
+++ b/src/lib/y2storage/lvm_lv.rb
@@ -159,6 +159,13 @@ module Y2Storage
       lvm_vg.lvm_pvs.map(&:blk_device).any?(&:in_network?)
     end
 
+    # @see BlkDevice#systemd_remote?
+    #
+    # @return [Boolean]
+    def systemd_remote?
+      lvm_vg.lvm_pvs.map(&:blk_device).any?(&:systemd_remote?)
+    end
+
     protected
 
     def types_for_is

--- a/src/lib/y2storage/multi_disk_device.rb
+++ b/src/lib/y2storage/multi_disk_device.rb
@@ -32,7 +32,7 @@ module Y2Storage
     #
     # @return [Boolean] true if any of disks is network-based
     def in_network?
-      parents.any? { |i| i.respond_to?(:in_network?) && i.in_network? }
+      any_parent?(:in_network?)
     end
 
     # Checks whether some of the disks of the device are connected through USB.
@@ -43,7 +43,14 @@ module Y2Storage
     #
     # @return [Boolean]
     def usb?
-      parents.any? { |i| i.respond_to?(:usb?) && i.usb? }
+      any_parent?(:usb?)
+    end
+
+    # @see BlkDevice#systemd_remote?
+    #
+    # @return [Boolean]
+    def systemd_remote?
+      any_parent?(:systemd_remote?)
     end
 
     # Default partition table type for newly created partition tables
@@ -55,6 +62,14 @@ module Y2Storage
     def default_ptable_type
       # We always suggest GPT
       PartitionTables::Type::GPT
+    end
+
+    # Checks whether any of the parent devices returns true for the given method
+    #
+    # @param method [Symbol] name of the method to be checked in all parents
+    # @return [Boolean]
+    def any_parent?(method)
+      parents.any? { |i| i.respond_to?(method) && i.send(method) }
     end
   end
 end

--- a/src/lib/y2storage/partition.rb
+++ b/src/lib/y2storage/partition.rb
@@ -279,6 +279,11 @@ module Y2Storage
       partitionable.in_network?
     end
 
+    # @see BlkDevice#systemd_remote?
+    def systemd_remote?
+      partitionable.systemd_remote?
+    end
+
     # Whether the partition fulfills conditions to be used for a Windows system
     #
     # @return [Boolean]

--- a/test/y2storage/encryption_test.rb
+++ b/test/y2storage/encryption_test.rb
@@ -185,15 +185,32 @@ describe Y2Storage::Encryption do
     let(:scenario) { "encrypted_partition.xml" }
     let(:disk) { devicegraph.find_by_name("/dev/sda") }
     let(:partition) { devicegraph.find_by_name(partition_name) }
+    let(:hwinfo) { OpenStruct.new }
 
-    before { allow(disk.transport).to receive(:network?).and_return network }
+    before do
+      allow(disk.transport).to receive(:network?).and_return network
+      allow_any_instance_of(Y2Storage::Disk).to receive(:hwinfo).and_return(hwinfo)
+    end
 
     RSpec.shared_examples "netdev for network device" do
       context "within a network disk" do
         let(:network) { true }
 
-        it "makes sure #crypt_options include _netdev" do
-          expect(encryption.crypt_options).to include("_netdev")
+        context "which uses a driver that needs an extra systemd service" do
+          let(:hwinfo) { OpenStruct.new(driver: ["sg", "bnx2i"]) }
+
+          it "makes sure #crypt_options include _netdev" do
+            expect(encryption.crypt_options).to include("_netdev")
+          end
+        end
+
+        context "which does not demand any extra systemd service in order to be used" do
+          # Test with fnic, based on what happened at bsc#1176140
+          let(:hwinfo) { OpenStruct.new(driver: ["sg", "fnic"]) }
+
+          it "makes no changes to #crypt_options" do
+            expect(encryption.crypt_options).to be_empty
+          end
         end
       end
 

--- a/test/y2storage/filesystems/blk_filesystem_test.rb
+++ b/test/y2storage/filesystems/blk_filesystem_test.rb
@@ -325,6 +325,32 @@ describe Y2Storage::Filesystems::BlkFilesystem do
         expect(filesystem.in_network?).to eq true
       end
     end
+
+    context "when the filesystem is in a logical volume of an encrypted LVM" do
+      let(:scenario) { "complex-lvm-encrypt" }
+      let(:dev_name) { "/dev/vg0/lv1" }
+      let(:disk) { Y2Storage::BlkDevice.find_by_name(fake_devicegraph, "/dev/sdd") }
+
+      before do
+        allow(disk.transport).to receive(:network?).and_return network_transport
+      end
+
+      context "and the underlying disk is in the network" do
+        let(:network_transport) { true }
+
+        it "returns true" do
+          expect(filesystem.in_network?).to eq true
+        end
+      end
+
+      context "and the underlying disk is local" do
+        let(:network_transport) { false }
+
+        it "returns false" do
+          expect(filesystem.in_network?).to eq false
+        end
+      end
+    end
   end
 
   describe "#match_fstab_spec?" do


### PR DESCRIPTION
## Problem

See [bsc#1176140](https://bugzilla.suse.com/show_bug.cgi?id=1176140).

YaST adds `_netdev` to the default mount options of all file systems that are placed on network-based disks.

Turns out that adding `_netdev` when not really needed is counterproductive and can cause ordering cycles in the systemd units. That's something that would need a more general solution, likely implemented in the systemd side.

On the other hand, YaST considers that all iSCSI and FCoE disks are network-based and, thus, their mount points could need the `_netdev` option. But turns out that is not true, many iSCSI and FCoE drivers can actually initialize the disks and make the corresponding block device available to the operating system before the network is fully configured.

## Solution

Do not blindly trust the data transport to decide if a device deserves the `_netdev` option in their mount points. Check also whether the driver is able to handle the situation on its own. So far, this implements a hard-coded list of drivers that would need `_netdev` and the option is only added if the current driver is in that list.

## Testing

- Added new unit tests
- Tested manually with a DUD on top of SLE-15-SP2
- Grab testing package [yast2-storage-ng-4.2.115](https://build.suse.de/package/show/home:ancorgs:branches:SUSE:SLE-15-SP2:Update/yast2-storage-ng)