### PR TITLE
Move the check for SD cards to a separate method

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov  2 15:46:24 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Change the API to avoid the performance penalty introduced by
+  the original check for SD Cards (related to bsc#1187438).
+
+-------------------------------------------------------------------
 Thu Oct 21 11:50:04 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Install by default to any available Dell BOSS drive and identify

--- a/src/lib/y2storage/dialogs/guided_setup/helpers/disk.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/helpers/disk.rb
@@ -76,7 +76,7 @@ module Y2Storage
           end
 
           def sd_label(disk)
-            return "" unless disk.is?(:sd_card)
+            return "" unless disk.sd_card?
 
             _("SD Card")
           end

--- a/src/lib/y2storage/disk.rb
+++ b/src/lib/y2storage/disk.rb
@@ -113,16 +113,8 @@ module Y2Storage
 
     protected
 
-    # @see #types_for_is
-    SD_CARD_DRIVER = "mmcblk".freeze
-    private_constant :SD_CARD_DRIVER
-
     def types_for_is
-      types = super
-      types << :disk
-      # Check whether this is a MMC (MultiMedia Card) or a SD (Secure Digital) card
-      types << :sd_card if driver&.include?(SD_CARD_DRIVER)
-      types
+      super << :disk
     end
 
     # Whether this device can be in general treated like a disk for YaST

--- a/src/lib/y2storage/disk_device.rb
+++ b/src/lib/y2storage/disk_device.rb
@@ -47,6 +47,19 @@ module Y2Storage
       descendants.any? { |d| d.is?(:bios_raid) }
     end
 
+    # @see #sd_card?
+    SD_CARD_DRIVER = "mmcblk".freeze
+    private_constant :SD_CARD_DRIVER
+
+    # Check if this is a MMC (MultiMedia Card) or a SD (Secure Digital) card
+    #
+    # @return [Boolean]
+    def sd_card?
+      return false unless respond_to?(:driver)
+
+      driver&.include?(SD_CARD_DRIVER)
+    end
+
     protected
 
     def types_for_is

--- a/src/lib/y2storage/guided_proposal.rb
+++ b/src/lib/y2storage/guided_proposal.rb
@@ -328,11 +328,24 @@ module Y2Storage
     # @param device [BlkDevice]
     # @return [boolean]
     def maybe_removable?(device)
-      return true if device.is?(:sd_card)
-      return true if device.respond_to?(:usb?) && device.usb?
-      return true if device.respond_to?(:firewire?) && device.firewire?
+      return true if dev_is?(device, :sd_card?)
+      return true if dev_is?(device, :usb?)
+      return true if dev_is?(device, :firewire?)
 
       false
+    end
+
+    # Checks whether the given device returns true for the given method
+    #
+    # @see #maybe_removable?
+    #
+    # @param device [BlkDevice]
+    # @param method [Symbol]
+    # @return [boolean]
+    def dev_is?(device, method)
+      return false unless device.respond_to?(method)
+
+      device.public_send(method)
     end
 
     # All proposed volumes sets from the settings

--- a/test/support/guided_setup_context.rb
+++ b/test/support/guided_setup_context.rb
@@ -42,7 +42,7 @@ RSpec.shared_context "guided setup requirements" do
   # @param args [Hash] the key :partitions is turned into a collection of Partition doubles to mock
   #   Disk#partitions, the rest are passed to the double instance as mocked messages
   def disk(name, args = {})
-    defaults = { size: Y2Storage::DiskSize.new(0), boss?: false, partitions: {} }
+    defaults = { size: Y2Storage::DiskSize.new(0), boss?: false, sd_card?: false, partitions: {} }
     args = defaults.merge(args)
     args[:name] = name
 

--- a/test/y2storage/dialogs/guided_setup/helpers/disk_test.rb
+++ b/test/y2storage/dialogs/guided_setup/helpers/disk_test.rb
@@ -35,7 +35,7 @@ describe Y2Storage::Dialogs::GuidedSetup::Helpers::Disk do
       allow(disk).to receive(:respond_to?).with(anything)
       allow(disk).to receive(:respond_to?).with(:transport).and_return(true)
       allow(disk).to receive(:transport).and_return(transport)
-      allow(disk).to receive(:is?).with(:sd_card).and_return(sd_card)
+      allow(disk).to receive(:sd_card?).and_return(sd_card)
       allow(disk).to receive(:boss?).and_return(boss)
 
       allow(transport).to receive(:is?).with(:usb).and_return(usb)


### PR DESCRIPTION
## Problem

Commit 41d4ae7a98824290b5 introduced a check to know whether a disk is an SD/MMC card. But it did it as part of the method `#types_for_is`. That implies such circumstance is checked too often. Not only when the caller wants to know whether the disk is an SD card... but basically every time the nature of the device is checked with any purpose.

The information about the disk being an SD card or not is not present in the devicegraph, it needs an extra check with hwinfo. During normal operation, the result of the calls to hwinfo are cached, so it doesn't have a big impact. But in the testsuite, where nothing is cached, the impact is huge. It multiplies x5 the execution time of the testsuite.

## Solution

Move the check to a separate method, so the hwinfo call is only executed when the caller really wants to know if this an SD Card or not.

## Testing

Adjusted unit tests (they run in ~4 minutes again on my machine).