### PR TITLE
New mountby2

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 16 17:42:49 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapt to new types of mount by in libstorage-ng. Skipped by now
+  as there is no request to support it. (bsc#1202225)
+- 4.5.8
+
+-------------------------------------------------------------------
 Tue May 31 13:04:11 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Partitioner: Allow min chunk size of 4 KiB (page size) for RAID0 /

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.7
+Version:        4.5.8
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -791,7 +791,7 @@ module Y2Storage
     #
     # @return [Filesystems::MountByType]
     def preferred_mount_by
-      Filesystems::MountByType.best_for(self, possible_mount_bys)
+      Filesystems::MountByType.best_for(self, possible_mount_bys & Filesystems::MountByType.all)
     end
 
     # @see Device#is?

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -289,13 +289,20 @@ module Y2Storage
     #   @return [Encryption] nil if the device is not encrypted
     storage_forward :encryption, as: "Encryption", check_with: :has_encryption
 
-    # @!method possible_mount_bys
+    # @!method storage_possible_mount_bys
     #   Possible mount-by methods to reference the block device itself, regardless of its content
     #
     #   @see #preferred_name
     #
     #   @return [Array<Filesystems::MountByType>]
-    storage_forward :possible_mount_bys, as: "Filesystems::MountByType"
+    storage_forward :storage_possible_mount_bys, as: "Filesystems::MountByType",
+      to: :possible_mount_bys
+    private :storage_possible_mount_bys
+
+    # overwritted possible_mount_bys to contain only supported types
+    def possible_mount_bys
+      storage_possible_mount_bys & Filesystems::MountByType.all
+    end
     private :possible_mount_bys
 
     # Checks whether the device is encrypted
@@ -791,7 +798,7 @@ module Y2Storage
     #
     # @return [Filesystems::MountByType]
     def preferred_mount_by
-      Filesystems::MountByType.best_for(self, possible_mount_bys & Filesystems::MountByType.all)
+      Filesystems::MountByType.best_for(self, possible_mount_bys)
     end
 
     # @see Device#is?

--- a/src/lib/y2storage/filesystems/mount_by_type.rb
+++ b/src/lib/y2storage/filesystems/mount_by_type.rb
@@ -90,6 +90,14 @@ module Y2Storage
       end
 
       class << self
+
+        alias_method :all_nonfiltered, :all
+
+        # Redefined `.all` method that filter out unsupported values
+        def all
+          all_nonfiltered.reject { |t| [PARTUUID, PARTLABEL].include?(t) }
+        end
+
         # Type corresponding to the given fstab spec
         #
         # @param spec [String] content of the first column of an /etc/fstab entry

--- a/src/lib/y2storage/filesystems/mount_by_type.rb
+++ b/src/lib/y2storage/filesystems/mount_by_type.rb
@@ -90,12 +90,11 @@ module Y2Storage
       end
 
       class << self
+        alias_method :storage_all, :all
 
-        alias_method :all_nonfiltered, :all
-
-        # Redefined `.all` method that filter out unsupported values
+        # Redefined `.storage_all` method that filter out unsupported values
         def all
-          all_nonfiltered.reject { |t| [PARTUUID, PARTLABEL].include?(t) }
+          storage_all.reject { |t| [PARTUUID, PARTLABEL].include?(t) }
         end
 
         # Type corresponding to the given fstab spec

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -183,18 +183,19 @@ module Y2Storage
     #   Set the mount-by method to the global default, see Storage::get_default_mount_by()
     storage_forward :set_default_mount_by, to: :default_mount_by=
 
-    # @!method possible_mount_bys_unfiltered
+    # @!method storage_possible_mount_bys
     #   Returns the possible mount-by methods for the mount point.
     #   LABEL is included even if the filesystem label is not set.
     #
     #   @return [Array<Filesystems::MountByType>]
-    storage_forward :possible_mount_bys_unfiltered, as: "Filesystems::MountByType", to: :possible_mount_bys
-    private :possible_mount_bys_unfiltered
+    storage_forward :storage_possible_mount_bys, as: "Filesystems::MountByType",
+      to: :possible_mount_bys
+    private :storage_possible_mount_bys
 
     # redefine possible_mount_bys to filter out unsupported values
-    # @see #possible_mount_bys_unfiltered
+    # @see #storage_possible_mount_bys
     def possible_mount_bys
-      possible_mount_bys_unfiltered & Filesystems::MountByType.all
+      storage_possible_mount_bys & Filesystems::MountByType.all
     end
 
     # @!attribute mount_type

--- a/src/lib/y2storage/mount_point.rb
+++ b/src/lib/y2storage/mount_point.rb
@@ -183,12 +183,19 @@ module Y2Storage
     #   Set the mount-by method to the global default, see Storage::get_default_mount_by()
     storage_forward :set_default_mount_by, to: :default_mount_by=
 
-    # @!method possible_mount_bys
+    # @!method possible_mount_bys_unfiltered
     #   Returns the possible mount-by methods for the mount point.
     #   LABEL is included even if the filesystem label is not set.
     #
     #   @return [Array<Filesystems::MountByType>]
-    storage_forward :possible_mount_bys, as: "Filesystems::MountByType"
+    storage_forward :possible_mount_bys_unfiltered, as: "Filesystems::MountByType", to: :possible_mount_bys
+    private :possible_mount_bys_unfiltered
+
+    # redefine possible_mount_bys to filter out unsupported values
+    # @see #possible_mount_bys_unfiltered
+    def possible_mount_bys
+      possible_mount_bys_unfiltered & Filesystems::MountByType.all
+    end
 
     # @!attribute mount_type
     #   Filesystem type used to mount the device, as specified in fstab and/or


### PR DESCRIPTION
## Problem

Libstorage-ng introduces new types for mount_by which causes failure in test suites and also other code is not adapted for it.

- [bsc#1202225](https://bugzilla.suse.com/show_bug.cgi?id=1202225)
- https://trello.com/c/Xz60ksqP/3042-p1-yast-storage-ng-broken-due-to-new-mount-bys-on-libstorage-ng
- https://github.com/openSUSE/libstorage-ng/pull/893
- original pr with alternative  solution https://github.com/yast/yast-storage-ng/pull/1306

## Solution

Adapt a code to skip newly added ones as there is no request to support them.


## Testing

- *Adapted unit tests*

