### PR TITLE
use libstorage-ng to determine whether efibootmgr is available (bsc#937067)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec  9 13:25:29 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>
+
+- use libstorage-ng to determine whether efibootmgr is available
+  (bsc#937067)
+- 4.4.22
+
+-------------------------------------------------------------------
 Wed Dec  8 10:01:35 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Prepare code for ruby3 - adapt openstruct usage (bsc#1193192)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.21
+Version:        4.4.22
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# Encryption#pbkdf
-BuildRequires:	libstorage-ng-ruby >= 4.4.56
+# Storage::Arch.is_efibootmgr
+BuildRequires:	libstorage-ng-ruby >= 4.4.61
 BuildRequires:  update-desktop-files
 # Yast::Kernel.propose_hibernation?
 BuildRequires:  yast2 >= 4.3.41
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# Encryption#pbkdf
-Requires:       libstorage-ng-ruby >= 4.4.56
+# Storage::Arch.is_efibootmgr
+Requires:       libstorage-ng-ruby >= 4.4.61
 # Yast::Kernel.propose_hibernation?
 Requires:       yast2 >= 4.3.41
 # Y2Packager::Repository

--- a/test/y2storage/arch_test.rb
+++ b/test/y2storage/arch_test.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+describe Y2Storage::Arch do
+  subject = described_class
+
+  describe "#new" do
+    it "returns a Y2Storage::Arch object" do
+      expect(subject.new).to be_a Y2Storage::Arch
+    end
+  end
+
+  describe "#efiboot?" do
+    context "if /etc/install.inf::EFI is set to 1" do
+      before do
+        allow(Yast::Linuxrc).to receive(:InstallInf).with("EFI").and_return("1")
+      end
+
+      it "returns true" do
+        expect(subject.new.efiboot?).to eq true
+      end
+    end
+
+    context "if /etc/install.inf::EFI is set to 0" do
+      before do
+        allow(Yast::Linuxrc).to receive(:InstallInf).with("EFI").and_return("0")
+      end
+
+      it "returns false" do
+        expect(subject.new.efiboot?).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

- https://trello.com/c/ZWMQnKom
- https://bugzilla.suse.com/show_bug.cgi?id=937067

EFI detection code is all over the place. Consolidate in one spot. As libstorage-ng is using this as well - rely on libstorage-ng.

## Solution

- add `Y2Storage::Arch.efibootmgr?` method
- `Y2Storage::Arch.efiboot?` takes `LIBSTORAGE_EFI` and `/etc/install.inf::efi` settings into account
- `Y2Storage::StorageManager.arch` is initialized  taking `LIBSTORAGE_EFI` and `/etc/install.inf::efi` settings into account

## Note

`#efibootmgr?` and `#efiboot?` are independent and do not rely on each other (`#efiboot? == false` does not imply `#efibootmgr? == false`, for example). This is how it works in libstorage-ng and the sematics are kept here.

## See also

- https://github.com/openSUSE/libstorage-ng/pull/846