### PR TITLE
HWInfoReader: always return HWInfoDisk objects

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 30 13:12:33 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Changed the HWInfoReader API: now it always returns objects of
+  a new Y2Storage::HWInfoDisk class (backwards compatible with
+  OpenStruct).
+
+-------------------------------------------------------------------
 Thu Nov 23 16:00:00 UTC 2021 - Stefan Knorr <sknorr@suse.com>
 
 - Fixed typo in message about encryption (part of jsc#SLE-21308)

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2020] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -23,6 +23,7 @@ require "y2storage/hwinfo_reader"
 require "y2storage/comparable_by_name"
 require "y2storage/match_volume_spec"
 require "y2storage/encryption_method"
+require "forwardable"
 
 module Y2Storage
   # Base class for most devices having a device name, udev path and udev ids.
@@ -34,6 +35,7 @@ module Y2Storage
 
     include ComparableByName
     include MatchVolumeSpec
+    extend Forwardable
 
     # @!method self.all(devicegraph)
     #   @param devicegraph [Devicegraph]
@@ -625,41 +627,35 @@ module Y2Storage
       Y2Storage::HWInfoReader.instance.for_device(name)
     end
 
-    # Device vendor
-    #
-    # @see #hwinfo
-    #
-    # @return [String, nil] nil if vendor is unknown
-    def vendor
-      hwinfo&.vendor
-    end
+    def_delegators :hwinfo, :vendor, :model, :bus, :driver
 
-    # Device model
+    # @!method vendor
+    #   Device vendor
     #
-    # @see #hwinfo
+    #   @see #hwinfo
     #
-    # @return [String, nil] nil if model is unknown
-    def model
-      hwinfo&.model
-    end
+    #   @return [String, nil] nil if vendor is unknown
 
-    # Device bus (IDE, SATA, etc)
+    # @!method model
+    #   Device model
     #
-    # @see #hwinfo
+    #   @see #hwinfo
     #
-    # @return [String, nil] nil if bus is unknown
-    def bus
-      hwinfo&.bus
-    end
+    #   @return [String, nil] nil if model is unknown
 
-    # Kernel drivers used by this device
+    # @!method hwinfo
+    #   Device bus (IDE, SATA, etc)
     #
-    # @see #hwinfo
+    #   @see #hwinfo
     #
-    # @return [Array<String>] empty if the driver is unknown
-    def driver
-      hwinfo&.driver || []
-    end
+    #   @return [String, nil] nil if bus is unknown
+
+    # @!method driver
+    #   Kernel drivers used by this device
+    #
+    #   @see #hwinfo
+    #
+    #   @return [Array<String>] empty if the driver is unknown
 
     # @see #boss?
     BOSS_REGEXP = Regexp.new("dellboss", Regexp::IGNORECASE).freeze

--- a/src/lib/y2storage/hwinfo_disk.rb
+++ b/src/lib/y2storage/hwinfo_disk.rb
@@ -1,0 +1,68 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "ostruct"
+
+module Y2Storage
+  # Hardware information for a storage device
+  #
+  # This class encapsulates the result of `hwinfo --disk` for a given block device.
+  # Since the structure of the information returned by `hwinfo` is dynamic by nature (new fields
+  # can be added or removed between versions) and AutoYaST relies on that flexibility (allowing
+  # to use several fields in the skip lists), this is a subclass of OpenStruct.
+  #
+  class HWInfoDisk < OpenStruct
+    # @return [Array<Symbol>] list of methods all HWInfoDisk objects are expected to respond to
+    KNOWN_PROPERTIES = [:vendor, :model, :bus, :driver, :driver_modules, :device_files].freeze
+    private_constant :KNOWN_PROPERTIES
+
+    # @return [Array<Symbol>] list of multi-valued properties (see KNOWN_PROPERTIES)
+    MULTI_VALUED = [:driver, :driver_modules, :device_files].freeze
+    private_constant :MULTI_VALUED
+
+    # Whether the given attribute should store and return arrays with multiple values
+    #
+    # @return [Boolean]
+    def self.multi_valued?(property)
+      MULTI_VALUED.include?(property.to_sym)
+    end
+
+    # Macro used to define the methods all HWInfoDisks should respond to
+    def self.define_property(name, multi: false)
+      define_method(name) do
+        if multi
+          super() || []
+        else
+          super()
+        end
+      end
+    end
+
+    KNOWN_PROPERTIES.each do |name|
+      define_property(name, multi: multi_valued?(name))
+    end
+
+    # Whether the object corresponds to an empty struct
+    #
+    # @return [Boolean]
+    def empty?
+      to_h.empty?
+    end
+  end
+end

--- a/test/y2partitioner/widgets/lvm_vg_devices_selector_test.rb
+++ b/test/y2partitioner/widgets/lvm_vg_devices_selector_test.rb
@@ -42,7 +42,7 @@ describe Y2Partitioner::Widgets::LvmVgDevicesSelector do
   before do
     devicegraph_stub(scenario)
 
-    allow_any_instance_of(Y2Storage::BlkDevice).to receive(:hwinfo).and_return(nil)
+    allow_any_instance_of(Y2Storage::BlkDevice).to receive(:hwinfo).and_return(Y2Storage::HWInfoDisk.new)
 
     initial_selected_devices.map { |d| controller.add_device(dev(d)) }
   end

--- a/test/y2storage/autoinst_profile/skip_list_value_test.rb
+++ b/test/y2storage/autoinst_profile/skip_list_value_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 
 #
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -57,7 +57,7 @@ describe Y2Storage::AutoinstProfile::SkipListValue do
   end
 
   describe "#method_missing" do
-    let(:hwinfo) { OpenStruct.new(driver: ["ahci"]) }
+    let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["ahci"]) }
 
     before do
       allow(disk).to receive(:hwinfo).and_return(hwinfo)
@@ -175,7 +175,7 @@ describe Y2Storage::AutoinstProfile::SkipListValue do
   end
 
   describe "#to_hash" do
-    let(:hwinfo) { OpenStruct.new(bios_id: "0x80", driver: ["ahci"], unknown: "value") }
+    let(:hwinfo) { Y2Storage::HWInfoDisk.new(bios_id: "0x80", driver: ["ahci"], unknown: "value") }
 
     before do
       allow(disk).to receive(:hwinfo).and_return hwinfo

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -1058,7 +1058,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "when hardware info is available" do
-      let(:hwinfo) { OpenStruct.new(driver_modules: ["ahci", "sd"]) }
+      let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver_modules: ["ahci", "sd"]) }
 
       it "returns the hardware info" do
         expect(device.hwinfo).to eq(hwinfo)
@@ -1084,7 +1084,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "when hardware info is available" do
-      let(:hwinfo) { OpenStruct.new(info) }
+      let(:hwinfo) { Y2Storage::HWInfoDisk.new(info) }
 
       context "and there is info about the vendor" do
         let(:info) { { vendor: vendor_name } }
@@ -1106,7 +1106,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "when hardware info is not available" do
-      let(:hwinfo) { nil }
+      let(:hwinfo) { Y2Storage::HWInfoDisk.new }
 
       it "returns nil" do
         expect(device.vendor).to be_nil
@@ -1124,7 +1124,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "when hardware info is available" do
-      let(:hwinfo) { OpenStruct.new(info) }
+      let(:hwinfo) { Y2Storage::HWInfoDisk.new(info) }
 
       context "and there is info about the model" do
         let(:info) { { model: device_model } }
@@ -1156,7 +1156,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "when hardware info is available" do
-      let(:hwinfo) { OpenStruct.new(info) }
+      let(:hwinfo) { Y2Storage::HWInfoDisk.new(info) }
 
       context "and there is info about the bus" do
         let(:info) { { bus: device_bus } }
@@ -1178,7 +1178,7 @@ describe Y2Storage::BlkDevice do
     end
 
     context "when hardware info is not available" do
-      let(:hwinfo) { nil }
+      let(:hwinfo) { Y2Storage::HWInfoDisk.new }
 
       it "returns nil" do
         expect(device.bus).to be_nil

--- a/test/y2storage/encryption_test.rb
+++ b/test/y2storage/encryption_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2018-2019] SUSE LLC
+# Copyright (c) [2018-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -185,7 +185,7 @@ describe Y2Storage::Encryption do
     let(:scenario) { "encrypted_partition.xml" }
     let(:disk) { devicegraph.find_by_name("/dev/sda") }
     let(:partition) { devicegraph.find_by_name(partition_name) }
-    let(:hwinfo) { OpenStruct.new }
+    let(:hwinfo) { Y2Storage::HWInfoDisk.new }
 
     def create_btrfs(blk_dev)
       fs = blk_dev.create_filesystem(Y2Storage::Filesystems::Type::BTRFS)
@@ -230,7 +230,7 @@ describe Y2Storage::Encryption do
         before { prepare_fs.call }
 
         context "which uses a driver that needs an extra systemd service" do
-          let(:hwinfo) { OpenStruct.new(driver: ["sg", "bnx2i"]) }
+          let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["sg", "bnx2i"]) }
 
           it "makes sure #crypt_options include _netdev" do
             expect(encryption.crypt_options).to include("_netdev")
@@ -239,7 +239,7 @@ describe Y2Storage::Encryption do
 
         context "which does not demand any extra systemd service in order to be used" do
           # Test with fnic, based on what happened at bsc#1176140
-          let(:hwinfo) { OpenStruct.new(driver: ["sg", "fnic"]) }
+          let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["sg", "fnic"]) }
 
           it "makes no changes to #crypt_options" do
             expect(encryption.crypt_options).to be_empty

--- a/test/y2storage/hwinfo_reader_test.rb
+++ b/test/y2storage/hwinfo_reader_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 
 #
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -37,7 +37,7 @@ describe Y2Storage::HWInfoReader do
   describe "#for_device" do
     it "returns hardware information for the given device" do
       data = reader.for_device("/dev/sda")
-      expect(data).to be_a(OpenStruct)
+      expect(data).to be_a(Y2Storage::HWInfoDisk)
       expect(data.to_h)
         .to include(bus:              "IDE",
                     unique_id:        "3OOL.7kkY9irDFZ4",
@@ -68,9 +68,10 @@ describe Y2Storage::HWInfoReader do
       reader.for_device("/dev/sda")
     end
 
-    it "returns nil for non-existing device names" do
+    it "returns an empty object for non-existing device names" do
       data = reader.for_device("/dev/nothing")
-      expect(data).to be_nil
+      expect(data).to be_a(Y2Storage::HWInfoDisk)
+      expect(data).to be_empty
     end
 
     context "when the system contains some zFCP multipath device" do
@@ -83,7 +84,7 @@ describe Y2Storage::HWInfoReader do
 
       it "returns hardware information for the given device" do
         data = reader.for_device("/dev/sda")
-        expect(data).to be_a(OpenStruct)
+        expect(data).to be_a(Y2Storage::HWInfoDisk)
         expect(data.to_h)
           .to include(bus:              "SCSI",
                       driver_modules:   ["zfcp", "sd_mod"],

--- a/test/y2storage/mount_point_test.rb
+++ b/test/y2storage/mount_point_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -596,13 +596,13 @@ describe Y2Storage::MountPoint do
           allow_any_instance_of(Y2Storage::Disk).to receive(:hwinfo).and_return(hwinfo)
         end
 
-        let(:hwinfo) { OpenStruct.new }
+        let(:hwinfo) { Y2Storage::HWInfoDisk.new }
 
         context "for a Btrfs file-system" do
           let(:dev_name) { "/dev/sda2" }
 
           context "if the disk uses a driver that depends on a systemd service" do
-            let(:hwinfo) { OpenStruct.new(driver: ["fcoe"]) }
+            let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["fcoe"]) }
 
             it "sets #mount_options to an array containing only '_netdev'" do
               mount_point.set_default_mount_options
@@ -634,7 +634,7 @@ describe Y2Storage::MountPoint do
           let(:dev_name) { "/dev/sda3" }
 
           context "if the disk uses a driver that depends on a systemd service" do
-            let(:hwinfo) { OpenStruct.new(driver: ["iscsi-tcp"]) }
+            let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["iscsi-tcp"]) }
 
             it "sets #mount_options to an array containing the 'data' and '_netdev' options" do
               mount_point.set_default_mount_options
@@ -643,7 +643,7 @@ describe Y2Storage::MountPoint do
           end
 
           context "if the disk driver does not depend on any systemd service" do
-            let(:hwinfo) { OpenStruct.new(driver: ["qla4xxx"]) }
+            let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["qla4xxx"]) }
 
             it "sets #mount_options to an array containing only the data option" do
               mount_point.set_default_mount_options


### PR DESCRIPTION
## Problem

`Y2Storage::HWInfoReader` used to return `OpenStruct` objects (for devices that are known to hwinfo) or `nil` (for not found devices). That left too much to be done in the side of the caller.

## Solution

The underlying `OpenStruct` objects are now encapsulated in objects of the new class `Y2Storage::HWInfoDisk`. To ensure backwards compatibility, the new class is a subclass of `OpenStruct`, but it offers additional information like proper default values in some well-known cases, like multi-valued attributes.

In addition `HWInfoReader` does not longer return nil for unknown devices, but an empty `HWInfoDisk` object.


## Testing
Unit tests adapted