### PR TITLE
Allow abort, even from standalone modules, when probing finds issues

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 15 18:48:46 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Add support for improving the handling if the user decides to
+  abort when reporting probing issues (bsc#1193749).
+- 4.4.27
+
+-------------------------------------------------------------------
 Wed Dec 15 16:28:02 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>
 
 - Partitioner: nest thin logical volumes below their thin pools (related to

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
 Wed Dec 15 18:48:46 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
-- Add support for improving the handling if the user decides to
-  abort when reporting probing issues (bsc#1193749).
+- Improve probing issues handling by raising exceptions.
+- Fix aborting from standalone modules when the user decides
+  to not continue (bsc#1193749).
 - 4.4.27
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.26
+Version:        4.4.27
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -233,25 +233,14 @@ module Y2Storage
     #   returned by libstorage-ng. This staging is initialized from the sanitized
     #   probed devicegraph (see {#manage_probing_issues}).
     #
-    # @return [Devicegraph]
-    def staging
-      @staging ||= begin
-        probe unless probed?
-        Devicegraph.new(storage.staging)
-      end
-    end
-
-    # Staging devicegraph
-    #
-    # @see #staging
-    #
     # @raise [Storage::Exception, Yast::AbortException] when probe fails
     #
     # @return [Devicegraph]
-    def staging!
-      probe! unless probed?
-
-      staging
+    def staging
+      @staging ||= begin
+        probe! unless probed?
+        Devicegraph.new(storage.staging)
+      end
     end
 
     # Copies the manually-calculated (no proposal) devicegraph to staging.

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -228,6 +228,20 @@ module Y2Storage
       end
     end
 
+    # Staging devicegraph
+    #
+    # @raise [Yast::AbortException] when {#probe} returns false
+    # @see #staging
+    #
+    # @return [Devicegraph]
+    def staging!
+      success = probed? ? true : probe
+
+      raise Yast::AbortException unless success
+
+      staging
+    end
+
     # Copies the manually-calculated (no proposal) devicegraph to staging.
     #
     # If the devicegraph was calculated by means of a proposal, use #proposal=

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -163,7 +163,9 @@ module Y2Storage
     def probe(probe_callbacks: nil)
       probe!(probe_callbacks: probe_callbacks)
       true
-    rescue Storage::Exception, Yast::AbortException
+    rescue Storage::Exception, Yast::AbortException => e
+      log.error("ERROR: #{e.message}")
+
       false
     end
 
@@ -491,9 +493,7 @@ module Y2Storage
     def manage_probing_issues
       continue = raw_probed.issues_manager.report_probing_issues
 
-      if !continue
-        raise Yast::AbortException, "User has aborted because probed devicegraph contains errors"
-      end
+      raise Yast::AbortException, "Devicegraph contains errors. User has aborted." unless continue
 
       sanitizer = DevicegraphSanitizer.new(raw_probed)
 

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -504,17 +504,17 @@ module Y2Storage
     def manage_probing_issues
       continue = raw_probed.issues_manager.report_probing_issues
 
-      if continue
-        sanitizer = DevicegraphSanitizer.new(raw_probed)
-
-        @probed_graph = sanitizer.sanitized_devicegraph
-        @probed_graph.safe_copy(staging)
-
-        # Save sanitized devicegraph into logs
-        log.info("Sanitized probed devicegraph\n#{probed.to_xml}")
-      else
+      if !continue
         raise Yast::AbortException, "User has aborted because probed devicegraph contains errors"
       end
+
+      sanitizer = DevicegraphSanitizer.new(raw_probed)
+
+      @probed_graph = sanitizer.sanitized_devicegraph
+      @probed_graph.safe_copy(staging)
+
+      # Save sanitized devicegraph into logs
+      log.info("Sanitized probed devicegraph\n#{probed.to_xml}")
     end
 
     # Whether the final steps to configure Snapper should be performed by YaST

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -205,13 +205,11 @@ module Y2Storage
     #   some errors (e.g., incomplete LVM VGs). This probed devicegraph
     #   is the result of sanitizing the initial raw probed.
     #
-    # @see #raw_probed
+    # @raise [Storage::Exception, Yast::AbortException] when probe fails
     #
     # @return [Devicegraph]
     def probed
-      return @probed_graph if @probed_graph
-
-      probe unless probed?
+      probe! unless probed?
       @probed_graph
     end
 

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -630,41 +630,144 @@ describe Y2Storage::StorageManager do
     end
   end
 
-  describe "#staging!" do
+  describe "#staging" do
     context "when system has not been probed yet" do
-      before do
-        allow(subject).to receive(:probed?).and_return(false)
-        allow(subject).to receive(:probe).and_return(probing_result)
+      it "performs probing" do
+        expect(manager).to receive(:probe!).and_call_original
+
+        manager.staging
       end
 
-      context "and probing returns true" do
-        let(:probing_result) { true }
+      it "returns a devicegraph" do
+        expect(manager.staging).to be_a(Y2Storage::Devicegraph)
+      end
 
-        it "does not raise an error" do
-          expect { subject.staging! }.to_not raise_error
+      context "and libstorage-ng fails while probing" do
+        before do
+          allow(manager.storage).to receive(:probe).and_raise Storage::Exception
+        end
+
+        it "does not raise an exception" do
+          expect { manager.staging }.to_not raise_error
         end
 
         it "returns a devicegraph" do
-          expect(subject.staging!).to be_a(Y2Storage::Devicegraph)
+          expect(manager.staging).to be_a(Y2Storage::Devicegraph)
         end
       end
 
-      context "and probing returns false" do
-        let(:probing_result) { false }
+      context "and there are issues during probing" do
+        before do
+          allow(manager.storage).to receive(:probed).and_return st_probed
+          allow_any_instance_of(Y2Storage::IssuesManager)
+            .to receive(:report_probing_issues).and_return(continue)
+        end
 
-        it "raises a Yast::AbortException" do
-          expect { subject.staging! }.to raise_error(Yast::AbortException)
+        let(:st_probed) { devicegraph_from("lvm-errors1-devicegraph.xml").to_storage_value }
+        let(:continue) { true }
+
+        it "reports the probing issues" do
+          expect_any_instance_of(Y2Storage::IssuesManager).to receive(:report_probing_issues)
+
+          manager.staging
+        end
+
+        context "but the user decides continue" do
+          let(:continue) { true }
+
+          it "does not raise an exception" do
+            expect { manager.staging }.to_not raise_error
+          end
+
+          it "returns a devicegraph" do
+            expect(manager.staging).to be_a(Y2Storage::Devicegraph)
+          end
+        end
+
+        context "and the user decides abort" do
+          let(:continue) { false }
+
+          it "does not raise an exception" do
+            expect { manager.staging }.to_not raise_error
+          end
+
+          it "returns a devicegraph" do
+            expect(manager.staging).to be_a(Y2Storage::Devicegraph)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#staging!" do
+    context "when system has not been probed yet" do
+      it "performs probing" do
+        expect(manager).to receive(:probe!).and_call_original
+
+        manager.staging!
+      end
+
+      it "returns a devicegraph" do
+        expect(manager.staging!).to be_a(Y2Storage::Devicegraph)
+      end
+
+      context "and libstorage-ng fails while probing" do
+        before do
+          allow(manager.storage).to receive(:probe).and_raise Storage::Exception
+        end
+
+        it "raises an exception" do
+          expect { manager.staging! }.to raise_error(Storage::Exception)
+        end
+      end
+
+      context "and there are issues during probing" do
+        before do
+          allow(manager.storage).to receive(:probed).and_return st_probed
+          allow_any_instance_of(Y2Storage::IssuesManager)
+            .to receive(:report_probing_issues).and_return(continue)
+        end
+
+        let(:st_probed) { devicegraph_from("lvm-errors1-devicegraph.xml").to_storage_value }
+        let(:continue) { true }
+
+        it "reports the probing issues" do
+          expect_any_instance_of(Y2Storage::IssuesManager).to receive(:report_probing_issues)
+
+          manager.staging!
+        end
+
+        context "but the user decides continue" do
+          let(:continue) { true }
+
+          it "does not raise an exception" do
+            expect { manager.staging! }.to_not raise_error
+          end
+
+          it "returns a devicegraph" do
+            expect(manager.staging!).to be_a(Y2Storage::Devicegraph)
+          end
+        end
+
+        context "and the user decides abort" do
+          let(:continue) { false }
+
+          it "raises a Yast::AbortException" do
+            expect { manager.staging! }.to raise_error(Yast::AbortException)
+          end
         end
       end
     end
 
     context "when system has been already probed" do
       before do
-        fake_scenario("gpt_and_msdos")
+        described_class.instance.probe_from_yaml(input_file_for("gpt_and_msdos"))
       end
 
-      it "does not raise an error" do
-        expect { subject.staging! }.to_not raise_error
+      it "does not perform probing" do
+        expect(manager).to_not receive(:probe!)
+
+        manager.staging!
       end
 
       it "returns a devicegraph" do
@@ -674,6 +777,59 @@ describe Y2Storage::StorageManager do
   end
 
   describe "#probe" do
+    context "when system has not been probed yet" do
+      it "performs probing" do
+        expect(manager).to receive(:probe!).and_call_original
+
+        manager.probe
+      end
+
+      context "and libstorage-ng fails while probing" do
+        before do
+          allow(manager.storage).to receive(:probe).and_raise Storage::Exception
+        end
+
+        it "returns false" do
+          expect(manager.probe).to eq(false)
+        end
+      end
+
+      context "and there are issues during probing" do
+        before do
+          allow(manager.storage).to receive(:probed).and_return st_probed
+          allow_any_instance_of(Y2Storage::IssuesManager)
+            .to receive(:report_probing_issues).and_return(continue)
+        end
+
+        let(:st_probed) { devicegraph_from("lvm-errors1-devicegraph.xml").to_storage_value }
+        let(:continue) { true }
+
+        it "reports the probing issues" do
+          expect_any_instance_of(Y2Storage::IssuesManager).to receive(:report_probing_issues)
+
+          manager.probe
+        end
+
+        context "but the user decides continue" do
+          let(:continue) { true }
+
+          it "returns true" do
+            expect(manager.probe).to eq(true)
+          end
+        end
+
+        context "and the user decides abort" do
+          let(:continue) { false }
+
+          it "returns false" do
+            expect(manager.probe).to eq(false)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#probe!" do
     before do
       described_class.instance.probe_from_yaml(input_file_for("gpt_and_msdos"))
       # Ensure old values have been queried at least once
@@ -702,7 +858,7 @@ describe Y2Storage::StorageManager do
       expect(manager.probed.disks.size).to eq 6
       expect(manager.probed.to_storage_value).to_not eq st_probed
 
-      manager.probe
+      manager.probe!
 
       expect(manager.probed.disks.size).to eq 0
       expect(manager.probed.to_storage_value).to eq st_probed
@@ -714,7 +870,7 @@ describe Y2Storage::StorageManager do
       expect(manager.probed.disks.size).to eq 6
       expect(manager.probed.to_storage_value).to_not eq st_staging
 
-      manager.probe
+      manager.probe!
 
       expect(manager.probed.disks.size).to eq 0
       expect(manager.probed.to_storage_value).to eq st_staging
@@ -726,7 +882,7 @@ describe Y2Storage::StorageManager do
       expect(manager.system.disks.size).to eq 6
       expect(manager.system.to_storage_value).to_not eq st_system
 
-      manager.probe
+      manager.probe!
 
       expect(manager.system.disks.size).to eq 0
       expect(manager.system.to_storage_value).to eq st_probed
@@ -734,7 +890,7 @@ describe Y2Storage::StorageManager do
 
     it "increments the staging revision" do
       pre = manager.staging_revision
-      manager.probe
+      manager.probe!
       expect(manager.staging_revision).to be > pre
     end
 
@@ -743,55 +899,43 @@ describe Y2Storage::StorageManager do
       # Calling twice (or more) does not result in a refresh
       expect(manager.probed_disk_analyzer).to eq pre
 
-      manager.probe
+      manager.probe!
       expect(manager.probed_disk_analyzer).to_not eq pre
     end
 
     it "sets #proposal to nil" do
       manager.proposal = proposal
-      manager.probe
+      manager.probe!
       expect(manager.proposal).to be_nil
     end
 
-    it "returns true if everything goes fine" do
-      expect(manager.probe).to eq true
+    it "returns nil if everything goes fine" do
+      expect(manager.probe!).to be_nil
     end
 
-    context "if libstorage-ng fails and the user decides to abort" do
+    context "and there are issues during probing" do
       before do
-        allow(manager.storage).to receive(:probe).and_raise Storage::Exception
-      end
-
-      it "returns false" do
-        expect(manager.probe).to eq false
-      end
-    end
-
-    context "if there are probing issues" do
-      shared_examples "sanitize" do
-        it "sanitizes the raw probed devicegraph" do
-          manager.probe
-          expect(manager.probed.disks).to_not be_empty
-          expect(manager.probed.lvm_vgs).to be_empty
-        end
-
-        it "copies the sanitized probed into staging" do
-          manager.probe
-          expect(manager.staging).to eq(manager.probed)
-        end
-      end
-
-      let(:st_probed) { devicegraph_from("lvm-errors1-devicegraph.xml").to_storage_value }
-
-      before do
+        allow(manager.storage).to receive(:probed).and_return st_probed
         allow_any_instance_of(Y2Storage::IssuesManager)
           .to receive(:report_probing_issues).and_return(continue)
       end
 
+      let(:st_probed) { devicegraph_from("lvm-errors1-devicegraph.xml").to_storage_value }
       let(:continue) { true }
 
+      it "sanitizes the raw probed devicegraph" do
+        manager.probe!
+        expect(manager.probed.disks).to_not be_empty
+        expect(manager.probed.lvm_vgs).to be_empty
+      end
+
+      it "copies the sanitized probed into staging" do
+        manager.probe!
+        expect(manager.staging).to eq(manager.probed)
+      end
+
       it "stores the issues" do
-        manager.probe
+        manager.probe!
         issues_manager = manager.probed.issues_manager
 
         expect(issues_manager.probing_issues).to be_a(Y2Issues::List)
@@ -801,29 +945,22 @@ describe Y2Storage::StorageManager do
       it "reports the probing issues" do
         expect_any_instance_of(Y2Storage::IssuesManager).to receive(:report_probing_issues)
 
-        manager.probe
+        manager.probe!
       end
 
-      context "and the reporter reports to continue" do
+      context "and the user decides continue" do
         let(:continue) { true }
 
-        include_examples "sanitize"
-
-        it "returns true" do
-          expect(manager.probe).to eq(true)
+        it "does not raise an exception" do
+          expect { manager.probe! }.to_not raise_error
         end
       end
 
-      context "and the reporter reports to abort" do
+      context "and the user decides abort" do
         let(:continue) { false }
 
-        it "does not sanitize the raw probed devicegraph" do
-          manager.probe
-          expect(manager.probed).to be_nil
-        end
-
-        it "returns false" do
-          expect(manager.probe).to eq(false)
+        it "raises a Yast::AbortException" do
+          expect { manager.probe! }.to raise_error(Yast::AbortException)
         end
       end
     end

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -913,6 +913,16 @@ describe Y2Storage::StorageManager do
       expect(manager.probe!).to be_nil
     end
 
+    context "and libstorage-ng fails while probing" do
+      before do
+        allow(manager.storage).to receive(:probe).and_raise Storage::Exception
+      end
+
+      it "raises an exception" do
+        expect { manager.probe! }.to raise_error(Storage::Exception)
+      end
+    end
+
     context "and there are issues during probing" do
       before do
         allow(manager.storage).to receive(:probed).and_return st_probed

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -25,6 +25,8 @@ require "y2storage"
 describe Y2Storage::StorageManager do
   subject(:manager) { described_class.instance }
 
+  include Yast::Logger
+
   before do
     described_class.create_test_instance
   end
@@ -670,6 +672,12 @@ describe Y2Storage::StorageManager do
         it "returns false" do
           expect(manager.probe).to eq(false)
         end
+
+        it "logs the error" do
+          expect(log).to receive(:error)
+
+          manager.probe
+        end
       end
 
       context "and there are issues during probing" do
@@ -701,6 +709,12 @@ describe Y2Storage::StorageManager do
 
           it "returns false" do
             expect(manager.probe).to eq(false)
+          end
+
+          it "logs an error" do
+            expect(log).to receive(:error).with(/Devicegraph contains errors/)
+
+            manager.probe
           end
         end
       end

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -647,12 +647,8 @@ describe Y2Storage::StorageManager do
           allow(manager.storage).to receive(:probe).and_raise Storage::Exception
         end
 
-        it "does not raise an exception" do
-          expect { manager.staging }.to_not raise_error
-        end
-
-        it "returns a devicegraph" do
-          expect(manager.staging).to be_a(Y2Storage::Devicegraph)
+        it "raises an exception" do
+          expect { manager.staging }.to raise_error(Storage::Exception)
         end
       end
 
@@ -687,73 +683,8 @@ describe Y2Storage::StorageManager do
         context "and the user decides to abort" do
           let(:continue) { false }
 
-          it "does not raise an exception" do
-            expect { manager.staging }.to_not raise_error
-          end
-
-          it "returns a devicegraph" do
-            expect(manager.staging).to be_a(Y2Storage::Devicegraph)
-          end
-        end
-      end
-    end
-  end
-
-  describe "#staging!" do
-    context "when system has not been probed yet" do
-      it "performs probing" do
-        expect(manager).to receive(:probe!).and_call_original
-
-        manager.staging!
-      end
-
-      it "returns a devicegraph" do
-        expect(manager.staging!).to be_a(Y2Storage::Devicegraph)
-      end
-
-      context "and libstorage-ng fails while probing" do
-        before do
-          allow(manager.storage).to receive(:probe).and_raise Storage::Exception
-        end
-
-        it "raises an exception" do
-          expect { manager.staging! }.to raise_error(Storage::Exception)
-        end
-      end
-
-      context "and there are issues during probing" do
-        before do
-          allow(manager.storage).to receive(:probed).and_return st_probed
-          allow_any_instance_of(Y2Storage::IssuesManager)
-            .to receive(:report_probing_issues).and_return(continue)
-        end
-
-        let(:st_probed) { devicegraph_from("lvm-errors1-devicegraph.xml").to_storage_value }
-        let(:continue) { true }
-
-        it "reports the probing issues" do
-          expect_any_instance_of(Y2Storage::IssuesManager).to receive(:report_probing_issues)
-
-          manager.staging!
-        end
-
-        context "but the user decides to continue" do
-          let(:continue) { true }
-
-          it "does not raise an exception" do
-            expect { manager.staging! }.to_not raise_error
-          end
-
-          it "returns a devicegraph" do
-            expect(manager.staging!).to be_a(Y2Storage::Devicegraph)
-          end
-        end
-
-        context "and the user decides to abort" do
-          let(:continue) { false }
-
           it "raises a Yast::AbortException" do
-            expect { manager.staging! }.to raise_error(Yast::AbortException)
+            expect { manager.staging }.to raise_error(Yast::AbortException)
           end
         end
       end
@@ -767,11 +698,11 @@ describe Y2Storage::StorageManager do
       it "does not perform probing" do
         expect(manager).to_not receive(:probe!)
 
-        manager.staging!
+        manager.staging
       end
 
       it "returns a devicegraph" do
-        expect(subject.staging!).to be_a(Y2Storage::Devicegraph)
+        expect(subject.staging).to be_a(Y2Storage::Devicegraph)
       end
     end
   end

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -630,6 +630,49 @@ describe Y2Storage::StorageManager do
     end
   end
 
+  describe "#staging!" do
+    context "when system has not been probed yet" do
+      before do
+        allow(subject).to receive(:probed?).and_return(false)
+        allow(subject).to receive(:probe).and_return(probing_result)
+      end
+
+      context "and probing returns true" do
+        let(:probing_result) { true }
+
+        it "does not raise an error" do
+          expect { subject.staging! }.to_not raise_error
+        end
+
+        it "returns a devicegraph" do
+          expect(subject.staging!).to be_a(Y2Storage::Devicegraph)
+        end
+      end
+
+      context "and probing returns false" do
+        let(:probing_result) { false }
+
+        it "raises a Yast::AbortException" do
+          expect { subject.staging! }.to raise_error(Yast::AbortException)
+        end
+      end
+    end
+
+    context "when system has been already probed" do
+      before do
+        fake_scenario("gpt_and_msdos")
+      end
+
+      it "does not raise an error" do
+        expect { subject.staging! }.to_not raise_error
+      end
+
+      it "returns a devicegraph" do
+        expect(subject.staging!).to be_a(Y2Storage::Devicegraph)
+      end
+    end
+  end
+
   describe "#probe" do
     before do
       described_class.instance.probe_from_yaml(input_file_for("gpt_and_msdos"))

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -631,79 +631,26 @@ describe Y2Storage::StorageManager do
   end
 
   describe "#staging" do
-    context "when system has not been probed yet" do
-      it "performs probing" do
-        expect(manager).to receive(:probe!).and_call_original
+    it "uses #probe! for performing probing" do
+      expect(manager).to receive(:probe!)
 
-        manager.staging
-      end
-
-      it "returns a devicegraph" do
-        expect(manager.staging).to be_a(Y2Storage::Devicegraph)
-      end
-
-      context "and libstorage-ng fails while probing" do
-        before do
-          allow(manager.storage).to receive(:probe).and_raise Storage::Exception
-        end
-
-        it "raises an exception" do
-          expect { manager.staging }.to raise_error(Storage::Exception)
-        end
-      end
-
-      context "and there are issues during probing" do
-        before do
-          allow(manager.storage).to receive(:probed).and_return st_probed
-          allow_any_instance_of(Y2Storage::IssuesManager)
-            .to receive(:report_probing_issues).and_return(continue)
-        end
-
-        let(:st_probed) { devicegraph_from("lvm-errors1-devicegraph.xml").to_storage_value }
-        let(:continue) { true }
-
-        it "reports the probing issues" do
-          expect_any_instance_of(Y2Storage::IssuesManager).to receive(:report_probing_issues)
-
-          manager.staging
-        end
-
-        context "but the user decides to continue" do
-          let(:continue) { true }
-
-          it "does not raise an exception" do
-            expect { manager.staging }.to_not raise_error
-          end
-
-          it "returns a devicegraph" do
-            expect(manager.staging).to be_a(Y2Storage::Devicegraph)
-          end
-        end
-
-        context "and the user decides to abort" do
-          let(:continue) { false }
-
-          it "raises a Yast::AbortException" do
-            expect { manager.staging }.to raise_error(Yast::AbortException)
-          end
-        end
-      end
+      manager.staging
     end
 
-    context "when system has been already probed" do
-      before do
-        described_class.instance.probe_from_yaml(input_file_for("gpt_and_msdos"))
-      end
+    it "returns a devicegraph" do
+      expect(manager.staging).to be_a(Y2Storage::Devicegraph)
+    end
+  end
 
-      it "does not perform probing" do
-        expect(manager).to_not receive(:probe!)
+  describe "#probed" do
+    it "uses #probe! for performing probing" do
+      expect(manager).to receive(:probe!)
 
-        manager.staging
-      end
+      manager.probed
+    end
 
-      it "returns a devicegraph" do
-        expect(subject.staging).to be_a(Y2Storage::Devicegraph)
-      end
+    it "returns a devicegraph" do
+      expect(manager.probed).to be_a(Y2Storage::Devicegraph)
     end
   end
 
@@ -902,67 +849,6 @@ describe Y2Storage::StorageManager do
 
         it "raises a Yast::AbortException" do
           expect { manager.probe! }.to raise_error(Yast::AbortException)
-        end
-      end
-    end
-  end
-
-  describe "#probed" do
-    context "when system has not been probed yet" do
-      it "performs probing" do
-        expect(manager).to receive(:probe!).and_call_original
-
-        manager.probed
-      end
-
-      it "returns a devicegraph" do
-        expect(manager.probed).to be_a(Y2Storage::Devicegraph)
-      end
-
-      context "and libstorage-ng fails while probing" do
-        before do
-          allow(manager.storage).to receive(:probe).and_raise Storage::Exception
-        end
-
-        it "raises an exception" do
-          expect { manager.probed }.to raise_error(Storage::Exception)
-        end
-      end
-
-      context "and there are issues during probing" do
-        before do
-          allow(manager.storage).to receive(:probed).and_return st_probed
-          allow_any_instance_of(Y2Storage::IssuesManager)
-            .to receive(:report_probing_issues).and_return(continue)
-        end
-
-        let(:st_probed) { devicegraph_from("lvm-errors1-devicegraph.xml").to_storage_value }
-        let(:continue) { true }
-
-        it "reports the probing issues" do
-          expect_any_instance_of(Y2Storage::IssuesManager).to receive(:report_probing_issues)
-
-          manager.probed
-        end
-
-        context "but the user decides to continue" do
-          let(:continue) { true }
-
-          it "does not raise an exception" do
-            expect { manager.probed }.to_not raise_error
-          end
-
-          it "returns a devicegraph" do
-            expect(manager.probed).to be_a(Y2Storage::Devicegraph)
-          end
-        end
-
-        context "and the user decides to abort" do
-          let(:continue) { false }
-
-          it "raises a Yast::AbortException" do
-            expect { manager.probed }.to raise_error(Yast::AbortException)
-          end
         end
       end
     end

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -672,7 +672,7 @@ describe Y2Storage::StorageManager do
           manager.staging
         end
 
-        context "but the user decides continue" do
+        context "but the user decides to continue" do
           let(:continue) { true }
 
           it "does not raise an exception" do
@@ -684,7 +684,7 @@ describe Y2Storage::StorageManager do
           end
         end
 
-        context "and the user decides abort" do
+        context "and the user decides to abort" do
           let(:continue) { false }
 
           it "does not raise an exception" do
@@ -737,7 +737,7 @@ describe Y2Storage::StorageManager do
           manager.staging!
         end
 
-        context "but the user decides continue" do
+        context "but the user decides to continue" do
           let(:continue) { true }
 
           it "does not raise an exception" do
@@ -749,7 +749,7 @@ describe Y2Storage::StorageManager do
           end
         end
 
-        context "and the user decides abort" do
+        context "and the user decides to abort" do
           let(:continue) { false }
 
           it "raises a Yast::AbortException" do
@@ -810,7 +810,7 @@ describe Y2Storage::StorageManager do
           manager.probe
         end
 
-        context "but the user decides continue" do
+        context "but the user decides to continue" do
           let(:continue) { true }
 
           it "returns true" do
@@ -818,7 +818,7 @@ describe Y2Storage::StorageManager do
           end
         end
 
-        context "and the user decides abort" do
+        context "and the user decides to abort" do
           let(:continue) { false }
 
           it "returns false" do
@@ -948,7 +948,7 @@ describe Y2Storage::StorageManager do
         manager.probe!
       end
 
-      context "and the user decides continue" do
+      context "and the user decides to continue" do
         let(:continue) { true }
 
         it "does not raise an exception" do
@@ -956,7 +956,7 @@ describe Y2Storage::StorageManager do
         end
       end
 
-      context "and the user decides abort" do
+      context "and the user decides to abort" do
         let(:continue) { false }
 
         it "raises a Yast::AbortException" do


### PR DESCRIPTION
## Problem

When a standalone client (e.g., yast2-bootloader in a running system) performs the probing and find issues, the report introduced in https://github.com/yast/yast-storage-ng/pull/1248 is shown. However, the standalone module continues anyway when the user decides to abort.

* https://bugzilla.suse.com/show_bug.cgi?id=1193749
* https://trello.com/c/9YjFdL0a/2774-3-yast2-bootloader-and-maybe-others-does-not-abort-in-probing-issues (internal link)

<details>
<summary>Click to show/hide some examples</summary>

---

<table>
<tr>
<th>yast-bootloader</th>
<th>yast-rear</th>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/1691872/146373046-3339d758-2008-45d5-8d40-dadefd812648.mp4

</td>
<td>

https://user-images.githubusercontent.com/1691872/146373104-fda7cb28-bbff-4b9f-a8ed-0d72720ee3ed.mp4

</td>
</tr>
</table>
</details>

## Solution

After several discussions, below actions were considered the best solution by now

* to introduce a `#probe!` method for not handling exceptions while probing (`#probe` handles them and simply returns `true` or `false`)
* to change `#staging` and `#probed` methods for relying on _#probe_**_!_** instead of _#probe_
* to use [the already handled `Yast::AbortException`](https://github.com/yast/yast-ruby-bindings/blob/master/src/ruby/yast/wfm.rb#L358) when the user decides to abort instead of continue when probing issues are found.

This solution helps to avoid making changes in other YaST modules asking for either, the _staging_ or _probed_ devicegraph. So it invalidates https://github.com/yast/yast-bootloader/pull/658.

## Tests

- Added a new unit tests
- Tested manually in an installed system (by running yast-bootloader, yast-kdump, and yast-rear)
- Tested manually during an openSUSE TW installation using `yupdate patch yast/yast-storage-ng raise-error-on-probing-issues` to patch the source
- Tested manually during an openSUSE TW auto-installation using `yupdate patch yast/yast-storage-ng raise-error-on-probing-issues` to patch the source and a minimal profile.

<details>
<summary>Click to show/hide above examples after changes</summary>

---

<table>
<tr>
<th>yast-bootloader</th>
<th>yast-rear</th>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/1691872/146374125-c10793d7-d492-4365-93d8-85693c48b968.mp4

</td>
<td>

https://user-images.githubusercontent.com/1691872/146374143-26002259-d8d4-4211-b84f-8354c9709744.mp4

</td>
</tr>
</table>
</details>
