### PR TITLE
Fix duplicate PV error detection with disabled multipath

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -3,7 +3,6 @@ Thu Nov 18 10:22:49 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Fix duplicate PV error detection with disabled multipath
   (related to bsc#1170216).
-- 4.4.14
 
 -------------------------------------------------------------------
 Wed Nov 17 13:31:47 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.14
+Version:        4.4.13
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only


### PR DESCRIPTION
## Problem

> The installer has lost a specific error message when the same LVM Physical Volume is found in several devices, which might means there are multipath devices in the system but multipath support is disabled

## Solution

See https://github.com/yast/yast-storage-ng/pull/1247 for reading the full story.