### PR TITLE
bsc#1187270: fix control center tooltip (master)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 15 10:21:16 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the Comment entry in the desktop file so the tooltip
+  in the control center is properly translated (bsc#1187270).
+- 4.4.6
+
+-------------------------------------------------------------------
 Mon Jun  7 09:26:58 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>
 
 - ensure mount options are not doubled (bsc#1186298)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.5
+Version:        4.4.6
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/desktop/org.opensuse.yast.Disk.desktop
+++ b/src/desktop/org.opensuse.yast.Disk.desktop
@@ -19,5 +19,5 @@ Exec=xdg-su -c "/sbin/yast2 partitioner"
 
 Name=YaST Partitioner
 GenericName=Partitioner
-Comment=Partition hard disks (including RAID, LVM, and encrypted file systems)
+Comment="Partition hard disks (including RAID, LVM, and encrypted file systems)"
 StartupNotify=true


### PR DESCRIPTION
Related to [bsc#1187270](https://bugzilla.opensuse.org/show_bug.cgi?id=1187270).

See #1225 (SLE-15-SP2) and [the original issue](https://github.com/yast/yast-users/pull/303) in the yast2-users module.