### PR TITLE
Unify the Yes/No popup button IDs (bsc#1193326)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec  2 14:44:24 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Unify the Yes/No popup button IDs (bsc#1193326)
+- 4.4.17
+
+-------------------------------------------------------------------
 Wed Dec  1 14:00:02 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Prepare code for ruby3 (bsc#1193192)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.16
+Version:        4.4.17
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/confirm_recursive_delete.rb
+++ b/src/lib/y2partitioner/confirm_recursive_delete.rb
@@ -39,7 +39,7 @@ module Y2Partitioner
       button_box = ButtonBox(
         PushButton(Id(:yes), Opt(:okButton), recursive_delete_yes_label),
         PushButton(
-          Id(:no_button),
+          Id(:no),
           Opt(:default, :cancelButton),
           recursive_delete_no_label
         )


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1193326
- Let's use the same button IDs in all Yes/No popups to make testing via libyui REST API easier