### PR TITLE
Ask for a --plain output when (un)masking systemd units

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 14 14:19:03 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Fix (un)masking systemd units by using the systemctl --plain
+  flag for getting an output without status glyphs (bsc#1191347).
+- 4.4.9
+
+-------------------------------------------------------------------
 Thu Sep 30 11:21:19 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Recommend to install libyui-qt-graph package (bsc#1191109) in

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.8
+Version:        4.4.9
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/bin/mask-systemd-units
+++ b/src/bin/mask-systemd-units
@@ -32,7 +32,7 @@
 
 query_units()
 {
-    /usr/bin/systemctl list-units --full --all --type mount,swap --no-legend | while read -r unit dummy ; do
+    /usr/bin/systemctl list-units --full --all --type mount,swap --no-legend --plain | while read -r unit dummy ; do
 
 	# skip root and sysroot
 	if [[ $unit == -.mount || $unit == sysroot.mount ]] ; then


### PR DESCRIPTION
Same than #1234, but for `master`.

See 

- https://bugzilla.suse.com/show_bug.cgi?id=1191347
- https://trello.com/c/Cs2LigI1/ (internal link)
