### PR TITLE
Avoid error when using self

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 30 10:31:55 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Avoid to call private methods over self because it raises an
+  exception with ruby < 2.7 (related to bsc#1180723).
+- 4.3.50
+
+-------------------------------------------------------------------
 Wed Mar 17 16:21:09 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Round-down the number of physical extends according to the

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.49
+Version:        4.3.50
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/dialogs/lvm_lv_size.rb
+++ b/src/lib/y2partitioner/dialogs/lvm_lv_size.rb
@@ -74,7 +74,7 @@ module Y2Partitioner
         #
         # @return [Boolean]
         def validate
-          errors = self.errors
+          errors = send(:errors)
 
           return true if errors.none?
 

--- a/src/lib/y2partitioner/widgets/lvm_vg_devices_selector.rb
+++ b/src/lib/y2partitioner/widgets/lvm_vg_devices_selector.rb
@@ -96,7 +96,7 @@ module Y2Partitioner
       #
       # @return [Boolean]
       def validate
-        errors = self.errors
+        errors = send(:errors)
 
         return true if errors.none?
 


### PR DESCRIPTION
## Problem

After merging https://github.com/yast/yast-storage-ng/pull/1212, unit tests started failing in IBS for SLE-15-SP3, but it worked fine in OBS for Factory. The error was produced because a private method is called over *self*, which raises an exception with ruby < 2.7, see:

* https://bugs.ruby-lang.org/issues/16123
*  https://bugs.ruby-lang.org/issues/11297
* https://blog.saeloun.com/2019/12/24/ruby-2-7-allows-calling-a-private-method-with-self.html


## Solution

Avoid direct calls of private methods over *self* to make it work in both: SLE-15-SP3 (ruby 2.5) and TW.

