### PR TITLE
Make  'Change Used Devices' menu item translatable (bsc#1185060)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 20 08:42:54 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Make the 'Change Used Devices' menu item translatable
+  (bsc#1185060).
+- 4.3.51
+
+-------------------------------------------------------------------
 Tue Mar 30 10:31:55 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Avoid to call private methods over self because it raises an

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.50
+Version:        4.3.51
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/widgets/menus/modify.rb
+++ b/src/lib/y2partitioner/widgets/menus/modify.rb
@@ -68,7 +68,7 @@ module Y2Partitioner
             Item("---"),
             Item(Id(:menu_resize), _("&Resize...")),
             Item(Id(:menu_move), _("&Move...")),
-            Item(Id(:menu_change_devs), "Change &Used Devices..."),
+            Item(Id(:menu_change_devs), _("Change &Used Devices...")),
             Item("---"),
             Item(Id(:menu_create_ptable), _("Create New &Partition Table...")),
             Item(Id(:menu_clone_ptable), _("&Clone Partitions to Another Device..."))


### PR DESCRIPTION
## Problem

In the Partitioner, the **'Change Used Devices'** menu item is not translatable.

- https://bugzilla.suse.com/show_bug.cgi?id=1185060
- https://trello.com/c/s7kg1VMD/2471-1-sle15-sp3-1185060-untranslated-text-change-used-devices-in-device-menu-in-partitioner

## Solution

Make it translatable.

