### PR TITLE
Adapt test to behavior change in libstorage-ng

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 21 08:08:01 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Unit tests adapted to a recent behavior change in libstorage-ng
+  (gh#openSUSE/libstorage-ng#900).
+- 4.5.10
+
+-------------------------------------------------------------------
 Mon Sep 26 10:48:49 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Decouple user interface logic from the probing process

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.9
+Version:        4.5.10
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/test/y2storage/partition_tables/msdos_test.rb
+++ b/test/y2storage/partition_tables/msdos_test.rb
@@ -51,8 +51,8 @@ describe Y2Storage::PartitionTables::Msdos do
       expect(subject.partition_id_supported?(Y2Storage::PartitionId::DOS32)).to eq true
     end
 
-    it "ms-dos can NOT have an UNKNOWN partition" do
-      expect(subject.partition_id_supported?(Y2Storage::PartitionId::UNKNOWN)).to eq false
+    it "ms-dos can have an UNKNOWN partition" do
+      expect(subject.partition_id_supported?(Y2Storage::PartitionId::UNKNOWN)).to eq true
     end
 
     it "ms-dos can NOT have partition id 0" do


### PR DESCRIPTION
## Problem

This was changed in libstorage-ng https://github.com/openSUSE/libstorage-ng/pull/900

Before that, `ms_dos_ptable.partition_id_supported?(Y2Storage::PartitionId::UNKNOWN)` returned false. Now it returns true.

The change is actually safe for the current code-base of yast-storage-ng (see below), but it broke the unit tests we intentionally have in place to detect changes in the libstorage-ng API (so we can manually check if there is any problematic implication).

## Solution

Just adapt the test to the new behavior of libstorage-ng. We verified the change is safe because:

- `PartitionTables::Base#supported_partition_ids` already filters UNKNOWN out. Among other things, that already guarantees UNKNOWN is never offered as an option in the UI.
- Calls to `whatever_ptable.partition_id_supported?(Y2Storage::PartitionId::UNKNOWN)` have always returned true for partition tables of type DASD and GPT and has never been a problem so far. Actually MS-DOS was the exception here.
