### PR TITLE
Mount options from control file

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 10 10:18:05 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Proposal: add support for mount options (related to fate#318196).
+- 4.4.23
+
+-------------------------------------------------------------------
 Thu Dec  9 13:25:29 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>
 
 - use libstorage-ng to determine whether efibootmgr is available

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.22
+Version:        4.4.23
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/proposal/devices_planner.rb
+++ b/src/lib/y2storage/proposal/devices_planner.rb
@@ -131,7 +131,7 @@ module Y2Storage
       # Plans a device based on a <volume> section from control file
       #
       # @param volume [VolumeSpecification]
-      # @return [Planned::device]
+      # @return [Planned::Device]
       def planned_device(volume)
         if settings.separate_vgs && volume.separate_vg?
           planned_separate_vg(volume)
@@ -176,8 +176,9 @@ module Y2Storage
         adjust_sizes(planned_device, volume)
         adjust_btrfs(planned_device, volume)
         adjust_device(planned_device, volume)
-
         adjust_swap(planned_device, volume) if planned_device.swap?
+
+        planned_device.fstab_options = volume.mount_options&.split(",")
       end
 
       # Adjusts planned device weight according to settings

--- a/src/lib/y2storage/volume_specification.rb
+++ b/src/lib/y2storage/volume_specification.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2020] SUSE LLC
+# Copyright (c) [2017-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -33,6 +33,9 @@ module Y2Storage
 
     # @return [String] directory where the volume will be mounted in the system
     attr_accessor :mount_point
+
+    # @return [String] mount options, separated by comma
+    attr_accessor :mount_options
 
     # @return [Boolean] whether this volume should be created or skipped
     attr_accessor :proposed
@@ -288,6 +291,7 @@ module Y2Storage
 
     FEATURES = {
       mount_point:                :string,
+      mount_options:              :string,
       proposed:                   :boolean,
       proposed_configurable:      :boolean,
       fs_types:                   :list,

--- a/test/y2storage/volume_specification_test.rb
+++ b/test/y2storage/volume_specification_test.rb
@@ -83,6 +83,7 @@ describe Y2Storage::VolumeSpecification do
     let(:volume_features) do
       {
         "mount_point"                => mount_point,
+        "mount_options"              => mount_options,
         "proposed"                   => proposed,
         "proposed_configurable"      => proposed_configurable,
         "desired_size"               => desired_size,
@@ -103,6 +104,7 @@ describe Y2Storage::VolumeSpecification do
     end
 
     let(:mount_point) { "/home" }
+    let(:mount_options) { "ro,defaults" }
     let(:proposed) { true }
     let(:proposed_configurable) { true }
     let(:desired_size) { "5 GiB" }
@@ -122,6 +124,7 @@ describe Y2Storage::VolumeSpecification do
 
     it "creates an object with the indicated features" do
       expect(subject.mount_point).to eq("/home")
+      expect(subject.mount_options).to eq("ro,defaults")
       expect(subject.proposed).to eq(true)
       expect(subject.proposed_configurable).to eq(true)
       expect(subject.desired_size).to eq(5.GiB)


### PR DESCRIPTION
## Problem

The installation control file now allows to indicate mount options, see https://github.com/yast/yast-installation-control/pull/115. The storage proposal needs to be adapted to take the given mount options into account.

* https://trello.com/c/NITXJzLx/1745-3-mount-options-for-a-volume-in-the-partitioning-section-of-controlxml

## Solution

Add support for mount options to the storage proposal. Default mount options are still used if the control file does not contain *<mount_options>*. 

Note: the term to refer to mount options lack of consistency through the code and UI:

* `VolumeSpecification#mount_options`
* `Planned::Device#fstab_options`
* `MountPoint#mount_options`
* Device Overview Dialog: "Mount Options"
* Edit device dialog: "Fstab Options" 
* AutoYaST profile: `<fstopt>`
* Control file: `<mount_options>`


## Testing

* Added unit tests
* Tested manually with *proposal_testing* client.
