### PR TITLE
Improve detection of candidate disks

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug  5 12:19:04 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Improve detection of devices that contain an installation
+  repository (bsc#1185694).
+- 4.4.7
+
+-------------------------------------------------------------------
 Tue Jun 15 10:21:16 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the Comment entry in the desktop file so the tooltip

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.6
+Version:        4.4.7
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -146,7 +146,7 @@ module Y2Storage
     #
     # Take into account that libstorage-ng intentionally filter outs many udev
     # paths and ids, so the list is expected to be incomplete. If you need to
-    # lookup a device by its udev name, check {.find_by_all_names}.
+    # lookup a device by its udev name, check {.find_by_any_name}.
     #
     # @see #udev_full_paths
     # @see #udev_full_ids

--- a/src/lib/y2storage/device_finder.rb
+++ b/src/lib/y2storage/device_finder.rb
@@ -182,7 +182,7 @@ module Y2Storage
       !StorageManager.instance.committed?
     end
 
-    # Alternative versions of the name to be also considered in searchs
+    # Alternative versions of the name to be also considered in searches
     #
     # @param device_name [String] a kernel name, udev name or any other device name
     # @return [Array<String>]

--- a/src/lib/y2storage/disk_analyzer.rb
+++ b/src/lib/y2storage/disk_analyzer.rb
@@ -315,11 +315,9 @@ module Y2Storage
 
     # Checks whether a device contains an installation repository
     #
-    # A device contains an installation repository if its kernel name or the kernel name of any of
-    # its descendant devices (see #{all_devices_from_device}) matches with the kernel name of the
-    # device included in the URI of an installation repository. Note that the device name indicated
-    # in the URI of a repository might not be a kernel name. The devices pointed by a repository are
-    # found by all its possible names, see #{repositories_devices}.
+    # A device contains an installation repository if the device or any of its descendant devices
+    # is included in the list of devices from the installation repository URI. For example, if the
+    # URI is "hd:/subdir?device=/dev/sda1", then "/dev/sda" contains an installation repository.
     #
     # @param device [BlkDevice]
     # @return [Boolean]
@@ -360,7 +358,7 @@ module Y2Storage
     def repositories_device_names
       return @repositories_device_names if @repositories_device_names
 
-      names = local_repositories.map { |r| repository_device_names(r) }.flatten.uniq
+      names = local_repositories.flat_map { |r| repository_device_names(r) }.uniq
 
       @repositories_device_names = names
     end

--- a/src/lib/y2storage/disk_analyzer.rb
+++ b/src/lib/y2storage/disk_analyzer.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2015-2019] SUSE LLC
+# Copyright (c) [2015-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -315,34 +315,18 @@ module Y2Storage
 
     # Checks whether a device contains an installation repository
     #
-    # For all possible names of the given device, it is checked if any of that
-    # names is included in the URI of an installation repository (see
-    # {#repositories_devices}). Note that the names of all devices inside the
-    # given device are considered as names of the given device (see #{device_names}),
-    # (e.g., when a disk contains a partition being used as LVM PV, the names of the
-    # LVM LVs are considered as names of the disk).
+    # A device contains an installation repository if its kernel name or the kernel name of any of
+    # its descendant devices (see #{all_devices_from_device}) matches with the kernel name of the
+    # device included in the URI of an installation repository. Note that the device name indicated
+    # in the URI of a repository might not be a kernel name. The devices pointed by a repository are
+    # found by all its possible names, see #{repositories_devices}.
     #
     # @param device [BlkDevice]
     # @return [Boolean]
     def contain_installation_repository?(device)
-      device_names(device).any? { |n| repositories_devices.include?(n) }
-    end
+      repositories_names = repositories_devices.map(&:name)
 
-    # All possible device names of a device
-    #
-    # Device names includes the kernel name and all udev names given by libstorage-ng.
-    # Moreover, it includes the names of all devices inside the given device
-    # (e.g., names of partitions inside a disk). Note that when a device contains a
-    # partition being used as LVM PV, the names of the LVM LVs are considered as names
-    # of the device.
-    #
-    # @param device [BlkDevice]
-    # @return [Array<String>]
-    def device_names(device)
-      devices = all_devices_from_device(device)
-
-      names = devices.map { |d| d.udev_full_all.prepend(d.name) }
-      names.flatten.compact.uniq
+      all_devices_from_device(device).any? { |d| repositories_names.include?(d.name) }
     end
 
     # All blk devices defined from a device, including the given device
@@ -357,13 +341,28 @@ module Y2Storage
       devices.prepend(device)
     end
 
+    # Devices whose name is indicated in the URI of the installation repositories
+    #
+    # @return [Array<BlkDevice>]
+    def repositories_devices
+      return @repositories_devices if @repositories_devices
+
+      devices = repositories_device_names.map { |n| devicegraph.find_by_any_name(n) }.compact
+
+      @repositories_devices = devices
+    end
+
     # Device names indicated in the URI of the installation repositories
     #
     # @see #local_repositories
     #
     # @return [Array<String>]
-    def repositories_devices
-      @repositories_devices ||= local_repositories.map { |r| repository_devices(r) }.flatten
+    def repositories_device_names
+      return @repositories_device_names if @repositories_device_names
+
+      names = local_repositories.map { |r| repository_device_names(r) }.flatten.uniq
+
+      @repositories_device_names = names
     end
 
     # TODO: This method should be moved to Y2Packager::Repository class
@@ -376,7 +375,7 @@ module Y2Storage
     #
     # @param repository [Y2Packager::Repository]
     # @return [Array<String>]
-    def repository_devices(repository)
+    def repository_device_names(repository)
       match_data = repository.url.to_s.match(/.*device[s]?=([^&]*)/)
       return [] unless match_data
 

--- a/test/y2storage/disk_analyzer_test.rb
+++ b/test/y2storage/disk_analyzer_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2016-2019] SUSE LLC
+
+# Copyright (c) [2016-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -685,6 +686,21 @@ describe Y2Storage::DiskAnalyzer do
 
         it "does not include the disk devices used by the MD RAID" do
           expect(candidate_disks).to_not include("/dev/sda", "/dev/sdb")
+        end
+      end
+
+      context "when the url of an installation repository points to an udev symlink" do
+        before do
+          allow(Y2Storage::BlkDevice).to receive(:find_by_any_name)
+            .with(fake_devicegraph, udev_name).and_return(sda1)
+        end
+
+        let(:udev_name) { "/dev/disk/by-id/111-222-3333" }
+
+        let(:repository_url) { "dvd:/?devices=#{udev_name}" }
+
+        it "does not include the disk device" do
+          expect(candidate_disks).to_not include("/dev/sda1")
         end
       end
     end


### PR DESCRIPTION
## Problem

The storage proposal looks for the devices that can be used for the installation (a.k.a. *candidate disks*). A device is considered a *candidate disk* if it fulfills some conditions. For example, the devices containing a repository  for the installation are discarded as *candidate disks*. The URI of the installation repositories (e.g., *hd:/?device=/dev/disk/by-id/mmc-EB1QT_0xd948672b-part2*) are analyzed to determine whether a device contains a repository. The devices indicated in the URI are not used as *candidate disks*. 

The URI of the repository can point to a device by the kernel name or by one of the udev symlinks. In the last case, the device could not be found if *libstorage-ng* does not provide that udev name (note that *libstorage-ng* filters some udev names). As result, the device is not excluded as *candidate disk*. 

* https://bugzilla.suse.com/show_bug.cgi?id=1185694


## Solution

Improve the detection of the devices indicated in the URI of an installation repository. Now, the `DeviceFinder` utility is used, which is able to find a device by any name including any symbolic link in the */dev* directory.

## Testing

- Added a new unit test
- This should be manually tested by the reported in the failing scenario.
