### PR TITLE
AutoYaST fixes for reusing encrypted devices and RAIDs

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 14 15:12:05 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- AutoYaST: fixes for reusing encrypted devices, RAIDs and bcache
+  devices (bsc#1193450).
+- 4.2.121
+
+-------------------------------------------------------------------
 Tue Nov 16 16:38:49 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Fix duplicate PV error detection with disabled multipath

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.120
+Version:        4.2.121
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -79,7 +79,7 @@ module Y2Storage
         result = super
         if create_encryption?
           method = encryption_method || EncryptionMethod.find(:luks1)
-          result = result.encrypt(method: method, password: encryption_password)
+          result = plain_device.encrypt(method: method, password: encryption_password)
           log.info "Device encrypted. Returning the new device #{result.inspect}"
         else
           log.info "No need to encrypt. Returning the existing device #{result.inspect}"

--- a/src/lib/y2storage/proposal/autoinst_bcache_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_bcache_planner.rb
@@ -95,6 +95,11 @@ module Y2Storage
           return
         end
         bcache.reuse_name = bcache_to_reuse.name
+
+        return unless section.is_a?(AutoinstProfile::PartitionSection)
+
+        bcache.reformat = !!section.format
+        check_reusable_filesystem(bcache, bcache_to_reuse, section)
       end
 
       # Finds the bcache to be reused by the given planned bcache

--- a/src/lib/y2storage/proposal/autoinst_bcache_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_bcache_planner.rb
@@ -95,11 +95,7 @@ module Y2Storage
           return
         end
         bcache.reuse_name = bcache_to_reuse.name
-
-        return unless section.is_a?(AutoinstProfile::PartitionSection)
-
-        bcache.reformat = !!section.format
-        check_reusable_filesystem(bcache, bcache_to_reuse, section)
+        config_filesystem_reuse(bcache, bcache_to_reuse, section)
       end
 
       # Finds the bcache to be reused by the given planned bcache

--- a/src/lib/y2storage/proposal/autoinst_drive_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_drive_planner.rb
@@ -286,14 +286,24 @@ module Y2Storage
         !!spec && spec.btrfs_read_only?
       end
 
-      # @param planned_device [Planned::Partition,Planned::LvmLV,Planned::Md] Planned device
+      # @param planned_device [Planned::Device] Planned device
       # @param device         [Y2Storage::Device] Device to reuse
       # @param section        [AutoinstProfile::PartitionSection] AutoYaST specification
       def add_device_reuse(planned_device, device, section)
-        planned_device.uuid = section.uuid
         planned_device.reuse_name = device.is_a?(LvmVg) ? device.volume_group_name : device.name
-        planned_device.reformat = !!section.format
+        planned_device.uuid = section.uuid
         planned_device.resize = !!section.resize if planned_device.respond_to?(:resize=)
+        config_filesystem_reuse(planned_device, device, section)
+      end
+
+      # @param planned_device [Planned::Device] Planned device
+      # @param device         [Y2Storage::Device] Device to reuse
+      # @param section        [AutoinstProfile::PartitionSection,AutoinstProfile::Drive] relevant section
+      #   of the AutoYaST specification
+      def config_filesystem_reuse(planned_device, device, section)
+        return unless section.is_a?(AutoinstProfile::PartitionSection)
+
+        planned_device.reformat = !!section.format
         check_reusable_filesystem(planned_device, device, section) if device.respond_to?(:filesystem)
       end
 

--- a/src/lib/y2storage/proposal/autoinst_md_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_md_planner.rb
@@ -145,10 +145,7 @@ module Y2Storage
           return
         end
         md.reuse_name = md_to_reuse.name
-        return unless section.is_a?(AutoinstProfile::PartitionSection)
-
-        md.reformat = !!section.format
-        check_reusable_filesystem(md, md_to_reuse, section)
+        config_filesystem_reuse(md, md_to_reuse, section)
       end
 
       # Parses the user specified chunk size

--- a/src/lib/y2storage/proposal/autoinst_md_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_md_planner.rb
@@ -145,6 +145,10 @@ module Y2Storage
           return
         end
         md.reuse_name = md_to_reuse.name
+        return unless section.is_a?(AutoinstProfile::PartitionSection)
+
+        md.reformat = !!section.format
+        check_reusable_filesystem(md, md_to_reuse, section)
       end
 
       # Parses the user specified chunk size

--- a/src/lib/y2storage/proposal/autoinst_partitioner.rb
+++ b/src/lib/y2storage/proposal/autoinst_partitioner.rb
@@ -119,7 +119,7 @@ module Y2Storage
       # @param planned_device [Planned::Device] Planned device
       # @return [Proposal::CreatorResult] Result containing the formatted device
       def format_device(device, planned_device)
-        planned_device.format!(device)
+        planned_device.format!(device) if can_format?(planned_device)
         CreatorResult.new(devicegraph, device.name => planned_device)
       end
 
@@ -161,6 +161,19 @@ module Y2Storage
 
         # Second try with more flexible planned partitions
         calculator.best_distribution(flexible_partitions(planned_partitions), spaces)
+      end
+
+      # Checks whether (re)formatting the given device is acceptable
+      #
+      # @see #format_device
+      #
+      # @param planned [Planned::Device] planned device
+      # @return [Boolean]
+      def can_format?(planned)
+        # If the device is not going to be reused, #reformat? is irrelevant
+        return true unless planned.reuse?
+
+        planned.reformat?
       end
     end
   end

--- a/test/data/devicegraphs/gpt_encryption.yml
+++ b/test/data/devicegraphs/gpt_encryption.yml
@@ -22,7 +22,6 @@
         name: "/dev/sda4"
         id: linux
         file_system: btrfs
-        mount_point: "/"
         encryption:
           type: luks
           name: "/dev/mapper/cr_sda4"

--- a/test/y2storage/autoinst_proposal_bcache_test.rb
+++ b/test/y2storage/autoinst_proposal_bcache_test.rb
@@ -47,8 +47,9 @@ describe Y2Storage::AutoinstProposal do
     let(:create) { true }
     let(:init) { true }
     let(:ptable_type) { "msdos" }
+    let(:format) { create }
     let(:root) do
-      { "create" => create, "filesystem" => :btrfs, "format" => create, "mount" => "/",
+      { "create" => create, "filesystem" => :btrfs, "format" => format, "mount" => "/",
         "partition_nr" => 1 }
     end
 
@@ -163,11 +164,51 @@ describe Y2Storage::AutoinstProposal do
       let(:init) { false }
       let(:create) { false }
 
-      it "does not create a new bcache" do
-        old_sid = fake_devicegraph.find_by_name("/dev/bcache0").sid
-        proposal.propose
-        bcache = proposal.devices.find_by_name("/dev/bcache0")
-        expect(bcache.sid).to eq(old_sid)
+      RSpec.shared_examples "reuse bcache" do
+        it "does not create a new bcache" do
+          old_sid = fake_devicegraph.find_by_name("/dev/bcache0").sid
+          proposal.propose
+          bcache = proposal.devices.find_by_name("/dev/bcache0")
+          expect(bcache.sid).to eq(old_sid)
+        end
+      end
+
+      include_examples "reuse bcache"
+
+      context "if the bcache is directly formatted" do
+        let(:ptable_type) { "none" }
+
+        before do
+          bcache0 = fake_devicegraph.find_by_name("/dev/bcache0")
+          bcache0.remove_descendants
+          bcache0.create_filesystem(Y2Storage::Filesystems::Type::EXT4)
+        end
+
+        context "and the bcache should be reformatted" do
+          let(:format) { true }
+
+          include_examples "reuse bcache"
+
+          it "formats the bcache as specified in the profile" do
+            proposal.propose
+            bcache = proposal.devices.find_by_name("/dev/bcache0")
+            expect(bcache.filesystem.type).to eq(Y2Storage::Filesystems::Type::BTRFS)
+            expect(bcache.filesystem.mount_point.path).to eq("/")
+          end
+        end
+
+        context "and the bcache should be not be formatted" do
+          let(:format) { false }
+
+          include_examples "reuse bcache"
+
+          it "mounts the existing bcache filesystem without destroying it" do
+            proposal.propose
+            bcache = proposal.devices.find_by_name("/dev/bcache0")
+            expect(bcache.filesystem.type).to eq(Y2Storage::Filesystems::Type::EXT4)
+            expect(bcache.filesystem.mount_point.path).to eq("/")
+          end
+        end
       end
     end
 

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -541,6 +541,7 @@ describe Y2Storage::AutoinstProposal do
 
           root_lv = devicegraph.lvm_lvs.find { |lv| lv.filesystem_mountpoint == "/" }
           expect(root_lv.sid).to eq lv2.sid
+          expect(root_lv.filesystem.sid).to eq lv2.filesystem.sid
         end
       end
 


### PR DESCRIPTION
## Problems in the code

As reported at [bsc#1193450](https://bugzilla.suse.com/show_bug.cgi?id=1193450), it currently seems to be impossible to keep the original file-system when reusing an existing software RAID with AutoYaST. AutoYaST always formats the MD again.

While investigating the fix, we found two other problems:

- Bcache devices that are directly formatted (without a partition table) are affected by a very similar problem, they are also always re-formatted when reused even if `<format>` is `false` in the profile.
- Reusing devices that were already encrypted was buggy. Under certain circumstances, when the profile specified that a new encryption should be created (replacing the previous one), it was possible to end up with a double-encrypted system (a LUKS directly on top of another LUKS).

## Problems in the unit tests

Turns out that a long time ago (during the development of SP1), we introduced fixes to make it possible to reuse existing RAID devices. See https://github.com/yast/yast-storage-ng/pull/835. That pull request included unit tests that verified the device was indeed reused... surprisingly they also verified that the MD is always formatted even if `<format>false</format>` was specified in the profile. So the implementation contained an error and we have wrong tests that actually verify the error is there!

On the other hand, not all possible scenarios for reusing devices are covered by the existing tests.

## Solution

1) Extend the tests to verify both the format=true and format=false case with RAIDs
2) Extend the tests to verify both the format=true and format=false case with bcache
3) Extend the tests to verify encrypted devices are properly re-encrypted if wanted.
4) Fix the code to make the format=false scenario work in all cases
5) Fix the code related to reusing already encrypted devices

NOTE: review commit by commit, it makes much more sense.