### PR TITLE
Document and fix BootRequirementsChecker for LUKS2

### DIFF
--- a/doc/boot-requirements.md
+++ b/doc/boot-requirements.md
@@ -281,12 +281,12 @@
 					- **requires a new GRUB partition**
 		- with an AutoYaST profile that places '/' in a LUKS2 device
 			- if there is no GRUB partition
-				- **requires new GRUB and /boot partitions (Grub2 auto-config cannot handle LUKS2**
+				- **requires new GRUB and /boot partitions (Grub2 auto-config cannot handle LUKS2)**
 			- if there is already a GRUB partition
 				- and it is on the boot disk
 					- **requires a new /boot partition (Grub2 auto-config cannot handle LUKS2)**
 				- and it is not on the boot disk
-					- **requires new GRUB and /boot partitions (Grub2 auto-config cannot handle LUKS2**
+					- **requires new GRUB and /boot partitions (Grub2 auto-config cannot handle LUKS2)**
 	- with a MS-DOS partition table
 		- if the MBR gap is big enough to embed Grub
 			- in a partitions-based proposal

--- a/doc/boot-requirements.md
+++ b/doc/boot-requirements.md
@@ -36,6 +36,11 @@
 				- **only requires to use the existing EFI partition**
 			- and it is not on the boot disk
 				- **requires only a new /boot/efi partition**
+- with an AutoYaST profile that places '/' in a LUKS2 device
+	- if there are no EFI partitions
+		- **requires new partitions for /boot/efi and for /boot (Grub2 auto-config cannot handle LUKS2)**
+	- if there is already a suitable EFI partition in the boot disk
+		- **requires to reuse EFI and create a /boot partition (Grub2 auto-config cannot handle LUKS2)**
 
 ## needed partitions in a PPC64 system
 - in a non-PowerNV system (KVM/LPAR)
@@ -66,14 +71,14 @@
 				- **does not require any partition (PReP will be reused and Grub2 can handle this setup)**
 			- and it is not on the boot disk
 				- **requires only a new PReP partition (to allocate Grub2)**
-	- with an encrypted proposal using LUKS2
+	- with an AutoYaST profile that places '/' in a LUKS2 device
 		- if there are no suitable PReP partitions in the target disk
-			- **requires a new PReP and a new /boot partition**
+			- **requires a new PReP and a new /boot partition (Grub2 auto-config cannot handle LUKS2)**
 		- if there is already a suitable PReP partition in the disk
 			- and it is on the boot disk
-				- **requires a /boot partition**
+				- **requires a separate /boot partition (Grub2 auto-config cannot handle LUKS2)**
 			- and it is not on the boot disk
-				- **requires a new PReP and a new /boot partition**
+				- **requires a new PReP and a new /boot partition (Grub2 auto-config cannot handle LUKS2)**
 - in bare metal (PowerNV)
 	- with a partitions-based proposal
 		- **does not require any booting partition (no Grub stage1, PPC firmware parses grub2.cfg)**
@@ -164,21 +169,25 @@
 		- not using Btrfs (i.e. /boot is within a XFS or ext2/3/4 partition)
 			- **does not require additional partitions (the firmware can find the kernel)**
 		- using Btrfs (i.e. /boot is not in XFS or ext2/3/4)
-			- **requires only a separate /boot/zipl partition (to allocate Grub2)**
+			- **requires only a separate /boot/zipl partition (to allocate Grub2+kernel+initrd)**
 	- with a LVM-based proposal
-		- **requires only a /boot/zipl partition (to allocate Grub2)**
+		- **requires only a /boot/zipl partition (to allocate Grub2+kernel+initrd)**
 	- with an encrypted proposal
-		- **requires only a /boot/zipl partition (to allocate Grub2)**
+		- **requires only a /boot/zipl partition (to allocate Grub2+kernel+initrd)**
+	- with an AutoYaST profile that places '/' in a LUKS2 device
+		- **requires only a /boot/zipl partition (to allocate Grub2+kernel+initrd)**
 - trying to install in a zFCP disk (no DASD)
 	- with a partitions-based proposal
 		- not using Btrfs (i.e. /boot is within a XFS or ext2/3/4 partition)
 			- **does not require additional partitions (the firmware can find the kernel)**
 		- using Btrfs (i.e. /boot is not in XFS or ext2/3/4)
-			- **requires only a separate /boot/zipl partition (to allocate Grub2)**
+			- **requires only a separate /boot/zipl partition (to allocate Grub2+kernel+initrd)**
 	- with a LVM-based proposal
-		- **requires only a /boot/zipl partition (to allocate Grub2)**
+		- **requires only a /boot/zipl partition (to allocate Grub2+kernel+initrd)**
 	- with an encrypted proposal
-		- **requires only a /boot/zipl partition (to allocate Grub2)**
+		- **requires only a /boot/zipl partition (to allocate Grub2+kernel+initrd)**
+	- with an AutoYaST profile that places '/' in a LUKS2 device
+		- **requires only a /boot/zipl partition (to allocate Grub2+kernel+initrd)**
 - trying to install in a (E)CKD DASD disk
 	- if the disk is formatted as LDL
 		- **raises an error (no proposal possible in such disk) - FIXME: why?**
@@ -187,11 +196,13 @@
 			- not using Btrfs (i.e. /boot is within a XFS or ext2/3/4 partition)
 				- **does not require additional partitions (the firmware can find the kernel)**
 			- using Btrfs (i.e. /boot is not in XFS or ext2/3/4)
-				- **requires only a separate /boot/zipl partition (to allocate Grub2)**
+				- **requires only a separate /boot/zipl partition (to allocate Grub2+kernel+initrd)**
 		- with a LVM-based proposal
-			- **requires only a /boot/zipl partition (to allocate Grub2)**
+			- **requires only a /boot/zipl partition (to allocate Grub2+kernel+initrd)**
 		- with an encrypted proposal
-			- **requires only a /boot/zipl partition (to allocate Grub2)**
+			- **requires only a /boot/zipl partition (to allocate Grub2+kernel+initrd)**
+		- with an AutoYaST profile that places '/' in a LUKS2 device
+			- **requires only a /boot/zipl partition (to allocate Grub2+kernel+initrd)**
 - when proposing a /boot/zipl partition
 	- **requires /boot/zipl to be on the boot disk**
 	- **requires /boot/zipl to be a non-encrypted partition**
@@ -237,6 +248,11 @@
 					- **only requires to use the existing EFI partition**
 				- and it is not on the boot disk
 					- **requires only a new /boot/efi partition**
+	- with an AutoYaST profile that places '/' in a LUKS2 device
+		- if there are no EFI partitions
+			- **requires new partitions for /boot/efi and for /boot (Grub2 auto-config cannot handle LUKS2)**
+		- if there is already a suitable EFI partition in the boot disk
+			- **requires to reuse EFI and create a /boot partition (Grub2 auto-config cannot handle LUKS2)**
 - not using UEFI (legacy PC)
 	- with GPT partition table
 		- in a partitions-based proposal
@@ -263,6 +279,14 @@
 					- **does not require any particular volume**
 				- and it is not on the boot disk
 					- **requires a new GRUB partition**
+		- with an AutoYaST profile that places '/' in a LUKS2 device
+			- if there is no GRUB partition
+				- **requires new GRUB and /boot partitions (Grub2 auto-config cannot handle LUKS2**
+			- if there is already a GRUB partition
+				- and it is on the boot disk
+					- **requires a new /boot partition (Grub2 auto-config cannot handle LUKS2)**
+				- and it is not on the boot disk
+					- **requires new GRUB and /boot partitions (Grub2 auto-config cannot handle LUKS2**
 	- with a MS-DOS partition table
 		- if the MBR gap is big enough to embed Grub
 			- in a partitions-based proposal
@@ -271,8 +295,8 @@
 				- **does not require any particular volume**
 			- in an encrypted proposal
 				- **does not require any particular volume**
-			- in an encrypted proposal using LUKS2
-				- **requires a new /boot partition to install Grub into it**
+			- with an AutoYaST profile that places '/' in a LUKS2 device
+				- **requires a new /boot partition (Grub2 auto-config cannot handle LUKS2)**
 		- with a MBR gap too small to accommodate Grub
 			- in a partitions-based proposal
 				- if the file-system selected for / can embed grub (ext2/3/4 or btrfs)

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Nov 18 16:22:04 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed calculation of partitions needed for booting when AutoYaST
+  specifies an alternative crypt_method, like pervasive_luks2
+  (related to jsc#SLE-7376 and jsc#SLE-21308).
+- 4.4.14
+
+-------------------------------------------------------------------
 Thu Nov 18 10:22:49 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Fix duplicate PV error detection with disabled multipath

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.13
+Version:        4.4.14
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/encryption_method/base.rb
+++ b/src/lib/y2storage/encryption_method/base.rb
@@ -124,6 +124,13 @@ module Y2Storage
         encryption_process.create_device(blk_device, dm_name)
       end
 
+      # Returns the encryption type to be used
+      #
+      # @return [Y2Storage::EncryptionType]
+      def encryption_type
+        encryption_process.encryption_type
+      end
+
       private
 
       # Returns an instance of the encryption process (e.g. EncryptionProcesses::Luks1)

--- a/src/lib/y2storage/encryption_processes/luks.rb
+++ b/src/lib/y2storage/encryption_processes/luks.rb
@@ -52,8 +52,6 @@ module Y2Storage
         enc
       end
 
-      private
-
       # @see EncryptionProcesses::Base#encryption_type
       def encryption_type
         return EncryptionType::LUKS2 if version == :luks2

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -122,6 +122,11 @@ module Y2Storage
         def record_stdin(_stdin); end
       end
 
+      # @see Base#encryption_type
+      def encryption_type
+        EncryptionType::LUKS2
+      end
+
       private
 
       # @return [SecureKey] master key used to encrypt the device
@@ -130,11 +135,6 @@ module Y2Storage
       # @return [Array<String>] lines of the output of the "zkey cryptsetup"
       #   command executed during the pre-commit phase
       attr_reader :zkey_cryptsetup_output
-
-      # @see Base#encryption_type
-      def encryption_type
-        EncryptionType::LUKS2
-      end
 
       # Custom Cheetah recorder to prevent leaking the password to the logs
       #

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -38,9 +38,9 @@ module Y2Storage
       private_constant :ENCRYPTION_OVERHEAD
 
       # @!attribute encryption_method
-      #   @return [String, nil] method used to encrypt the device. If is nil,
+      #   @return [EncryptionMethod::Base, nil] method used to encrypt the device. If is nil,
       #     it means the device will not be encrypted
-      secret_attr :encryption_method
+      attr_accessor :encryption_method
 
       # @!attribute encryption_password
       #   @return [String, nil] password used to encrypt the device.

--- a/test/y2storage/boot_requirements_checker_ppc_test.rb
+++ b/test/y2storage/boot_requirements_checker_ppc_test.rb
@@ -83,11 +83,12 @@ describe Y2Storage::BootRequirementsChecker do
       end
     end
 
+    # See https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/message/5L6XAYM2JFBP5RJOIFKFM34D3BK7VHWS/
     RSpec.shared_examples "PReP + /boot partition" do
       context "if there are no suitable PReP partitions in the target disk" do
         let(:prep_partitions) { [] }
 
-        it "requires a new PReP and a new /boot partition" do
+        it "requires a new PReP and a new /boot partition (Grub2 auto-config cannot handle LUKS2)" do
           expect(checker.needed_partitions).to contain_exactly(
             an_object_having_attributes(mount_point: nil, partition_id: prep_id),
             an_object_having_attributes(mount_point: "/boot")
@@ -101,7 +102,7 @@ describe Y2Storage::BootRequirementsChecker do
         context "and it is on the boot disk" do
           let(:boot_disk) { dev_sda }
 
-          it "requires a /boot partition" do
+          it "requires a separate /boot partition (Grub2 auto-config cannot handle LUKS2)" do
             expect(checker.needed_partitions).to contain_exactly(
               an_object_having_attributes(mount_point: "/boot")
             )
@@ -111,7 +112,7 @@ describe Y2Storage::BootRequirementsChecker do
         context "and it is not on the boot disk" do
           let(:boot_disk) { dev_sdb }
 
-          it "requires a new PReP and a new /boot partition" do
+          it "requires a new PReP and a new /boot partition (Grub2 auto-config cannot handle LUKS2)" do
             expect(checker.needed_partitions).to contain_exactly(
               an_object_having_attributes(mount_point: nil, partition_id: prep_id),
               an_object_having_attributes(mount_point: "/boot")
@@ -140,7 +141,7 @@ describe Y2Storage::BootRequirementsChecker do
         include_examples "PReP partition"
       end
 
-      context "with an encrypted proposal using LUKS2" do
+      context "with an AutoYaST profile that places '/' in a LUKS2 device" do
         let(:use_lvm) { false }
         let(:use_encryption) { true }
         let(:boot_enc_type) { Y2Storage::EncryptionType::LUKS2 }

--- a/test/y2storage/boot_requirements_checker_s390_test.rb
+++ b/test/y2storage/boot_requirements_checker_s390_test.rb
@@ -54,7 +54,7 @@ describe Y2Storage::BootRequirementsChecker do
         context "using Btrfs (i.e. /boot is not in XFS or ext2/3/4)" do
           let(:use_btrfs) { true }
 
-          it "requires only a separate /boot/zipl partition (to allocate Grub2)" do
+          it "requires only a separate /boot/zipl partition (to allocate Grub2+kernel+initrd)" do
             expect(checker.needed_partitions).to contain_exactly(
               an_object_having_attributes(mount_point: "/boot/zipl")
             )
@@ -65,7 +65,7 @@ describe Y2Storage::BootRequirementsChecker do
       context "with a LVM-based proposal" do
         let(:use_lvm) { true }
 
-        it "requires only a /boot/zipl partition (to allocate Grub2)" do
+        it "requires only a /boot/zipl partition (to allocate Grub2+kernel+initrd)" do
           expect(checker.needed_partitions).to contain_exactly(
             an_object_having_attributes(mount_point: "/boot/zipl")
           )
@@ -76,7 +76,19 @@ describe Y2Storage::BootRequirementsChecker do
         let(:use_lvm) { false }
         let(:use_encryption) { true }
 
-        it "requires only a /boot/zipl partition (to allocate Grub2)" do
+        it "requires only a /boot/zipl partition (to allocate Grub2+kernel+initrd)" do
+          expect(checker.needed_partitions).to contain_exactly(
+            an_object_having_attributes(mount_point: "/boot/zipl")
+          )
+        end
+      end
+
+      context "with an AutoYaST profile that places '/' in a LUKS2 device" do
+        let(:use_lvm) { false }
+        let(:use_encryption) { true }
+        let(:boot_enc_type) { Y2Storage::EncryptionType::LUKS2 }
+
+        it "requires only a /boot/zipl partition (to allocate Grub2+kernel+initrd)" do
           expect(checker.needed_partitions).to contain_exactly(
             an_object_having_attributes(mount_point: "/boot/zipl")
           )

--- a/test/y2storage/boot_requirements_checker_x86_test.rb
+++ b/test/y2storage/boot_requirements_checker_x86_test.rb
@@ -147,7 +147,7 @@ describe Y2Storage::BootRequirementsChecker do
           let(:boot_enc_type) { Y2Storage::EncryptionType::LUKS2 }
 
           RSpec.shared_examples "needs grub and /boot" do
-            it "requires new GRUB and /boot partitions (Grub2 auto-config cannot handle LUKS2" do
+            it "requires new GRUB and /boot partitions (Grub2 auto-config cannot handle LUKS2)" do
               expect(checker.needed_partitions).to contain_exactly(
                 an_object_having_attributes(partition_id: bios_boot_id, reuse_name: nil),
                 an_object_having_attributes(mount_point: "/boot")

--- a/test/y2storage/boot_requirements_strategies/analyzer_test.rb
+++ b/test/y2storage/boot_requirements_strategies/analyzer_test.rb
@@ -851,7 +851,7 @@ describe Y2Storage::BootRequirementsStrategies::Analyzer do
       end
     end
 
-    context "if '/boot' is a planned encrypted partition" do
+    context "if '/boot' is a planned partition to be encrypted with LUKS1" do
       let(:planned_boot) { planned_partition(mount_point: "/boot", encryption_password: "12345678") }
 
       it "returns type luks1" do
@@ -864,6 +864,18 @@ describe Y2Storage::BootRequirementsStrategies::Analyzer do
 
       it "returns type luks1" do
         expect(analyzer.boot_encryption_type).to eq Y2Storage::EncryptionType::LUKS1
+      end
+    end
+
+    context "if '/boot' is a planned partition to be encrypted with pervasive encryption" do
+      let(:planned_boot) do
+        planned_partition(
+          mount_point: "/boot", encryption_method: Y2Storage::EncryptionMethod::PERVASIVE_LUKS2
+        )
+      end
+
+      it "returns type luks1" do
+        expect(analyzer.boot_encryption_type).to eq Y2Storage::EncryptionType::LUKS2
       end
     end
 


### PR DESCRIPTION
## Problem

`BootRequirementsChecker` was already adapted to deal with LUKS2 encryption at https://github.com/yast/yast-storage-ng/pull/964.

But the [boot-requirements.md](https://github.com/yast/yast-storage-ng/blob/master/doc/boot-requirements.md) document we always use to reflect how the proposals (both the Guided Proposal and the AutoYaST one) work was only updated in a couple of not-so-visible sections back then. Due to that, we even overlooked that `BootRequirementsChecker` already supported LUKS2-based scenarios.

On the other hand, while checking that everything worked as expected, I found that `BootRequirementsChecker` assumed that both the guided proposal and the AutoYaST one used always LUKS1. That is currently true for the guided proposal but not for the AutoYaST one. The AutoYaST property `<crypt_method>` can be used to specify, for example, than the root partition should be encrypted using IBM's pervasive volume encryption (that is based on LUKS2). See [AutoYaST documentation](https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-configuration-installation-options.html#ay-partition-configuration).

## Solution

- Extended `BootRequirementsChecker` unit tests to cover LUKS2 scenarios in all architectures and boot systems.
- Document `doc/boot-requirements.md` updated accordingly
- Fixed detection of planned LUKS2 encryption

## Testing

Unit tests extended