### PR TITLE
Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov  2 16:04:22 UTC 2022 - Martin Vidner <mvidner@suse.com>
+
+- Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)
+- 4.5.11
+
+-------------------------------------------------------------------
 Fri Oct 21 08:08:01 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Unit tests adapted to a recent behavior change in libstorage-ng

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.10
+Version:        4.5.11
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/test/y2storage/clients/manual_test_test.rb
+++ b/test/y2storage/clients/manual_test_test.rb
@@ -157,7 +157,8 @@ describe Y2Storage::Clients::ManualTest do
       include_examples "mock devicegraph"
 
       it "mocks the product features" do
-        expect(Yast::ProductFeatures).to receive(:Import).with(some: "value")
+        profile = { some: "value" }
+        expect(Yast::ProductFeatures).to receive(:Import).with(profile)
         described_class.run
       end
 


### PR DESCRIPTION
- https://bugzilla.opensuse.org/show_bug.cgi?id=1204871 "- [Staging] rubygem-rspec-* 3.12 breaks various yast modules build"
- see https://github.com/yast/yast-yast2/pull/1279 for details
