### PR TITLE
Improve RSpec compatibility

### DIFF
--- a/test/y2storage/planned/can_be_formatted_test.rb
+++ b/test/y2storage/planned/can_be_formatted_test.rb
@@ -89,7 +89,7 @@ describe Y2Storage::Planned::CanBeFormatted do
 
       it "sets the 'ro' option exactly once" do
         planned.format!(blk_device)
-        expect(blk_device.filesystem.mount_options).to include("ro").once
+        expect(blk_device.filesystem.mount_options.count { |x| x == "ro" }).to eq(1)
       end
 
       context "and fstab options also include the 'ro' flag" do
@@ -99,7 +99,7 @@ describe Y2Storage::Planned::CanBeFormatted do
 
         it "sets the 'ro' option exactly once" do
           planned.format!(blk_device)
-          expect(blk_device.filesystem.mount_options).to include("ro").once
+          expect(blk_device.filesystem.mount_options.count { |x| x == "ro" }).to eq(1)
         end
       end
 


### PR DESCRIPTION
## Problem

The unit tests are failing with the version of RSpec currently available in SLE-15-SP4.

The test was introduced (in a way that was actually compatible with old versions of RSpec) in #1222, which was a pull request against the SLE-15-SP3 branch. But when merging that into the master branch (#1223), an extra commit 62f3f49b2d85 was introduced to use the most modern syntax introduced in RSpec 3.10.

Now that we are submitting the master branch of the repository to the SP4 project in the build system (which includes RSpec 3.7), that modern syntax turns to be a problem.

## Solution

Reverted commit 62f3f49b2d85 so the more compatible test is used again. Now the test looks the same in SLE-15-SP3 and in master.