### PR TITLE
Improve LUKS activation

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,3 +1,13 @@
+
+-------------------------------------------------------------------
+Wed Jan 12 11:12:13 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Allow to skip the activation of the rest of LUKS devices
+  (bsc#1162545).
+- Partitioner: always allow to provide password for closed LUKS
+  devices.
+- 4.4.32
+
 -------------------------------------------------------------------
 Wed Jan  5 21:38:56 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# Storage::Arch.is_efibootmgr
-BuildRequires:	libstorage-ng-ruby >= 4.4.61
+# Storage::Luks.reset_activation_infos
+BuildRequires:	libstorage-ng-ruby >= 4.4.69
 BuildRequires:  update-desktop-files
 # Yast::Kernel.propose_hibernation?
 BuildRequires:  yast2 >= 4.3.41
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# Storage::Arch.is_efibootmgr
-Requires:       libstorage-ng-ruby >= 4.4.61
+# Storage::Luks.reset_activation_infos
+Requires:       libstorage-ng-ruby >= 4.4.69
 # Yast::Kernel.propose_hibernation?
 Requires:       yast2 >= 4.3.41
 # Y2Packager::Repository

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.31
+Version:        4.4.32
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/configure_actions.rb
+++ b/src/lib/y2partitioner/actions/configure_actions.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018-2020] SUSE LLC
+# Copyright (c) [2018-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -64,9 +64,27 @@ module Y2Partitioner
         return unless warning_accepted? && availability_ensured?
 
         Yast::WFM.call(client) if client
+        reset_activation if reset_activation?
         reprobe(activate: activate)
 
         :finish
+      end
+
+      # Resets the activation cached information
+      #
+      # libstorage-ng caches some information, for example which LUKS devices the activation was
+      # canceled for.
+      def reset_activation
+        Y2Storage::Luks.reset_activation_infos
+      end
+
+      # Whether the ctivation cached information should be reset
+      #
+      # @see #reset_activation
+      #
+      # @return [Boolean]
+      def reset_activation?
+        false
       end
 
       # Whether YaST is running in the initial stage of installation
@@ -180,6 +198,11 @@ module Y2Partitioner
 
       # @see ConfigureAction#activate
       def activate
+        true
+      end
+
+      # @see ConfigureAction#reset_activation?
+      def reset_activation?
         true
       end
     end

--- a/src/lib/y2storage/callbacks/activate.rb
+++ b/src/lib/y2storage/callbacks/activate.rb
@@ -23,6 +23,7 @@ require "y2storage/dialogs/callbacks/activate_luks"
 require "y2storage/callbacks/issues_callback"
 require "y2storage/storage_env"
 require "y2storage/issue"
+require "y2storage/disk_size"
 
 Yast.import "Mode"
 
@@ -91,9 +92,12 @@ module Y2Storage
 
         return Storage::PairBoolString.new(false, "") if attempt == 1 && !activate_luks?
 
-        luks_error(info, attempt) if attempt > 1
+        info_presenter = InfoPresenter.new(info)
 
-        dialog = Dialogs::Callbacks::ActivateLuks.new(info, attempt, always_skip: !activate_luks?)
+        luks_error(info_presenter, attempt) if attempt > 1
+
+        dialog = Dialogs::Callbacks::ActivateLuks.new(info_presenter, attempt,
+          always_skip: !activate_luks?)
         result = dialog.run
 
         activate = result == :accept
@@ -108,17 +112,15 @@ module Y2Storage
 
       # Error popup when the LUKS could not be activated
       #
-      # @param info [Storage::LuksInfo]
+      # @param info [InfoPresenter]
       # @param attempt [Numeric] current attempt
       def luks_error(info, attempt)
-        # TODO: inform about the size once libstorage-ng provides it
         message = format(
-          _("The following encrypted volume could not be activated (attempt number %{attempt}):\n\n" \
-            "%{device} %{label}\n\n" \
+          _("The following encrypted device could not be activated (attempt number %{attempt}):\n\n" \
+            "%{info}\n\n" \
             "Please, make sure you are entering the correct password."),
           attempt: attempt - 1,
-          device:  info.device_name,
-          label:   info.label
+          info:    info.to_text
         )
 
         Yast2::Popup.show(message, headline: :error, buttons: :ok)
@@ -193,6 +195,36 @@ module Y2Storage
       # @return [Boolean]
       def activate_luks?
         StorageEnv.instance.activate_luks? && !@skip_decrypt
+      end
+
+      # Auxiliary class to present LUKS info
+      class InfoPresenter
+        # Constructor
+        #
+        # @param info [Storage::LuksInfo]
+        def initialize(info)
+          @info = info
+        end
+
+        # Converts LUKS info into text
+        #
+        # @return [String] e.g., "/dev/sda1 System (20 GiB)"
+        def to_text
+          text = [info.device_name]
+          text << info.label unless info.label.empty?
+          text << "(#{size.to_human_string})"
+
+          text.join(" ")
+        end
+
+        private
+
+        attr_reader :info
+
+        # @return [DiskSize]
+        def size
+          @size ||= DiskSize.new(info.size)
+        end
       end
     end
   end

--- a/src/lib/y2storage/dialogs/callbacks/activate_luks.rb
+++ b/src/lib/y2storage/dialogs/callbacks/activate_luks.rb
@@ -40,7 +40,7 @@ module Y2Storage
 
         # Constructor
         #
-        # @param info [Storage::LuksInfo]
+        # @param info [Callbacks::Activate::InfoPresenter]
         # @param attempt [Numeric]
         # @param always_skip [Boolean] default value for skip decrypt checkbox
         def initialize(info, attempt, always_skip: false)
@@ -74,8 +74,7 @@ module Y2Storage
                 Left(Heading(_("Encrypted Device"))),
                 VSpacing(0.2),
                 Left(Label(_("The following device is encrypted:"))),
-                # TODO: inform about the size once libstorage-ng provides it
-                Left(Label("#{info.device_name} #{info.label}")),
+                Left(Label(info.to_text)),
                 Left(password_widget),
                 VSpacing(0.2),
                 HBox(

--- a/src/lib/y2storage/luks.rb
+++ b/src/lib/y2storage/luks.rb
@@ -32,6 +32,14 @@ module Y2Storage
     #   @return [Array<Luks>] all the LUKS encryption devices in the given devicegraph
     storage_class_forward :all, as: "Luks"
 
+    # @!method self.reset_activation_infos
+    #
+    # While activating LUKSes, libstorage-ng caches the given passwords and also for which devices the
+    # activation was canceled.
+    #
+    # This method resets all that information.
+    storage_class_forward :reset_activation_infos
+
     # @!method uuid
     #   @return [String] UUID of the LUKS device
     storage_forward :uuid

--- a/test/y2storage/callbacks/activate_test.rb
+++ b/test/y2storage/callbacks/activate_test.rb
@@ -107,16 +107,19 @@ describe Y2Storage::Callbacks::Activate do
       allow(dialog).to receive(:run).and_return(action)
       allow(dialog).to receive(:encryption_password).and_return(encryption_password)
       allow(dialog).to receive(:always_skip?).and_return(always_skip)
-      allow(Y2Storage::Dialogs::Callbacks::ActivateLuks).to receive(:new).and_return dialog
+      allow(Y2Storage::Dialogs::Callbacks::ActivateLuks).to receive(:new).and_return(dialog)
 
       allow(Yast2::Popup).to receive(:show)
     end
 
-    let(:info) { instance_double(Storage::LuksInfo, device_name: device_name, uuid: uuid, label: label) }
+    let(:info) do
+      instance_double(Storage::LuksInfo, device_name: device_name, uuid: uuid, label: label, size: size)
+    end
 
     let(:device_name) { "/dev/sda1" }
     let(:uuid) { "11111111-1111-1111-1111-11111111" }
     let(:label) { "" }
+    let(:size) { 1024 }
 
     let(:attempts) { 1 }
     let(:action) { nil }
@@ -125,7 +128,12 @@ describe Y2Storage::Callbacks::Activate do
     let(:env_vars) { {} }
 
     it "opens a dialog to request the password" do
+      expect(Y2Storage::Dialogs::Callbacks::ActivateLuks).to receive(:new) do |info, _, _|
+        expect(info).to be_a(Y2Storage::Callbacks::Activate::InfoPresenter)
+      end.and_return(dialog)
+
       expect(dialog).to receive(:run).once
+
       subject.luks(info, attempts)
     end
 
@@ -157,7 +165,10 @@ describe Y2Storage::Callbacks::Activate do
       let(:attempts) { 2 }
 
       it "shows an error popup" do
-        expect(Yast2::Popup).to receive(:show).with(/could not be activated/, anything)
+        expect(Yast2::Popup).to receive(:show) do |text, _|
+          expect(text).to match(/could not be activated/)
+          expect(text).to match(/sda1 \(1.00 KiB\)/)
+        end
 
         subject.luks(info, attempts)
       end
@@ -321,6 +332,32 @@ describe Y2Storage::Callbacks::Activate do
         let(:env_vars) { {} }
 
         include_examples "ask user about multipath"
+      end
+    end
+  end
+
+  describe Y2Storage::Callbacks::Activate::InfoPresenter do
+    subject { described_class.new(info) }
+
+    let(:info) { instance_double(Storage::LuksInfo, device_name: device, label: label, size: size) }
+    let(:device) { "/dev/sda1" }
+    let(:size) { 1024 }
+
+    describe "#to_text" do
+      context "when the LUKS info has no label" do
+        let(:label) { "" }
+
+        it "returns the name and size of the encrypted device" do
+          expect(subject.to_text).to match("/dev/sda1 (1.00 KiB)")
+        end
+      end
+
+      context "when the LUKS info has a label" do
+        let(:label) { "System" }
+
+        it "returns the name, label and size of the encrypted device" do
+          expect(subject.to_text).to match("/dev/sda1 System (1.00 KiB)")
+        end
       end
     end
   end

--- a/test/y2storage/dialogs/callbacks/activate_luks_test.rb
+++ b/test/y2storage/dialogs/callbacks/activate_luks_test.rb
@@ -35,11 +35,7 @@ describe Y2Storage::Dialogs::Callbacks::ActivateLuks do
 
   subject { described_class.new(info, attempts, always_skip: always_skip) }
 
-  let(:info) { instance_double(Storage::LuksInfo, device_name: device_name, uuid: uuid, label: label) }
-
-  let(:device_name) { "/dev/sda1" }
-  let(:uuid) { "11111111-1111-1111-1111-11111111" }
-  let(:label) { "" }
+  let(:info) { instance_double(Y2Storage::Callbacks::Activate::InfoPresenter, to_text: "/dev/sda1") }
 
   let(:attempts) { 1 }
   let(:always_skip) { false }


### PR DESCRIPTION
## Problem

When there are several encrypted devices, the user is asked to provide the password for every one. This could be very annoying when the user is only interested on activating some of the encrypted devices.

* https://bugzilla.suse.com/show_bug.cgi?id=1162545

## Solution

Improve the *activate callback* used for requesting a LUKS password during the activation. The dialog was simplified (less text) and an option was added for skipping the activation of the rest of devices. This is a conservative change that does not cover all possible use cases:

* [Covered ] Many encrypted devices and the user wants to activate none.
* [Partially covered] Many encryption devices and the user only wants to activate some of them.
  * The user still has to skip devices one by one until reaching the devices on interest.
  * Possible improvement: use a boot option to indicate the devices to decrypt (e.g., YAST_OPEN_LUKS=/dev/sda2,/dev/sda3). 
* [Not covered] Many encrypted devices and the user wants to use the same password for all them.
  * Finding a good UI for this was challeging.
  * We decided to not support that scenario because it has not been requested yet. 

Note: The Expert Partitioner has a menu option to provide the encryption passwords. This was working only the first time the option is used because libstorage-ng was caching the activation information for the next calls. Now the cached information is reset when the Partitioner menu option is used.


## Testing

* Added new unit tests
* Tested manually


## Screenshots

<details>
<summary>Show/Hide</summary>


### Previous Dialogs

![Screenshot from 2021-12-17 00-13-00](https://user-images.githubusercontent.com/1112304/146467648-0fe6d52b-81a7-4f67-94f8-57123a2bd65e.png)

![Screenshot from 2021-12-17 00-13-44](https://user-images.githubusercontent.com/1112304/146467664-c439c654-0cb1-4266-a576-62d3bb6ef4a3.png)

### New Dialogs

![Screenshot from 2022-01-07 15-15-00](https://user-images.githubusercontent.com/1112304/148565108-6b2cb878-82a6-4af4-b282-f925a0b9ebd2.png)

![Screenshot from 2022-01-07 15-15-50](https://user-images.githubusercontent.com/1112304/148565123-05c90848-d75a-4a95-be7c-d50df57c88e3.png)

![Screenshot from 2022-01-07 15-18-08](https://user-images.githubusercontent.com/1112304/148565143-cc21c1d0-7d28-442f-a031-454e3d12a441.png)

![Screenshot from 2022-01-07 15-18-59](https://user-images.githubusercontent.com/1112304/148565168-f6bad27e-dafd-4175-b716-ed8714a8da50.png)

</details>
