### PR TITLE
Y2Partitioner: Allow 4 KiB Min Chunk Size for RAID0 / RAID10 [master]

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 31 13:04:11 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Partitioner: Allow min chunk size of 4 KiB (page size) for RAID0 /
+  RAID10 (bsc#1200018)
+- 4.5.7
+
+-------------------------------------------------------------------
 Mon May 23 13:12:58 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Fixed failing unit test: Added translatable message for new

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.6
+Version:        4.5.7
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/md.rb
+++ b/src/lib/y2partitioner/actions/controllers/md.rb
@@ -294,7 +294,14 @@ module Y2Partitioner
         end
 
         def min_chunk_size
-          [default_chunk_size, Y2Storage::DiskSize.KiB(64)].min
+          case md.md_level.to_sym
+          when :raid0
+            [block_size, Y2Storage::DiskSize.KiB(4)].max # bsc#1200018
+          when :raid10
+            [block_size, page_size, Y2Storage::DiskSize.KiB(4)].max # bsc#1200018
+          else # including raid1/5/6
+            [default_chunk_size, Y2Storage::DiskSize.KiB(64)].min
+          end
         end
 
         def max_chunk_size
@@ -310,6 +317,14 @@ module Y2Partitioner
           else # including raid0 and raid10
             Y2Storage::DiskSize.KiB(64)
           end
+        end
+
+        def block_size
+          md.block_size
+        end
+
+        def page_size
+          Y2Storage::DiskSize.B(Y2Storage::StorageManager.instance.arch.page_size)
         end
 
         def default_md_parity

--- a/test/y2partitioner/actions/controllers/md_test.rb
+++ b/test/y2partitioner/actions/controllers/md_test.rb
@@ -716,6 +716,62 @@ describe Y2Partitioner::Actions::Controllers::Md do
     end
   end
 
+  describe "#min_chunk_size" do
+    # rubocop:disable Layout/LineLength
+    before do
+      controller.md_level = md_level
+      # Prevent unpleasant surprises on different architectures
+      allow_any_instance_of(Y2Storage::Md).to receive(:block_size).and_return(Y2Storage::DiskSize.B(512))
+      allow_any_instance_of(Y2Storage::Arch).to receive(:page_size).and_return(Y2Storage::DiskSize.KiB(8))
+    end
+    # rubocop:enable Layout/LineLength
+
+    context "when the Md device is a RAID0" do
+      let(:md_level) { Y2Storage::MdLevel::RAID0 }
+
+      it "returns 4 KiB" do
+        size = Y2Storage::DiskSize.KiB(4)
+        expect(controller.chunk_sizes.min).to eq size
+      end
+    end
+
+    context "when the Md device is a RAID1" do
+      let(:md_level) { Y2Storage::MdLevel::RAID1 }
+
+      it "returns 4 KiB" do
+        size = Y2Storage::DiskSize.KiB(4)
+        expect(controller.chunk_sizes.min).to eq size
+      end
+    end
+
+    context "when the Md device is a RAID5" do
+      let(:md_level) { Y2Storage::MdLevel::RAID5 }
+
+      it "returns 64 KiB" do
+        size = Y2Storage::DiskSize.KiB(64)
+        expect(controller.chunk_sizes.min).to eq size
+      end
+    end
+
+    context "when the Md device is a RAID6" do
+      let(:md_level) { Y2Storage::MdLevel::RAID6 }
+
+      it "returns 64 KiB" do
+        size = Y2Storage::DiskSize.KiB(64)
+        expect(controller.chunk_sizes.min).to eq size
+      end
+    end
+
+    context "when the Md device is a RAID10" do
+      let(:md_level) { Y2Storage::MdLevel::RAID10 }
+
+      it "returns the page size (8 KiB)" do
+        size = Y2Storage::DiskSize.KiB(8)
+        expect(controller.chunk_sizes.min).to eq size
+      end
+    end
+  end
+
   describe "#md_parity" do
     it "returns the parity algorithm of the Md device" do
       parity = Y2Storage::MdParity::OFFSET_2


### PR DESCRIPTION
## Target Branch

This is the merge to _master_ / _Factory_ of https://github.com/yast/yast-storage-ng/pull/1303.

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1200018


## Trello

https://trello.com/c/YN8fSMy3


## Problem

A customer wishes to use 4 KiB (page size) chunks for creating a RAID0 on NVME, but the YaST partitioner does not offer that selection; it starts with 64 KiB.

![yast-raid-chunk-size](https://user-images.githubusercontent.com/11538225/170991193-18d38ea7-820a-489a-8e07-3f7b3b4878d6.png)


## Cause

Back when we introduced that feature, we decided on a minimum chunk size of 64 KiB unless the default chunk size for that RAID type would suggest something smaller. For RAID0, there was no different default, so the minimum was 64 KiB.

There was no strict technical limitation behind this minimum, only our belief back at the time (in 2017) that smaller values would not be useful.


## Fix

Use a more elaborate minimum, depending on RAID type:

- RAID0: At least 4 KiB or the block size, whichever is larger.
- RAID10: At least 4 KiB or the block size or the page size, whichever is largest. Notice that some architectures have a pretty large page size (64 KiB for ppc64).
- Other RAID levels use their default chunk size as the minimum, but no more than 64 KiB.

![yast-raid-chunk-size-4k](https://user-images.githubusercontent.com/11538225/170992508-793d9088-eb27-40b8-abd3-01d9ee404d41.png)

Now the minimum chunk size for RAID0 is 4 KiB, but the default is still 64 KiB which might is probably better for performance in most scenarios.

## Related PR

- This raised the minimum:
  https://github.com/yast/yast-storage-ng/pull/426

- PR for SLE-15-SP4: https://github.com/yast/yast-storage-ng/pull/1303
