### PR TITLE
Partitioner: Fix used devices tab

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 22 15:37:00 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: show used devices for MD BIOS RAID (bsc#1181300).
+- 4.3.39
+
+-------------------------------------------------------------------
 Thu Jan 21 12:20:34 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Partitioner: properly set subvolume limit when creating a new

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.38
+Version:        4.3.39
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/widgets/pages/disk.rb
+++ b/src/lib/y2partitioner/widgets/pages/disk.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2020] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -79,7 +79,13 @@ module Y2Partitioner
       class DiskUsedDevicesTab < UsedDevicesTab
         # @see UsedDevicesTab#used_devices
         def used_devices
-          device.is?(:multipath, :dm_raid) ? device.parents : []
+          if device.is?(:multipath, :dm_raid)
+            device.parents
+          elsif device.is?(:md)
+            device.devices
+          else
+            []
+          end
         end
       end
     end

--- a/test/y2partitioner/widgets/pages/disk_test.rb
+++ b/test/y2partitioner/widgets/pages/disk_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2017-2020] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -106,18 +106,34 @@ describe Y2Partitioner::Widgets::Pages::Disk do
     describe "#contents" do
       let(:items) { column_values(table, 0) }
 
-      context "when the device is a BIOS RAID" do
+      context "when the device is a DM RAID" do
         let(:scenario) { "empty-dm_raids.xml" }
 
         let(:device) { current_graph.find_by_name("/dev/mapper/isw_ddgdcbibhd_test1") }
 
-        it "shows a table with the BIOS RAID and its devices" do
+        it "shows a table with the MD RAID and its devices" do
           expect(table).to_not be_nil
 
           expect(remove_sort_keys(items)).to contain_exactly(
             "/dev/mapper/isw_ddgdcbibhd_test1",
             "/dev/sdb",
             "/dev/sdc"
+          )
+        end
+      end
+
+      context "when the device is a MD BIOS RAID" do
+        let(:scenario) { "md-imsm1-devicegraph.xml" }
+
+        let(:device) { current_graph.find_by_name("/dev/md/a") }
+
+        it "shows a table with the MD BIOS RAID and its devices" do
+          expect(table).to_not be_nil
+
+          expect(remove_sort_keys(items)).to contain_exactly(
+            "/dev/md/a",
+            "/dev/sdb",
+            "/dev/sdd"
           )
         end
       end


### PR DESCRIPTION
## Problem

In the Expert Partitioner, when going to the "Used Devices" tab of a MD BIOS RAID, the list does not contain the devices used by the MD.

* https://bugzilla.suse.com/show_bug.cgi?id=1181300


## Solution

The devices used by the MD are included in the list of used devices. 


## Testing

* Added a new unit test.
* Tested manually with the *partitioner_testing* client.

