### PR TITLE
Fix tests

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 21 15:33:45 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Fix tests according to new Md size reported by libstorage-ng
+  (related to bsc#1168914).
+- 4.4.33
+
+-------------------------------------------------------------------
 Tue Jan 18 15:59:33 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Enable RSpec verifying doubles (bsc#1194784)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.32
+Version:        4.4.33
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# Storage::Luks.reset_activation_infos
-BuildRequires:	libstorage-ng-ruby >= 4.4.69
+# New Md size calculation
+BuildRequires:	libstorage-ng-ruby >= 4.4.76
 BuildRequires:  update-desktop-files
 # Yast::Kernel.propose_hibernation?
 BuildRequires:  yast2 >= 4.3.41
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# Storage::Luks.reset_activation_infos
-Requires:       libstorage-ng-ruby >= 4.4.69
+# New Md size calculation
+Requires:       libstorage-ng-ruby >= 4.4.76
 # Yast::Kernel.propose_hibernation?
 Requires:       yast2 >= 4.3.41
 # Y2Packager::Repository

--- a/test/y2storage/md_test.rb
+++ b/test/y2storage/md_test.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env rspec
+
 # Copyright (c) [2017] SUSE LLC
 #
 # All Rights Reserved.
@@ -184,7 +185,7 @@ describe Y2Storage::Md do
   describe "#inspect" do
 
     it "inspects a MD object" do
-      expect(md.inspect).to eq "<Md /dev/md0 15875 MiB (15.50 GiB) raid0>"
+      expect(md.inspect).to eq "<Md /dev/md0 16220688 KiB (15.47 GiB) raid0>"
     end
 
   end

--- a/test/y2storage/yaml_writer_test.rb
+++ b/test/y2storage/yaml_writer_test.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env rspec
+
 # Copyright (c) 2016 SUSE LLC
 #
 # All Rights Reserved.
@@ -673,7 +674,7 @@ describe Y2Storage::YamlWriter do
                   type: primary
                   id: linux
               - free:
-                  size: 19659744 KiB (18.75 GiB)
+                  size: 19637506 KiB (18.73 GiB)
                   start: 1025 MiB (1.00 GiB)
               md_devices:
               - md_device:


### PR DESCRIPTION
## Problem

Lastest changes in libstorage-ng adjust the calculum of the Md size. Now, Md reports a slightlty different size, making some unit tests to fail.

* https://github.com/openSUSE/libstorage-ng/pull/857


## Solution

Adjust unit tests to the new sizes reported by libstorage-ng.

Note: unit tests will fail until having libstorage-ng 4.4.76 in the docker image.