### PR TITLE
Partitioner: improved help

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 25 09:20:13 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Partitioner: extended the text of the help to cover the new menu
+  and the general navigation (related to bsc#1181590).
+- 4.3.45
+
+-------------------------------------------------------------------
 Fri Feb 19 13:21:35 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Partitioner: ask for recursively unmounting affected devices when

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.44
+Version:        4.3.45
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
+++ b/src/lib/y2partitioner/widgets/configurable_blk_devices_table.rb
@@ -152,7 +152,7 @@ module Y2Partitioner
       # @macro seeAbstractWidget
       # @see #columns_help
       def help
-        "<p>Table containing the selected list of devices, where:</p>" + columns_help
+        _("<p>The table contains the following columns:</p>") + columns_help
       end
 
       private

--- a/src/lib/y2partitioner/widgets/main_menu_bar.rb
+++ b/src/lib/y2partitioner/widgets/main_menu_bar.rb
@@ -29,6 +29,7 @@ module Y2Partitioner
   module Widgets
     # Main menu bar of the partitioner
     class MainMenuBar < CWM::CustomWidget
+      include Yast::I18n
       Yast.import "UI"
 
       # @return [Array<Menus::Base>]
@@ -36,6 +37,7 @@ module Y2Partitioner
 
       # Constructor
       def initialize
+        textdomain "storage"
         self.handle_all_events = true
         @device = nil
         @menus = []
@@ -77,6 +79,34 @@ module Y2Partitioner
           result = menu.handle(id)
         end
         result
+      end
+
+      # @macro seeAbstractWidget
+      # @return [String] localized help text
+      def help
+        _(
+          # TRANSLATORS: html text containing the help for the Partitioner menubar, make
+          # sure the titles match the menu names
+          "<p>All the possible Partitioner actions are represented in the\n" \
+          "menu bar at the top:</p>\n" \
+          "<ul>\n" \
+          "<li><b>System</b>\n" \
+          "contains global actions that affect the storage setup as a whole.\n" \
+          "</li>\n" \
+          "<li><b>Add</b>\n" \
+          "allows to create new virtual devices and also to divide the device\n" \
+          "selected below into logical units like partitions or subvolumes.\n" \
+          "</li>\n" \
+          "<li><b>Device</b>\n" \
+          "gathers all the actions that can be performed on the entry currently\n" \
+          "selected in the table below.\n" \
+          "</li>\n" \
+          "<li><b>View</b>\n" \
+          "grants access to special sections of the Partitioner not strictly related\n" \
+          "to the current selected device.\n" \
+          "</li>\n" \
+          "</ul>"
+        )
       end
 
       private

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -162,6 +162,22 @@ module Y2Partitioner
         valid_setup? && packages_installed?
       end
 
+      # @macro seeAbstractWidget
+      # @return [String] localized help text
+      def help
+        _(
+          # TRANSLATORS: html text of the Partitioner Help. Please make sure the menu
+          # names actually match the ones in the menubar widget
+          "<p>Below the menu bar, the main element of the interface is the table\n" \
+          "that represents the available devices, with some buttons to provide quick\n" \
+          "access to the most common actions. Additionally, the <b>Add</b> and \n" \
+          "<b>Device</b> menus can be used to perform any action on the device\n" \
+          "selected in the table.</p>\n" \
+          "<p>The left tree can be used to navigate through the list of devices,\n" \
+          "focusing on a particular device or type of devices.</p>"
+        )
+      end
+
       private
 
       attr_reader :tree

--- a/test/y2partitioner/widgets/configurable_blk_devices_table_test.rb
+++ b/test/y2partitioner/widgets/configurable_blk_devices_table_test.rb
@@ -47,6 +47,7 @@ describe Y2Partitioner::Widgets::ConfigurableBlkDevicesTable do
 
   # FIXME: default tests check that all column headers are strings, but they also can be a Yast::Term
   # include_examples "CWM::Table"
+  include_examples "CWM::AbstractWidget"
 
   describe "#header" do
     it "returns array" do

--- a/test/y2partitioner/widgets/main_menu_bar_test.rb
+++ b/test/y2partitioner/widgets/main_menu_bar_test.rb
@@ -148,4 +148,19 @@ describe Y2Partitioner::Widgets::MainMenuBar do
       end
     end
   end
+
+  describe "#help" do
+    before { widget.select_page }
+
+    it "includes some content about each menu" do
+      menus = widget.contents.params[1]
+      titles = menus.map { |m| m.params[0].gsub("&", "") }
+      expect(titles.size).to be > 1
+
+      help = widget.help
+      titles.each do |title|
+        expect(help).to include title
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

As explained [in this ML thread](https://lists.opensuse.org/archives/list/yast-devel@lists.opensuse.org/thread/X6OWMUXFWUPKA4R6EB33AIXJDH23R362/), the new interface of the Partitioner ([summarized here](https://github.com/yast/yast-storage-ng/pull/1157)) is causing confusion in some of our traditional users.

## Solution

After discarding the implementation of a more advanced help dialog that could provide a more guided experience (see [this other ML thread](https://lists.opensuse.org/archives/list/yast-devel@lists.opensuse.org/thread/B6VANW7DAYBZ6ZIYX5HOW3LHYZK2EE4G/)), I tried to just extend the current help texts.

The goal is to provide enough details to make the new menu-driven approach obvious without going too much into details so the information still fits in a regular help pop-up with no additional features.

## Screenshots

Qt version

![qt-help](https://user-images.githubusercontent.com/3638289/108874256-45e86a80-75fc-11eb-896f-07a5cf004690.png)

Ncurses version (85 columns and 28 lines)

![ncurses85x28-help](https://user-images.githubusercontent.com/3638289/108874333-5862a400-75fc-11eb-82d0-e1b830bda441.png)


