### PR TITLE
Improve documentation for PReP

### DIFF
--- a/src/lib/y2storage/volume_specification_builder.rb
+++ b/src/lib/y2storage/volume_specification_builder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -158,7 +158,10 @@ module Y2Storage
         v.min_size = DiskSize.MiB(2)
         v.desired_size = DiskSize.MiB(4)
         v.max_size = DiskSize.MiB(8)
-        # Maximum size firmware can handle (bsc#1081979)
+        # 8 MiB is the maximum recommended size, more than enough for the image (bsc#1081979).
+        # If the optimal I/O size of the disk is bigger than 8MiB, the alignment performed by YaST
+        # can result in a bigger PReP. That's ok - the firmware in machines with such disks can (and
+        # should) be configured to properly read such a partition (see bsc#1192448).
         v.max_size_limit = DiskSize.MiB(8)
         v.partition_id = PartitionId::PREP
       end

--- a/test/support/proposed_partitions_examples.rb
+++ b/test/support/proposed_partitions_examples.rb
@@ -72,7 +72,7 @@ RSpec.shared_examples "proposed GRUB partition" do
       expect(grub_part.min).to eq 4.MiB
     end
 
-    it "requires it to be at most 8 MiB (anything bigger would mean wasting space)" do
+    it "requires it to be at most 8 MiB (or optimal I/O size, bsc#1192448) for firmware to load it" do
       expect(grub_part.max).to eq 8.MiB
     end
   end
@@ -84,7 +84,7 @@ RSpec.shared_examples "proposed GRUB partition" do
       expect(grub_part.min).to eq 2.MiB
     end
 
-    it "requires it to be at most 8 MiB (anything bigger would mean wasting space)" do
+    it "requires it to be at most 8 MiB (or optimal I/O size, bsc#1192448) for firmware to load it" do
       expect(grub_part.max).to eq 8.MiB
     end
   end


### PR DESCRIPTION
## Problem

In a PPC system with a disk that reports an optimal I/O size of 16 MiB, YaST will create a PReP partition of that size (creating an smaller one would imply a missaligned end). That's perfectly fine, since recent IBM's firmware can deal with "big" PReP partitions like that. But the firmware can be wrongly configured with some settings that limit the size of the PReP partition it accepts.

The problem was reported by some SUSE customers and the situation was clarified. The technical details and the procedure to configure the firmware were documented at [bsc#1192448](https://bugzilla.suse.com/show_bug.cgi?id=1192448), including the text of a TID (Technical Information Document) that will be soon be published through the usual SUSE channels.

## Solution

Add enough pointers in the boot requirements documentation so the relevant bug is easily found if the same problem pop-us up again. Not linking to the TID because is not yet published, but in fact the relevant information is already in the bug.
