### PR TITLE
Partitioner: do not offer LVM pools for bcache and btrfs (bsc#1170044)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  4 14:17:09 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Partitioner: stop offering LVM pools as possible base devices
+  for bcache devices and for multi-device btrfs (bsc#1170044).
+- 4.3.42
+
+-------------------------------------------------------------------
 Thu Jan 28 17:07:25 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - AutoYaST UI: improved visualization of some partition sections

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.41
+Version:        4.3.42
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/bcache.rb
+++ b/src/lib/y2partitioner/actions/controllers/bcache.rb
@@ -155,7 +155,7 @@ module Y2Partitioner
         # @param device [Y2Storage::BlkDevice]
         # @return [Boolean]
         def valid_device_type?(device)
-          device.is?(:disk, :multipath, :dasd, :stray, :partition, :lvm_lv)
+          device.is?(:disk, :multipath, :stray, :partition, :lvm_lv) && device.usable_as_blk_device?
         end
 
         # Whether the device is part of a bcache device

--- a/src/lib/y2partitioner/actions/controllers/btrfs_devices.rb
+++ b/src/lib/y2partitioner/actions/controllers/btrfs_devices.rb
@@ -202,7 +202,7 @@ module Y2Partitioner
         # @param device [Y2Storage::BlkDevice]
         # @return [Boolean]
         def valid_device?(device)
-          !device.is?(:encryption) && !selected_device?(device)
+          !device.is?(:encryption) && device.usable_as_blk_device? && !selected_device?(device)
         end
 
         # Whether the device is already selected for being used by the Btrfs

--- a/test/y2partitioner/actions/controllers/bcache_test.rb
+++ b/test/y2partitioner/actions/controllers/bcache_test.rb
@@ -162,6 +162,41 @@ describe Y2Partitioner::Actions::Controllers::Bcache do
         expect(name_of_devices).to_not include("/dev/sdb1")
       end
     end
+
+    context "when there are several types of LVM volume groups" do
+      let(:scenario) { "lvm-types1.xml" }
+
+      let(:cache) { ["/dev/vg0/cached1", "/dev/vg0/cached2"] }
+      let(:raid) { ["/dev/vg0/mirror_lv1", "/dev/vg0/raid1_lv1"] }
+      let(:snapshot) { ["/dev/vg0/snap_normal1"] }
+      let(:thin_pool) { ["/dev/vg0/thinpool0"] }
+      let(:cache_pool) { ["/dev/vg0/unused_cache_pool"] }
+      let(:thin) do
+        [
+          "/dev/vg0/snap_snap_thinvol1", "/dev/vg0/snap_thinvol1", "/dev/vg0/thin_snap_normal2",
+          "/dev/vg0/thinvol1", "/dev/vg0/thinvol2"
+        ]
+      end
+      let(:normal) do
+        [
+          "/dev/vg0/normal1", "/dev/vg0/normal2", "/dev/vg0/normal3",
+          "/dev/vg0/striped1", "/dev/vg0/striped2"
+        ]
+      end
+
+      it "includes logical volumes of type normal, thin, raid, snapshot and cache" do
+        expect(name_of_devices).to include(*normal)
+        expect(name_of_devices).to include(*thin)
+        expect(name_of_devices).to include(*raid)
+        expect(name_of_devices).to include(*snapshot)
+        expect(name_of_devices).to include(*cache)
+      end
+
+      it "excludes logical volumes of type thin-pool and chache-pool" do
+        expect(name_of_devices).to_not include(*thin_pool)
+        expect(name_of_devices).to_not include(*cache_pool)
+      end
+    end
   end
 
   describe "#suitable_backing_devices" do

--- a/test/y2partitioner/actions/controllers/btrfs_devices_test.rb
+++ b/test/y2partitioner/actions/controllers/btrfs_devices_test.rb
@@ -308,6 +308,42 @@ describe Y2Partitioner::Actions::Controllers::BtrfsDevices do
         end
       end
     end
+
+    context "when the device is an unmounted normal LV" do
+      let(:scenario) { "lvm-types1.xml" }
+      let(:device_name) { "/dev/vg0/normal1" }
+
+      it "includes the device" do
+        expect(subject.available_devices).to include(device)
+      end
+    end
+
+    context "when the device is an unmounted thin LV" do
+      let(:scenario) { "lvm-types1.xml" }
+      let(:device_name) { "/dev/vg0/thinvol1" }
+
+      it "includes the device" do
+        expect(subject.available_devices).to include(device)
+      end
+    end
+
+    context "when the device is a thin-pool LV" do
+      let(:scenario) { "lvm-types1.xml" }
+      let(:device_name) { "/dev/vg0/thinpool0" }
+
+      it "does not include the device" do
+        expect(subject.available_devices).to_not include(device)
+      end
+    end
+
+    context "when the device is a cache-pool LV" do
+      let(:scenario) { "lvm-types1.xml" }
+      let(:device_name) { "/dev/vg0/unused_cache_pool" }
+
+      it "does not include the device" do
+        expect(subject.available_devices).to_not include(device)
+      end
+    end
   end
 
   describe "#selected_devices" do


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1170044

Some special kinds of LVM logical volumes (thin pools and cache pools) cannot be used as base for a bcache (nor backing or caching device) or for a Btrfs filesystem, because those logical volumes are not block devices.

But the Partitioner was not making any distinction, so they were offered in the UI just like any other logical volume. Of course, that leaded to problems at a later point if the user selected any of them to be part of any bcache or btrfs.

## Solution

In both cases, check the `Storage::BlkDevice#usable_as_blk_device?` method offered by libstorage-ng to distinguish those devices that, despite being represented as an instance of `BlkDevice`, are not really block devices in the full sense.

## Testing

Added new unit tests