### PR TITLE
Partitioner: Fix subvolume dialog

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 21 12:20:34 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: properly set subvolume limit when creating a new
+  subvolume (bsc#1181205).
+- 4.3.38
+
+-------------------------------------------------------------------
 Thu Jan 14 13:40:54 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Partitioner: removed warning for too small EFI system partition.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.37
+Version:        4.3.38
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/add_btrfs_subvolume.rb
+++ b/src/lib/y2partitioner/actions/add_btrfs_subvolume.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2020] SUSE LLC
+# Copyright (c) [2020-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -50,7 +50,7 @@ module Y2Partitioner
 
         return unless dialog.run == :next
 
-        controller.create_subvolume(controller.subvolume_path, controller.subvolume_nocow)
+        controller.create_subvolume
         UIState.instance.select_row(controller.subvolume.sid)
 
         :finish

--- a/src/lib/y2partitioner/actions/controllers/btrfs_subvolume.rb
+++ b/src/lib/y2partitioner/actions/controllers/btrfs_subvolume.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2020] SUSE LLC
+# Copyright (c) [2020-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -59,15 +59,13 @@ module Y2Partitioner
           set_default_values
         end
 
-        # Adds a new Btrfs subvolume
+        # Creates a new Btrfs subvolume according to the values stored in the controller
         #
         # Note that the new added subvolume could be shadowed. In that case, the mount point of the
         # subvolume is removed, see {Y2Storage::Shadower#refresh_shadowing}.
-        #
-        # @param path [String]
-        # @param nocow [Booelan]
-        def create_subvolume(path, nocow = false)
-          @subvolume = filesystem.create_btrfs_subvolume(path, nocow)
+        def create_subvolume
+          @subvolume = filesystem.create_btrfs_subvolume(subvolume_path, subvolume_nocow)
+          subvolume.referenced_limit = subvolume_referenced_limit
 
           Y2Storage::Shadower.new(current_graph, filesystems: [filesystem]).refresh_shadowing
 


### PR DESCRIPTION
## Problem

When creating a new subvolume and the "Size Limit" checkbox is marked, the subvolume is created without the indicated limit.

* https://bugzilla.suse.com/show_bug.cgi?id=1181205


## Solution

Fix controller to take into account the limit option.


## Testing

* Added new unit tests
* Tested manually with *partitioner_testing* client
