### PR TITLE
Ruby3

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec  8 10:01:35 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Prepare code for ruby3 - adapt openstruct usage (bsc#1193192)
+- 4.4.21
+
+-------------------------------------------------------------------
 Fri Dec  3 12:21:14 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Fix regression for unit tests: mock the generation of Bcache

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.20
+Version:        4.4.21
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/hwinfo_disk.rb
+++ b/src/lib/y2storage/hwinfo_disk.rb
@@ -47,9 +47,9 @@ module Y2Storage
     def self.define_property(name, multi: false)
       define_method(name) do
         if multi
-          super() || []
+          self[name] || []
         else
-          super()
+          self[name]
         end
       end
     end


### PR DESCRIPTION
Follow up of adaptation for ruby3. Finally found what was issue with OpenStruct. It is changed how it defines methods and as result, super no longer works and returns always nil. So I use access with method[]. Verified in Staging:L
