### PR TITLE
SP4 (master) merge of AutoYaST fixes for reusing encrypted devices and RAIDs

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 14 15:12:05 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- AutoYaST: fixes for reusing encrypted devices, RAIDs and bcache
+  devices (bsc#1193450).
+- 4.3.59
+
+-------------------------------------------------------------------
 Fri Dec 10 15:29:16 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>
 
 - document UEFI handling (bsc#937067)

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -3,7 +3,7 @@ Tue Dec 14 15:12:05 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - AutoYaST: fixes for reusing encrypted devices, RAIDs and bcache
   devices (bsc#1193450).
-- 4.3.59
+- 4.4.25
 
 -------------------------------------------------------------------
 Fri Dec 10 15:29:16 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.24
+Version:        4.4.25
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -79,7 +79,7 @@ module Y2Storage
         result = super
         if create_encryption?
           method = encryption_method || EncryptionMethod.find(:luks1)
-          result = result.encrypt(method: method, password: encryption_password)
+          result = plain_device.encrypt(method: method, password: encryption_password)
           log.info "Device encrypted. Returning the new device #{result.inspect}"
         else
           log.info "No need to encrypt. Returning the existing device #{result.inspect}"

--- a/src/lib/y2storage/proposal/autoinst_bcache_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_bcache_planner.rb
@@ -98,6 +98,7 @@ module Y2Storage
           return
         end
         bcache.reuse_name = bcache_to_reuse.name
+        config_filesystem_reuse(bcache, bcache_to_reuse, section)
       end
 
       # Finds the bcache to be reused by the given planned bcache

--- a/src/lib/y2storage/proposal/autoinst_drive_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_drive_planner.rb
@@ -313,14 +313,24 @@ module Y2Storage
         !!spec && spec.btrfs_read_only?
       end
 
-      # @param planned_device [Planned::Partition,Planned::LvmLV,Planned::Md] Planned device
+      # @param planned_device [Planned::Device] Planned device
       # @param device         [Y2Storage::Device] Device to reuse
       # @param section        [AutoinstProfile::PartitionSection] AutoYaST specification
       def add_device_reuse(planned_device, device, section)
-        planned_device.uuid = section.uuid
         planned_device.reuse_name = device.is_a?(LvmVg) ? device.volume_group_name : device.name
-        planned_device.reformat = !!section.format
+        planned_device.uuid = section.uuid
         planned_device.resize = !!section.resize if planned_device.respond_to?(:resize=)
+        config_filesystem_reuse(planned_device, device, section)
+      end
+
+      # @param planned_device [Planned::Device] Planned device
+      # @param device         [Y2Storage::Device] Device to reuse
+      # @param section        [AutoinstProfile::PartitionSection,AutoinstProfile::Drive] relevant section
+      #   of the AutoYaST specification
+      def config_filesystem_reuse(planned_device, device, section)
+        return unless section.is_a?(AutoinstProfile::PartitionSection)
+
+        planned_device.reformat = !!section.format
         check_reusable_filesystem(planned_device, device, section) if device.respond_to?(:filesystem)
       end
 

--- a/src/lib/y2storage/proposal/autoinst_md_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_md_planner.rb
@@ -145,6 +145,7 @@ module Y2Storage
           return
         end
         md.reuse_name = md_to_reuse.name
+        config_filesystem_reuse(md, md_to_reuse, section)
       end
 
       # Parses the user specified chunk size

--- a/src/lib/y2storage/proposal/autoinst_partitioner.rb
+++ b/src/lib/y2storage/proposal/autoinst_partitioner.rb
@@ -119,7 +119,7 @@ module Y2Storage
       # @param planned_device [Planned::Device] Planned device
       # @return [Proposal::CreatorResult] Result containing the formatted device
       def format_device(device, planned_device)
-        planned_device.format!(device)
+        planned_device.format!(device) if can_format?(planned_device)
         CreatorResult.new(devicegraph, device.name => planned_device)
       end
 
@@ -161,6 +161,19 @@ module Y2Storage
 
         # Second try with more flexible planned partitions
         calculator.best_distribution(flexible_partitions(planned_partitions), spaces)
+      end
+
+      # Checks whether (re)formatting the given device is acceptable
+      #
+      # @see #format_device
+      #
+      # @param planned [Planned::Device] planned device
+      # @return [Boolean]
+      def can_format?(planned)
+        # If the device is not going to be reused, #reformat? is irrelevant
+        return true unless planned.reuse?
+
+        planned.reformat?
       end
     end
   end

--- a/test/data/devicegraphs/gpt_encryption.yml
+++ b/test/data/devicegraphs/gpt_encryption.yml
@@ -22,7 +22,6 @@
         name: "/dev/sda4"
         id: linux
         file_system: btrfs
-        mount_point: "/"
         encryption:
           type: luks
           name: "/dev/mapper/cr_sda4"

--- a/test/y2storage/autoinst_proposal_test.rb
+++ b/test/y2storage/autoinst_proposal_test.rb
@@ -277,6 +277,76 @@ describe Y2Storage::AutoinstProposal do
         end
       end
 
+      context "when the partition is encrypted" do
+        let(:scenario) { "gpt_encryption" }
+
+        context "and marked to be formatted with no encryption information" do
+          let(:root) do
+            { "mount" => "/", "partition_nr" => 4, "create" => false,
+              "format" => true, "filesystem" => :ext2 }
+          end
+
+          it "reuses the encrypted partition (keeping the LUKS) and formats it" do
+            initial_part = fake_devicegraph.find_by_name("/dev/sda4")
+            luks_sid = initial_part.encryption.sid
+
+            proposal.propose
+            devicegraph = proposal.devices
+            reused_part = devicegraph.find_by_name("/dev/sda4")
+
+            expect(reused_part.encryption.sid).to eq luks_sid
+            expect(reused_part).to have_attributes(
+              filesystem_type:       Y2Storage::Filesystems::Type::EXT2,
+              filesystem_mountpoint: "/"
+            )
+          end
+        end
+
+        context "and marked to be formatted with encryption" do
+          let(:root) do
+            { "mount" => "/", "partition_nr" => 4, "create" => false, "crypt_fs" => true,
+              "format" => true, "crypt_key" => "secret", "filesystem" => :ext2 }
+          end
+
+          it "encrypts the partition (replacing the previous LUKS) and formats it" do
+            initial_part = fake_devicegraph.find_by_name("/dev/sda4")
+            luks_sid = initial_part.encryption.sid
+
+            proposal.propose
+            devicegraph = proposal.devices
+            reused_part = devicegraph.find_by_name("/dev/sda4")
+
+            expect(reused_part.encrypted?).to eq true
+            expect(reused_part.encryption.sid).to_not eq luks_sid
+            expect(reused_part).to have_attributes(
+              filesystem_type:       Y2Storage::Filesystems::Type::EXT2,
+              filesystem_mountpoint: "/"
+            )
+            # At some point, AutoYaST used to wrongly add an extra LUKS layer
+            expect(reused_part.encryption.encrypted?).to eq false
+          end
+        end
+
+        context "and not marked to be re-formatted" do
+          let(:root) do
+            { "mount" => "/", "partition_nr" => 4, "create" => false, "crypt_fs" => true,
+              "format" => false, "crypt_key" => "secret", "filesystem" => :ext2 }
+          end
+
+          it "keeps the existing encryption and filesystem" do
+            proposal.propose
+            devicegraph = proposal.devices
+            reused_part = devicegraph.find_by_name("/dev/sda4")
+
+            expect(reused_part.encrypted?).to eq true
+            expect(reused_part).to have_attributes(
+              filesystem_type:       Y2Storage::Filesystems::Type::BTRFS,
+              filesystem_mountpoint: "/"
+            )
+          end
+        end
+      end
+
       context "when the reused partition is in a DASD" do
         let(:scenario) { "dasd_50GiB" }
 
@@ -541,6 +611,7 @@ describe Y2Storage::AutoinstProposal do
 
           root_lv = devicegraph.lvm_lvs.find { |lv| lv.filesystem_mountpoint == "/" }
           expect(root_lv.sid).to eq lv2.sid
+          expect(root_lv.filesystem.sid).to eq lv2.filesystem.sid
         end
       end
 


### PR DESCRIPTION
This is a merge of #1266 into master (future SLE-15-SP4)

For the corresponding merge to SLE-15-SP3, see #1268.

The reporter of [bsc#1193450](https://bugzilla.suse.com/show_bug.cgi?id=1193450) confirmed that fix worked as expected for SLE-15-SP2.