### PR TITLE
Added YaST Console checkbox for enabling LUKS2 support

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 22 17:37:23 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Display LUKS2 configuration checkbox in the installer console
+  (related to jsc#SLE-21308)
+- 4.4.29
+
+-------------------------------------------------------------------
 Wed Dec 22 14:06:54 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Dropped test clients proposal_testing and partitioner_testing in

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.28
+Version:        4.4.29
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/installation/console/plugins/luks2_checkbox.rb
+++ b/src/lib/installation/console/plugins/luks2_checkbox.rb
@@ -1,0 +1,73 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "yast"
+
+require "cwm"
+require "installation/console/menu_plugin"
+require "y2storage/storage_env"
+
+module Installation
+  module Console
+    module Plugins
+      # define a checkbox for enabling the experimental LUKS2 support in the installer
+      class LUKS2CheckBox < CWM::CheckBox
+        include Yast::Logger
+        def initialize
+          textdomain "storage"
+        end
+
+        # set the initial status
+        def init
+          check if Y2Storage::StorageEnv.instance.luks2_available?
+        end
+
+        def label
+          # TRANSLATORS: check box label
+          _("Enable Experimental LUKS2 Encryption Support")
+        end
+
+        def store
+          # the evaluated env variables are cached, we need to drop the cache
+          # when doing any change
+          Y2Storage::StorageEnv.instance.reset_cache
+
+          if checked?
+            ENV["YAST_LUKS2_AVAILABLE"] = "1"
+          else
+            ENV.delete("YAST_LUKS2_AVAILABLE")
+          end
+        end
+
+        def help
+          # TRANSLATORS: help text for the checkbox enabling LUKS2 support
+          _("<p>You can enable experimental LUKS2 encryption support in "\
+            "the YaST partitioner. It is not supported and is designed as a " \
+            "technology preview only.</p>")
+        end
+      end
+
+      # define the plugin
+      class LUKS2CheckBoxPlugin < MenuPlugin
+        def widget
+          LUKS2CheckBox.new
+        end
+
+        # at the end
+        def order
+          2000
+        end
+      end
+    end
+  end
+end

--- a/src/lib/installation/console/plugins/luks2_checkbox.rb
+++ b/src/lib/installation/console/plugins/luks2_checkbox.rb
@@ -23,6 +23,7 @@ module Installation
       # define a checkbox for enabling the experimental LUKS2 support in the installer
       class LUKS2CheckBox < CWM::CheckBox
         include Yast::Logger
+
         def initialize
           textdomain "storage"
         end

--- a/src/lib/y2storage/storage_env.rb
+++ b/src/lib/y2storage/storage_env.rb
@@ -40,6 +40,13 @@ module Y2Storage
     private_constant :ENV_LIBSTORAGE_IGNORE_PROBE_ERRORS
 
     def initialize
+      reset_cache
+    end
+
+    # Reset the cached values of the environment variables,
+    # call this after changing the value of any used environment variable
+    def reset_cache
+      log.debug "Resetting ENV values cache"
       @active_cache = {}
     end
 

--- a/test/installation/console/plugins/luks2_checkbox_test.rb
+++ b/test/installation/console/plugins/luks2_checkbox_test.rb
@@ -1,0 +1,107 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../spec_helper"
+
+# mock the "installation/console/menu_plugin" content (from yast2-installation)
+module Installation
+  module Console
+    class MenuPlugin
+    end
+  end
+end
+
+require "installation/console/plugins/luks2_checkbox"
+require "cwm/rspec"
+
+describe Installation::Console::Plugins::LUKS2CheckBox do
+  subject(:widget) { described_class.new }
+
+  include_examples "CWM::CheckBox"
+
+  describe "#init" do
+    before do
+      expect(Y2Storage::StorageEnv.instance).to receive(:luks2_available?)
+        .and_return(luks2_available)
+    end
+
+    context "LUKS2 available" do
+      let(:luks2_available) { true }
+
+      it "sets the initial state to checked" do
+        expect(widget).to receive(:check)
+        widget.init
+      end
+    end
+
+    context "LUKS2 not available" do
+      let(:luks2_available) { false }
+
+      it "sets the initial state to unchecked" do
+        expect(widget).to_not receive(:check)
+        widget.init
+      end
+    end
+  end
+
+  describe "#store" do
+    before do
+      allow(Y2Storage::StorageEnv.instance).to receive(:reset_cache)
+      allow(ENV).to receive(:delete)
+      allow(ENV).to receive(:[]=)
+
+      allow(widget).to receive(:checked?).and_return(checked)
+    end
+
+    context "the checkbox is checked" do
+      let(:checked) { true }
+
+      it "sets the YAST_LUKS2_AVAILABLE env variable to 1" do
+        expect(Y2Storage::StorageEnv.instance).to receive(:reset_cache)
+        expect(ENV).to receive(:[]=).with("YAST_LUKS2_AVAILABLE", "1")
+        widget.store
+      end
+    end
+
+    context "the checkbox is not checked" do
+      let(:checked) { false }
+
+      it "deletes the YAST_LUKS2_AVAILABLE env variable" do
+        expect(Y2Storage::StorageEnv.instance).to receive(:reset_cache)
+        expect(ENV).to receive(:delete).with("YAST_LUKS2_AVAILABLE")
+        widget.store
+      end
+    end
+  end
+end
+
+describe Installation::Console::Plugins::LUKS2CheckBoxPlugin do
+  describe "#order" do
+    it "returns a positive number" do
+      expect(subject.order).to be_a(Numeric)
+      expect(subject.order).to be > 0
+    end
+  end
+
+  describe "#widget" do
+    it "returns a CWM widget" do
+      expect(subject.widget).to be_a(CWM::AbstractWidget)
+    end
+  end
+end

--- a/test/installation/console/plugins/luks2_checkbox_test.rb
+++ b/test/installation/console/plugins/luks2_checkbox_test.rb
@@ -19,10 +19,17 @@
 
 require_relative "../../../spec_helper"
 
-# mock the "installation/console/menu_plugin" content (from yast2-installation)
-module Installation
-  module Console
-    class MenuPlugin
+begin
+  # in development or in GitHub Actions the file might be present,
+  # try loading the original file
+  old_require "installation/console/menu_plugin"
+rescue LoadError
+  # the file is missing, mock the "installation/console/menu_plugin" content,
+  # needed during RPM build
+  module Installation
+    module Console
+      class MenuPlugin
+      end
     end
   end
 end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -29,7 +29,7 @@ ENV["LC_ALL"] = "en_US.UTF-8"
 # fail fast if a class does not declare textdomain (bsc#1130822)
 ENV["Y2STRICTTEXTDOMAIN"] = "1"
 
-LIBS_TO_SKIP = ["y2packager/repository"]
+LIBS_TO_SKIP = ["y2packager/repository", "installation/console/menu_plugin"]
 
 # Hack to avoid to require some files
 #


### PR DESCRIPTION
## Problem

Activating the experimental LUKS2 support added in #1245 is quite tricky:
- You need to remember the quite long `YAST_LUKS2_AVAILABLE` variable name
- If you forget to set it before starting YaST then you have to reboot the installation and start again :thinking: 
- Once set you cannot change it later

## Solution

Add an checkbox in the YaST expert console, that makes the setting easily accessible and it can be changed even during installation.

This is a perfect use case why I introduced the YaST expert console.

## Testing

- Tested manually
- Use the `Ctrl+Alt+Shift+C` (in Qt) or `Ctrl+D Shift+C` (in ncurses) keyboard shortcut to activate the expert console

## Screenshots

#### Console Option

![luks2](https://user-images.githubusercontent.com/907998/144902418-07e36349-ce2b-44c1-917b-ef07a68eeaed.png)

#### How it Works

- First show the default encryption options
- Then activate the YaST expert console and enable LUKS2
- Show the encryption options again, now with the LUKS2 option available

![luks2](https://user-images.githubusercontent.com/907998/144902511-2a00b7be-8ea7-436d-99bc-9e548eb635da.gif)

## Notes

When we add some more options in the future we could add `[Configure Partitioner]` button and group the partitioner options in a separate subdialog like the network settings.

