### PR TITLE
[SLE-15-SP3] Fix duplicate PV error detection with disabled multipath

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 16 16:38:49 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Fix duplicate PV error detection with disabled multipath
+  (related to bsc#1170216).
+- 4.3.58
+
+-------------------------------------------------------------------
 Wed Nov  3 11:46:26 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Set the volume group extent size according to the AutoYaST

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.3.57
+Version:        4.3.58
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/callbacks/libstorage_callback.rb
+++ b/src/lib/y2storage/callbacks/libstorage_callback.rb
@@ -118,7 +118,7 @@ module Y2Storage
       # @param what [String] details coming from libstorage-ng
       # @return [String]
       def error_description(what)
-        if what.match?(/WARNING: PV .* was already found on .*/i)
+        if what.match?(/Cannot activate LVs in VG .* while PVs appear on duplicate devices/i)
           duplicated_pv_description
         else
           _("Unexpected situation found in the system.")

--- a/test/y2storage/callbacks/callbacks_examples.rb
+++ b/test/y2storage/callbacks/callbacks_examples.rb
@@ -95,7 +95,7 @@ RSpec.shared_examples "general #error examples" do
 
         stderr:
           WARNING: Failed to connect to lvmetad. Falling back to device scanning.
-          WARNING: PV uecMW2-1Qgu-b367-WBKL-uM2h-BRDB-nYva0a on /dev/sda4 was already found on /dev/sda2.
+          WARNING: Not using device /dev/sda4 for PV uecMW2-1Qgu-b367-WBKL-uM2h-BRDB-nYva0a.
           WARNING: PV uecMW2-1Qgu-b367-WBKL-uM2h-BRDB-nYva0a prefers device /dev/sda2 because device size is correct.
           Cannot activate LVs in VG vg0 while PVs appear on duplicate devices.
 


### PR DESCRIPTION
## Problem

> The installer has lost a specific error message when the same LVM Physical Volume is found in several devices, which might means there are multipath devices in the system but multipath support is disabled

## Solution

See https://github.com/yast/yast-storage-ng/pull/1247 for reading the full story.

## Manual test

* Tested manually via driver update (SLE-15-SP3)

| Error | Details |
|-|-|
| ![sle15sp3-multipath-pv-fixed-dud](https://user-images.githubusercontent.com/1691872/142254835-3bf0b8d2-e814-49dc-bcfe-c9e06cca2a66.png) | ![sle15sp3-multipath-pv-details-fixed-dud](https://user-images.githubusercontent.com/1691872/142254846-63d2ffea-6e4d-4e84-9be6-9c7f477ca195.png) |

