### PR TITLE
Fixed plural string comments

### DIFF
--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -145,10 +145,10 @@ module Y2Storage
       def boss_html
         return "" if boss_devices.empty?
 
+        # TRANSLATORS: %s is a linux device name (eg. /dev/sda) (singular),
+        #  or a list of comma-separated device names (eg. "/dev/sda, /dev/sdb") (plural)
         n_(
-          # TRANSLATORS: %s is a linux device name (eg. /dev/sda)
           "<p>The device %s is a Dell BOSS drive.</p>",
-          # TRANSLATORS: %s is a list of comma-separated device names (eg. "/dev/sda, /dev/sdb")
           "<p>The following devices are Dell BOSS drives: %s.</p>",
           boss_devices.size
         ) % boss_devices.map(&:name).join(", ")


### PR DESCRIPTION
## Problem

The Ruby gettext crashes when the comments are *inside* the n_() call, calling `rake pot` failed with this error:

```
/usr/lib64/ruby/gems/2.5.0/gems/gettext-3.2.5/lib/gettext/po_entry.rb:305:in `format':
This POEntry is a kind of plural but the msgid_plural property is nil. msgid:
<p>The device %s is a Dell BOSS drive.</p> (GetText::POEntry::NoMsgidPluralError)
```

## Solution

Move the comments outside the `n_()` call.

## Testing

The `rake pot` now does not crash and the generated `storage.pot` file contains
the text also with the comment:

```
#. TRANSLATORS: %s is a linux device name (eg. /dev/sda) (singular),
#. or a list of comma-separated device names (eg. "/dev/sda, /dev/sdb") (plural)
#: src/lib/y2storage/dialogs/proposal.rb:150
#, c-format
msgid "<p>The device %s is a Dell BOSS drive.</p>"
msgid_plural "<p>The following devices are Dell BOSS drives: %s.</p>"
msgstr[0] ""
msgstr[1] ""
```

## Notes

I tried using the latest Ruby gettext gem and it works fine with it. So my first idea was to upgrade the gem which we use.

But unfortunately it turned out that the [latest gettext version](https://rubygems.org/gems/gettext/versions/3.4.1) (3.4.1) depends on the [red-datasets](https://rubygems.org/gems/red-datasets) gem which depends on the [csv](https://rubygems.org/gems/csv) and [rubyzip](https://rubygems.org/gems/rubyzip) gems. We would need to update or add all these dependencies in SLE15-SP4... :thinking: 

I checked the version which is currently in [Factory](https://build.opensuse.org/package/show/openSUSE:Factory/rubygem-gettext) (3.3.8) but this already includes these new dependencies. :worried: At this point I gave up and simply fixed the comments... 

