### PR TITLE
Partitioner: only collapse by default Btrfs with snapshots

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 11 14:16:57 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Partitioner: in general, collapse branches of the tables only if
+  they contain Btrfs snapshots (related to bsc#1181464).
+- 4.3.43
+
+-------------------------------------------------------------------
 Thu Feb  4 14:17:09 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Partitioner: stop offering LVM pools as possible base devices

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.42
+Version:        4.3.43
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/widgets/blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/blk_devices_table.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -107,10 +107,6 @@ module Y2Partitioner
 
       private
 
-      # Children limit to decide whether an entry is open/close by default
-      OPEN_CHILDREN_LIMIT = 10
-      private_constant :OPEN_CHILDREN_LIMIT
-
       # @see #helptext_for
       def columns_help
         cols.map { |column| helptext_for(column.id) }.join("\n")
@@ -145,15 +141,23 @@ module Y2Partitioner
 
       # Items to be open by default
       #
-      # Items with more than {OPEN_CHILDREN_LIMIT} children are closed by default.
-      #
       # @see #open_items
       #
       # @return [Hash{String => Boolean}]
       def default_open_items
         all_entries.each_with_object({}) do |entry, result|
-          result[entry.row_id] = (entry.children.size <= OPEN_CHILDREN_LIMIT)
+          result[entry.row_id] = open_by_default?(entry)
         end
+      end
+
+      # Whether the given table entry should be expanded by default
+      #
+      # @see #default_open_items
+      #
+      # @param _entry [DeviceTableEntry]
+      # @return [Boolean] false if the list of entry children should be collapsed
+      def open_by_default?(_entry)
+        true
       end
 
       # Plain collection including the first level entries and all its descendants

--- a/src/lib/y2partitioner/widgets/btrfs_filesystems_table.rb
+++ b/src/lib/y2partitioner/widgets/btrfs_filesystems_table.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019-2020] SUSE LLC
+# Copyright (c) [2019-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -50,6 +50,13 @@ module Y2Partitioner
           Columns::BtrfsExclusive,
           Columns::MountPoint
         ]
+      end
+
+      # @see BlkDevicesTable#open_by_default?
+      def open_by_default?(_entry)
+        # Restores the base BlkDevicesTable behavior (everything open by default) to avoid
+        # collapsing the Btrfs subvolumes (we are in the Btrfs section, after all)
+        true
       end
     end
   end

--- a/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2020] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -189,6 +189,28 @@ module Y2Partitioner
 
       def default_columns
         DEFAULT_COLUMNS
+      end
+
+      # @see BlkDevicesTable#open_by_default?
+      #
+      # @param entry [DeviceTableEntry]
+      # @return [Boolean]
+      def open_by_default?(entry)
+        return true unless entry_with_subvols?(entry)
+
+        entry.children.none? { |c| c.device.snapshot? }
+      end
+
+      # Whether the children of the given entry are Btrfs subvolumes
+      #
+      # @return [Boolean]
+      def entry_with_subvols?(entry)
+        # We never mix subvolumes and other kind of devices in the same level of
+        # a branch, so checking the first child is enough
+        child = entry.children.first
+        return false unless child
+
+        child.device.is?(:btrfs_subvolume)
       end
 
       # Table entry to select initially when the table is rendered

--- a/src/lib/y2storage/btrfs_subvolume.rb
+++ b/src/lib/y2storage/btrfs_subvolume.rb
@@ -226,6 +226,13 @@ module Y2Storage
       path == filesystem.subvolumes_prefix
     end
 
+    # Whether the subvolume is a snapshot
+    #
+    # @return [Boolean]
+    def snapshot?
+      path.start_with?(filesystem.snapshots_root + "/")
+    end
+
     protected
 
     # Whether the subvolume requires a default mount point
@@ -256,9 +263,7 @@ module Y2Storage
     #
     # @return [Boolean]
     def for_snapshots?
-      snapshots_root = filesystem.snapshots_root
-
-      path == snapshots_root || path.start_with?(snapshots_root + "/")
+      path == filesystem.snapshots_root || snapshot?
     end
 
     # Parent subvolume

--- a/test/y2partitioner/actions/controllers/encryption_test.rb
+++ b/test/y2partitioner/actions/controllers/encryption_test.rb
@@ -89,6 +89,7 @@ describe Y2Partitioner::Actions::Controllers::Encryption do
       let(:dev_name) { "/dev/dasdb1" }
 
       before do
+        allow(Yast::Execute).to receive(:locally).with(/zkey/, any_args)
         device.encrypt(method: Y2Storage::EncryptionMethod::PERVASIVE_LUKS2, apqns: apqns)
       end
 

--- a/test/y2partitioner/widgets/btrfs_filesystems_table_test.rb
+++ b/test/y2partitioner/widgets/btrfs_filesystems_table_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2019-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -53,6 +53,29 @@ describe Y2Partitioner::Widgets::BtrfsFilesystemsTable do
     it "returns array of CWM table items" do
       expect(subject.items).to be_a(::Array)
       expect(subject.items.first).to be_a(CWM::TableItem)
+    end
+  end
+
+  describe "#open_items" do
+    context "when #open_items has not been set" do
+      before { subject.open_items = nil }
+
+      let(:sids_with_snapshots) { filesystems.select(&:snapshots?).map(&:sid) }
+      let(:sids_without_snapshots) { filesystems.reject(&:snapshots?).map(&:sid) }
+
+      it "reports true for items with only regular subvolumes as children" do
+        result = subject.open_items
+        sids_without_snapshots.each do |sid|
+          expect(result["table:device:#{sid}"]).to eq true
+        end
+      end
+
+      it "reports true for items with some btrfs snapshot as child" do
+        result = subject.open_items
+        sids_with_snapshots.each do |sid|
+          expect(result["table:device:#{sid}"]).to eq true
+        end
+      end
     end
   end
 end

--- a/test/y2partitioner/widgets/encrypt_method_options_test.rb
+++ b/test/y2partitioner/widgets/encrypt_method_options_test.rb
@@ -158,6 +158,8 @@ describe Y2Partitioner::Widgets::EncryptMethodOptions do
       before do
         allow(Y2Partitioner::Widgets::ApqnSelector).to receive(:new).and_return(apqn_widget)
 
+        allow(controller).to receive(:secure_key)
+
         allow(controller).to receive(:online_apqns).and_return(apqns)
 
         allow(controller).to receive(:test_secure_key_generation).and_return(generation_test_error)

--- a/test/y2partitioner/widgets/encrypt_password_test.rb
+++ b/test/y2partitioner/widgets/encrypt_password_test.rb
@@ -30,7 +30,7 @@ describe Y2Partitioner::Widgets::EncryptPassword do
 
   let(:controller) { double("FilesystemController", password: "secret123") }
   let(:pw1) { "password1" }
-  let(:pw2) { "password2" }
+  let(:pw2) { "password1" }
   let(:password_checker) { Y2Storage::EncryptPasswordChecker.new }
   let(:enabled) { true }
 
@@ -86,6 +86,7 @@ describe Y2Partitioner::Widgets::EncryptPassword do
         let(:enabled) { true }
 
         it "returns false" do
+          allow(Yast::Report).to receive(:Error)
           expect(widget.validate).to eq(false)
         end
 

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -1347,6 +1347,8 @@ describe Y2Storage::BlkDevice do
       include_examples "given method"
 
       context "and the method is pervasive encryption" do
+        before { allow(Yast::Execute).to receive(:locally).with(/zkey/, any_args) }
+
         let(:method) { Y2Storage::EncryptionMethod::PERVASIVE_LUKS2 }
 
         let(:apqn) { instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "01.0001") }

--- a/test/y2storage/boot_requirements_strategies/analyzer_test.rb
+++ b/test/y2storage/boot_requirements_strategies/analyzer_test.rb
@@ -222,7 +222,12 @@ describe Y2Storage::BootRequirementsStrategies::Analyzer do
   let(:planned_boot) { planned_partition(mount_point: "/boot") }
   let(:planned_devs) { [planned_boot, planned_root] }
 
-  before { fake_scenario(scenario) }
+  before do
+    # Needed for the s390_luks2 scenario
+    allow(Yast::Execute).to receive(:locally).with(/zkey/, any_args)
+
+    fake_scenario(scenario)
+  end
 
   describe ".new" do
     # There was such a bug, test added to avoid regression"

--- a/test/y2storage/boot_requirements_strategies/zipl_test.rb
+++ b/test/y2storage/boot_requirements_strategies/zipl_test.rb
@@ -24,6 +24,7 @@ describe Y2Storage::BootRequirementsStrategies::ZIPL do
   subject { described_class.new(fake_devicegraph, [], "/dev/dasdc") }
 
   before do
+    allow(Yast::Execute).to receive(:locally).with(/zkey/, any_args)
     fake_scenario("s390_luks2")
     allow(Y2Storage::BootRequirementsStrategies::Analyzer).to receive(:new).and_return(analyzer)
     allow(analyzer).to receive(:device_for_zipl).and_return(device_for_zipl)

--- a/test/y2storage/clients/partitions_proposal_test.rb
+++ b/test/y2storage/clients/partitions_proposal_test.rb
@@ -312,6 +312,7 @@ describe Y2Storage::Clients::PartitionsProposal do
         end
 
         it "returns a hash with :back for 'workflow_sequence' key" do
+          allow(Yast::Report).to receive(:Warning)
           result = subject.ask_user(param)
           expect(result).to be_a(Hash)
           expect(result["workflow_sequence"]).to eq :back

--- a/test/y2storage/package_handler_test.rb
+++ b/test/y2storage/package_handler_test.rb
@@ -56,13 +56,16 @@ describe Y2Storage::PackageHandler do
   describe "#set_proposal_packages" do
     let(:installation) { true }
 
+    before do
+      allow(Yast::PackagesProposal).to receive(:SetResolvables).and_return true
+    end
+
     it "sets the proposal packages" do
       expect(Yast::PackagesProposal).to receive(:SetResolvables)
       subject.set_proposal_packages
     end
 
     it "does not try to install the packages" do
-      allow(Yast::PackagesProposal).to receive(:SetResolvables)
       expect(Yast::Package).to_not receive(:DoInstall)
       subject.set_proposal_packages
     end
@@ -74,14 +77,16 @@ describe Y2Storage::PackageHandler do
     end
 
     it "does not check for already installed packages" do
-      allow(Yast::PackagesProposal).to receive(:SetResolvables)
       expect(Yast::Package).to_not receive(:Installed)
       subject.set_proposal_packages
     end
   end
 
   describe "#install" do
-    before { allow(Yast::Package).to receive(:Installed).and_return false }
+    before do
+      allow(Yast::Package).to receive(:Installed).and_return false
+      allow(Yast::Package).to receive(:DoInstall).and_return true
+    end
     let(:installation) { false }
 
     context "with :ask set to false" do
@@ -106,6 +111,10 @@ describe Y2Storage::PackageHandler do
     end
 
     context "by default (:ask is true)" do
+      before do
+        allow(Yast::PackageSystem).to receive(:CheckAndInstallPackages).and_return true
+      end
+
       it "installs packages directly in the installed system" do
         expect(Yast::PackageSystem).to receive(:CheckAndInstallPackages).with(subject.pkg_list)
         subject.install


### PR DESCRIPTION
## Problem

To avoid the situation in which a filesystem with many subvolumes (specially snapshots) hides other devices (eg. subsequent disks), we decided to display some branches of all tables of devices collapsed by default. But the original criteria to decide whether a given branch should be initially opened or closed was pretty simplistic - just collapsing branches with more than 10 elements. That turned to be inconvenient in many cases like the one reported at [bsc#1181464](https://bugzilla.suse.com/show_bug.cgi?id=1181464): a single disk with many partitions... in which all the interesting information (the list of partitions) is hidden by default.

## Solution

By default, only collapse branches that contain Btrfs snapshots. Except for the tables in the Btrfs section of the Partitioner, in which everything is displayed as initially expanded. 

## Testing

- Tested manually with the `partitioner_testing` client
- Adapted the unit tests and added more
