### PR TITLE
AutoYaST UI: improved visualization of some partition sections

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 28 17:07:25 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- AutoYaST UI: improved visualization of some partition sections
+  in the left tree (related to jsc#SLE-11308).
+- 4.3.41
+
+-------------------------------------------------------------------
 Mon Jan 25 11:52:18 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Partitioner: fix typo calling to popup (bsc#1181348).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.40
+Version:        4.3.41
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/test/y2storage/autoinst_profile/drive_section_test.rb
+++ b/test/y2storage/autoinst_profile/drive_section_test.rb
@@ -1053,13 +1053,10 @@ describe Y2Storage::AutoinstProfile::DriveSection do
 
     let(:home_spec) { Y2Storage::AutoinstProfile::PartitionSection.new }
 
-    before do
-      section.partitions = [home_spec, part0_spec]
-    end
-
     context "when diskabel is set to 'none'" do
       before do
         section.disklabel = "none"
+        section.partitions = [home_spec, part0_spec]
       end
 
       it "returns the partition which partition_nr is set to '0'" do
@@ -1088,6 +1085,10 @@ describe Y2Storage::AutoinstProfile::DriveSection do
     end
 
     context "when a partition section has the partition_nr set to '0'" do
+      before do
+        section.partitions = [home_spec, part0_spec]
+      end
+
       it "returns that partition section" do
         expect(section.master_partition).to eq(part0_spec)
       end
@@ -1100,6 +1101,26 @@ describe Y2Storage::AutoinstProfile::DriveSection do
         it "still returns the partition section which has the partition_nr set to '0'" do
           expect(section.master_partition).to eq(part0_spec)
         end
+      end
+    end
+
+    context "for a drive describing a multi-device btrfs" do
+      let(:scenario) { "btrfs2-devicegraph.xml" }
+      let(:section) { described_class.new_from_storage(filesystem) }
+      let(:filesystem) { device("sdb1").filesystem }
+
+      before do
+        # The disklabel attribute is irrelevant here. Even if it's omitted, everything should work
+        section.disklabel = nil
+      end
+
+      it "returns the first partition section" do
+        expect(section.master_partition.mount).to eq "/test"
+      end
+
+      it "returns nil if there are no partitions" do
+        section.partitions = []
+        expect(section.master_partition).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Problem

There are several situations in the AutoYaST profile in which the `<partition>` subsection within a given `<drive>` section does not really represent a partition, but it contains general information about the drive itself. For example, when the drive contains a disklabel set to the value "none" or when the drive represents an NFS or btrfs filesystem.

In those cases, the corresponding entry in the left tree of the AutoYaST UI should read "Partition (Drive)" instead of just "Partition". That was happening for drives with the disklabel "none", but not for drives of type `CT_NFS` or `CT_BTRFS`.

![autoyast_tree1](https://user-images.githubusercontent.com/3638289/106207823-ada8c280-61c2-11eb-9ff5-26635a225447.png)

## Solution

Fixed the method used to get the so-called "master" partition section (that is, the partition section that actually is meant to describe the whole drive). Now the tree looks as expected.

![autoyast_tree2](https://user-images.githubusercontent.com/3638289/106207845-b600fd80-61c2-11eb-84ce-b53d52b511df.png)

## Testing

Tested manually

## See also

https://github.com/yast/yast-autoinstallation/pull/727