### PR TITLE
New mountby

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 16 17:42:49 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapt to new types of mount by in libstorage-ng. Skipped by now
+  as there is no request to support it. (bsc#1202225)
+- 4.5.8
+
+-------------------------------------------------------------------
 Tue May 31 13:04:11 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Partitioner: Allow min chunk size of 4 KiB (page size) for RAID0 /

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.7
+Version:        4.5.8
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/filesystems/mount_by_type.rb
+++ b/src/lib/y2storage/filesystems/mount_by_type.rb
@@ -90,12 +90,10 @@ module Y2Storage
       end
 
       class << self
-
-
         # Supported types
 
         def all_supported
-          all.reject { |t| t == PARTUUID || t == PARTLABEL }
+          all.reject { |t| [PARTUUID, PARTLABEL].include?(t) }
         end
 
         # Type corresponding to the given fstab spec

--- a/src/lib/y2storage/filesystems/mount_by_type.rb
+++ b/src/lib/y2storage/filesystems/mount_by_type.rb
@@ -90,6 +90,14 @@ module Y2Storage
       end
 
       class << self
+
+
+        # Supported types
+
+        def all_supported
+          all.reject { |t| t == PARTUUID || t == PARTLABEL }
+        end
+
         # Type corresponding to the given fstab spec
         #
         # @param spec [String] content of the first column of an /etc/fstab entry

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -484,8 +484,7 @@ module Y2Storage
       candidates.delete(Filesystems::MountByType::LABEL) unless label
       candidates.delete(Filesystems::MountByType::UUID) unless uuid
       # filter out yast unsupported partuuid and partlabel
-      candidates.delete(Filesystems::MountByType::PARTLABEL)
-      candidates.delete(Filesystems::MountByType::PARTUUID)
+      candidates.select! { |c| Filesystems::MountByType.all_supported.include?(c) }
     end
   end
 end

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -483,6 +483,9 @@ module Y2Storage
     def filter_mount_bys(candidates, label, uuid)
       candidates.delete(Filesystems::MountByType::LABEL) unless label
       candidates.delete(Filesystems::MountByType::UUID) unless uuid
+      # filter out yast unsupported partuuid and partlabel
+      candidates.delete(Filesystems::MountByType::PARTLABEL)
+      candidates.delete(Filesystems::MountByType::PARTUUID)
     end
   end
 end

--- a/test/y2storage/mount_point_test.rb
+++ b/test/y2storage/mount_point_test.rb
@@ -178,15 +178,15 @@ describe Y2Storage::MountPoint do
         context "and the filesystem has a label" do
           before { filesystem.label = "something" }
 
-          it "returns all the existing types" do
+          it "returns all the supported types" do
             expect(mount_point.suitable_mount_bys(label: label))
-              .to contain_exactly(*Y2Storage::Filesystems::MountByType.all)
+              .to contain_exactly(*Y2Storage::Filesystems::MountByType.all_supported)
           end
         end
 
         context "and the filesystem has no label" do
-          it "returns all the existing types except LABEL" do
-            types = Y2Storage::Filesystems::MountByType.all.reject { |t| t.is?(:label) }
+          it "returns all the supported types except LABEL" do
+            types = Y2Storage::Filesystems::MountByType.all_supported.reject { |t| t.is?(:label) }
             expect(mount_point.suitable_mount_bys(label: label)).to contain_exactly(*types)
           end
         end
@@ -198,16 +198,16 @@ describe Y2Storage::MountPoint do
         context "and the filesystem has a label" do
           before { filesystem.label = "something" }
 
-          it "returns all the existing types" do
+          it "returns all the supported types" do
             expect(mount_point.suitable_mount_bys(label: label))
-              .to contain_exactly(*Y2Storage::Filesystems::MountByType.all)
+              .to contain_exactly(*Y2Storage::Filesystems::MountByType.all_supported)
           end
         end
 
         context "and the filesystem has no label" do
-          it "returns all the existing types" do
+          it "returns all the supported types" do
             expect(mount_point.suitable_mount_bys(label: label))
-              .to contain_exactly(*Y2Storage::Filesystems::MountByType.all)
+              .to contain_exactly(*Y2Storage::Filesystems::MountByType.all_supported)
           end
         end
       end
@@ -288,8 +288,8 @@ describe Y2Storage::MountPoint do
         context "and the filesystem has a label" do
           before { filesystem.label = "something" }
 
-          it "returns all the existing types except the ones associated to udev links" do
-            types = Y2Storage::Filesystems::MountByType.all.reject { |t| t.is?(:id, :path) }
+          it "returns all the supported types except the ones associated to udev links" do
+            types = Y2Storage::Filesystems::MountByType.all_supported.reject { |t| t.is?(:id, :path) }
             expect(mount_point.suitable_mount_bys(label: label)).to contain_exactly(*types)
           end
         end
@@ -309,15 +309,15 @@ describe Y2Storage::MountPoint do
         context "and the filesystem has a label" do
           before { filesystem.label = "something" }
 
-          it "returns all the existing types except the ones associated to udev links" do
-            types = Y2Storage::Filesystems::MountByType.all.reject { |t| t.is?(:id, :path) }
+          it "returns all the supported types except the ones associated to udev links" do
+            types = Y2Storage::Filesystems::MountByType.all_supported.reject { |t| t.is?(:id, :path) }
             expect(mount_point.suitable_mount_bys(label: label)).to contain_exactly(*types)
           end
         end
 
         context "although the filesystem has no label" do
-          it "returns all the existing types except the ones associated to udev links" do
-            types = Y2Storage::Filesystems::MountByType.all.reject { |t| t.is?(:id, :path) }
+          it "returns all the supported types except the ones associated to udev links" do
+            types = Y2Storage::Filesystems::MountByType.all_supported.reject { |t| t.is?(:id, :path) }
             expect(mount_point.suitable_mount_bys(label: label)).to contain_exactly(*types)
           end
         end
@@ -329,15 +329,15 @@ describe Y2Storage::MountPoint do
         context "and the filesystem has a label" do
           before { filesystem.label = "something" }
 
-          it "returns all the existing types" do
+          it "returns all the supported types" do
             expect(mount_point.suitable_mount_bys(encryption: encryption))
-              .to contain_exactly(*Y2Storage::Filesystems::MountByType.all)
+              .to contain_exactly(*Y2Storage::Filesystems::MountByType.all_supported)
           end
         end
 
         context "and the filesystem has no label" do
-          it "returns all the existing types except LABEL" do
-            types = Y2Storage::Filesystems::MountByType.all.reject { |t| t.is?(:label) }
+          it "returns all the supported types except LABEL" do
+            types = Y2Storage::Filesystems::MountByType.all_supported.reject { |t| t.is?(:label) }
             expect(mount_point.suitable_mount_bys(encryption: encryption)).to contain_exactly(*types)
           end
         end


### PR DESCRIPTION
## Problem

Libstorage-ng introduces new types for mount_by which causes failure in test suites and also other code is not adapted for it.

- [bsc#1202225](https://bugzilla.suse.com/show_bug.cgi?id=1202225)
- https://trello.com/c/Xz60ksqP/3042-p1-yast-storage-ng-broken-due-to-new-mount-bys-on-libstorage-ng
- https://github.com/openSUSE/libstorage-ng/pull/893

## Solution

Introduce list of supported mount by and skip newly added ones as there is no request to support them.


## Testing

- *Adapted unit tests*

