### PR TITLE
Partitioner: allow to define the filesystem label

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar  9 16:40:38 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: allow to define the file system label (bsc#1183220).
+- 4.3.47
+
+-------------------------------------------------------------------
 Wed Feb 25 16:26:55 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Improved mechanism to detect whether _netdev is needed for a

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.46
+Version:        4.3.47
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2020] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -259,9 +259,7 @@ module Y2Partitioner
       #
       # @return [Boolean]
       def supported_by_filesystem?
-        return false unless filesystem.supports_label?
-
-        super
+        filesystem.supports_label?
       end
 
       # @macro seeAbstractWidget

--- a/test/y2partitioner/widgets/fstab_options_test.rb
+++ b/test/y2partitioner/widgets/fstab_options_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017-2020] SUSE LLC
+
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -100,6 +101,30 @@ describe Y2Partitioner::Widgets do
     subject { described_class.new(controller, parent_widget) }
 
     include_examples "InputField"
+
+    describe "#supported_by_filesystem?" do
+      before do
+        filesystem = device.filesystem
+        allow(controller).to receive(:filesystem).and_return(filesystem)
+        allow(filesystem).to receive(:supports_label?).and_return(supported)
+      end
+
+      context "when the filesystem supports a label" do
+        let(:supported) { true }
+
+        it "returns true" do
+          expect(subject.supported_by_filesystem?).to eq(true)
+        end
+      end
+
+      context "when the filesystem does not support a label" do
+        let(:supported) { false }
+
+        it "returns false" do
+          expect(subject.supported_by_filesystem?).to eq(false)
+        end
+      end
+    end
 
     describe "#validate" do
       RSpec.shared_examples "given_label" do


### PR DESCRIPTION
## Problem

In the Expert Partitioner, when editing the fstab options of a file system, the text field to give a label is not shown.

https://bugzilla.suse.com/show_bug.cgi?id=1183220

## Solution

Fix bug in method that checks whether a file system supports a label.


## Testing

* Added new unit tests
* Tested manually with *partitioner_testing* client.
