### PR TITLE
Remove question mark icon

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 11 00:01:59 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Stop using the question mark icon in the recursive deletion
+  confirm didalog (bsc#1183088).
+- 4.3.48
+
+-------------------------------------------------------------------
 Tue Mar  9 16:40:38 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Partitioner: allow to define the file system label (bsc#1183220).

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -2,7 +2,7 @@
 Thu Mar 11 00:01:59 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Stop using the question mark icon in the recursive deletion
-  confirm didalog (bsc#1183088).
+  confirm dialog (bsc#1183088).
 - 4.3.48
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.47
+Version:        4.3.48
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/confirm_recursive_delete.rb
+++ b/src/lib/y2partitioner/confirm_recursive_delete.rb
@@ -59,21 +59,18 @@ module Y2Partitioner
     # @param button_term [Yast::UI::Term]
     # @return [Boolean]
     def fancy_question(headline, label_before, rich_text, label_after, button_term)
-      layout = VBox(
-        VSpacing(0.4),
-        HBox(
-          Top(Yast::Icon.Simple("question")),
-          HSpacing(1),
-          VBox(
-            Left(Heading(headline)),
-            VSpacing(0.2),
-            Left(Label(label_before)),
-            VSpacing(0.2),
-            Left(RichText(rich_text)),
-            VSpacing(0.2),
-            Left(Label(label_after)),
-            button_term
-          )
+      layout = MarginBox(
+        1.45,
+        0.5,
+        VBox(
+          Left(Heading(headline)),
+          VSpacing(0.2),
+          Left(Label(label_before)),
+          VSpacing(0.2),
+          Left(RichText(rich_text)),
+          VSpacing(0.2),
+          Left(Label(label_after)),
+          button_term
         )
       )
 


### PR DESCRIPTION
### Problem

The _recursive deletion_ confirm dialog includes a question mark icon it its heading which

* is vertically cut-off, and
* **should not be there** (_ALL icons in dialogues should have been removed a long time ago_, https://bugzilla.suse.com/show_bug.cgi?id=1182497#c8)

- https://bugzilla.suse.com/show_bug.cgi?id=1183088

### Solution

Drop it.

### Testing

- *Tested manually*


### Screenshots

| Before | After |
|-|-|
| ![dialog_using_the_question_mark_icon](https://user-images.githubusercontent.com/1691872/110716467-260d9500-81ff-11eb-9ab7-ffc69a8f2fca.png) | ![dialog_not_using_the_question_mark_icon](https://user-images.githubusercontent.com/1691872/110716508-3887ce80-81ff-11eb-98c9-a215becf57c1.png) |
