### PR TITLE
Recommends libyui-qt-graph

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep 30 11:21:19 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Recommend to install libyui-qt-graph package (bsc#1191109) in
+  order to offer the View/Device Graphs menu option.
+- 4.4.8
+
+-------------------------------------------------------------------
 Thu Aug  5 12:19:04 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Improve detection of devices that contain an installation

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.7
+Version:        4.4.8
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -61,6 +61,8 @@ Requires:       yast2-ycp-ui-bindings >= 4.3.4
 Requires:       rubygem(%{rb_default_ruby_abi}:ruby-dbus)
 Requires(post): %fillup_prereq
 
+Recommends:	(libyui-qt-graph if libyui-qt)
+
 Obsoletes:      yast2-storage
 
 %description


### PR DESCRIPTION
## Problem

The menu option "View --> Device Graphs" is not shown if *libyui-qt-graph* package is not installed. yast2-storage-ng should recommend such a package. 

* https://bugzilla.suse.com/show_bug.cgi?id=1191109 

## Solution

Recommends to install *libyui-qt-graph*, but only if *libyui-qt* is already installed.

* See https://documentation.suse.com/sbp/all/single-html/SBP-RPM-Packaging/index.html#sec-weak-dependencies