### PR TITLE
Security policy checks

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 30 10:06:43 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Validate security policies in both guided proposal and
+  partitioner (part of jsc#SLE-24764).
+- 4.4.41
+
+-------------------------------------------------------------------
 Mon May 30 12:35:08 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Partitioner: Allow min chunk size of 4 KiB (page size) for RAID0 /

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.40
+Version:        4.4.41
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/widgets/overview.rb
+++ b/src/lib/y2partitioner/widgets/overview.rb
@@ -24,7 +24,7 @@ require "cwm/tree"
 require "y2partitioner/icons"
 require "y2partitioner/ui_state"
 require "y2partitioner/widgets/pages"
-require "y2partitioner/setup_errors_presenter"
+require "y2storage/setup_errors_presenter"
 require "y2storage/setup_checker"
 require "y2storage/package_handler"
 require "y2storage/bcache"
@@ -188,7 +188,7 @@ module Y2Partitioner
         setup_checker = Y2Storage::SetupChecker.new(device_graph)
         return true if setup_checker.valid?
 
-        errors = SetupErrorsPresenter.new(setup_checker).to_html
+        errors = Y2Storage::SetupErrorsPresenter.new(setup_checker).to_html
 
         if setup_checker.errors.empty? # so only warnings there
           # FIXME: improve Yast2::Popup to allow some text before the buttons

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2016] SUSE LLC
+# Copyright (c) [2016-2022] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -23,6 +23,8 @@ require "ui/installation_dialog"
 require "y2storage"
 require "y2storage/actions_presenter"
 require "y2storage/dump_manager"
+require "y2storage/setup_checker"
+require "y2storage/setup_errors_presenter"
 
 Yast.import "HTML"
 
@@ -137,6 +139,7 @@ module Y2Storage
       def actions_html
         actions_source_html +
           boss_html +
+          setup_errors_html +
           # Reuse the exact string "Changes to partitioning" from the partitioner
           _("<p>Changes to partitioning:</p>") +
           @actions_presenter.to_html
@@ -181,6 +184,16 @@ module Y2Storage
       # @see #actions_source_html
       def actions_source_for_default_settings
         para(_("Initial layout proposed with the default Guided Setup settings."))
+      end
+
+      # Setup errors
+      #
+      # @return [String] HTML-formatted text
+      def setup_errors_html
+        setup_checker = Y2Storage::SetupChecker.new(devicegraph)
+        return "" if setup_checker.valid?
+
+        Y2Storage::SetupErrorsPresenter.new(setup_checker).to_html
       end
 
       # Text for the summary in cases in which it was not possible to propose

--- a/src/lib/y2storage/setup_checker.rb
+++ b/src/lib/y2storage/setup_checker.rb
@@ -143,7 +143,11 @@ module Y2Storage
 
     # Ensures security polices are correctly loaded
     #
-    # Package yast2-security is not added as dependency to avoid cyclic dependencies.
+    # The package yast2-security has yast2-storage-ng as dependency, so yast2-storage-ng does not
+    # require yast2-security at RPM level to avoid cyclic dependencies. Note that yast2-security is
+    # always included in the installation image, but it could be missing at building time. And
+    # missing yast2-security in a running system should not be relevant because the policies are
+    # only checked during the installation.
     def ensure_security_policies
       require "y2security/security_policies"
       yield

--- a/src/lib/y2storage/setup_checker.rb
+++ b/src/lib/y2storage/setup_checker.rb
@@ -116,7 +116,9 @@ module Y2Storage
       return @security_policies_warnings if @security_policies_warnings
 
       policies_warnings = security_policies_failing_rules.map do |policy, failing_rules|
-        warnings = failing_rules.map { |r| SetupError.new(message: "#{r.id} #{r.description}") }
+        warnings = failing_rules.sort_by(&:id).map do |rule|
+          SetupError.new(message: "#{rule.id} #{rule.description}")
+        end
         [policy, warnings]
       end
 

--- a/src/lib/y2storage/setup_checker.rb
+++ b/src/lib/y2storage/setup_checker.rb
@@ -42,6 +42,7 @@ module Y2Storage
   #   checker.valid? #=> true
   class SetupChecker
     include Yast::I18n
+    include Yast::Logger
 
     # @return [Devicegraph]
     attr_reader :devicegraph
@@ -147,6 +148,7 @@ module Y2Storage
       require "y2security/security_policies"
       yield
     rescue LoadError
+      log.warn("Security policies cannot be loaded. Make sure yast2-security is installed.")
       nil
     end
 

--- a/src/lib/y2storage/setup_errors_presenter.rb
+++ b/src/lib/y2storage/setup_errors_presenter.rb
@@ -60,7 +60,7 @@ module Y2Storage
         boot_warnings_html,
         product_warnings_html,
         mount_warnings_html,
-        security_policies_warnings_html
+        security_policy_warnings_html
       ].compact
 
       return nil if warnings.empty?
@@ -103,27 +103,15 @@ module Y2Storage
       create_html(header, warnings)
     end
 
-    # HTML representation for warnings about the security policies
-    #
-    # @return [String, nil] nil if there are no warnings
-    def security_policies_warnings_html
-      policies_warnings = setup_checker.security_policies_failing_rules.map do |policy, rules|
-        security_policy_warnings_html(policy, rules)
-      end
-
-      policies_warnings.compact!
-      return nil if policies_warnings.none?
-
-      policies_warnings.join(Yast::HTML.Newline)
-    end
-
-    # HTML representation for warnings about a specific security policy
-    #
-    # @param policy [Y2Security::SecurityPolicies::Policy]
-    # @param failing_rules [Array<Y2Security::SecurityPolicies::Rule>]
+    # HTML representation for warnings from the enabled security policy
     #
     # @return [String, nil] nil if warnings cannot be represented, see {#with_security_policies}
-    def security_policy_warnings_html(policy, failing_rules)
+    def security_policy_warnings_html
+      policy = setup_checker.security_policy
+      failing_rules = setup_checker.security_policy_failing_rules
+
+      return nil if policy.nil? || failing_rules.none?
+
       with_security_policies do
         require "y2security/security_policies/rule_presenter"
 

--- a/src/lib/y2storage/with_security_policies.rb
+++ b/src/lib/y2storage/with_security_policies.rb
@@ -1,0 +1,42 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+module Y2Storage
+  # Mixin to ensure that security policies can be used
+  #
+  # The package yast2-security requires yast2-storage-ng as dependency, so yast2-storage-ng does not
+  # require yast2-security at RPM level to avoid cyclic dependencies. Note that yast2-security is
+  # always included in the installation image, but it could be missing at building time.
+  # Missing yast2-security in a running system should not be relevant because the policies are
+  # only checked during the installation.
+  module WithSecurityPolicies
+    include Yast::Logger
+
+    # Runs a block ensuring that security policies are correctly loaded
+    def with_security_policies
+      require "y2security/security_policies"
+      yield
+    rescue LoadError
+      log.warn("Security policies cannot be loaded. Make sure yast2-security is installed.")
+      nil
+    end
+  end
+end

--- a/test/y2partitioner/widgets/overview_test.rb
+++ b/test/y2partitioner/widgets/overview_test.rb
@@ -322,7 +322,7 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
       allow(checker).to receive(:valid?).and_return(valid_setup)
       allow(checker).to receive(:errors).and_return(fatal_errors)
 
-      allow(Y2Partitioner::SetupErrorsPresenter).to receive(:new).and_return(presenter)
+      allow(Y2Storage::SetupErrorsPresenter).to receive(:new).and_return(presenter)
       allow(presenter).to receive(:to_html).and_return("html representation")
 
       allow(Yast2::Popup).to receive(:show).and_return(user_input)
@@ -336,7 +336,7 @@ describe Y2Partitioner::Widgets::OverviewTreePager do
 
     let(:checker) { instance_double(Y2Storage::SetupChecker) }
 
-    let(:presenter) { instance_double(Y2Partitioner::SetupErrorsPresenter) }
+    let(:presenter) { instance_double(Y2Storage::SetupErrorsPresenter) }
 
     let(:valid_setup) { nil }
 

--- a/test/y2storage/setup_checker_test.rb
+++ b/test/y2storage/setup_checker_test.rb
@@ -161,7 +161,13 @@ describe Y2Storage::SetupChecker do
         let(:policy1) { double("Y2Security::SecurityPolicies::DisaStigPolicy", name: "STIG") }
 
         let(:policy1_failing_rules) do
-          [double("Y2Security::SecurityPolicies::Rule", id: "Test1", description: "policy rule 1")]
+          [
+            double("Y2Security::SecurityPolicies::Rule",
+              id:          "Test1",
+              identifiers: [],
+              references:  [],
+              description: "policy rule 1")
+          ]
         end
 
         it "returns false" do
@@ -203,7 +209,13 @@ describe Y2Storage::SetupChecker do
     let(:policy1) { double("Y2Security::SecurityPolicies::DisaStigPolicy", name: "STIG") }
 
     let(:policy1_failing_rules) do
-      [double("Y2Security::SecurityPolicies::Rule", id: "Test1", description: "policy rule 1")]
+      [
+        double("Y2Security::SecurityPolicies::Rule",
+          id:          "Test1",
+          identifiers: [],
+          references:  [],
+          description: "policy rule 1")
+      ]
     end
 
     it "only includes boot errors" do
@@ -279,8 +291,16 @@ describe Y2Storage::SetupChecker do
 
       let(:policy1_failing_rules) do
         [
-          double("Y2Security::SecurityPolicies::Rule", id: "Test1", description: "policy rule 1"),
-          double("Y2Security::SecurityPolicies::Rule", id: "Test2", description: "policy rule 2")
+          double("Y2Security::SecurityPolicies::Rule",
+            id:          "test1",
+            identifiers: [],
+            references:  [],
+            description: "policy rule 1"),
+          double("Y2Security::SecurityPolicies::Rule",
+            id:          "test2",
+            identifiers: [],
+            references:  [],
+            description: "policy rule 2")
         ]
       end
 
@@ -452,27 +472,27 @@ describe Y2Storage::SetupChecker do
     end
   end
 
-  describe "#security_policies_warnings" do
+  describe "#security_policies_failing_rules" do
     context "when y2security cannot be required" do
       before do
         allow(subject).to receive(:require).with("y2security/security_policies").and_raise(LoadError)
       end
 
       it "returns an empty hash" do
-        expect(subject.security_policies_warnings).to eq({})
+        expect(subject.security_policies_failing_rules).to eq({})
       end
     end
 
     context "when y2security can be required" do
       before do
-        allow(subject).to receive(:security_policies_failing_rules).and_return(policies_failing_rules)
+        allow(subject).to receive(:with_security_policies).and_return(policies_failing_rules)
       end
 
       context "and there are no failing rules for the policies" do
         let(:policies_failing_rules) { {} }
 
         it "returns an empty hash" do
-          expect(subject.security_policies_warnings).to eq({})
+          expect(subject.security_policies_failing_rules).to eq({})
         end
       end
 
@@ -483,8 +503,16 @@ describe Y2Storage::SetupChecker do
 
         let(:policy1_failing_rules) do
           [
-            double("Y2Security::SecurityPolicies::Rule", id: "Test1", description: "policy rule 1"),
-            double("Y2Security::SecurityPolicies::Rule", id: "Test2", description: "policy rule 2")
+            double("Y2Security::SecurityPolicies::Rule",
+              id:          "test1",
+              identifiers: [],
+              references:  [],
+              description: "policy rule 1"),
+            double("Y2Security::SecurityPolicies::Rule",
+              id:          "test2",
+              identifiers: [],
+              references:  [],
+              description: "policy rule 2")
           ]
         end
 
@@ -494,7 +522,7 @@ describe Y2Storage::SetupChecker do
           end
 
           it "returns an empty hash" do
-            expect(subject.security_policies_warnings).to eq({})
+            expect(subject.security_policies_failing_rules).to eq({})
           end
         end
 
@@ -504,8 +532,8 @@ describe Y2Storage::SetupChecker do
           end
 
           it "returns a hash with the failing rules of each policy" do
-            warnings = subject.security_policies_warnings
-            expect(warnings[policy1].map(&:message)).to include(
+            failing_rules = subject.security_policies_failing_rules
+            expect(failing_rules[policy1].map(&:description)).to include(
               an_object_matching(/policy rule 1/),
               an_object_matching(/policy rule 2/)
             )

--- a/test/y2storage/setup_errors_presenter_test.rb
+++ b/test/y2storage/setup_errors_presenter_test.rb
@@ -33,7 +33,7 @@ describe Y2Storage::SetupErrorsPresenter do
     allow(setup_checker).to receive(:boot_warnings).and_return(boot_errors)
     allow(setup_checker).to receive(:product_warnings).and_return(product_errors)
     allow(setup_checker).to receive(:mount_warnings).and_return(mount_errors)
-    allow(setup_checker).to receive(:security_policies_warnings).and_return(policies_errors)
+    allow(setup_checker).to receive(:security_policies_failing_rules).and_return(policies_errors)
     allow(setup_checker).to receive(:errors).and_return(fatal_errors)
   end
 
@@ -77,16 +77,14 @@ describe Y2Storage::SetupErrorsPresenter do
       let(:product_error3) { instance_double(Y2Storage::SetupError, message: "product error 3") }
       let(:mount_error1) { instance_double(Y2Storage::SetupError, message: "missing option 1") }
 
-      let(:policies_errors) { { policy1 => policy1_errors } }
-      let(:policy1) { double("Y2Security::SecurityPolicies::DisaStigPolicy", name: "STIG") }
-      let(:policy1_errors) { [instance_double(Y2Storage::SetupError, message: "policy error")] }
+      let(:policies_errors) { {} }
 
       let(:boot_errors) { [boot_error1, boot_error2] }
       let(:product_errors) { [product_error1, product_error2, product_error3] }
       let(:mount_errors) { [mount_error1] }
 
       it "contains a message for each error" do
-        expect(subject.to_html.scan(/<li>/).size).to eq(7)
+        expect(subject.to_html.scan(/<li>/).size).to eq(6)
       end
 
       context "and there are boot errors" do
@@ -108,7 +106,9 @@ describe Y2Storage::SetupErrorsPresenter do
         end
 
         it "does not contain a general error message for policies errors" do
-          expect(subject.to_html).to_not match(/security policy/)
+          expect(subject).to_not receive(:security_policy_warnings_html)
+
+          subject.to_html
         end
       end
 
@@ -131,7 +131,9 @@ describe Y2Storage::SetupErrorsPresenter do
         end
 
         it "does not contain a general error message for policies errors" do
-          expect(subject.to_html).to_not match(/security policy/)
+          expect(subject).to_not receive(:security_policy_warnings_html)
+
+          subject.to_html
         end
       end
 
@@ -154,7 +156,9 @@ describe Y2Storage::SetupErrorsPresenter do
         end
 
         it "does not contain a general error message for policies errors" do
-          expect(subject.to_html).to_not match(/security policy/)
+          expect(subject).to_not receive(:security_policy_warnings_html)
+
+          subject.to_html
         end
       end
 
@@ -164,10 +168,12 @@ describe Y2Storage::SetupErrorsPresenter do
         let(:mount_errors) { [] }
         let(:policies_errors) { { policy1 => policy1_errors } }
         let(:policy1) { double("Y2Security::SecurityPolicies::DisaStigPolicy", name: "STIG") }
-        let(:policy1_errors) { [instance_double(Y2Storage::SetupError, message: "policy error")] }
+        let(:policy1_errors) { [double("Y2Security::SecurityPolicies::Rule")] }
 
         it "contains a general error message for each policy" do
-          expect(subject.to_html).to match(/STIG security policy/)
+          expect(subject).to receive(:security_policy_warnings_html).with(policy1, policy1_errors)
+
+          subject.to_html
         end
 
         it "does not contain a general error message for boot errors" do
@@ -204,7 +210,9 @@ describe Y2Storage::SetupErrorsPresenter do
         end
 
         it "contains a general error message for each policy" do
-          expect(subject.to_html).to match(/STIG security policy/)
+          expect(subject).to receive(:security_policy_warnings_html).with(policy1, policy1_errors)
+
+          subject.to_html
         end
       end
     end


### PR DESCRIPTION
## Problem

YaST installer is now able to validate whether a setup fulfills the installation requirements of the DISA STIG security policy, see https://github.com/yast/yast-security/pull/128. Some of those checks affect to the storage setup. But neither Guided Setup nor Expert Partitioner are performing checks for the enabled security policy.  

* Part of
  * https://trello.com/c/SqFGWTyB/3044-build-a-basic-initial-api-for-the-stig-checker
  * https://jira.suse.com/browse/PM-3526
* Requires: https://github.com/yast/yast-security/pull/128


## Solution

Perform policy checks and show issues in both the storage proposal dialog and the Expert Partitioner. Note that a policy can be enabled by default with the `YAST_SECURITY_POLICY` boot parameter, for example `YAST_SECURITY_POLICY=stig`.

NOTE: this will be merged after https://github.com/yast/yast-security/pull/128.


## Testing

* Added new unit tests
* Tested manually


## Screenshots

![Screenshot from 2022-10-03 16-55-32](https://user-images.githubusercontent.com/1112304/193622961-303e83ef-792c-480c-a0ad-658c3e80f2f8.png)

![Screenshot from 2022-10-03 16-56-13](https://user-images.githubusercontent.com/1112304/193623220-56511085-aa48-45b6-9294-852d0328ad23.png)
