### PR TITLE
Fixed Build Failure because of new "bitlocker" Enum

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 23 13:12:58 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed failing unit test: Added translatable message for new
+  libstorage enum type for bitlocker (bsc#1199832)
+- 4.5.6
+
+-------------------------------------------------------------------
 Mon May  9 11:28:26 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Handle the new libstorage-ng "storage feature" for NILFS2

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.5
+Version:        4.5.6
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/encryption_type.rb
+++ b/src/lib/y2storage/encryption_type.rb
@@ -60,6 +60,7 @@ module Y2Storage
       twofish256_old: N_("Old Twofish (loop_fish2) 256-bit"),
       luks1:          N_("LUKS1"),
       luks2:          N_("LUKS2"),
+      bitlocker:      N_("BitLocker"),
       plain:          N_("Plain encryption")
     }
     private_constant :TRANSLATIONS


### PR DESCRIPTION
## Bugzilla

https://bugzilla.opensuse.org/show_bug.cgi?id=1199832


## Problem

Unit tests fail after a new enum was added in libstorage-ng for _bitlocker_.

```
[  122s] Failures:
[  122s] 
[  122s]   1) Y2Storage::EncryptionType#to_human_string for all the possible values of the library returns the translated string
[  122s]      Failure/Error: expect(value.to_human_string).to be_a(::String)
[  122s] 
[  122s]      RuntimeError:
[  122s]        Unhandled encryption type '#<Y2Storage::EncryptionType bitlocker>'
[  122s]      # ./src/lib/y2storage/encryption_type.rb:74:in `to_human_string'
[  122s]      # ./test/y2storage/encryption_type_test.rb:29:in `block (5 levels) in <top (required)>'
[  122s]      # ./test/y2storage/encryption_type_test.rb:28:in `each'
[  122s]      # ./test/y2storage/encryption_type_test.rb:28:in `block (4 levels) in <top (required)>'
[  122s] 
[  122s] Finished in 1 minute 13.75 seconds (files took 3.65 seconds to load)
[  122s] 1070 examples, 1 failure
[  122s] 
[  122s] Failed examples:
[  122s] 
[  122s] rspec ./test/y2storage/encryption_type_test.rb:27 # Y2Storage::EncryptionType#to_human_string for all the possible values of the library returns the translated string
```

## Fix

Added the value to our translatable messages.