### PR TITLE
ensure mount options are not doubled (bsc#1186298)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun  7 09:15:49 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>
+
+- ensure mount options are not doubled (bsc#1186298)
+- 4.3.53
+
+-------------------------------------------------------------------
 Fri Jun  4 12:07:22 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>
 
 - try harder matching device names (bsc#1186268)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.52
+Version:        4.3.53
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/planned/can_be_formatted.rb
+++ b/src/lib/y2storage/planned/can_be_formatted.rb
@@ -220,7 +220,7 @@ module Y2Storage
             []
           end
         options.push("ro") if read_only && !options.include?("rw")
-        options
+        options.uniq
       end
 
       # Creates subvolumes in the previously created filesystem that is placed

--- a/test/y2storage/planned/can_be_formatted_test.rb
+++ b/test/y2storage/planned/can_be_formatted_test.rb
@@ -87,9 +87,20 @@ describe Y2Storage::Planned::CanBeFormatted do
         planned.read_only = true
       end
 
-      it "sets the 'ro' option" do
+      it "sets the 'ro' option exactly once" do
         planned.format!(blk_device)
-        expect(blk_device.filesystem.mount_options).to include("ro")
+        expect(blk_device.filesystem.mount_options.count { |x| x == "ro" }).to eq(1)
+      end
+
+      context "and fstab options also include the 'ro' flag" do
+        before do
+          planned.fstab_options = ["ro"]
+        end
+
+        it "sets the 'ro' option exactly once" do
+          planned.format!(blk_device)
+          expect(blk_device.filesystem.mount_options.count { |x| x == "ro" }).to eq(1)
+        end
       end
 
       context "but fstab options include the 'rw' flag" do


### PR DESCRIPTION
## Task

Port https://github.com/yast/yast-storage-ng/pull/1219 to SLE-15-SP3 branch.

## Original problem

- https://bugzilla.suse.com/show_bug.cgi?id=1186298
- https://trello.com/c/I08exOoV

If a filesystem is both marked as read-only and explicitly includes `ro` in its fstab option list, it should not end up with `ro` twice in its fstab entry.

## Solution

De-duplicate fstab options.

## Note

Receive counts in `include` seem to be a rather recent rspec feature (3.10, it seems); so replacing `include().once` with something weird to make the tests work in travis.