### PR TITLE
Modify fstab entry match Regexp

### DIFF
--- a/src/lib/y2storage/filesystems/blk_filesystem.rb
+++ b/src/lib/y2storage/filesystems/blk_filesystem.rb
@@ -229,12 +229,12 @@ module Y2Storage
 
       # @see Filesystems::Base#match_fstab_spec?
       def match_fstab_spec?(spec)
-        if /^UUID="(.*)"/ =~ spec || /^UUID='(.*)'/ =~ spec || /^UUID=(.*)/ =~ spec
-          return !Regexp.last_match(1).empty? && uuid == Regexp.last_match(1)
+        if /^UUID=(['"]?)(.*)\1$/ =~ spec
+          return !Regexp.last_match(2).empty? && uuid == Regexp.last_match(2)
         end
 
-        if /^LABEL="(.*)"/ =~ spec || /^LABEL='(.*)'/ =~ spec || /^LABEL=(.*)/ =~ spec
-          return !Regexp.last_match(1).empty? && label == Regexp.last_match(1)
+        if /^LABEL=(['"]?)(.*)\1$/ =~ spec
+          return !Regexp.last_match(2).empty? && label == Regexp.last_match(2)
         end
 
         named_device = devicegraph.find_by_any_name(spec)

--- a/src/lib/y2storage/luks.rb
+++ b/src/lib/y2storage/luks.rb
@@ -63,8 +63,8 @@ module Y2Storage
     # @param spec [String] content of the second column of an /etc/crypttab entry
     # @return [Boolean]
     def match_crypttab_spec?(spec)
-      if /^UUID=(.*)/ =~ spec
-        return !Regexp.last_match(1).empty? && uuid == Regexp.last_match(1)
+      if /^UUID=(['"]?)(.*)\1$/ =~ spec
+        return !Regexp.last_match(2).empty? && uuid == Regexp.last_match(2)
       end
 
       super

--- a/test/y2storage/luks_test.rb
+++ b/test/y2storage/luks_test.rb
@@ -53,6 +53,8 @@ describe Y2Storage::Luks do
 
     it "returns true for the encryption device UUID when using UUID=" do
       expect(subject.match_crypttab_spec?("UUID=#{luks_uuid}")).to eq(true)
+      expect(subject.match_crypttab_spec?("UUID='#{luks_uuid}'")).to eq(true)
+      expect(subject.match_crypttab_spec?("UUID=\"#{luks_uuid}\"")).to eq(true)
     end
 
     it "returns false for the kernel name of the encryption device" do


### PR DESCRIPTION
It just extend #1291 improving the **Regexp** for matching the **fstab** first field entry where needed. 

Version increase is not needed as I have not submitted the changes yet.

