### PR TITLE
Allow quotes when matching fstab device entries

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr  7 16:29:00 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix fstab entry filesystem matching allowing the use of quotes
+  surrounding the device UUID or label (bsc#1197692)
+- 4.2.122
+
+-------------------------------------------------------------------
 Tue Dec 14 15:12:05 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - AutoYaST: fixes for reusing encrypted devices, RAIDs and bcache

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.2.121
+Version:        4.2.122
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -229,11 +229,11 @@ module Y2Storage
 
       # @see Filesystems::Base#match_fstab_spec?
       def match_fstab_spec?(spec)
-        if /^UUID=(.*)/ =~ spec
+        if /^UUID="(.*)"/ =~ spec || /^UUID='(.*)'/ =~ spec || /^UUID=(.*)/ =~ spec
           return !Regexp.last_match(1).empty? && uuid == Regexp.last_match(1)
         end
 
-        if /^LABEL=(.*)/ =~ spec
+        if /^LABEL="(.*)"/ =~ spec || /^LABEL='(.*)'/ =~ spec || /^LABEL=(.*)/ =~ spec
           return !Regexp.last_match(1).empty? && label == Regexp.last_match(1)
         end
 

--- a/test/y2storage/filesystems/blk_filesystem_test.rb
+++ b/test/y2storage/filesystems/blk_filesystem_test.rb
@@ -371,6 +371,9 @@ describe Y2Storage::Filesystems::BlkFilesystem do
 
     it "returns true for the correct label using LABEL=" do
       expect(filesystem.match_fstab_spec?("LABEL=root")).to eq true
+      # labels surrounded by quotes are considered also valid
+      expect(filesystem.match_fstab_spec?("LABEL='root'")).to eq true
+      expect(filesystem.match_fstab_spec?('LABEL="root"')).to eq true
     end
 
     it "returns false for the wrong label using LABEL=" do
@@ -385,6 +388,9 @@ describe Y2Storage::Filesystems::BlkFilesystem do
 
     it "returns true for the correct UUID using UUID=" do
       expect(filesystem.match_fstab_spec?("UUID=4d2e6fde-d105-4f15-b8e1-4173badc8c66")).to eq true
+      # UUIDs surrounded by quotes are considered also valid
+      expect(filesystem.match_fstab_spec?("UUID='4d2e6fde-d105-4f15-b8e1-4173badc8c66'")).to eq true
+      expect(filesystem.match_fstab_spec?('UUID="4d2e6fde-d105-4f15-b8e1-4173badc8c66"')).to eq true
     end
 
     it "returns false for the wrong UUID using UUID=" do


### PR DESCRIPTION
## Problem

When an **fstab** first field entry contains quotes surrounding the **UUID** or **label** then the filesystem match fails and do not find any filesystem for the given device.

- https://bugzilla.suse.com/show_bug.cgi?id=1197692

## Solution

Modify the Regexp for matching device names using **UUID** or **labels** surrounded by quotes.

## Testing

- *Added a new unit test*
- *Tested manually*


