### PR TITLE
[SLE-15-SP1] Fix duplicate PV error detection with disabled multipath

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 16 16:38:49 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Fix duplicate PV error detection with disabled multipath
+  (related to bsc#1170216).
+- 4.1.99
+
+-------------------------------------------------------------------
 Wed Nov  3 11:46:26 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Set the volume group extent size according to the AutoYaST

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-storage-ng
-Version:        4.1.98
+Version:        4.1.99
 Release:	0
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2storage/callbacks/libstorage_callback.rb
+++ b/src/lib/y2storage/callbacks/libstorage_callback.rb
@@ -123,7 +123,7 @@ module Y2Storage
       # @param what [String] details coming from libstorage-ng
       # @return [String]
       def error_description(what)
-        if what.match?(/WARNING: PV .* was already found on .*/i)
+        if what.match?(/Cannot activate LVs in VG .* while PVs appear on duplicate devices/i)
           duplicated_pv_description
         else
           _("Unexpected situation found in the system.")

--- a/test/y2storage/callbacks/callbacks_examples.rb
+++ b/test/y2storage/callbacks/callbacks_examples.rb
@@ -74,7 +74,7 @@ stdout:
 
 stderr:
   WARNING: Failed to connect to lvmetad. Falling back to device scanning.
-  WARNING: PV uecMW2-1Qgu-b367-WBKL-uM2h-BRDB-nYva0a on /dev/sda4 was already found on /dev/sda2.
+  WARNING: Not using device /dev/sda4 for PV uecMW2-1Qgu-b367-WBKL-uM2h-BRDB-nYva0a.
   WARNING: PV uecMW2-1Qgu-b367-WBKL-uM2h-BRDB-nYva0a prefers device /dev/sda2 because device size is correct.
   Cannot activate LVs in VG vg0 while PVs appear on duplicate devices.
 


### PR DESCRIPTION
## Problem

The installer has lost a specific error message when the same LVM **P**hysical **V**olume is found in several devices, which might means there are multipath devices in the system but multipath support is disabled. See screenshots below:

| SLE-15-GA | SLE-15-SP1 | openSUE TW |
| - | - | - |
| ![sle-15-ga-lvm-failed](https://user-images.githubusercontent.com/1691872/142013862-244695d6-0c6e-4938-a915-a16eedba177a.png) | ![sle-15-sp1-lvm-failed](https://user-images.githubusercontent.com/1691872/142013901-9476ab05-c047-4424-b730-94eac0cb1639.png) | ![openSUSE-TW-lvm-failed](https://user-images.githubusercontent.com/1691872/142013922-126c2172-15dd-4a77-b5e0-0ace7f0d341d.png) |
| lvm2 2.02.177-5.11.x86_64 | lvm2 2.02.180-10.16.x86_64 | lvm2 2.03.12-3.2.x86_64 |

* https://trello.com/c/jFw6d1l4/ (internal link)


## Why?

Because the lvm2 `"PV %s on %s was already found on %s."` message error used to catch the problem is not available anymore

* it was introduced [on May 6, 2016](https://github.com/lvmteam/lvm2/commit/8b7a78c728be3b9af698dae9344d01752c4cf615)  (lvm2 2.02.153) as part of the improvements of duplicate PVs handling
* **[on May 21, 2018](https://github.com/lvmteam/lvm2/commit/3c9ed33f83c90aa15e57ba6dc12d8f1a80afab6d) (lvm2 2.02.178) it changed from _warning_ to _debug cache_**. See [L2306-R2403](https://github.com/lvmteam/lvm2/commit/3c9ed33f83c90aa15e57ba6dc12d8f1a80afab6d#diff-7d86c19b8443c191b1e6bd52aec69a3a797b45c8e6a1757e2fd1324fbced42a7L2306-R2403)
* Finally, on [Aug 16, 2019](https://github.com/lvmteam/lvm2/commit/e01fddc5789b10d1bd15e8aee8985f14e81d3087) (lvm2 2.03.06) it was replaced by `Saving initial duplicate device %s previously seen on %s with PVID %s."` (but still being not a warning).

## Solution

Changing the [expected message to detect the situation](https://github.com/yast/yast-storage-ng/blob/7f15304a0b7226804f3570d8db58f20bf71af7d4/src/lib/y2storage/callbacks/libstorage_callback.rb#L121). 

Taking a closer look to the details (see below) can be checked that [`"Cannot activate LVs in VG %s while PVs appear on duplicate devices."`](https://github.com/lvmteam/lvm2/blob/e01fddc5789b10d1bd15e8aee8985f14e81d3087/tools/toollib.c#L1054) error message [still](https://github.com/lvmteam/lvm2/commit/8b7a78c728be3b9af698dae9344d01752c4cf615#diff-91736a4c44bf479e93e5aa351435f8cf6f54ea00603222c2083e56cc022a5187R1077) there. So, looks _stable_ enough to match the expectation for displaying the [_human-readable description to report the same PV is found more than once_](https://github.com/yast/yast-storage-ng/blob/7f15304a0b7226804f3570d8db58f20bf71af7d4/src/lib/y2storage/callbacks/libstorage_callback.rb#L128-L157).


| SLE-15-GA | SLE-15-SP1 | openSUE TW |
| - | - | - |
| ![sle-15-ga-lvm-failed-details](https://user-images.githubusercontent.com/1691872/142014383-96d0cf74-9c42-4ac6-8507-6125c74c059b.png) | ![sle-15-sp1-lvm-failed-details](https://user-images.githubusercontent.com/1691872/142014409-5e4d2080-3b8d-4077-8a93-087f508aa53c.png) | ![openSUSE-TW-lvm-failed-details](https://user-images.githubusercontent.com/1691872/142014423-09e43e5b-f160-4f1e-a793-958d23c62e55.png) |

## Tests

* Unit tests updated (libstorage callback examples)
* Tested manually via driver update (SLE-15-SP1)

| Error | Details |
|-|-|
| ![sle15sp1-multipath-pv-fixed-dud](https://user-images.githubusercontent.com/1691872/142035460-f8878e12-c2af-4e5c-871b-8c2c52629a42.png) | ![sle15sp1-multipath-pv-details-fixed-dud](https://user-images.githubusercontent.com/1691872/142035481-84e26071-cc41-440d-9fef-123193e48b1b.png) |

### Steps to reproduce the scenario (aka _emulating a multipath LVM PV_)

* Using `yast2 disk` (or the tool(s) of your choice)
  - Create a partition (hereinafter _part1_)
  - Create an LVM VG (onwards _vg1_) using _part1_ as PV
  - Create an LVM LV on top of _vg1_
  - Create another partition (henceforward _part2_)
  - Commit changes
* Clone _part1_ into _part2_
  - `dd if=part1 of=part2`

## Aside note

While trying to reproduce the scenario, I was hit by a known (and fortunately fixed) yast2-network issue about triggering the storage probing. See https://github.com/yast/yast-network/pull/1176 for more details. Unfortunately, the fix cannot be applied via installer self-update because the network activation and configuration happens before.

---

:warning: Please, ignore the _vg15_ references in the screenshots. Only _vg16_ is relevant for the purpose of this _documentation_ :warning:
