### PR TITLE
Fix empty help in some Partitioner dialogs (bsc#1194274)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr 18 09:01:42 UTC 2022 - Martin Vidner <mvidner@suse.com>
+
+- Fix empty help in some Partitioner dialogs (bsc#1194274)
+- 4.4.38
+
+-------------------------------------------------------------------
 Thu Apr  7 16:29:00 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix fstab entry filesystem matching allowing the use of quotes

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.37
+Version:        4.4.38
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/dialogs/fstab_options.rb
+++ b/src/lib/y2partitioner/dialogs/fstab_options.rb
@@ -33,17 +33,22 @@ module Y2Partitioner
         textdomain "storage"
 
         @controller = controller
+        @widget = Widgets::FstabOptions.new(@controller)
       end
 
       def title
         _("Fstab Options:")
       end
 
+      def help
+        @widget.help
+      end
+
       def contents
         HBox(
           HStretch(),
           HSpacing(1),
-          HVSquash(Widgets::FstabOptions.new(@controller)),
+          HVSquash(@widget),
           HStretch(),
           HSpacing(1)
         )

--- a/src/lib/y2partitioner/dialogs/import_mount_points.rb
+++ b/src/lib/y2partitioner/dialogs/import_mount_points.rb
@@ -32,10 +32,15 @@ module Y2Partitioner
         textdomain "storage"
 
         @controller = controller
+        @widget = fstab_selector
       end
 
       def title
         _("Import Mount Points from Existing System:")
+      end
+
+      def help
+        @widget.help
       end
 
       # @see #fstab_selector
@@ -44,7 +49,7 @@ module Y2Partitioner
           1,
           0.5,
           VBox(
-            fstab_selector,
+            @widget,
             VSpacing(1),
             Left(format_widget)
           )

--- a/src/lib/y2partitioner/dialogs/mkfs_options.rb
+++ b/src/lib/y2partitioner/dialogs/mkfs_options.rb
@@ -32,16 +32,21 @@ module Y2Partitioner
         textdomain "storage"
 
         @controller = controller
+        @widget = Widgets::MkfsOptions.new(@controller)
       end
 
       def title
         _("Format Options:")
       end
 
+      def help
+        @widget.help
+      end
+
       def contents
         HBox(
           HSpacing(2),
-          HVSquash(Widgets::MkfsOptions.new(@controller)),
+          HVSquash(@widget),
           HSpacing(1)
         )
       end

--- a/src/lib/y2partitioner/dialogs/partition_table_clone.rb
+++ b/src/lib/y2partitioner/dialogs/partition_table_clone.rb
@@ -39,6 +39,7 @@ module Y2Partitioner
         textdomain "storage"
 
         @controller = controller
+        @widget = DevicesSelector.new(controller)
       end
 
       # @macro seeDialog
@@ -47,10 +48,14 @@ module Y2Partitioner
         format(_("Clone partition layout of %{name}"), name: controller.device.name)
       end
 
+      def help
+        @widget.help
+      end
+
       # @macro seeDialog
       # @see DevicesSelector
       def contents
-        @contents ||= VBox(DevicesSelector.new(controller))
+        @contents ||= VBox(@widget)
       end
 
       # Widget to select devices for cloning

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -188,20 +188,12 @@ module Y2Partitioner
         disable if !supported_by_filesystem?
       end
 
-      # @macro seeAbstractWidget
-      def handle(event)
-        case event["ID"]
-        when :help
-          help = []
-
-          widgets.each do |w|
-            help << w.help if w.respond_to? "help"
-          end
-
-          Yast::Wizard.ShowHelp(help.join("\n"))
-        end
-
-        nil
+      def help
+        # FIXME: this method causes duplicated help text
+        # if Wizard.SetHelpText is used
+        Yast::CWM.widgets_in_contents(contents).find_all do |w|
+          w.respond_to?(:help)
+        end.map(&:help).join("\n")
       end
 
       # @macro seeCustomWidget

--- a/src/lib/y2partitioner/widgets/mkfs_options.rb
+++ b/src/lib/y2partitioner/widgets/mkfs_options.rb
@@ -107,6 +107,8 @@ module Y2Partitioner
       # @return [String]
       #
       def help
+        # FIXME: this method causes duplicated help text
+        # if Wizard.SetHelpText is used
         Yast::CWM.widgets_in_contents(contents).find_all do |w|
           w.respond_to?(:help)
         end.map(&:help).join("\n")


### PR DESCRIPTION
## Problem

Some dialogs in the partitioner have a *Help* button that pops up an empty window.

- https://bugzilla.suse.com/show_bug.cgi?id=1194274
- https://trello.com/c/22Mos13d

## Solution

These fixes work via a method of a base class of all these dialogs, [Y2Partitioner::Dialogs::Popup#set_help_text](https://github.com/yast/yast-storage-ng/blob/SLE-15-SP4/src/lib/y2partitioner/dialogs/popup.rb#L100).

A better fix would be to use a common mechanism of CWM+Wizard:
Wizard.SetHelpText relying on existence of a widget with Id(:WizardDialog)
but that is risky for SLE15-SP4

## Testing

Tested manually.
For easier testing, the dialogs are:

- MkfsOptions "Format Options"
  Add Partition, Next, Next, Options, Help
- FstabOptions "Fstab Options"
  Add Partition, Next, Next, Mount Device, Fstab Options, Help
- ImportMountPoints "Import Mount Points from Existing System"
  System menu, Import Mount Points (in installation mode)
- PartitionTableClone "Clone partition layout of /dev/sdx"
  Device menu, Clone Partitions to Another Device, Help

## Screenshots

Working help popups with this fix:

![nohelp-format-options](https://user-images.githubusercontent.com/102056/163782766-249fafa4-46be-420a-b1ed-a1a83a411c03.png)
![nohelp-fstab-options](https://user-images.githubusercontent.com/102056/163782782-2e5bdbfe-75f5-4866-89a1-265090ac0cdc.png)
![nohelp-import-mount-points](https://user-images.githubusercontent.com/102056/163782789-a19f6b44-f94b-4f71-a3ba-e5659b4f314a.png)
![nohelp-clone-partition-table](https://user-images.githubusercontent.com/102056/163782801-b65faa06-2998-43f7-a41b-6ed32f811bfb.png)

