### PR TITLE
ensure no install media are mounted when storage proposal is run (bsc#1196061)

### DIFF
--- a/src/lib/y2storage/clients/inst_disk_proposal.rb
+++ b/src/lib/y2storage/clients/inst_disk_proposal.rb
@@ -50,6 +50,8 @@ module Y2Storage
       def initialize
         textdomain "storage"
 
+        detach_media_and_reprobe
+
         @devicegraph = storage_manager.staging
         @proposal = storage_manager.proposal
         # Save staging revision to check later if the system was reprobed
@@ -88,6 +90,20 @@ module Y2Storage
       end
 
       private
+
+      # Local (disk) media sources should not be mounted as the additional
+      # mountpoints will confuse libstorage-ng when doing the commit.
+      #
+      # Then reprobe to get data without any interference from installation
+      # media.
+      def detach_media_and_reprobe
+        Yast.import "PackageCallbacks"
+
+        log.info("ensure installation media are not mounted")
+        Pkg.SourceReleaseAll
+
+        storage_manager.probe
+      end
 
       # @return [Integer]
       attr_reader :initial_staging_revision


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1196061
- https://trello.com/c/bC5yVZas

When the installation repository is on some local disk partition and the partition is included in the storage setup, the existing mountpoints will lead to confusion.

libstorage-ng

- has problems with existing mountpoints in probing data that no longer exist in the commit phase
- mixes up mountpoints as it does not know the difference between installation system (no prefix) and target system (`/mnt` prefix)
- may show popups and/or remove the mountpoint from the target system's fstab

## Solution

To avoid this, unmount all installation media before probing.

## See also

- https://github.com/openSUSE/linuxrc/issues/288