### PR TITLE
Adjust _netdev only in the GuidedProposal (jsc#SLE-20535)

### DIFF
--- a/doc/netdev.md
+++ b/doc/netdev.md
@@ -1,0 +1,64 @@
+# YaST and the `_netdev` mount option
+
+For historical reasons, YaST handles the `_netdev` mount option of the mount points. The mechanism
+to do it and the criteria to decide whether the option is desirable for a given mount point have
+changed over time. This document offers a brief historical summary of the topic.
+
+## Chapter 1
+
+The whole thing originated as [bsc#1047099](https://bugzilla.suse.com/show_bug.cgi?id=1047099) that
+was then used as a base to create [bsc#1075529](https://bugzilla.suse.com/show_bug.cgi?id=1075529).
+That turned into Fate#325472 and later into
+[Fate#325473](https://w3.suse.de/~lpechacek/fate-archive/325473.html).
+
+Finally the discussion in that Fate entry was moved to
+[jsc#SLE-7687](https://jira.suse.com/browse/SLE-7687). The conclusion there was that YaST should add
+`_netdev` to all mount points based on iSCSI or FCoE disks. A subtask
+[jsc#SLE-9191](https://jira.suse.com/browse/SLE-9191) was added to backport that solution to
+SLE-15-SP2.
+
+Implemented at [pull request 995](https://github.com/yast/yast-storage-ng/pull/995).
+
+## Chapter 2
+
+A customer reported [bsc#1158536](https://bugzilla.suse.com/show_bug.cgi?id=1158536) which was used
+as a base to create [bsc#1165937](https://bugzilla.suse.com/show_bug.cgi?id=1165937).
+
+There it was concluded that the `_netdev` parameter should never be automatically added by YaST to
+"_the system root mount or any of the btrfs subvolume mounts that belongs to it_" (almost literal
+quote). For non-root mounts, it was concluded it would stay as it was.
+
+Implemented at [pull request 1073](https://github.com/yast/yast-storage-ng/pull/1073).
+
+## Chapter 3
+
+A customer reported [bsc#1176140](https://bugzilla.suse.com/show_bug.cgi?id=1176140) because YaST
+was again adding `_netdev` in a situation in which it was not really needed and that prevented the
+system from booting. But it was not the root mount point this time.
+
+The conclusions there were that:
+
+- Not all iSCSI or FCoE disks should qualify as remote disks in this context. It was pointed that
+  likely the driver was the best way to distinguish whether `_netdev` was applicable to a disk.
+- YaST should avoid `_netdev` not only for the root mount and its subvolumes, but also for any
+  other mount point based on the same disk than root or, to be more precise, for any mount point
+  based on a disk that is initialized by initrd (something that is decided by dracut).
+- If a system is using wicked, `/var` must be mounted for the network to be configured. So `/var`
+  (and likely other mount points in its same disk) should never get the `_netdev` option.
+
+Since a full-blown fix was impossible for an already released product, the partial fix of filtering
+devices by driver was implemented at [pull request
+1198](https://github.com/yast/yast-storage-ng/pull/1198).
+
+## Chapter 4
+
+The entry [jsc#PM-2830](https://jira.suse.com/browse/PM-2830) was created to find the best way to
+handle the option for SLE-15-SP4 and upcoming versions.
+
+The conclusions there were that:
+
+- The YaST approach should be changed to only add `_netdev` automatically if the Guided Proposal
+  is used.
+- The criteria for handling `_netdev` should be refined based on the information from chapter 3.
+
+Implemented at [pull request 1254](https://github.com/yast/yast-storage-ng/pull/1254).

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Thu Dec  2 16:36:41 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Refined the criteria used to check whether a certain mount point
+  needs the _netdev mount option (jsc#SLE-20535).
+- Now _netdev is only added if needed at the end of the Guided
+  Proposal, is not longer suggested as part of the default mount
+  options for new mount points.
+- 4.4.19
+
+-------------------------------------------------------------------
 Thu Dec  2 15:16:17 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Improve probing errors handling: when there are several errors,

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.18
+Version:        4.4.19
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -722,6 +722,14 @@ module Y2Storage
       end
     end
 
+    # Whether this device contains, directly or indirectly, a mount point returning true for the
+    # given block
+    #
+    # @return [Boolean]
+    def contain_mount_point?(&block)
+      descendants.any? { |desc| desc.is_a?(MountPoint) && block.call(desc) }
+    end
+
     # Whether the block device fulfills conditions to be used for a Windows system
     #
     # Note that only partitions can be used for installing Windows.

--- a/src/lib/y2storage/devicegraph.rb
+++ b/src/lib/y2storage/devicegraph.rb
@@ -318,6 +318,13 @@ module Y2Storage
       Filesystems::Base.all(self)
     end
 
+    # All mount points in the devicegraph, in no particular order
+    #
+    # @return [Array<MountPoint>]
+    def mount_points
+      MountPoint.all(self)
+    end
+
     # @param mountpoint [String] mountpoint of the filesystem (e.g. "/").
     # @return [Boolean]
     def filesystem_in_network?(mountpoint)

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -388,9 +388,13 @@ module Y2Storage
       #
       # @return [Boolean]
       def needs_network_mount_options?
-        # Adding "_netdev" and similar options in fstab for / should not be necessary
-        # and it confuses (or used to confuse) systemd. See bsc#1165937.
-        systemd_remote? && !root?
+        # Adding "_netdev" and similar options in fstab for /var, for / or for any mount point that
+        # is hosted in the same disk than / should not be necessary and it confuses systemd.
+        # See bsc#1165937, bsc#176140 and jsc#SLE-20535
+        return false if disk_with_mount_point?(&:mounted_by_init?)
+        return false if disk_with_mount_point? { |mp| mp.path == "/var" }
+
+        systemd_remote?
       end
 
       # Network-related mount options (e.g. _netdev) in the current {#mount_options}

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -162,6 +162,14 @@ module Y2Storage
       mount_options
     end
 
+    # Adjusts the mount options as needed to avoid problems during booting
+    #
+    # See jsc#SLE-20535, bsc#1176140, bsc#1165937 and jsc#SLE-7687
+    def adjust_mount_options
+      self.mount_options =
+        mount_options + mountable.missing_mount_options - mountable.unwanted_mount_options
+    end
+
     # @!method set_default_mount_by
     #   Set the mount-by method to the global default, see Storage::get_default_mount_by()
     storage_forward :set_default_mount_by, to: :default_mount_by=

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -383,6 +383,19 @@ module Y2Storage
       self.mount_options = default_mount_options
     end
 
+    # @see #mounted_by_init?
+    INITRD_MOUNT_OPTION = "x-initrd.mount".freeze
+    private_constant :INITRD_MOUNT_OPTION
+
+    # Whether YaST expects this mount point to be already initialized in the initramfs
+    #
+    # @return [Boolean]
+    def mounted_by_init?
+      # Intentionally avoiding String#casecmp to check the mount option, turns out
+      # X-what.ever has a different semantic than x-what.ever (see "man -s8 mount")
+      root? || mount_options.include?(INITRD_MOUNT_OPTION)
+    end
+
     protected
 
     # @see Device#is?

--- a/src/lib/y2storage/mountable.rb
+++ b/src/lib/y2storage/mountable.rb
@@ -130,6 +130,18 @@ module Y2Storage
       mount_point.root?
     end
 
+    # Whether the device contains a mount point that returns true for the given block or whether the
+    # device is based in the same disk than another device containing such a mount point
+    #
+    # @return [Boolean]
+    def disk_with_mount_point?(&block)
+      return true if mount_point && block.call(mount_point)
+
+      ([self] + ancestors).any? do |dev|
+        dev.is_a?(BlkDevice) && dev.contain_mount_point?(&block)
+      end
+    end
+
     # Creates a mount point object for the device
     #
     # @param path [String]

--- a/src/lib/y2storage/mountable.rb
+++ b/src/lib/y2storage/mountable.rb
@@ -91,6 +91,26 @@ module Y2Storage
       mount_point.mount_options
     end
 
+    # Mount options that may be needed for the system to boot correctly, but that are not currently
+    # part of #{mount_options}
+    #
+    # @see MountPoint#adjust_mount_options
+    #
+    # @return [Array<String>]
+    def missing_mount_options
+      []
+    end
+
+    # Mount options that are currently part of #{mount_options} but that may prevent a correct
+    # system boot
+    #
+    # @see MountPoint#adjust_mount_options
+    #
+    # @return [Array<String>]
+    def unwanted_mount_options
+      []
+    end
+
     # Is the mount persistent?
     #
     # @return [Boolean] true if the mount point is saved to /etc/fstab

--- a/src/lib/y2storage/proposal/devicegraph_generator.rb
+++ b/src/lib/y2storage/proposal/devicegraph_generator.rb
@@ -73,6 +73,7 @@ module Y2Storage
           graph = lvm_helper.create_volumes(graph, new_pvs)
         end
 
+        graph.mount_points.each(&:adjust_mount_options)
         graph
       end
 

--- a/test/y2storage/encryption_test.rb
+++ b/test/y2storage/encryption_test.rb
@@ -226,7 +226,7 @@ describe Y2Storage::Encryption do
     RSpec.shared_examples "netdev for network device" do
       context "within a network disk" do
         let(:network) { true }
-        let(:mountpoint) { "/var" }
+        let(:mountpoint) { "/home" }
         let(:mount_options) { [] }
 
         before { prepare_fs.call }
@@ -251,7 +251,7 @@ describe Y2Storage::Encryption do
 
       context "within a local disk" do
         let(:network) { false }
-        let(:mountpoint) { "/var" }
+        let(:mountpoint) { "/home" }
         let(:mount_options) { [] }
 
         before { prepare_fs.call }

--- a/test/y2storage/encryption_test.rb
+++ b/test/y2storage/encryption_test.rb
@@ -193,6 +193,7 @@ describe Y2Storage::Encryption do
       # To have full effect, this must be done after creating the mount point
       fs.add_btrfs_subvolumes(Y2Storage::SubvolSpecification.fallback_list)
       fs.mount_point.set_default_mount_options
+      fs.mount_point.adjust_mount_options
       fs
     end
 
@@ -200,6 +201,7 @@ describe Y2Storage::Encryption do
       fs = encryption.filesystem
       fs.create_mount_point(mountpoint)
       fs.mount_point.set_default_mount_options
+      fs.mount_point.adjust_mount_options
       fs.mount_point.mount_options |= mount_options
     end
 

--- a/test/y2storage/mount_point_test.rb
+++ b/test/y2storage/mount_point_test.rb
@@ -510,56 +510,16 @@ describe Y2Storage::MountPoint do
       end
     end
 
-    context "in a local disk" do
+    context "in a disk" do
       let(:blk_device) { Y2Storage::BlkDevice.find_by_name(fake_devicegraph, dev_name) }
       let(:mountable) { blk_device.filesystem }
-
-      context "for a Btrfs file-system" do
-        let(:dev_name) { "/dev/sda2" }
-
-        it "sets #mount_options to an empty array" do
-          mount_point.set_default_mount_options
-          expect(mount_point.mount_options).to be_empty
-        end
-      end
-
-      context "for a Btrfs subvolume" do
-        let(:dev_name) { "/dev/sda2" }
-        let(:mountable) { blk_device.filesystem.btrfs_subvolumes.last }
-
-        it "sets #mount_options to an array containing only the subvol option" do
-          mount_point.set_default_mount_options
-          options = mount_point.mount_options
-          expect(options.size).to eq 1
-          expect(options.first).to match(/^subvol=/)
-        end
-      end
-
-      context "for an Ext3 file-system " do
-        let(:dev_name) { "/dev/sda3" }
-
-        it "sets #mount_options to an array containing only the data option" do
-          mount_point.set_default_mount_options
-          expect(mount_point.mount_options).to eq ["data=ordered"]
-        end
-      end
-    end
-
-    context "in a network disk" do
-      let(:blk_device) { Y2Storage::BlkDevice.find_by_name(fake_devicegraph, dev_name) }
-      let(:mountable) { blk_device.filesystem }
-
-      before do
-        disk = Y2Storage::BlkDevice.find_by_name(fake_devicegraph, "/dev/sda")
-        allow(disk.transport).to receive(:network?).and_return true
-      end
 
       context "for the root filesystem" do
         before do
           mount_point.path = "/"
         end
 
-        context "for a Btrfs file-system" do
+        context "for a Btrfs file-system (the same applies to most file-system types)" do
           let(:dev_name) { "/dev/sda2" }
 
           it "sets #mount_options to an empty array" do
@@ -580,7 +540,7 @@ describe Y2Storage::MountPoint do
           end
         end
 
-        context "for an Ext3 file-system " do
+        context "for an Ext3 or Ext4 file-system" do
           let(:dev_name) { "/dev/sda3" }
 
           it "sets #mount_options to an empty array" do
@@ -593,28 +553,14 @@ describe Y2Storage::MountPoint do
       context "for a non-root filesystem" do
         before do
           mount_point.path = "/home"
-          allow_any_instance_of(Y2Storage::Disk).to receive(:hwinfo).and_return(hwinfo)
         end
 
-        let(:hwinfo) { Y2Storage::HWInfoDisk.new }
-
-        context "for a Btrfs file-system" do
+        context "for a Btrfs file-system (the same applies to most file-system types)" do
           let(:dev_name) { "/dev/sda2" }
 
-          context "if the disk uses a driver that depends on a systemd service" do
-            let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["fcoe"]) }
-
-            it "sets #mount_options to an array containing only '_netdev'" do
-              mount_point.set_default_mount_options
-              expect(mount_point.mount_options).to eq ["_netdev"]
-            end
-          end
-
-          context "if the disk driver does not depend on any systemd service" do
-            it "sets #mount_options to an empty array" do
-              mount_point.set_default_mount_options
-              expect(mount_point.mount_options).to eq []
-            end
+          it "sets #mount_options to an empty array" do
+            mount_point.set_default_mount_options
+            expect(mount_point.mount_options).to eq []
           end
         end
 
@@ -630,26 +576,90 @@ describe Y2Storage::MountPoint do
           end
         end
 
-        context "for an Ext3 file-system " do
+        context "for an Ext3 or Ext4 file-system" do
           let(:dev_name) { "/dev/sda3" }
 
-          context "if the disk uses a driver that depends on a systemd service" do
-            let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["iscsi-tcp"]) }
-
-            it "sets #mount_options to an array containing the 'data' and '_netdev' options" do
-              mount_point.set_default_mount_options
-              expect(mount_point.mount_options).to contain_exactly("data=ordered", "_netdev")
-            end
+          it "sets #mount_options to an array containing only the data option" do
+            mount_point.set_default_mount_options
+            expect(mount_point.mount_options).to eq ["data=ordered"]
           end
+        end
+      end
+    end
+  end
 
-          context "if the disk driver does not depend on any systemd service" do
-            let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["qla4xxx"]) }
+  describe "#adjust_mount_options" do
+    subject(:mount_point) { mountable.mount_point }
 
-            it "sets #mount_options to an array containing only the data option" do
-              mount_point.set_default_mount_options
-              expect(mount_point.mount_options).to eq ["data=ordered"]
-            end
+    RSpec.shared_examples "remove netdev" do
+      it "removes the _netdev option if it is there" do
+        mount_point.mount_options = ["one", "_netdev", "two"]
+        mount_point.adjust_mount_options
+        expect(mount_point.mount_options).to eq ["one", "two"]
+      end
+    end
+
+    context "in an NFS filesystem" do
+      let(:mountable) { Y2Storage::Filesystems::Nfs.create(fake_devicegraph, "server", "path") }
+      before { mountable.create_mount_point("/mnt") }
+
+      it "does not change #mount_options" do
+        mount_point.mount_options = ["one", "_netdev", "two"]
+        mount_point.adjust_mount_options
+        expect(mount_point.mount_options).to eq ["one", "_netdev", "two"]
+      end
+    end
+
+    context "for a filesystem in a local disk (i.e. BlkDevice#in_network? returns false)" do
+      let(:blk_device) { Y2Storage::BlkDevice.find_by_name(fake_devicegraph, dev_name) }
+      let(:mountable) { blk_device.filesystem }
+
+      include_examples "remove netdev"
+    end
+
+    context "for a filesystem in a network disk (i.e. BlkDevice#in_network? returns true)" do
+      let(:blk_device) { Y2Storage::BlkDevice.find_by_name(fake_devicegraph, dev_name) }
+      let(:mountable) { blk_device.filesystem }
+      let(:hwinfo) { Y2Storage::HWInfoDisk.new }
+
+      before do
+        disk = Y2Storage::BlkDevice.find_by_name(fake_devicegraph, "/dev/sda")
+        allow(disk.transport).to receive(:network?).and_return true
+
+        allow_any_instance_of(Y2Storage::Disk).to receive(:hwinfo).and_return(hwinfo)
+      end
+
+      context "if the disk uses a driver that depends on a systemd service" do
+        let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["fcoe"]) }
+
+        context "for the root filesystem" do
+          before { mount_point.path = "/" }
+
+          include_examples "remove netdev"
+        end
+
+        context "for a non-root filesystem" do
+          before { mount_point.path = "/home" }
+
+          it "adds the _netdev option if it is not there" do
+            mount_point.mount_options = ["one", "two"]
+            mount_point.adjust_mount_options
+            expect(mount_point.mount_options).to eq ["one", "two", "_netdev"]
           end
+        end
+      end
+
+      context "if the disk driver does not depend on any systemd service" do
+        context "for the root filesystem" do
+          before { mount_point.path = "/" }
+
+          include_examples "remove netdev"
+        end
+
+        context "for a non-root filesystem" do
+          before { mount_point.path = "/home" }
+
+          include_examples "remove netdev"
         end
       end
     end

--- a/test/y2storage/proposal_mount_options_test.rb
+++ b/test/y2storage/proposal_mount_options_test.rb
@@ -1,0 +1,182 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "storage"
+require "y2storage"
+require_relative "#{TEST_PATH}/support/proposal_examples"
+require_relative "#{TEST_PATH}/support/proposal_context"
+require_relative "#{TEST_PATH}/support/candidate_devices_context"
+
+describe Y2Storage::GuidedProposal do
+  using Y2Storage::Refinements::SizeCasts
+  let(:architecture) { :x86 }
+
+  include_context "proposal"
+  let(:separate_home) { true }
+
+  let(:scenario) { "empty_disks" }
+  before { settings.candidate_devices = ["/dev/sdb", "/dev/sdc"] }
+
+  let(:control_file_content) do
+    { "partitioning" => { "proposal" => {}, "volumes" => volumes } }
+  end
+
+  let(:volumes) { [root_vol, home_vol] }
+  let(:root_vol) { { "mount_point" => "/", "fs_type" => root_fstype, "desired_size" => "390 GiB" } }
+  let(:home_vol) { { "mount_point" => "/home", "fs_type" => home_fstype, "desired_size" => "300 GiB" } }
+
+  let(:root_fstype) { "btrfs" }
+  let(:home_fstype) { "ext3" }
+
+  describe "#propose" do
+    subject(:proposal) { described_class.new(settings: settings) }
+
+    context "locating a filesystem in a local disk" do
+      let(:blk_device) { proposal.devices.find_by_name(dev_name) }
+      let(:mountable) { blk_device.filesystem }
+
+      context "for a Btrfs file-system" do
+        let(:dev_name) { "/dev/sdb2" }
+
+        it "sets #mount_options to an empty array" do
+          proposal.propose
+          expect(mountable.mount_options).to be_empty
+        end
+      end
+
+      context "for a Btrfs subvolume" do
+        let(:dev_name) { "/dev/sdb2" }
+        let(:mountable) { blk_device.filesystem.btrfs_subvolumes.last }
+
+        it "sets #mount_options to an array containing only the subvol option" do
+          proposal.propose
+          options = mountable.mount_options
+          expect(options.size).to eq 1
+          expect(options.first).to match(/^subvol=/)
+        end
+      end
+
+      context "for an Ext3 file-system " do
+        let(:dev_name) { "/dev/sdc1" }
+
+        it "sets #mount_options to an array containing only the data option" do
+          proposal.propose
+          expect(mountable.mount_options).to eq ["data=ordered"]
+        end
+      end
+    end
+
+    context "locating a filesystem in a network disk" do
+      let(:blk_device) { proposal.devices.find_by_name(dev_name) }
+      let(:mountable) { blk_device.filesystem }
+
+      before do
+        allow_any_instance_of(Y2Storage::DataTransport).to receive(:network?).and_return true
+      end
+
+      context "for the root filesystem" do
+        let(:dev_name) { "/dev/sdb2" }
+
+        context "if it is a Btrfs file-system" do
+          let(:root_fstype) { "btrfs" }
+
+          it "sets #mount_options to an empty array" do
+            proposal.propose
+            expect(mountable.mount_options).to be_empty
+          end
+        end
+
+        context "for a Btrfs subvolume" do
+          let(:root_fstype) { "btrfs" }
+          let(:mountable) { blk_device.filesystem.btrfs_subvolumes.last }
+
+          it "sets #mount_options to an array containing only the subvol option" do
+            proposal.propose
+            options = mountable.mount_options
+            expect(options.size).to eq 1
+            expect(options.first).to match(/^subvol=/)
+          end
+        end
+
+        context "for an Ext3 file-system " do
+          let(:root_fstype) { "ext3" }
+
+          it "sets #mount_options to an empty array" do
+            proposal.propose
+            expect(mountable.mount_options).to be_empty
+          end
+        end
+      end
+
+      context "for a non-root filesystem" do
+        let(:dev_name) { "/dev/sdc1" }
+
+        before do
+          allow_any_instance_of(Y2Storage::Disk).to receive(:hwinfo).and_return(hwinfo)
+        end
+
+        let(:hwinfo) { Y2Storage::HWInfoDisk.new }
+
+        context "for a Btrfs file-system" do
+          let(:home_fstype) { "btrfs" }
+
+          context "if the disk uses a driver that depends on a systemd service" do
+            let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["fcoe"]) }
+
+            it "sets #mount_options to an array containing only '_netdev'" do
+              proposal.propose
+              expect(mountable.mount_options).to eq ["_netdev"]
+            end
+          end
+
+          context "if the disk driver does not depend on any systemd service" do
+            it "sets #mount_options to an empty array" do
+              proposal.propose
+              expect(mountable.mount_options).to be_empty
+            end
+          end
+        end
+
+        context "for an Ext3 file-system " do
+          let(:home_fstype) { "ext3" }
+
+          context "if the disk uses a driver that depends on a systemd service" do
+            let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["iscsi-tcp"]) }
+
+            it "sets #mount_options to an array containing the 'data' and '_netdev' options" do
+              proposal.propose
+              expect(mountable.mount_options).to contain_exactly("data=ordered", "_netdev")
+            end
+          end
+
+          context "if the disk driver does not depend on any systemd service" do
+            let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["qla4xxx"]) }
+
+            it "sets #mount_options to an array containing only the data option" do
+              proposal.propose
+              expect(mountable.mount_options).to eq ["data=ordered"]
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

YaST proposes the mount option "_netdev" in those scenarios when it's needed for the system to boot properly. But that's a task that comes with some challenges:

- If the "_netdev" option is needed but omitted, the system will have problems to boot.
- If the "_netdev" option is added to a mount point for which is not needed, the system will have problems to boot.
- The criteria to determine if "_netdev" is needed depends on:
  - the mount point path
  - the driver used by the device(s) supporting such a mount point
  - which other mount points are based on the same device(s)
  - what dracut is going to do regarding initrd generation

So far, YaST used to add "_netdev" if needed to the list of default options proposed for every new mount point. This is a problem because that decision is not revisited later, when the mount point is modified by the user or when other mount points are defined or deleted. For example, imagine we plan a mount point for "/var" in sda2 (with sda being one remote disk that uses one of the affected drivers). In that moment, YaST will add "_netdev" to its mount options since there is no evidence of that partition being in the root disk. If at a later point, sda3 is created and mounted as "/", the mount options of sda2 will not be re-adjusted.

See https://jira.suse.com/browse/SLE-20535

## Solution

This pull request changes two things (each one in a separate commit for easier review):

- It stops suggesting the "_netdev" option at such an early point in the workflow. Now the "_netdev" option is only added if the Guided Proposal is used and only at the very end of such a process, when all mount points are fully defined. That means that users modifying the resulting proposal or setting up the system manually are completely on their own, they must manually adjust the mount options.
- It refines the criteria for adding/removing the "_netdev" option for a given mount point, by also having the relationship with other mount points into account.

## Testing

Added new unit tests
