### PR TITLE
try harder matching device names (bsc#1186268)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun  4 12:07:22 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>
+
+- try harder matching device names (bsc#1186268)
+- 4.3.52
+
+-------------------------------------------------------------------
 Thu May 20 08:42:54 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Make the 'Change Used Devices' menu item translatable

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.51
+Version:        4.3.52
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -279,9 +279,8 @@ module Y2Storage
           return !Regexp.last_match(1).empty? && label == Regexp.last_match(1)
         end
 
-        blk_devices.any? do |dev|
-          dev.name == spec || dev.udev_full_all.include?(spec)
-        end
+        named_device = devicegraph.find_by_any_name(spec)
+        blk_devices.include?(named_device)
       end
 
       # Whether it makes sense modify the attribute about snapper configuration

--- a/test/y2storage/filesystems/blk_filesystem_test.rb
+++ b/test/y2storage/filesystems/blk_filesystem_test.rb
@@ -499,6 +499,22 @@ describe Y2Storage::Filesystems::BlkFilesystem do
         end
       end
     end
+
+    context "when the udev name has to be looked up externally" do
+      let(:scenario) { "lvm-disk-as-pv.xml" }
+      let(:dev_name) { "/dev/system/boot" }
+      let(:dev_name_alternative) { "/dev/mapper/system-boot" }
+
+      before do
+        allow(Y2Storage::BlkDevice).to receive(:find_by_any_name)
+          .with(fake_devicegraph, dev_name_alternative)
+          .and_return(Y2Storage::BlkDevice.find_by_name(fake_devicegraph, dev_name))
+      end
+
+      it "returns true if the udev name matches" do
+        expect(filesystem.match_fstab_spec?(dev_name_alternative)).to eq true
+      end
+    end
   end
 
   describe "#display_name" do


### PR DESCRIPTION
## Task

Port https://github.com/yast/yast-storage-ng/pull/1218 to SLE15-SP3 branch.

## Original problem

- https://bugzilla.suse.com/show_bug.cgi?id=1186268
- https://trello.com/c/gNgBB1Qh

When looking up device names from fstab, check against all possible variants (udev symlinks).