### PR TITLE
Improve show details for NFS devices 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb  3 16:12:52 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: use 'defaults' for empty mount options in the
+  details popup of a NFS (related to fate#318196).
+
+-------------------------------------------------------------------
 Wed Feb  2 20:53:34 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Partitioner: improve integration with yast2-nfs-client to offer

--- a/src/lib/y2partitioner/widgets/description_section/filesystem.rb
+++ b/src/lib/y2partitioner/widgets/description_section/filesystem.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019-2020] SUSE LLC
+# Copyright (c) [2019-2022] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -18,6 +18,8 @@
 # find current contact information at www.suse.com.
 
 require "y2partitioner/widgets/description_section/base"
+require "y2storage/filesystems/nfs"
+require "y2storage/filesystems/nfs_options"
 
 module Y2Partitioner
   module Widgets
@@ -194,7 +196,11 @@ module Y2Partitioner
         def mount_options
           return "" unless filesystem&.mount_point
 
-          filesystem.mount_point.mount_options.join(" ")
+          options = filesystem.mount_point.mount_options
+
+          return options.join(", ") unless filesystem.is_a?(Y2Storage::Filesystems::Nfs)
+
+          Y2Storage::Filesystems::NfsOptions.new(options).to_fstab
         end
 
         # Information about journal

--- a/test/y2partitioner/widgets/description_section/filesystem_test.rb
+++ b/test/y2partitioner/widgets/description_section/filesystem_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2019-2020] SUSE LLC
+# Copyright (c) [2019-2022] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -71,6 +71,23 @@ describe Y2Partitioner::Widgets::DescriptionSection::Filesystem do
         .and_return(double(path: "/", active?: false).as_null_object)
 
       expect(subject.value).to match(/Mount Point: \/ \(not mounted\)/)
+    end
+
+    context "when the filesystem is a NFS" do
+      let(:device) { Y2Storage::Filesystems::Nfs.create(current_graph, "example.suse.com", "/data") }
+
+      let(:filesystem) { device }
+
+      context "and it has no mount options" do
+        before do
+          device.mount_path = "/mnt"
+          device.mount_point.mount_options = []
+        end
+
+        it "contains 'defaults' in the mount options" do
+          expect(subject.value).to match(/Mount Options: defaults/)
+        end
+      end
     end
 
     context "when the filesystem is a block filesystem" do


### PR DESCRIPTION
## Problem

As part of improving the integration with *yast2-nfs-client* (see https://github.com/yast/yast-storage-ng/pull/1283), it was decided to always show *defaults* instead of an empty string when the NFS has no mount options. This is done everywhere, namely lists and forms. But there was one more place: the popup to show the details of a device (*Device -> Show Details* menu option). 

## Solution

Use *defaults* in the device details when there are no mount options. 

## Testing

* Added unit test
* Tested manually

## Screenshots

![Screenshot from 2022-02-03 16-10-40](https://user-images.githubusercontent.com/1112304/152381722-57c32ab0-5cc2-4084-8383-7290b6fbf137.png)
