### PR TITLE
bsc#1192124: AutoYaST does not honor the `pesize` element

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov  3 11:46:26 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Set the volume group extent size according to the AutoYaST
+  profile (bsc#1192124).
+- 4.2.119
+
+-------------------------------------------------------------------
 Tue Jun 15 10:21:16 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the Comment entry in the desktop file so the tooltip

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.118
+Version:        4.2.119
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/proposal/autoinst_vg_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_vg_planner.rb
@@ -31,10 +31,7 @@ module Y2Storage
       # @return [Planned::LvmVg] Planned volume group
       def planned_devices(drive)
         planned_vg = Y2Storage::Planned::LvmVg.new(volume_group_name: File.basename(drive.device))
-
-        if drive.pesize
-          planned_vg.extent_size = DiskSize.parse(drive.pesize, legacy_units: true)
-        end
+        planned_vg.extent_size = DiskSize.parse(drive.pesize, legacy_units: true) if drive.pesize
 
         pools, regular = drive.partitions.partition(&:pool)
         (pools + regular).each_with_object(planned_vg.lvs) do |lv_section, planned_lvs|

--- a/src/lib/y2storage/proposal/autoinst_vg_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_vg_planner.rb
@@ -32,6 +32,10 @@ module Y2Storage
       def planned_devices(drive)
         planned_vg = Y2Storage::Planned::LvmVg.new(volume_group_name: File.basename(drive.device))
 
+        if drive.pesize
+          planned_vg.extent_size = DiskSize.parse(drive.pesize, legacy_units: true)
+        end
+
         pools, regular = drive.partitions.partition(&:pool)
         (pools + regular).each_with_object(planned_vg.lvs) do |lv_section, planned_lvs|
           planned_lv = planned_for_lv(drive, planned_vg, lv_section)

--- a/src/lib/y2storage/proposal/lvm_creator.rb
+++ b/src/lib/y2storage/proposal/lvm_creator.rb
@@ -106,7 +106,9 @@ module Y2Storage
       # @return [Devicegraph] New devicegraph containing the new volume group
       def create_volume_group(planned_vg, devicegraph)
         name = available_name(planned_vg.volume_group_name, devicegraph)
-        LvmVg.create(devicegraph, name)
+        vg = LvmVg.create(devicegraph, name)
+        vg.extent_size = planned_vg.extent_size if planned_vg.extent_size
+        vg
       end
 
       # Extends the given volume group by adding as physical volumes the

--- a/test/y2storage/proposal/autoinst_vg_planner_test.rb
+++ b/test/y2storage/proposal/autoinst_vg_planner_test.rb
@@ -41,7 +41,8 @@ describe Y2Storage::Proposal::AutoinstVgPlanner do
     let(:drive) { Y2Storage::AutoinstProfile::DriveSection.new_from_hashes(vg) }
 
     let(:vg) do
-      { "device" => "/dev/#{lvm_group}", "partitions" => partitions, "type" => :CT_LVM }
+      { "device" => "/dev/#{lvm_group}", "partitions" => partitions,
+        "type" => :CT_LVM, "pesize" => "8M" }
     end
 
     let(:root_spec) do
@@ -62,7 +63,8 @@ describe Y2Storage::Proposal::AutoinstVgPlanner do
       expect(vg).to be_a(Y2Storage::Planned::LvmVg)
       expect(vg).to have_attributes(
         "volume_group_name" => lvm_group,
-        "reuse_name"        => nil
+        "reuse_name"        => nil,
+        "extent_size"       => 8.MiB
       )
       expect(vg.lvs).to contain_exactly(
         an_object_having_attributes(


### PR DESCRIPTION
This PR merges #1241 into `SLE-15-SP2`.

## Problem

AutoYaST ignores the `pesize` element.

- [bsc#1192124](https://bugzilla.suse.com/show_bug.cgi?id=1192124)

## Solution

Initialize the `extent_size` according to the `pesize` when planning the LVM volume group.

## Testing

- *Added a new unit test*
- *Tested manually*