### PR TITLE
Enable RSpec verifying doubles

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,3 +1,7 @@
+-------------------------------------------------------------------
+Tue Jan 18 15:59:33 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Enable RSpec verifying doubles (bsc#1194784)
 
 -------------------------------------------------------------------
 Wed Jan 12 11:12:13 UTC 2022 - José Iván López González <jlopez@suse.com>

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -31,8 +31,8 @@ BuildRequires:  update-desktop-files
 # Yast::Kernel.propose_hibernation?
 BuildRequires:  yast2 >= 4.3.41
 BuildRequires:  yast2-devtools >= 4.2.2
-# for AbortException and handle direct abort
-BuildRequires:  yast2-ruby-bindings >= 4.0.6
+# yast/rspec/helpers.rb
+BuildRequires:  yast2-ruby-bindings >= 4.4.7
 # yast2-xml dependency is added by yast2 but ignored in the
 # openSUSE:Factory project config
 BuildRequires:  yast2-xml

--- a/test/y2partitioner/widgets/btrfs_devices_selector_test.rb
+++ b/test/y2partitioner/widgets/btrfs_devices_selector_test.rb
@@ -236,14 +236,14 @@ describe Y2Partitioner::Widgets::BtrfsDevicesSelector do
 
   describe "#contents" do
     it "does not display the selected size" do
-      expect(Yast).to_not receive(:Id).with(:selected_size)
+      expect(subject).to_not receive(:Id).with(:selected_size)
       expect(Yast::UI).to_not receive(:ReplaceWidget)
 
       subject.refresh
     end
 
     it "does not display the unselected size" do
-      expect(Yast).to_not receive(:Id).with(:unselected_size)
+      expect(subject).to_not receive(:Id).with(:unselected_size)
       expect(Yast::UI).to_not receive(:ReplaceWidget)
 
       subject.refresh

--- a/test/y2partitioner/widgets/columns/format_test.rb
+++ b/test/y2partitioner/widgets/columns/format_test.rb
@@ -39,6 +39,7 @@ describe Y2Partitioner::Widgets::Columns::Format do
   describe "#value_for" do
     context "when the device responds to #to_be_formatted?" do
       before do
+        allow(device).to receive(:respond_to?).and_call_original
         allow(device).to receive(:respond_to?).with(:to_be_formatted?).and_return(true)
         allow(device).to receive(:to_be_formatted?).and_return(to_be_formatted)
       end

--- a/test/y2partitioner/widgets/columns/size_test.rb
+++ b/test/y2partitioner/widgets/columns/size_test.rb
@@ -68,7 +68,7 @@ describe Y2Partitioner::Widgets::Columns::Size do
 
   describe "#value_for" do
     context "when no device is given" do
-      let(:device_name) { "unknonw" }
+      let(:device_name) { "unknown" }
 
       it "returns an empty string" do
         expect(subject.value_for(device)).to eq("")
@@ -97,6 +97,14 @@ describe Y2Partitioner::Widgets::Columns::Size do
       context "and the device is found in the system" do
         let(:device) { root_fstab_entry }
 
+        # FIXME: this fails with:
+        # Failure/Error: allow(device).to receive(:size).and_return(disk_size)
+        # #<Y2Storage::SimpleEtcFstabEntry:0x000055c60a5e21f0 @storage_object=
+        #   #<InstanceDouble(Storage::SimpleEtcFstabEntry) (anonymous)>> does not implement: size
+        # Shared Example Group: "value for size" called from
+        #   ./test/y2partitioner/widgets/columns/size_test.rb:100
+        # # ./test/y2partitioner/widgets/columns/size_test.rb:46:in `block (3 levels) in
+        #   <top (required)>'
         include_examples "value for size"
       end
 

--- a/test/y2partitioner/widgets/columns/size_test.rb
+++ b/test/y2partitioner/widgets/columns/size_test.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env rspec
+
 # Copyright (c) [2020] SUSE LLC
 #
 # All Rights Reserved.
@@ -40,12 +41,6 @@ describe Y2Partitioner::Widgets::Columns::Size do
   end
 
   shared_examples "value for size" do
-    let(:disk_size) { Y2Storage::DiskSize.new(60.GiB) }
-
-    before do
-      allow(device).to receive(:size).and_return(disk_size)
-    end
-
     it "returns a Yast::Term" do
       expect(subject.value_for(device)).to be_a(Yast::Term)
     end
@@ -67,6 +62,8 @@ describe Y2Partitioner::Widgets::Columns::Size do
   end
 
   describe "#value_for" do
+    let(:disk_size) { Y2Storage::DiskSize.new(60.GiB) }
+
     context "when no device is given" do
       let(:device_name) { "unknown" }
 
@@ -76,6 +73,10 @@ describe Y2Partitioner::Widgets::Columns::Size do
     end
 
     context "when the device responds to #size method" do
+      before do
+        allow(device).to receive(:size).and_return(disk_size)
+      end
+
       include_examples "value for size"
     end
 
@@ -90,26 +91,30 @@ describe Y2Partitioner::Widgets::Columns::Size do
     end
 
     context "when a fstab entry is given" do
+      let(:device) { fstab }
+
+      let(:fstab) { fstab_entry(fstab_device_name, "/", btrfs, ["subvol=@/"], 0, 0) }
+
+      let(:fstab_device) { devicegraph.find_by_name(fstab_device_name) }
+
       let(:btrfs) { Y2Storage::Filesystems::Type::BTRFS }
-      let(:root_fstab_entry) { fstab_entry("/dev/sdb2", "/", btrfs, ["subvol=@/"], 0, 0) }
-      let(:unknown_fstab_entry) { fstab_entry("/dev/vdz", "/home", btrfs, [], 0, 0) }
 
-      context "and the device is found in the system" do
-        let(:device) { root_fstab_entry }
+      before do
+        allow(fstab).to receive(:device).and_return(fstab_device)
+      end
 
-        # FIXME: this fails with:
-        # Failure/Error: allow(device).to receive(:size).and_return(disk_size)
-        # #<Y2Storage::SimpleEtcFstabEntry:0x000055c60a5e21f0 @storage_object=
-        #   #<InstanceDouble(Storage::SimpleEtcFstabEntry) (anonymous)>> does not implement: size
-        # Shared Example Group: "value for size" called from
-        #   ./test/y2partitioner/widgets/columns/size_test.rb:100
-        # # ./test/y2partitioner/widgets/columns/size_test.rb:46:in `block (3 levels) in
-        #   <top (required)>'
+      context "and the device in the fstab entry is found in the system" do
+        let(:fstab_device_name) { "/dev/sdb2" }
+
+        before do
+          allow(fstab_device).to receive(:size).and_return(disk_size)
+        end
+
         include_examples "value for size"
       end
 
       context "but the device is not found in the system" do
-        let(:device) { unknown_fstab_entry }
+        let(:fstab_device_name) { "/dev/vdz" }
 
         it "returns an empty string" do
           expect(subject.value_for(device)).to eq("")

--- a/test/y2partitioner/widgets/device_buttons_set_test.rb
+++ b/test/y2partitioner/widgets/device_buttons_set_test.rb
@@ -46,12 +46,9 @@ describe Y2Partitioner::Widgets::DeviceButtonsSet do
 
   describe "#device=" do
     before do
-      # FIXME: this fails with
-      # Failure/Error: allow(device).to receive(:formatted_as?).with(:btrfs).and_return(btrfs)
-      # #<Y2Storage::Filesystems::BlkFilesystem:0x000055edf405af40 @storage_object=
-      # #<Storage::BlkFilesystem:0x000055edf405ae50 @__swigtype__="_p_storage__BlkFilesystem">>
-      #   does not implement: formatted_as?
-      allow(device).to receive(:formatted_as?).with(:btrfs).and_return(btrfs)
+      if device.respond_to?(:formatted_as?)
+        allow(device).to receive(:formatted_as?).with(:btrfs).and_return(btrfs)
+      end
     end
 
     let(:btrfs) { false }

--- a/test/y2partitioner/widgets/device_buttons_set_test.rb
+++ b/test/y2partitioner/widgets/device_buttons_set_test.rb
@@ -46,6 +46,11 @@ describe Y2Partitioner::Widgets::DeviceButtonsSet do
 
   describe "#device=" do
     before do
+      # FIXME: this fails with
+      # Failure/Error: allow(device).to receive(:formatted_as?).with(:btrfs).and_return(btrfs)
+      # #<Y2Storage::Filesystems::BlkFilesystem:0x000055edf405af40 @storage_object=
+      # #<Storage::BlkFilesystem:0x000055edf405ae50 @__swigtype__="_p_storage__BlkFilesystem">>
+      #   does not implement: formatted_as?
       allow(device).to receive(:formatted_as?).with(:btrfs).and_return(btrfs)
     end
 

--- a/test/y2partitioner/widgets/pages/nfs_mounts_test.rb
+++ b/test/y2partitioner/widgets/pages/nfs_mounts_test.rb
@@ -27,6 +27,10 @@ require "y2partitioner/widgets/pages"
 describe Y2Partitioner::Widgets::Pages::NfsMounts do
   before do
     devicegraph_stub("nfs1.xml")
+
+    # do not read the real NFS settings (including the firewall) from the system
+    allow(Yast::WFM).to receive(:CallFunction).and_call_original
+    allow(Yast::WFM).to receive(:CallFunction).with("nfs-client4part", ["Read"])
   end
 
   let(:device_graph) { Y2Partitioner::DeviceGraphs.instance.current }

--- a/test/y2storage/boot_requirements_duplicate_test.rb
+++ b/test/y2storage/boot_requirements_duplicate_test.rb
@@ -162,6 +162,19 @@ describe Y2Storage::BootRequirementsChecker do
         let(:planned_prep_partition) { [planned_partition] }
 
         before do
+          # FIXME: removing this fails with
+          # NoMethodError:
+          # undefined method `match_volume?' for #<Array:0x000055cd3dcab6a0>
+          # ./src/lib/y2storage/boot_requirements_strategies/prep.rb:113:in
+          #   `block in prep_partition_missing?'
+          # ./src/lib/y2storage/boot_requirements_strategies/prep.rb:113:in `each'
+          # ./src/lib/y2storage/boot_requirements_strategies/prep.rb:113:in `none?'
+          # ./src/lib/y2storage/boot_requirements_strategies/prep.rb:113:in `prep_partition_missing?'
+          # ./src/lib/y2storage/boot_requirements_strategies/prep.rb:35:in `needed_partitions'
+          # ./src/lib/y2storage/boot_requirements_checker.rb:66:in `needed_partitions'
+          # ./test/y2storage/boot_requirements_duplicate_test.rb:165:in `block (5 levels) in
+          #    <top (required)>'
+
           allow(planned_prep_partition).to receive(:match_volume?).and_return(true)
         end
 

--- a/test/y2storage/boot_requirements_duplicate_test.rb
+++ b/test/y2storage/boot_requirements_duplicate_test.rb
@@ -159,22 +159,9 @@ describe Y2Storage::BootRequirementsChecker do
       context "and a suitable PReP is already in the list of planned partitions" do
         let(:planned_prep_partitions) { [planned_prep_partition] }
 
-        let(:planned_prep_partition) { [planned_partition] }
+        let(:planned_prep_partition) { planned_partition }
 
         before do
-          # FIXME: removing this fails with
-          # NoMethodError:
-          # undefined method `match_volume?' for #<Array:0x000055cd3dcab6a0>
-          # ./src/lib/y2storage/boot_requirements_strategies/prep.rb:113:in
-          #   `block in prep_partition_missing?'
-          # ./src/lib/y2storage/boot_requirements_strategies/prep.rb:113:in `each'
-          # ./src/lib/y2storage/boot_requirements_strategies/prep.rb:113:in `none?'
-          # ./src/lib/y2storage/boot_requirements_strategies/prep.rb:113:in `prep_partition_missing?'
-          # ./src/lib/y2storage/boot_requirements_strategies/prep.rb:35:in `needed_partitions'
-          # ./src/lib/y2storage/boot_requirements_checker.rb:66:in `needed_partitions'
-          # ./test/y2storage/boot_requirements_duplicate_test.rb:165:in `block (5 levels) in
-          #    <top (required)>'
-
           allow(planned_prep_partition).to receive(:match_volume?).and_return(true)
         end
 

--- a/test/y2storage/encryption_method_test.rb
+++ b/test/y2storage/encryption_method_test.rb
@@ -184,7 +184,8 @@ describe Y2Storage::EncryptionMethod do
 
     context "if secure swap is not available" do
       before do
-        allow(Y2Storage::EncryptionMethod::SecureSwap).to receive(:available?).and_return(false)
+        allow_any_instance_of(Y2Storage::EncryptionMethod::SecureSwap).to receive(:available?)
+          .and_return(false)
       end
 
       it "does not include secure swap method" do


### PR DESCRIPTION
## Problem

- RSpec verifying doubles are not enabled in the tests
- That can hide some possible problems

## Solution

- Enable verifying doubles in `test/spec_helper.rb`
- Fix reported issues
- Additionally fixed missing mock for reading the NFS configuration. Originally it read the real configuration from the system including the firewalld configuration which displays a PolicyKit popup asking for the `root` password on my system.
- See https://github.com/yast/yast-ruby-bindings/pull/281 for the new mocking helper

## TODO

- [x] Fix the remaining test failures, these need a real storage expert :smiley: 


## Testing

- Updated unit tests
