### PR TITLE
Mock yast-installation classes and modules in tests

### DIFF
--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -29,7 +29,7 @@ ENV["LC_ALL"] = "en_US.UTF-8"
 # fail fast if a class does not declare textdomain (bsc#1130822)
 ENV["Y2STRICTTEXTDOMAIN"] = "1"
 
-LIBS_TO_SKIP = ["y2packager/repository"]
+LIBS_TO_SKIP = ["y2packager/repository", "installation/proposal_store", "installation/proposal_runner"]
 
 # Hack to avoid to require some files
 #
@@ -76,6 +76,13 @@ end
 
 require_relative "support/storage_helpers"
 
+module Installation
+  # The Installation::ProposalStore and Installation::ProposalRunner classes are not loaded in the
+  # tests to avoid cyclic dependencies with yast2-installation at build time.
+  class ProposalStore; end
+  class ProposalRunner; end
+end
+
 RSpec.configure do |c|
   c.include Yast::RSpec::StorageHelpers
 
@@ -85,6 +92,16 @@ RSpec.configure do |c|
     # is mocked.
     stub_const("Y2Packager::Repository", double("Y2Packager::Repository"))
     allow(Y2Packager::Repository).to receive(:all).and_return([])
+
+    allow(Yast).to receive(:import).and_call_original
+    # Yast::Profile, AutoinstStorage and AutoinstConfig are not loaded in the tests to avoid cyclic
+    # dependencies with the yast-installation package at build time.
+    allow(Yast).to receive(:import).with("Profile")
+    allow(Yast).to receive(:import).with("AutoinstStorage")
+    allow(Yast).to receive(:import).with("AutoinstConfig")
+    stub_const("Yast::Profile", double("Yast::Profile"))
+    stub_const("Yast::AutoinstStorage", double("Yast::AutoinstStorage"))
+    stub_const("Yast::AutoinstConfig", double("Yast::AutoinstConfig"))
 
     allow(Y2Storage::DumpManager.instance).to receive(:dump)
 

--- a/test/y2storage/clients/manual_test_test.rb
+++ b/test/y2storage/clients/manual_test_test.rb
@@ -191,10 +191,9 @@ describe Y2Storage::Clients::ManualTest do
       let(:args) { ["autoinst", "/path/to/devicegraph.xml", "/the/profile.xml"] }
 
       before do
-        Yast.import "Profile"
         allow(Yast::Profile).to receive(:ReadXML)
-
-        Yast.import "AutoinstStorage"
+        allow(Yast::Profile).to receive(:current).and_return({})
+        allow(Yast::AutoinstConfig).to receive(:Confirm=)
         allow(Yast::AutoinstStorage).to receive(:Import)
         allow(Installation::ProposalRunner).to receive(:new).and_return runner
 
@@ -214,6 +213,7 @@ describe Y2Storage::Clients::ManualTest do
       end
 
       it "displays the proposal dialog" do
+        expect(Yast::AutoinstConfig).to receive(:Confirm=).with(true)
         expect(runner).to receive(:run)
         described_class.run
       end


### PR DESCRIPTION
## Problem

The manual testing client introduced at #1274 depends on yast2-installation being installed on the machine in order to execute the AutoYaST "simulation". That's perfectly fine since that client (specially when testing AutoYaST) is a developer-oriented tool.

But we don't want to introduce a hard dependency from yast2-storage-ng to yast2-installation.

On the other hand, we want the `ManualTest` client to be covered by some unit tests. Since those unit tests are executed while building the package... we have a chicken and egg problem.

## Solution

Mock all the components from yast2-installation used during the unit test for `Y2Storage::Clients::ManualTest`
