### PR TITLE
Y2Partitioner: Allow 4 KiB Min Chunk Size for RAID0 / RAID10

### DIFF
--- a/src/lib/y2partitioner/actions/controllers/md.rb
+++ b/src/lib/y2partitioner/actions/controllers/md.rb
@@ -294,7 +294,13 @@ module Y2Partitioner
         end
 
         def min_chunk_size
-          [default_chunk_size, Y2Storage::DiskSize.KiB(64)].min
+          case md.md_level.to_sym
+          when :raid0, :raid10
+            puts "\n*** md.block_size: #{md.block_size}"
+            [md.block_size, Y2Storage::DiskSize.KiB(4)].max # bsc#1200018
+          else # including raid1/5/6
+            [default_chunk_size, Y2Storage::DiskSize.KiB(64)].min
+          end
         end
 
         def max_chunk_size

--- a/test/y2partitioner/actions/controllers/md_test.rb
+++ b/test/y2partitioner/actions/controllers/md_test.rb
@@ -716,6 +716,59 @@ describe Y2Partitioner::Actions::Controllers::Md do
     end
   end
 
+  describe "#min_chunk_size" do
+    before do
+      controller.md_level = md_level
+      # Prevent unpleasant surprises on different architectures
+      allow_any_instance_of(Y2Storage::Md).to receive(:block_size).and_return(Y2Storage::DiskSize.KiB(4))
+    end
+
+    context "when the Md device is a RAID0" do
+      let(:md_level) { Y2Storage::MdLevel::RAID0 }
+
+      it "returns 4 KiB" do
+        size = Y2Storage::DiskSize.KiB(4)
+        expect(controller.chunk_sizes.min).to eq size
+      end
+    end
+
+    context "when the Md device is a RAID1" do
+      let(:md_level) { Y2Storage::MdLevel::RAID1 }
+
+      it "returns 4 KiB" do
+        size = Y2Storage::DiskSize.KiB(4)
+        expect(controller.chunk_sizes.min).to eq size
+      end
+    end
+
+    context "when the Md device is a RAID5" do
+      let(:md_level) { Y2Storage::MdLevel::RAID5 }
+
+      it "returns 64 KiB" do
+        size = Y2Storage::DiskSize.KiB(64)
+        expect(controller.chunk_sizes.min).to eq size
+      end
+    end
+
+    context "when the Md device is a RAID6" do
+      let(:md_level) { Y2Storage::MdLevel::RAID6 }
+
+      it "returns 64 KiB" do
+        size = Y2Storage::DiskSize.KiB(64)
+        expect(controller.chunk_sizes.min).to eq size
+      end
+    end
+
+    context "when the Md device is a RAID10" do
+      let(:md_level) { Y2Storage::MdLevel::RAID10 }
+
+      it "returns 64 KiB" do
+        size = Y2Storage::DiskSize.KiB(4)
+        expect(controller.chunk_sizes.min).to eq size
+      end
+    end
+  end
+
   describe "#md_parity" do
     it "returns the parity algorithm of the Md device" do
       parity = Y2Storage::MdParity::OFFSET_2


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1200018


## Trello

_TBD_


## Problem

A customer wishes to use 4 KiB (page size) chunks for creating RAID0 on NVME, but the YaST partitioner does not offer that selection; it starts with 64 KiB.

![yast-raid-chunk-size](https://user-images.githubusercontent.com/11538225/170991193-18d38ea7-820a-489a-8e07-3f7b3b4878d6.png)


## Cause

Back when we introduced that feature, we decided on a minimum chunk size of 64 KiB unless the default chunk size for that RAID type would suggest something smaller. For RAID0, there was no different default, so the minimum was 64 KiB.

There was no strict technical reason behind this minimum, only our belief back at the time (in 2017) that smaller values would not be useful.


## Related PR

This raised the minimum:

https://github.com/yast/yast-storage-ng/pull/426