### PR TITLE
Alternative implementation of: use the driver to decide whether _netdev is needed

### DIFF
--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -611,6 +611,17 @@ module Y2Storage
       hwinfo.bus
     end
 
+    # Kernel drivers used by this device
+    #
+    # @see #hwinfo
+    #
+    # @return [Array<String>] empty if the driver is unknown
+    def driver
+      return [] if hwinfo.nil?
+
+      hwinfo.driver
+    end
+
     # Size of the space that could be theoretically reclaimed by shrinking the
     # device
     #
@@ -642,6 +653,19 @@ module Y2Storage
     # @return [Boolean] true if this is a network-based disk or depends on one
     def in_network?
       false
+    end
+
+    # Whether the block device must be considered remote regarding how and when
+    # things are mounted during the systemd boot process
+    #
+    # Remote mount units have dependencies on some systemd targets like
+    # remote-fs-pre, remote-fs, network and network-online.
+    #
+    # See bsc#1176140
+    #
+    # @return [Boolean]
+    def systemd_remote?
+      in_network?
     end
 
     # Whether the block device fulfills conditions to be used for a Windows system

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -329,16 +329,6 @@ module Y2Storage
       self.mount_by = Filesystems::MountByType.best_for(blk_device, suitable_mount_bys)
     end
 
-    # @see BlkDevice#in_network?
-    def in_network?
-      blk_device.in_network?
-    end
-
-    # @see BlkDevice#systemd_remote?
-    def systemd_remote?
-      blk_device.systemd_remote?
-    end
-
     # Options that must be propagated from the fstab entries of the mount points
     # to the crypttab entries of the corresponding device
     OPTIONS_TO_PROPAGATE = ["_netdev", "noauto", "nofail"]

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -334,6 +334,11 @@ module Y2Storage
       blk_device.in_network?
     end
 
+    # @see BlkDevice#systemd_remote?
+    def systemd_remote?
+      blk_device.systemd_remote?
+    end
+
     # Options that must be propagated from the fstab entries of the mount points
     # to the crypttab entries of the corresponding device
     OPTIONS_TO_PROPAGATE = ["_netdev", "noauto", "nofail"]

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -170,6 +170,13 @@ module Y2Storage
         blk_devices.any?(&:in_network?)
       end
 
+      # @see BlkDevice#systemd_remote?
+      #
+      # @return [Boolean]
+      def systemd_remote?
+        blk_devices.any?(&:systemd_remote?)
+      end
+
       # Option used in the fstab file for devices that require network
       NETWORK_OPTION = "_netdev".freeze
       private_constant :NETWORK_OPTION
@@ -265,7 +272,7 @@ module Y2Storage
       def needs_network_mount_options?
         # Adding "_netdev" and similar options in fstab for / should not be necessary
         # and it confuses (or used to confuse) systemd. See bsc#1165937.
-        in_network? && !root?
+        systemd_remote? && !root?
       end
 
       # @see Device#is?

--- a/src/lib/y2storage/lvm_lv.rb
+++ b/src/lib/y2storage/lvm_lv.rb
@@ -159,6 +159,13 @@ module Y2Storage
       lvm_vg.lvm_pvs.map(&:blk_device).any?(&:in_network?)
     end
 
+    # @see BlkDevice#systemd_remote?
+    #
+    # @return [Boolean]
+    def systemd_remote?
+      lvm_vg.lvm_pvs.map(&:blk_device).any?(&:systemd_remote?)
+    end
+
     protected
 
     def types_for_is

--- a/src/lib/y2storage/lvm_lv.rb
+++ b/src/lib/y2storage/lvm_lv.rb
@@ -152,20 +152,6 @@ module Y2Storage
       log.info "Size of #{name} set to #{size}"
     end
 
-    # @see BlkDevice#in_network?
-    #
-    # @return [Boolean]
-    def in_network?
-      lvm_vg.lvm_pvs.map(&:blk_device).any?(&:in_network?)
-    end
-
-    # @see BlkDevice#systemd_remote?
-    #
-    # @return [Boolean]
-    def systemd_remote?
-      lvm_vg.lvm_pvs.map(&:blk_device).any?(&:systemd_remote?)
-    end
-
     protected
 
     def types_for_is

--- a/src/lib/y2storage/multi_disk_device.rb
+++ b/src/lib/y2storage/multi_disk_device.rb
@@ -28,13 +28,6 @@ module Y2Storage
   # Mixin for devices that, from the libstorage point of view, are basically
   # an aggregation of several disks. I.e. Multipath I/O or BIOS RAID.
   module MultiDiskDevice
-    # Checks whether this is a network device.
-    #
-    # @return [Boolean] true if any of disks is network-based
-    def in_network?
-      any_parent?(:in_network?)
-    end
-
     # Checks whether some of the disks of the device are connected through USB.
     #
     # Although that is obviously very unlikely, this method is offered for
@@ -44,13 +37,6 @@ module Y2Storage
     # @return [Boolean]
     def usb?
       any_parent?(:usb?)
-    end
-
-    # @see BlkDevice#systemd_remote?
-    #
-    # @return [Boolean]
-    def systemd_remote?
-      any_parent?(:systemd_remote?)
     end
 
     # Default partition table type for newly created partition tables

--- a/src/lib/y2storage/multi_disk_device.rb
+++ b/src/lib/y2storage/multi_disk_device.rb
@@ -32,7 +32,7 @@ module Y2Storage
     #
     # @return [Boolean] true if any of disks is network-based
     def in_network?
-      parents.any? { |i| i.respond_to?(:in_network?) && i.in_network? }
+      any_parent?(:in_network?)
     end
 
     # Checks whether some of the disks of the device are connected through USB.
@@ -43,7 +43,14 @@ module Y2Storage
     #
     # @return [Boolean]
     def usb?
-      parents.any? { |i| i.respond_to?(:usb?) && i.usb? }
+      any_parent?(:usb?)
+    end
+
+    # @see BlkDevice#systemd_remote?
+    #
+    # @return [Boolean]
+    def systemd_remote?
+      any_parent?(:systemd_remote?)
     end
 
     # Default partition table type for newly created partition tables
@@ -55,6 +62,14 @@ module Y2Storage
     def default_ptable_type
       # We always suggest GPT
       PartitionTables::Type::GPT
+    end
+
+    # Checks whether any of the parent devices returns true for the given method
+    #
+    # @param method [Symbol] name of the method to be checked in all parents
+    # @return [Boolean]
+    def any_parent?(method)
+      parents.any? { |i| i.respond_to?(method) && i.send(method) }
     end
   end
 end

--- a/src/lib/y2storage/partition.rb
+++ b/src/lib/y2storage/partition.rb
@@ -274,16 +274,6 @@ module Y2Storage
       id.is?(:esp) && formatted_as?(:vfat)
     end
 
-    # @see BlkDevice#in_network?
-    def in_network?
-      partitionable.in_network?
-    end
-
-    # @see BlkDevice#systemd_remote?
-    def systemd_remote?
-      partitionable.systemd_remote?
-    end
-
     # Whether the partition fulfills conditions to be used for a Windows system
     #
     # @return [Boolean]

--- a/src/lib/y2storage/partition.rb
+++ b/src/lib/y2storage/partition.rb
@@ -279,6 +279,11 @@ module Y2Storage
       partitionable.in_network?
     end
 
+    # @see BlkDevice#systemd_remote?
+    def systemd_remote?
+      partitionable.systemd_remote?
+    end
+
     # Whether the partition fulfills conditions to be used for a Windows system
     #
     # @return [Boolean]


### PR DESCRIPTION
This is the same than #1198 but with an extra commit to reduce the code duplication based on @joseivanlopez's comment at the original pull request.

Done in a separate pull request just to showcase the idea because I'm not sure it's a good idea to include it as part of the maintenance update.