### PR TITLE
Fix tests

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Dec  3 12:21:14 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Fix regression for unit tests: mock the generation of Bcache
+  issues to avoid setting the architecture for every test (related
+  to jsc#SLE-18430).
+- 4.4.20
+
+-------------------------------------------------------------------
 Thu Dec  2 16:36:41 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Refined the criteria used to check whether a certain mount point

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.19
+Version:        4.4.20
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -109,15 +109,14 @@ RSpec.configure do |c|
       end
     end
 
-    # Bcache is only supported for x86_64 architecture. The sanitizer complains when
-    # Bcache is used with another architecture. Bcache errors are mocked here to avoid
-    # to have to indicate x86_84 architecture in every test using Bcache (which has
-    # demonstrated to be quite error prone).
+    # Bcache is only supported for x86_64 architecture. Probing the devicegraph complains if Bcache is
+    # used with another architecture. Bcache error is avoided here. Otherwise, x86_84 architecture must
+    # to be set for every test using Bcache (which has demonstrated to be quite error prone).
     #
-    # This should be properly unmocked in the tests where real Bcache checking needs
-    # to be performed (e.g., DevicegraphSanitizer tests).
-    allow_any_instance_of(Y2Storage::DevicegraphSanitizer)
-      .to receive(:bcaches_errors).and_return([])
+    # This should be properly unmocked in the tests where real Bcache checking needs to be performed
+    # (e.g., for ProbedDevicegraphChecker tests).
+    allow_any_instance_of(Y2Storage::ProbedDevicegraphChecker)
+      .to receive(:unsupported_bcache?).and_return(false)
   end
 
   # Some tests use ProposalSettings#new_for_current_product to initialize

--- a/test/y2storage/probed_devicegraph_checker_test.rb
+++ b/test/y2storage/probed_devicegraph_checker_test.rb
@@ -60,6 +60,14 @@ describe Y2Storage::ProbedDevicegraphChecker do
     end
 
     context "when there is a bcache device" do
+      before do
+        # Unmock #unsupported_bcache?, see RSpec config at spec_helper.rb
+        allow_any_instance_of(Y2Storage::ProbedDevicegraphChecker)
+          .to receive(:unsupported_bcache?).and_call_original
+      end
+
+      # Note: the devicegraph is only loaded but not probed, see {#devicegraph_from}. If the devicegraph
+      # is probed, then the test would fail because a Bcache error is reported.
       let(:devicegraph) { devicegraph_from("bcache2.xml") }
 
       context "on an architecture that supports bcache (x86_64)" do
@@ -73,9 +81,8 @@ describe Y2Storage::ProbedDevicegraphChecker do
       context "on an architecture that does not support bcache (ppc)" do
         let(:architecture) { :ppc }
 
-        it "contains a unsupported bcache issues" do
+        it "contains an unsupported bcache issue" do
           issues = subject.issues
-
           expect(issues).not_to be_empty
           expect(issues).to include(be_a(Y2Storage::UnsupportedBcacheIssue))
         end


### PR DESCRIPTION
## Problem

Unit tests are failing in OBS when the architecture is not x86. Failing after merging https://github.com/yast/yast-storage-ng/pull/1248.

The tests are failing now because the generation of Bcache probing errors were mocked in order to avoid to indicate the architecture for every test. But such a mock became obsolete with the last chages.

* https://build.opensuse.org/request/show/935417

## Solution

Fix regression in unit tests by properly mocking the generation of Bcache errors.

## Testing

* Tests adapted.
