### PR TITLE
Recognize new libstorage-ng feature for NILFS2

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May  9 11:28:26 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Handle the new libstorage-ng "storage feature" for NILFS2
+  (gh#openSUSE/libstorage-ng#874)
+- 4.5.5
+
+-------------------------------------------------------------------
 Thu Apr 28 11:22:27 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Mark properly help text in tmpfs widget for localization

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.4
+Version:        4.5.5
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/storage_feature.rb
+++ b/src/lib/y2storage/storage_feature.rb
@@ -72,6 +72,7 @@ module Y2Storage
         UF_EXT4:             "e2fsprogs",
         UF_XFS:              "xfsprogs",
         UF_REISERFS:         "reiserfs",
+        UF_NILFS2:           "nilfs-utils",
         UF_NFS:              "nfs-client",
         UF_NTFS:             ["ntfs-3g", "ntfsprogs"],
         UF_VFAT:             "dosfstools",
@@ -108,7 +109,7 @@ module Y2Storage
     # NTFS Windows partition on the disk; don't throw an error pop-up in that
     # case, just log a warning (bsc#1039830).
     #
-    OPTIONAL_PACKAGES = ["ntfs-3g", "ntfsprogs", "exfat-utils", "f2fs-tools", "jfsutils"]
+    OPTIONAL_PACKAGES = ["ntfs-3g", "ntfsprogs", "exfat-utils", "f2fs-tools", "jfsutils", "nilfs-utils"]
     # configurable part ends here
     #======================================================================
 


### PR DESCRIPTION
## Problem

Recently support for the NILFS2 file-system was introduced in libstorage-ng. As a result, a new value was introduced for the so-called "storage features". See https://github.com/openSUSE/libstorage-ng/pull/874

yast-storage-ng contains a unit test to detect that situation and stop building when a new unknown feature is introduced. As expected, the unit test is failing now.

## Solution

Adapt yast-storage-ng to correctly handle the new support for NILFS2, requesting the corresponding package if NILFS2 is used in the system and the package is available.
