### PR TITLE
Improve LVM striped volumes support

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Mar 17 16:21:09 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Round-down the number of physical extends according to the
+  stripes of the logical volume (bsc#1180723).
+- Add extra validations when creating a striped volume and when
+  editing the physical volumes.
+- 4.3.49
+
+-------------------------------------------------------------------
 Thu Mar 11 00:01:59 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Stop using the question mark icon in the recursive deletion

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.48
+Version:        4.3.49
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/lvm_lv.rb
+++ b/src/lib/y2partitioner/actions/controllers/lvm_lv.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -92,8 +92,12 @@ module Y2Partitioner
         end
 
         # Creates the LV in the VG according to the controller attributes
+        #
+        # The size of the new LV is rounded-down according to the extent size and the number of stripes,
+        # see bsc#1180723.
         def create_lv
           @lv = lv_type.is?(:thin) ? create_thin_lv : create_normal_or_pool_lv
+          @lv.size = @lv.rounded_size
         end
 
         # Removes the previously created logical volume
@@ -304,7 +308,7 @@ module Y2Partitioner
         def create_normal_or_pool_lv
           lv = vg.create_lvm_lv(lv_name, lv_type, size)
           lv.stripes = stripes_number if stripes_number
-          lv.stripe_size = stripes_size  if stripes_size
+          lv.stripe_size = stripes_size if stripes_size
           lv
         end
 

--- a/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
@@ -218,7 +218,7 @@ module Y2Partitioner
         # Maximum number of stripes used by the striped logical volumes of the volume group
         #
         # @return [Integer] 0 if no striped volumes
-        def max_stripes
+        def lvs_stripes
           return 0 if striped_lvs.none?
 
           striped_lvs.map(&:stripes).max

--- a/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
+++ b/src/lib/y2partitioner/actions/controllers/lvm_vg.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -203,6 +203,27 @@ module Y2Partitioner
           BlkDeviceRestorer.new(device.plain_device).restore_from_checkpoint
         end
 
+        # Whether the volume group can allocate each striped logical volume.
+        #
+        # Note that this method only checks that the volume group has the necessary physical volumes to
+        # allocate each striped volume individually. Checking that the volume group can allocate all the
+        # striped volumes at the same time would be very tricky. Such a check requires to know how the
+        # volumes are distributed in the physical volumes.
+        #
+        # @return [Boolean]
+        def size_for_striped_lvs?
+          striped_lvs.all? { |l| vg.size_for_striped_lv?(l.size, l.stripes) }
+        end
+
+        # Maximum number of stripes used by the striped logical volumes of the volume group
+        #
+        # @return [Integer] 0 if no striped volumes
+        def max_stripes
+          return 0 if striped_lvs.none?
+
+          striped_lvs.map(&:stripes).max
+        end
+
         private
 
         # Current action to perform
@@ -379,6 +400,13 @@ module Y2Partitioner
         # @return [Boolean]
         def valid_device_for_vg?(device)
           device.is?(:disk, :multipath, :bios_raid, :md)
+        end
+
+        # Striped logical volumes from the volume group
+        #
+        # @return [Array<Y2Storage::LvmLv>]
+        def striped_lvs
+          vg.lvm_lvs.select(&:striped?)
         end
       end
     end

--- a/src/lib/y2partitioner/widgets/lvm_vg_devices_selector.rb
+++ b/src/lib/y2partitioner/widgets/lvm_vg_devices_selector.rb
@@ -140,14 +140,14 @@ module Y2Partitioner
       #
       # @return [String, nil]
       def striped_lvs_devices_error
-        return nil if controller.devices_in_vg.size >= controller.max_stripes
+        return nil if controller.devices_in_vg.size >= controller.lvs_stripes
 
         format(
-          # TRANSLATORS: Error message, where %{max_stripes} is replaced by a number (e.g., 3).
+          # TRANSLATORS: Error message, where %s is replaced by a number (e.g., 3).
           _("The number of physcal volumes is not enough. The volume group contains striped logical " \
-            "volumes. Please, select at least %{max_stripes} devices in order to satisfy the number " \
-            "of stripes of the current volumes."),
-          max_stripes: controller.max_stripes
+            "volumes. Please, select at least %s devices in order to satisfy the number of stripes of " \
+            "the current volumes."),
+          controller.lvs_stripes
         )
       end
 

--- a/src/lib/y2storage/callbacks/check.rb
+++ b/src/lib/y2storage/callbacks/check.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2021] SUSE LLC
+# Copyright (c) [2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -17,9 +17,20 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2storage/callbacks/initialize"
-require "y2storage/callbacks/activate"
-require "y2storage/callbacks/probe"
-require "y2storage/callbacks/sanitize"
-require "y2storage/callbacks/commit"
-require "y2storage/callbacks/check"
+require "yast"
+
+module Y2Storage
+  module Callbacks
+    # Class to implement callbacks used during libstorage-ng checks
+    class Check < Storage::CheckCallbacks
+      include Yast::Logger
+
+      # Method called when there is an error
+      #
+      # @param message [String]
+      def error(message)
+        log.error(message.force_encoding("UTF-8"))
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/lvm_lv.rb
+++ b/src/lib/y2storage/lvm_lv.rb
@@ -174,7 +174,7 @@ module Y2Storage
       size < DiskSize.sum(lvm_lvs.map(&:size))
     end
 
-    # Resizes the volume, taking resizing limits and extent size into account.
+    # Resizes the volume, taking resizing limits, extent size and stripes into account.
     #
     # It does nothing if resizing is not possible (see {ResizeInfo#resize_ok?}).
     # Otherwise, it sets the size of the LV based on the requested size.
@@ -186,7 +186,11 @@ module Y2Storage
     # closest valid (i.e. divisible by the extent size) value, rounding down if
     # needed.
     #
-    # @param new_size [DiskSize] temptative new size of the volume, take into
+    # The resulting size is also rounded down according to the number of stripes,
+    # except when setting the minimum size. Note that lvcreate command will round
+    # it up anyway.
+    #
+    # @param new_size [DiskSize] tentative new size of the volume, take into
     #   account that the result may be slightly smaller after rounding it down
     #   based on the extent size
     def resize(new_size)
@@ -202,6 +206,9 @@ module Y2Storage
         else
           new_size
         end
+
+      self.size = rounded_size if size != resize_info.min_size
+
       log.info "Size of #{name} set to #{size}"
     end
 

--- a/src/lib/y2storage/lvm_lv.rb
+++ b/src/lib/y2storage/lvm_lv.rb
@@ -186,9 +186,11 @@ module Y2Storage
     # closest valid (i.e. divisible by the extent size) value, rounding down if
     # needed.
     #
-    # The resulting size is also rounded down according to the number of stripes,
-    # except when setting the minimum size. Note that lvcreate command will round
-    # it up anyway.
+    # The resulting size is also rounded down according to the number of stripes. In
+    # case of setting the minimum possible size, this method does not round the size
+    # down in order to avoid sizes below the minimum. Anyway, lvcreate command always
+    # tries to round the number of extents up. So, even though the minimum size is not
+    # rounded here, it will be correctly rounded by lvcreate.
     #
     # @param new_size [DiskSize] tentative new size of the volume, take into
     #   account that the result may be slightly smaller after rounding it down

--- a/src/lib/y2storage/lvm_pv.rb
+++ b/src/lib/y2storage/lvm_pv.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -45,6 +45,12 @@ module Y2Storage
     #
     #   @return [BlkDevice]
     storage_forward :blk_device, as: "BlkDevice", check_with: :has_blk_device
+
+    # @!method usable_size
+    #   Returns the size of the PV usable for extents.
+    #
+    #   @return [DiskSize]
+    storage_forward :usable_size, as: "DiskSize"
 
     # Raw (non encrypted) version of the device hosting the PV.
     #

--- a/src/lib/y2storage/lvm_vg.rb
+++ b/src/lib/y2storage/lvm_vg.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -214,6 +214,68 @@ module Y2Storage
     # @return [Array<Device>]
     def potential_orphans
       lvm_pvs
+    end
+
+    # Size of the physical volume that limits the maximum size of a new striped logical volume
+    #
+    # The maximum size of a striped logical volume is limited by the n-th biggest physical volume. For
+    # example, let's say we have a volume group with 3 physical volumes: pv1 (2 GiB), pv2 (50 GiB) and
+    # pv3 (1 GiB). For a striped volume with 2 stripes, the second biggest physical volume (pv1)
+    # restricts its maximum size. In this case, the maximum size would be:
+    # 2 (stripes) * 2 GiB (pv1 size) = 4 GiB.
+    # If the number of stripes is 3, then the maximum size is limited by the third biggest physical
+    # volume (pv3), so the maximum size would be: 3 (stripes) * 1 GiB (pv3 size) = 3 GiB.
+    #
+    # @param stripes [Integer] number of stripes. It must be bigger than 1
+    #
+    # @raise [RuntimeError] when the given number of stripes is incorrect (i.e., less than 1)
+    # @return [DiskSize, nil] nil if no enough physical volumes for the given number of stripes
+    def pv_size_for_striped_lv(stripes)
+      raise "stripes must be bigger than 1" unless stripes > 1
+
+      return nil if stripes > lvm_pvs.size
+
+      lvm_pvs.map(&:blk_device).map(&:size).sort[-stripes]
+    end
+
+    # Maximum size for a new striped logical volume
+    #
+    # @note This size is not 100% accurate. It is based on the size of the block devices used as physical
+    #   volumes. But LVM probably uses some space to allocate its metadata. libstorage-ng provides some
+    #   methods to calculate the maximum size of a linear or a thin volume, but there is no API for
+    #   striped ones. This approximation is the best we can do.
+    #
+    # @param stripes [Integer] number of stripes. It must be bigger than 1
+    #
+    # @raise [RuntimeError] @see #pv_size_for_striped_lv
+    # @return [DiskSize, nil] nil if no enough physical volumes for the given number of stripes
+    def max_size_for_striped_lv(stripes)
+      pv_size = pv_size_for_striped_lv(stripes)
+
+      return nil unless pv_size
+
+      pv_size * stripes
+    end
+
+    # Whether the volume group has enough size to allocate a striped logical volume
+    #
+    # @note This method only checks that the volume group has enough physical volumes to allocate a
+    # striped logical volume with the given size and number of stripes. But it does not take into account
+    # the current logical volumes assigned to it.
+    #
+    # @param size [DiskSize] required size for the striped volume
+    # @param stripes [Integer] number of stripes. It must be bigger than 1
+    #
+    # @raise [RuntimeError] @see #pv_size_for_striped_lv
+    # @return [Boolean]
+    def size_for_striped_lv?(size, stripes)
+      pv_size = pv_size_for_striped_lv(stripes)
+
+      return false unless pv_size
+
+      required_pv_size = size / stripes
+
+      pv_size >= required_pv_size
     end
 
     protected

--- a/src/lib/y2storage/proposal/lvm_creator.rb
+++ b/src/lib/y2storage/proposal/lvm_creator.rb
@@ -1,8 +1,4 @@
-#!/usr/bin/env ruby
-#
-# encoding: utf-8
-
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -319,6 +315,10 @@ module Y2Storage
       def add_stripes_config(lv, planned_lv)
         lv.stripes = planned_lv.stripes if planned_lv.stripes
         lv.stripe_size = planned_lv.stripe_size if planned_lv.stripe_size
+
+        # The size of the new LV is rounded-down according to the extent size and the number of stripes,
+        # see bsc#1180723.
+        lv.size = lv.rounded_size
       end
     end
   end

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2015-2020] SUSE LLC
+# Copyright (c) [2015-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -309,6 +309,9 @@ module Y2Storage
       # Save committed devicegraph into logs
       log.info("Committed devicegraph\n#{staging.to_xml}")
       DumpManager.dump(staging, "committed")
+
+      # Log libstorage-ng checks
+      staging.check
 
       storage.commit(commit_options, callbacks)
       staging.post_commit

--- a/test/data/devicegraphs/lvm_several_pvs.yml
+++ b/test/data/devicegraphs/lvm_several_pvs.yml
@@ -1,0 +1,35 @@
+---
+- disk:
+    name: /dev/sda
+    size: 200 GiB
+    partition_table:  gpt
+    partitions:
+    - partition:
+        size:         2 GiB
+        name:         /dev/sda1
+        id:           lvm
+    - partition:
+        size:         1 GiB
+        name:         /dev/sda2
+        id:           lvm
+    - partition:
+        size:         5 GiB
+        name:         /dev/sda3
+        id:           lvm
+
+- lvm_vg:
+    vg_name: vg0
+    lvm_pvs:
+        - lvm_pv:
+            blk_device: /dev/sda1
+        - lvm_pv:
+            blk_device: /dev/sda2
+        - lvm_pv:
+            blk_device: /dev/sda3
+
+    lvm_lvs:
+        - lvm_lv:
+            size:         3 GiB
+            lv_name:      lv1
+            file_system:  btrfs
+            mount_point:  /

--- a/test/y2partitioner/actions/controllers/lvm_lv_test.rb
+++ b/test/y2partitioner/actions/controllers/lvm_lv_test.rb
@@ -64,7 +64,7 @@ describe Y2Partitioner::Actions::Controllers::LvmLv do
 
     let(:size) { 3.GiB }
 
-    let(:stripes_number) { 2 }
+    let(:stripes_number) { 5 }
 
     let(:stripes_size) { 16.KiB }
 
@@ -82,7 +82,7 @@ describe Y2Partitioner::Actions::Controllers::LvmLv do
 
       expect(lv.lv_name).to eq(lv_name)
       expect(lv.lv_type).to eq(lv_type)
-      expect(lv.size).to eq(size)
+      expect(lv.size).to eq(size - 12.MiB)
       expect(lv.stripes).to eq(stripes_number)
       expect(lv.stripe_size).to eq(stripes_size)
     end

--- a/test/y2partitioner/actions/controllers/lvm_vg_test.rb
+++ b/test/y2partitioner/actions/controllers/lvm_vg_test.rb
@@ -590,8 +590,8 @@ describe Y2Partitioner::Actions::Controllers::LvmVg do
 
     context "if the volume group contains striped volumes" do
       before do
-        lv2 = vg.create_lvm_lv("lv2", Y2Storage::LvType::NORMAL, 3.GiB)
-        lv3 = vg.create_lvm_lv("lv3", Y2Storage::LvType::NORMAL, 4.GiB)
+        lv2 = vg.create_lvm_lv("lv2", Y2Storage::LvType::NORMAL, 2.9.GiB)
+        lv3 = vg.create_lvm_lv("lv3", Y2Storage::LvType::NORMAL, 3.9.GiB)
 
         lv2.stripes = stripes
         lv3.stripes = stripes

--- a/test/y2partitioner/actions/controllers/lvm_vg_test.rb
+++ b/test/y2partitioner/actions/controllers/lvm_vg_test.rb
@@ -615,14 +615,14 @@ describe Y2Partitioner::Actions::Controllers::LvmVg do
     end
   end
 
-  describe "#max_stripes" do
+  describe "#lvs_stripes" do
     let(:scenario) { "lvm_several_pvs" }
 
     let(:vg) { current_graph.find_by_name("/dev/vg0") }
 
     context "if the volume group does not contain striped volumes" do
       it "returns 0" do
-        expect(controller.max_stripes).to eq(0)
+        expect(controller.lvs_stripes).to eq(0)
       end
     end
 
@@ -636,7 +636,7 @@ describe Y2Partitioner::Actions::Controllers::LvmVg do
       end
 
       it "returns the maximum number of stripes used by its logical volumnes" do
-        expect(controller.max_stripes).to eq(3)
+        expect(controller.lvs_stripes).to eq(3)
       end
     end
   end

--- a/test/y2partitioner/actions/controllers/lvm_vg_test.rb
+++ b/test/y2partitioner/actions/controllers/lvm_vg_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017] SUSE LLC
+
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,12 +34,14 @@ describe Y2Partitioner::Actions::Controllers::LvmVg do
   end
 
   before do
-    devicegraph_stub("complex-lvm-encrypt.yml")
+    devicegraph_stub(scenario)
   end
 
   let(:current_graph) { Y2Partitioner::DeviceGraphs.instance.current }
 
   subject(:controller) { described_class.new(vg: vg) }
+
+  let(:scenario) { "complex-lvm-encrypt.yml" }
 
   let(:vg) { nil }
 
@@ -571,6 +574,70 @@ describe Y2Partitioner::Actions::Controllers::LvmVg do
     it "raises an exception if trying to remove a device that is not in the vg physical volumes" do
       controller.remove_device(sda2)
       expect { controller.remove_device(sda2) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#size_for_striped_lvs?" do
+    let(:scenario) { "lvm_several_pvs" }
+
+    let(:vg) { current_graph.find_by_name("/dev/vg0") }
+
+    context "if the volume group does not contain striped volumes" do
+      it "returns true" do
+        expect(controller.size_for_striped_lvs?).to eq(true)
+      end
+    end
+
+    context "if the volume group contains striped volumes" do
+      before do
+        lv2 = vg.create_lvm_lv("lv2", Y2Storage::LvType::NORMAL, 3.GiB)
+        lv3 = vg.create_lvm_lv("lv3", Y2Storage::LvType::NORMAL, 4.GiB)
+
+        lv2.stripes = stripes
+        lv3.stripes = stripes
+      end
+
+      context "and the physical volumes are big enough to allocate the volumes" do
+        let(:stripes) { 2 }
+
+        it "returns true" do
+          expect(controller.size_for_striped_lvs?).to eq(true)
+        end
+      end
+
+      context "and the physical volumes are not big enough to allocate the volumes" do
+        let(:stripes) { 3 }
+
+        it "returns false" do
+          expect(controller.size_for_striped_lvs?).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe "#max_stripes" do
+    let(:scenario) { "lvm_several_pvs" }
+
+    let(:vg) { current_graph.find_by_name("/dev/vg0") }
+
+    context "if the volume group does not contain striped volumes" do
+      it "returns 0" do
+        expect(controller.max_stripes).to eq(0)
+      end
+    end
+
+    context "if the volume group contains striped volumes" do
+      before do
+        lv2 = vg.create_lvm_lv("lv2", Y2Storage::LvType::NORMAL, 3.GiB)
+        lv3 = vg.create_lvm_lv("lv3", Y2Storage::LvType::NORMAL, 4.GiB)
+
+        lv2.stripes = 3
+        lv3.stripes = 2
+      end
+
+      it "returns the maximum number of stripes used by its logical volumnes" do
+        expect(controller.max_stripes).to eq(3)
+      end
     end
   end
 end

--- a/test/y2partitioner/dialogs/blk_device_resize_test.rb
+++ b/test/y2partitioner/dialogs/blk_device_resize_test.rb
@@ -673,6 +673,22 @@ describe Y2Partitioner::Dialogs::BlkDeviceResize do
         include_examples "error"
       end
 
+      context "when the device is a striped logical volume" do
+        let(:scenario) { "lvm_several_pvs" }
+
+        let(:device) { current_graph.find_by_name("/dev/vg0/lv1") }
+
+        before do
+          device.stripes = 2
+        end
+
+        context "and the given value is bigger than the max size for a striped volume" do
+          let(:custom_size) { 5.GiB  }
+
+          include_examples "error"
+        end
+      end
+
       context "when the given value is bigger than min and less than max" do
         let(:custom_size) { 10.GiB }
 

--- a/test/y2partitioner/widgets/lvm_vg_devices_selector_test.rb
+++ b/test/y2partitioner/widgets/lvm_vg_devices_selector_test.rb
@@ -461,8 +461,8 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
 
       before do
         controller.vg.create_lvm_lv("test1", 1.GiB)
-        test2 = controller.vg.create_lvm_lv("test2", 3.GiB)
-        test2.stripes = 3 # max size is limited by /dev/sda2 (1 GiB)
+        test2 = controller.vg.create_lvm_lv("test2", 2.9.GiB)
+        test2.stripes = 3 # max size is limited by /dev/sda2 (~1 GiB)
       end
 
       it "does not show an error popup" do

--- a/test/y2partitioner/widgets/lvm_vg_devices_selector_test.rb
+++ b/test/y2partitioner/widgets/lvm_vg_devices_selector_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2018] SUSE LLC
+
+# Copyright (c) [2018-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -39,13 +40,16 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
   subject(:widget) { described_class.new(controller) }
 
   before do
-    devicegraph_stub("complex-lvm-encrypt.yml")
+    devicegraph_stub(scenario)
 
     allow_any_instance_of(Y2Storage::BlkDevice).to receive(:hwinfo).and_return(nil)
 
-    controller.add_device(dev("/dev/sdc"))
-    controller.add_device(dev("/dev/sda2"))
+    initial_selected_devices.map { |d| controller.add_device(dev(d)) }
   end
+
+  let(:scenario) { "complex-lvm-encrypt" }
+
+  let(:initial_selected_devices) { ["/dev/sdc", "/dev/sda2"] }
 
   include_examples "CWM::CustomWidget"
 
@@ -179,6 +183,10 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
   context "pushing the 'Remove All' button" do
     let(:event) { { "ID" => :remove_all } }
 
+    before do
+      allow(Yast2::Popup).to receive(:show)
+    end
+
     describe "#handle" do
       context "when there is no committed pv in the vg" do
         it "removes all devices from the vg" do
@@ -198,7 +206,7 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
         let(:vg) { Y2Storage::LvmVg.find_by_vg_name(current_graph, "vg0") }
 
         it "shows an error popup" do
-          expect(Yast::Popup).to receive(:Error)
+          expect(Yast2::Popup).to receive(:show)
           widget.handle(event)
         end
 
@@ -247,6 +255,8 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
 
     before do
       allow(selected_table).to receive(:value).and_return selection
+
+      allow(Yast2::Popup).to receive(:show)
     end
 
     context "if there is no selected item in the 'selected' table" do
@@ -327,7 +337,7 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
 
         describe "#handle" do
           it "shows an error popup" do
-            expect(Yast::Popup).to receive(:Error)
+            expect(Yast2::Popup).to receive(:show)
             widget.handle(event)
           end
 
@@ -366,67 +376,103 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
   end
 
   describe "#validate" do
-    context "if there are selected devices" do
-      before do
-        # sdc + sda2 = 510 GiB
-        controller.vg.create_lvm_lv("lvm-test", lv_size)
-      end
+    let(:scenario) { "lvm_several_pvs" }
 
-      context "if the vg size is bigger than the logical volumes size" do
-        let(:lv_size) { 500.GiB }
-
-        it "does not show an error popup" do
-          expect(Yast::Popup).to_not receive(:Error)
-          widget.validate
-        end
-
-        it "returns true" do
-          expect(widget.validate).to eq(true)
-        end
-      end
-
-      context "if the vg size is equal than the logical volumes size" do
-        let(:lv_size) { controller.vg.size }
-
-        it "does not show an error popup" do
-          expect(Yast::Popup).to_not receive(:Error)
-          widget.validate
-        end
-
-        it "returns true" do
-          expect(widget.validate).to eq(true)
-        end
-      end
-
-      context "if the vg size is less than the logical volumes size" do
-        let(:lv_size) { 600.GiB }
-
-        it "shows an error popup" do
-          expect(Yast::Popup).to receive(:Error)
-          widget.validate
-        end
-
-        it "returns false" do
-          allow(Yast::Popup).to receive(:Error)
-          expect(widget.validate).to eq(false)
-        end
-      end
+    before do
+      allow(Yast2::Popup).to receive(:show)
     end
 
-    context "if there are not selected devices" do
-      before do
-        controller.remove_device(dev("/dev/sdc"))
-        controller.remove_device(dev("/dev/sda2"))
-      end
+    context "if there are no selected devices" do
+      let(:initial_selected_devices) { [] }
 
       it "shows an error popup" do
-        expect(Yast::Popup).to receive(:Error)
+        expect(Yast2::Popup).to receive(:show).with(/at least one/, anything)
+
         widget.validate
       end
 
       it "returns false" do
-        allow(Yast::Popup).to receive(:Error)
         expect(widget.validate).to eq(false)
+      end
+    end
+
+    context "if the vg size is less than the logical volumes size" do
+      let(:initial_selected_devices) { ["/dev/sda1"] } # 2 GiB
+
+      before do
+        controller.vg.create_lvm_lv("test1", 1.GiB)
+        controller.vg.create_lvm_lv("test2", 3.GiB)
+      end
+
+      it "shows an error popup" do
+        expect(Yast2::Popup).to receive(:show).with(/size cannot be less than/, anything)
+
+        widget.validate
+      end
+
+      it "returns false" do
+        expect(widget.validate).to eq(false)
+      end
+    end
+
+    context "if the number of physical volumes is less than max stripes" do
+      let(:initial_selected_devices) { ["/dev/sda1", "/dev/sda3"] }
+
+      before do
+        test1 = controller.vg.create_lvm_lv("test1", 1.GiB)
+        test2 = controller.vg.create_lvm_lv("test2", 1.GiB)
+        test1.stripes = 2
+        test2.stripes = 3
+      end
+
+      it "shows an error popup" do
+        expect(Yast2::Popup).to receive(:show).with(/number of physcal volumes is not enough/, anything)
+
+        widget.validate
+      end
+
+      it "returns false" do
+        expect(widget.validate).to eq(false)
+      end
+    end
+
+    context "if the physical volumes are not big enough to allocate the striped volumes" do
+      let(:initial_selected_devices) { ["/dev/sda1", "/dev/sda2", "/dev/sda3"] }
+
+      before do
+        controller.vg.create_lvm_lv("test1", 1.GiB)
+        test2 = controller.vg.create_lvm_lv("test2", 4.GiB)
+        test2.stripes = 3 # max size is limited by /dev/sda2 (1 GiB)
+      end
+
+      it "shows an error popup" do
+        expect(Yast2::Popup).to receive(:show).with(/selected devices are too small/, anything)
+
+        widget.validate
+      end
+
+      it "returns false" do
+        expect(widget.validate).to eq(false)
+      end
+    end
+
+    context "if the logical volumes can be allocated" do
+      let(:initial_selected_devices) { ["/dev/sda1", "/dev/sda2", "/dev/sda3"] }
+
+      before do
+        controller.vg.create_lvm_lv("test1", 1.GiB)
+        test2 = controller.vg.create_lvm_lv("test2", 3.GiB)
+        test2.stripes = 3 # max size is limited by /dev/sda2 (1 GiB)
+      end
+
+      it "does not show an error popup" do
+        expect(Yast2::Popup).to_not receive(:show)
+
+        widget.validate
+      end
+
+      it "returns true" do
+        expect(widget.validate).to eq(true)
       end
     end
   end

--- a/test/y2storage/callbacks/check_test.rb
+++ b/test/y2storage/callbacks/check_test.rb
@@ -1,4 +1,6 @@
-# Copyright (c) [2017-2021] SUSE LLC
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -17,9 +19,19 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2storage/callbacks/initialize"
-require "y2storage/callbacks/activate"
-require "y2storage/callbacks/probe"
-require "y2storage/callbacks/sanitize"
-require "y2storage/callbacks/commit"
+require_relative "../spec_helper"
 require "y2storage/callbacks/check"
+
+describe Y2Storage::Callbacks::Check do
+  subject(:callbacks) { described_class.new }
+
+  include Yast::Logger
+
+  describe "#error" do
+    it "logs the error" do
+      expect(log).to receive(:error).with(/error message/)
+
+      subject.error("error message")
+    end
+  end
+end

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2017-2020] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -65,6 +65,34 @@ describe Y2Storage::Devicegraph do
 
       it "returns true" do
         expect(subject.safe_copy(other_devicegraph)).to eq(true)
+      end
+    end
+  end
+
+  describe "#check" do
+    include Yast::Logger
+
+    before do
+      fake_scenario("mixed_disks")
+    end
+
+    subject { fake_devicegraph }
+
+    it "runs the library checks with the corresping callbacks" do
+      expect(subject).to receive(:storage_check).with(instance_of(Y2Storage::Callbacks::Check))
+
+      subject.check
+    end
+
+    context "when the check raises an error" do
+      before do
+        allow(subject).to receive(:storage_check).and_raise(Storage::Exception, "check error")
+      end
+
+      it "logs the error" do
+        expect(log).to receive(:error).with(/check error/)
+
+        subject.check
       end
     end
   end

--- a/test/y2storage/lvm_lv_test.rb
+++ b/test/y2storage/lvm_lv_test.rb
@@ -325,10 +325,12 @@ describe Y2Storage::LvmLv do
   end
 
   describe "#resize" do
-    before do
-      fake_scenario("complex-lvm-encrypt")
+    let(:scenario) { "complex-lvm-encrypt" }
 
+    before do
       allow(lv).to receive(:detect_resize_info).and_return resize_info
+
+      lv.stripes = stripes
     end
 
     let(:resize_info) do
@@ -342,6 +344,12 @@ describe Y2Storage::LvmLv do
 
     let(:device_name) { "/dev/vg0/lv1" }
 
+    let(:extent_size) { lv.lvm_vg.extent_size }
+
+    let(:stripes) { 1 }
+
+    let(:lv_extents) { lv.size.to_i / extent_size.to_i }
+
     context "if the volume cannot be resized" do
       let(:ok) { false }
 
@@ -353,8 +361,10 @@ describe Y2Storage::LvmLv do
     end
 
     context "if the new size is bigger than the max resizing size" do
-      context "and not divisible by the extent size" do
-        let(:new_size) { 5.5.GiB - 1.MiB }
+      let(:new_size) { 10.GiB }
+
+      context "and the volume is not a striped volume" do
+        let(:stripes) { 1 }
 
         it "sets the size of the volume to the max" do
           lv.resize(new_size)
@@ -362,19 +372,48 @@ describe Y2Storage::LvmLv do
         end
       end
 
-      context "and divisible by the extent size" do
-        let(:new_size) { 5.5.GiB }
+      context "and the volume is a striped volume" do
+        let(:stripes) { 2 }
 
-        it "sets the size of the volume to the max" do
-          lv.resize(new_size)
-          expect(lv.size).to eq max
+        context "and the max number of extents is divisible by the number of stripes" do
+          let(:max) { extent_size * (5.GiB.to_i / extent_size.to_i) * stripes }
+
+          it "sets the size of the volume to the max" do
+            lv.resize(new_size)
+
+            expect(lv.size).to eq max
+          end
+        end
+
+        context "and the max number of extents is not divisible by the number of stripes" do
+          let(:max) { extent_size * (5.GiB.to_i / extent_size.to_i) * stripes + extent_size }
+
+          it "sets a number of extents divisible by the number of stripes" do
+            lv.resize(new_size)
+
+            expect(lv_extents % lv.stripes).to eq(0)
+          end
+
+          it "sets the size to a value smaller than the max value" do
+            lv.resize(new_size)
+
+            expect(lv.size).to be < max
+          end
+
+          it "sets the size to the closest possible value to the max" do
+            lv.resize(new_size)
+
+            expect(max - lv.size).to be < extent_size * stripes
+          end
         end
       end
     end
 
     context "if the new size is smaller than the min resizing size" do
-      context "and not divisible by the extent size" do
-        let(:new_size) { 0.5.GiB - 1.MiB }
+      let(:new_size) { 0.5.GiB }
+
+      context "and the volume is not a striped volume" do
+        let(:stripes) { 1 }
 
         it "sets the size of the volume to the min" do
           lv.resize(new_size)
@@ -382,36 +421,99 @@ describe Y2Storage::LvmLv do
         end
       end
 
-      context "and divisible by the extent size" do
-        let(:new_size) { 0.5.GiB }
+      context "and the volume is a striped volume" do
+        let(:stripes) { 2 }
 
-        it "sets the size of the volume to the min" do
-          lv.resize(new_size)
-          expect(lv.size).to eq min
+        context "and the min number of extents is divisible by the number of stripes" do
+          let(:min) { extent_size * (1.GiB.to_i / extent_size.to_i) * stripes }
+
+          it "sets the size of the volume to the min" do
+            lv.resize(new_size)
+            expect(lv.size).to eq min
+          end
+        end
+
+        context "and the min number of extents is not divisible by the number of stripes" do
+          let(:min) { extent_size * (1.GiB.to_i / extent_size.to_i) * stripes + extent_size }
+
+          it "sets the size of the volume to the min" do
+            lv.resize(new_size)
+            expect(lv.size).to eq min
+          end
+
+          it "does not round the size according the number of stripes" do
+            lv.resize(new_size)
+
+            expect(lv_extents % lv.stripes).to_not eq(0)
+          end
         end
       end
     end
 
     context "if the new size is within the resizing limits" do
-      context "and not divisible by the extent size" do
-        let(:new_size) { 2.5.GiB - 1.MiB }
-        let(:extent_size) { lv.lvm_vg.extent_size }
+      context "and the volume is not a striped volume" do
+        let(:stripes) { 1 }
 
-        it "sets the size to a value divisible by the extent size" do
-          expect(new_size.to_i.to_f % extent_size.to_i).to_not be_zero
-          expect(lv.size.to_i.to_f % extent_size.to_i).to be_zero
+        context "and the new size is divisible by the extent size" do
+          let(:new_size) { 2.5.GiB }
+
+          it "sets the size of the volume to the requested size" do
+            lv.resize(new_size)
+            expect(lv.size).to eq new_size
+          end
         end
 
-        it "sets the size to a value smaller than the requested" do
+        context "and the new size is not divisible by the extent size" do
+          let(:new_size) { 2.5.GiB - 1.MiB }
+
+          it "sets the size to a value divisible by the extent size" do
+            expect(new_size.to_i.to_f % extent_size.to_i).to_not be_zero
+            expect(lv.size.to_i.to_f % extent_size.to_i).to be_zero
+          end
+
+          it "sets the size to a value smaller than the requested size" do
+            lv.resize(new_size)
+            expect(lv.size).to be < new_size
+          end
+
+          it "sets the size to closest possible value" do
+            lv.resize(new_size)
+            expect(new_size - lv.size).to be < extent_size
+          end
+        end
+      end
+
+      context "and the volume is a striped volume" do
+        let(:stripes) { 3 }
+
+        let(:new_size) { 2.5.GiB - 1.MiB }
+
+        it "sets the size to a value divisible by the extent size" do
           lv.resize(new_size)
+
+          expect(lv.size.to_i % extent_size.to_i).to eq(0)
+        end
+
+        it "sets a number of extents divisible by the number of stripes" do
+          lv.resize(new_size)
+
+          expect(lv_extents % lv.stripes).to eq(0)
+        end
+
+        it "sets the size to a value smaller than the requested size" do
+          lv.resize(new_size)
+
           expect(lv.size).to be < new_size
         end
 
-        it "sets the size to closest possible value" do
+        it "sets the size to the closest possible value" do
           lv.resize(new_size)
-          expect(new_size - lv.size).to be < extent_size
+
+          expect(new_size - lv.size).to be < extent_size * stripes
         end
       end
+    end
+  end
 
   describe "#rounded_size" do
     let(:scenario) { "complex-lvm-encrypt" }

--- a/test/y2storage/lvm_vg_test.rb
+++ b/test/y2storage/lvm_vg_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2017] SUSE LLC
+
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -27,6 +28,7 @@ describe Y2Storage::LvmVg do
   before do
     fake_scenario(scenario)
   end
+
   let(:scenario) { "complex-lvm-encrypt" }
 
   subject(:vg) { Y2Storage::LvmVg.find_by_vg_name(fake_devicegraph, vg_name) }
@@ -131,6 +133,107 @@ describe Y2Storage::LvmVg do
         vg.delete_lvm_lv(normal1)
         expect(vg.lvm_lvs.map(&:lv_name)).to_not include "normal1"
         expect(vg.lvm_lvs.map(&:lv_name)).to_not include "snap_normal1"
+      end
+    end
+  end
+
+  describe "#pv_size_for_striped_lv" do
+    let(:scenario) { "lvm_several_pvs" }
+
+    let(:vg_name) { "vg0" }
+
+    # Pv sizes are 1 GiB, 2 GiB and 5 GiB
+
+    it "returns a disk size" do
+      expect(vg.pv_size_for_striped_lv(2)).to be_a(Y2Storage::DiskSize)
+    end
+
+    it "returns the size of the n-th biggest pv according to the given number of stripes" do
+      expect(vg.pv_size_for_striped_lv(2)).to eq(2.GiB)
+      expect(vg.pv_size_for_striped_lv(3)).to eq(1.GiB)
+    end
+
+    context "when the given number of stripes is not valid" do
+      it "raises an error" do
+        expect { vg.pv_size_for_striped_lv(1) }.to raise_error(RuntimeError)
+      end
+    end
+
+    context "when the given number of stripes is bigger than the number of physical volumes" do
+      it "returns nil" do
+        expect(vg.pv_size_for_striped_lv(10)).to be_nil
+      end
+    end
+  end
+
+  describe "#max_size_for_striped_lv" do
+    let(:scenario) { "lvm_several_pvs" }
+
+    let(:vg_name) { "vg0" }
+
+    # Pv sizes are 1 GiB, 2 GiB and 5 GiB
+
+    it "returns a disk size" do
+      expect(vg.max_size_for_striped_lv(2)).to be_a(Y2Storage::DiskSize)
+    end
+
+    it "returns the maximum size for a stripped volume with the given number of stripes" do
+      expect(vg.max_size_for_striped_lv(2)).to eq(4.GiB)
+      expect(vg.max_size_for_striped_lv(3)).to eq(3.GiB)
+    end
+
+    context "when the given number of stripes is not valid" do
+      it "raises an error" do
+        expect { vg.max_size_for_striped_lv(1) }.to raise_error(RuntimeError)
+      end
+    end
+
+    context "when the given number of stripes is bigger than the number of physical volumes" do
+      it "returns nil" do
+        expect(vg.max_size_for_striped_lv(10)).to be_nil
+      end
+    end
+  end
+
+  describe "#size_for_striped_lv?" do
+    let(:scenario) { "lvm_several_pvs" }
+
+    let(:vg_name) { "vg0" }
+
+    # Pv sizes are 1 GiB, 2 GiB and 5 GiB
+
+    context "when the given size is bigger than the volume group size" do
+      it "returns false" do
+        expect(vg.size_for_striped_lv?(10.GiB, 2)).to eq(false)
+      end
+    end
+
+    context "when the given number of stripes is not valid" do
+      it "raises an error" do
+        expect { vg.size_for_striped_lv?(1.GiB, 1) }.to raise_error(RuntimeError)
+      end
+    end
+
+    context "when the given number of stripes is bigger than the number of physcial volumes" do
+      it "returns false" do
+        expect(vg.size_for_striped_lv?(4.GiB, 4)).to eq(false)
+      end
+    end
+
+    context "when the given number of stripes is not bigger than the number of physcial volumes" do
+      context "and the physical volumes are big enough to allocate the required size" do
+        it "returns true" do
+          expect(vg.size_for_striped_lv?(3.5.GiB, 2)).to eq(true)
+          expect(vg.size_for_striped_lv?(4.GiB, 2)).to eq(true)
+          expect(vg.size_for_striped_lv?(1.5.GiB, 3)).to eq(true)
+        end
+      end
+
+      context "and the physical volumes are not big enough to allocate the required size" do
+        it "returns false" do
+          expect(vg.size_for_striped_lv?(5.GiB, 2)).to eq(false)
+          expect(vg.size_for_striped_lv?(4.GiB, 3)).to eq(false)
+        end
       end
     end
   end

--- a/test/y2storage/proposal/lvm_creator_test.rb
+++ b/test/y2storage/proposal/lvm_creator_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2016] SUSE LLC
+
+# Copyright (c) [2016-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -251,7 +252,7 @@ describe Y2Storage::Proposal::LvmCreator do
         lvs = devicegraph.lvm_lvs.select { |lv| lv.lvm_vg.vg_name == "system" }
 
         expect(lvs).to contain_exactly(
-          an_object_having_attributes(lv_name: "one", size: 15.GiB - 4.MiB),
+          an_object_having_attributes(lv_name: "one", size: 15.GiB - 16.MiB),
           an_object_having_attributes(lv_name: "two", size: 5.GiB - 4.MiB)
         )
       end
@@ -276,7 +277,7 @@ describe Y2Storage::Proposal::LvmCreator do
         lvs = devicegraph.lvm_lvs.select { |lv| lv.lvm_vg.vg_name == "system" }
 
         expect(lvs).to contain_exactly(
-          an_object_having_attributes(lv_name: "one", size: 9.GiB - 4.MiB),
+          an_object_having_attributes(lv_name: "one", size: 9.GiB - 16.MiB),
           an_object_having_attributes(lv_name: "two", size: 9.GiB - 4.MiB),
           an_object_having_attributes(lv_name: "three", size: 2.GiB)
         )
@@ -288,7 +289,7 @@ describe Y2Storage::Proposal::LvmCreator do
         lvs = system_vg.lvm_lvs
         lvs_size = lvs.reduce(Y2Storage::DiskSize.zero) { |sum, lv| sum + lv.size }
 
-        expect(system_vg.size).to eq lvs_size
+        expect(system_vg.size >= lvs_size).to eq(true)
       end
     end
 
@@ -330,7 +331,7 @@ describe Y2Storage::Proposal::LvmCreator do
         lvs = devicegraph.lvm_lvs.select { |lv| lv.lvm_vg.vg_name == "system" }
 
         expect(lvs).to contain_exactly(
-          an_object_having_attributes(lv_name: "one", size: 15.GiB - 4.MiB),
+          an_object_having_attributes(lv_name: "one", size: 15.GiB - 16.MiB),
           an_object_having_attributes(lv_name: "two", size: 15.GiB)
         )
       end


### PR DESCRIPTION
## Problem

When a striped logical volume is going to be created, its size should be multiple of the physical extend size. Moreover, its resulting number of physical extents should be multiple of the number of stripes. Otherwise, *lvcreate* command will round the number of extents of the new logical volume up to make it multiple of the number of stripes. This could lead to a number of extents that exceeds the number of free extents from the volume group. 

* https://bugzilla.suse.com/show_bug.cgi?id=1180723


## Solution

Now on, the size of the new striped volume is rounded-down to make the number of extents multiple of the number of stripes. This is done by the Expert Partitioner and also by the storage proposal when a new logical volume is created . Note that the size of the logical volume is also rounded when the volume is resized.

Moreover, some new validations where added in order to ensure that the user does not try to create a striped volume with a size impossible to fit according to new number of stripes and the size of the physical volumes. Take into account that the size of a striped volume is limited by the size of the physical volumes. For example, if the volume group has 3 physical volumes whose usable sizes are: 1 GiB, 2 GiB and 5 GiB:

* A volume with 2 stripes cannot be bigger than 4 GiB.
* A volume with 3 stripes cannot be bigger than 3 GiB.
* A linear volume cannot be bigger than 8 GiB.

Similarly, when the physical volumes are edited, some new validations ensure that the striped volumes can still be created with the selected physical volumes. 

Anyway, all these new validations are not 100% accurate:

* They are based on the usable size of the physical volumes but they do not consider the free extents of each physical volume (*libstorage-ng* does not provide that info yet).
* They only check whether every individual striped volume can be allocated, but they do not check whether the volume group can allocate all the striped volumes at the same time (*libstorage-ng* should calculate how the extents are assigned between the physical volumes).


## Testing

* Tested manually
* Added new unit tests


## Screenshots

<details>
<summary>Show/Hide</summary>

![Screenshot from 2021-03-17 15-36-38](https://user-images.githubusercontent.com/1112304/111505262-5f368f80-8740-11eb-84a3-5d2492010e4b.png)

![Screenshot from 2021-03-17 15-35-34](https://user-images.githubusercontent.com/1112304/111505267-5fcf2600-8740-11eb-9914-a04d29964f56.png)

![Screenshot from 2021-03-17 15-30-42](https://user-images.githubusercontent.com/1112304/111505270-6067bc80-8740-11eb-8483-85c1e95d8ce5.png)

</details>

