### PR TITLE
Release sources before probing

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 31 12:37:01 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Release sources before probing during installation to avoid
+  issues when unmounting devices (related to bsc#1196061).
+
+-------------------------------------------------------------------
 Thu Feb 10 10:18:23 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Partitioner: 'Add NFS' instead of 'Add Nfs' in the menu (related

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2015-2021] SUSE LLC
+# Copyright (c) [2015-2022] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -34,6 +34,7 @@ require "y2issues/list"
 
 Yast.import "Mode"
 Yast.import "Stage"
+Yast.import "Pkg"
 
 module Y2Storage
   # Singleton class to provide access to the libstorage Storage object and
@@ -182,6 +183,12 @@ module Y2Storage
     # @param probe_callbacks [Callbacks::Probe, nil]
     def probe!(probe_callbacks: nil)
       probe_callbacks ||= Callbacks::Probe.new
+
+      # Release all sources before probing. Otherwise, unmount action could fail if the mount point
+      # of the software source device is modified. Note that this is only necessary during the
+      # installation because libstorage-ng would try to unmount from the chroot path
+      # (e.g., /mnt/mount/point) and there is nothing mounted there.
+      Yast::Pkg.SourceReleaseAll if Yast::Mode.installation
 
       begin
         @storage.probe(probe_callbacks)

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2017-2021] SUSE LLC
+# Copyright (c) [2017-2022] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -29,6 +29,7 @@ describe Y2Storage::StorageManager do
 
   before do
     described_class.create_test_instance
+    allow(Yast::Pkg).to receive(:SourceReleaseAll)
   end
 
   describe ".new" do
@@ -803,6 +804,30 @@ describe Y2Storage::StorageManager do
 
     it "returns nil if everything goes fine" do
       expect(manager.probe!).to be_nil
+    end
+
+    context "during installation" do
+      before do
+        allow(Yast::Mode).to receive(:installation).and_return(true)
+      end
+
+      it "releases software source devices before probing" do
+        expect(Yast::Pkg).to receive(:SourceReleaseAll)
+
+        manager.probe!
+      end
+    end
+
+    context "in an installed system" do
+      before do
+        allow(Yast::Mode).to receive(:installation).and_return(false)
+      end
+
+      it "does not release software source devices before probing" do
+        expect(Yast::Pkg).to_not receive(:SourceReleaseAll)
+
+        manager.probe!
+      end
     end
 
     context "and libstorage-ng fails while probing" do


### PR DESCRIPTION
## Problem

An installation repo can be provided from a local disk by using *install=* boot option (e.g., *install=hd:/isos/tw.iso*). YaST mounts the device containing the local repository. If *libstorage-ng* has to unmount such a device (e.g., because the mount point of the repo device was edited in the Expert Partitioner), then the unmount action fails. Note that *libstorage-ng* would try to unmount the device by using a device path as the device would be mounted under the installation mount point (e.g., */mnt/var/adm/mount/AP_0xppFmPE*).

![Screenshot_SLE-15-SP4_2022-03-31_12:14:25](https://user-images.githubusercontent.com/1112304/161083258-c65c942f-7bf5-4433-a58c-f2a00a398d3c.png)


## Solution

Always release all installation sources before probing. With that, *libstorage-ng* will never try to unmount the device. Note that YaST Packager will mount the source devices again under demand, for example, when the installation starts.  Also note that this is only needed during installation. In a running system there are no chroot paths involved.

NOTE: this PR will be merged into *pre-SLE-15-SP4* brach. Such a brach will be merged into master after branching *SLE-15-SP4*. The version should be bumped while merging *pre-SLE-15-SP4* into master.

## Testing

- Added a new unit test
- Tested manually

