### PR TITLE
Support for LUKS2 in the GuidedProposal

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 21 11:33:52 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- GuidedProposal: support for LUKS2 encryption with a configurable
+  PBKDF to be used by D-Installer (related to jsc#PED-2182).
+- 4.5.14
+
+-------------------------------------------------------------------
 Tue Nov 15 11:40:40 UTC 2022 - José Iván López González <jlopez@suse.com>
 
 - Validate security policies in both guided proposal and

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.13
+Version:        4.5.14
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/encryption.rb
+++ b/src/lib/y2partitioner/actions/controllers/encryption.rb
@@ -58,7 +58,7 @@ module Y2Partitioner
         # @return [String] Label for the encryption device if the method supports setting one
         attr_accessor :label
 
-        # @return [String] Password-based key derivation function (PBKDF) for the LUKS2 device
+        # @return [PbkdFunction] Password-based key derivation function (PBKDF) for the LUKS2 device
         attr_accessor :pbkdf
 
         # Contructor
@@ -71,7 +71,7 @@ module Y2Partitioner
           @fs_controller = fs_controller
           @action = actions.first
           @password = encryption&.password || ""
-          @pbkdf = encryption&.pbkdf || ""
+          @pbkdf = encryption&.pbkdf
           @method = initial_method
           @apqns = initial_apqns
           @label = initial_label

--- a/src/lib/y2partitioner/widgets/description_section/blk_device.rb
+++ b/src/lib/y2partitioner/widgets/description_section/blk_device.rb
@@ -102,7 +102,7 @@ module Y2Partitioner
         #
         # @return [String]
         def pbkdf_value
-          pbkdf = Y2Storage::PbkdFunction.find(blk_device.encryption.pbkdf)
+          pbkdf = blk_device.encryption.pbkdf
           # TRANSLATORS: %s becomes the name of the PBKDF function used by a LUKS2 device (eg. Argon2i)
           format(_("Key Derivation Function (PBKDF): %s"), pbkdf.name)
         end

--- a/src/lib/y2partitioner/widgets/description_section/blk_device.rb
+++ b/src/lib/y2partitioner/widgets/description_section/blk_device.rb
@@ -19,7 +19,7 @@
 
 require "y2partitioner/widgets/description_section/base"
 require "y2partitioner/widgets/blk_device_attributes"
-require "y2partitioner/pbkd_function"
+require "y2storage/pbkd_function"
 
 module Y2Partitioner
   module Widgets
@@ -102,7 +102,7 @@ module Y2Partitioner
         #
         # @return [String]
         def pbkdf_value
-          pbkdf = PbkdFunction.find(blk_device.encryption.pbkdf)
+          pbkdf = Y2Storage::PbkdFunction.find(blk_device.encryption.pbkdf)
           # TRANSLATORS: %s becomes the name of the PBKDF function used by a LUKS2 device (eg. Argon2i)
           format(_("Key Derivation Function (PBKDF): %s"), pbkdf.name)
         end

--- a/src/lib/y2partitioner/widgets/pbkdf_selector.rb
+++ b/src/lib/y2partitioner/widgets/pbkdf_selector.rb
@@ -19,7 +19,7 @@
 
 require "yast"
 require "cwm"
-require "y2partitioner/pbkd_function"
+require "y2storage/pbkd_function"
 
 module Y2Partitioner
   module Widgets
@@ -50,7 +50,7 @@ module Y2Partitioner
 
       # @macro seeItemsSelection
       def items
-        PbkdFunction.all.map { |opt| [opt.value, opt.name] }
+        Y2Storage::PbkdFunction.all.map { |opt| [opt.value, opt.name] }
       end
 
       # @macro seeAbstractWidget

--- a/src/lib/y2partitioner/widgets/pbkdf_selector.rb
+++ b/src/lib/y2partitioner/widgets/pbkdf_selector.rb
@@ -45,7 +45,7 @@ module Y2Partitioner
       # Sets the initial value
       def init
         enable_on_init ? enable : disable
-        self.value = @controller.pbkdf
+        self.value = @controller.pbkdf&.value
       end
 
       # @macro seeItemsSelection
@@ -55,7 +55,7 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def store
-        @controller.pbkdf = value
+        @controller.pbkdf = Y2Storage::PbkdFunction.find(value)
       end
 
       private

--- a/src/lib/y2storage.rb
+++ b/src/lib/y2storage.rb
@@ -63,6 +63,7 @@ require "y2storage/btrfs_raid_level"
 require "y2storage/btrfs_qgroup"
 require "y2storage/btrfs_subvolume"
 require "y2storage/storage_features_list"
+require "y2storage/pbkd_function"
 
 require "y2storage/exceptions"
 require "y2storage/boot_requirements_checker"

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -67,15 +67,12 @@ module Y2Storage
     storage_forward :cipher
     storage_forward :cipher=
 
-    # @!attribute pbkdf
-    #   PBKDF (Password-Based Key Derivation Function), currently only supported for LUKS2 where
-    #   this attribute corresponds to the PBKDF of the first used keyslot.
-    #
-    #   If is set to empty, during the commit phase the default of cryptsetup will be used.
+    # @!attribute pbkdf_value
+    #   String representation of {#pbkdf}, an empty string is equivalent to a nil value on {#pbkdf}
     #
     #   @return [String]
-    storage_forward :pbkdf
-    storage_forward :pbkdf=
+    storage_forward :pbkdf_value, to: :pbkdf
+    storage_forward :pbkdf_value=, to: :pbkdf=
 
     # @!attribute crypt_options
     #   Options in the fourth field of /etc/crypttab
@@ -406,6 +403,23 @@ module Y2Storage
     # @see Device#update_etc_attributes
     def assign_etc_attribute(value)
       self.storage_in_etc_crypttab = value
+    end
+
+    # PBKDF (Password-Based Key Derivation Function), currently only supported for LUKS2 where
+    # this attribute corresponds to the PBKDF of the first used keyslot.
+    #
+    # If is set to nil, during the commit phase the default of cryptsetup will be used.
+    #
+    # @return [PbkdFunction, nil]
+    def pbkdf
+      PbkdFunction.find(pbkdf_value)
+    end
+
+    # @see #pbkdf
+    #
+    # @param function [PbkdFunction, nil]
+    def pbkdf=(function)
+      self.pbkdf_value = function&.value || ""
     end
 
     protected

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -422,6 +422,13 @@ module Y2Storage
       self.pbkdf_value = function&.value || ""
     end
 
+    # Whether the attribute #pbkdf makes sense for this object
+    #
+    # @return [Boolean]
+    def supports_pbkdf?
+      type.is?(:luks2)
+    end
+
     protected
 
     # @see Device#is?

--- a/src/lib/y2storage/encryption_method/luks2.rb
+++ b/src/lib/y2storage/encryption_method/luks2.rb
@@ -21,6 +21,7 @@ require "y2storage/storage_env"
 require "y2storage/encryption_method/base"
 require "y2storage/encryption_method/pervasive_luks2"
 require "y2storage/encryption_processes/luks"
+require "y2storage/pbkd_function"
 
 module Y2Storage
   module EncryptionMethod
@@ -48,12 +49,12 @@ module Y2Storage
       #
       # @param blk_device [Y2Storage::BlkDevice]
       # @param dm_name [String]
-      # @param pbkdf [String] password-based key derivation function to be used by the created
+      # @param pbkdf [PbkdFunction, nil] password-based key derivation function to be used by the created
       #   LUKS2 device
       # @param label [String] optional LUKS label
       #
       # @return [Y2Storage::Encryption]
-      def create_device(blk_device, dm_name, pbkdf: "", label: "")
+      def create_device(blk_device, dm_name, pbkdf: nil, label: "")
         encryption_process.create_device(blk_device, dm_name, pbkdf: pbkdf, label: label)
       end
 

--- a/src/lib/y2storage/encryption_processes/luks.rb
+++ b/src/lib/y2storage/encryption_processes/luks.rb
@@ -41,7 +41,7 @@ module Y2Storage
       #
       # @param blk_device [Y2Storage::BlkDevice]
       # @param dm_name [String]
-      # @param pbkdf [String, nil] PBKDF of the LUKS device, only relevant for LUKS2
+      # @param pbkdf [PbkdFunction] PBKDF of the LUKS device, only relevant for LUKS2
       # @param label [String, nil] label of the LUKS device, only relevant for LUKS2
       #
       # @return [Encryption]

--- a/src/lib/y2storage/pbkd_function.rb
+++ b/src/lib/y2storage/pbkd_function.rb
@@ -36,15 +36,18 @@ module Y2Storage
       @name = name
     end
 
+    # Instance of the function to be always returned by the class
+    # TRANSLATORS: name of a key derivation function used by LUKS
+    ARGON2ID = new("argon2id", N_("Argon2id"))
+    # Instance of the function to be always returned by the class
+    # TRANSLATORS: name of a key derivation function used by LUKS
+    ARGON2I = new("argon2i", N_("Argon2i"))
+    # Instance of the function to be always returned by the class
+    # TRANSLATORS: name of a key derivation function used by LUKS
+    PBKDF2 = new("pbkdf2", N_("PBKDF2"))
+
     # All possible instances
-    ALL = [
-      # TRANSLATORS: name of a key derivation function used by LUKS
-      new("argon2id", N_("Argon2id")),
-      # TRANSLATORS: name of a key derivation function used by LUKS
-      new("argon2i",  N_("Argon2i")),
-      # TRANSLATORS: name of a key derivation function used by LUKS
-      new("pbkdf2",   N_("PBKDF2"))
-    ].freeze
+    ALL = [ARGON2ID, ARGON2I, PBKDF2].freeze
     private_constant :ALL
 
     # Sorted list of all possible roles
@@ -54,10 +57,10 @@ module Y2Storage
 
     # Finds a function by its value
     #
-    # @param value [String, nil]
+    # @param value [#to_s]
     # @return [PbkdFunction, nil] nil if such value does not exist
     def self.find(value)
-      ALL.find { |opt| opt.value == value }
+      ALL.find { |opt| opt.value == value.to_s }
     end
 
     # @return [String] value for {Y2Storage::Encryption#pbkdf}
@@ -66,6 +69,35 @@ module Y2Storage
     # @return [String] localized name for the function to display in the UI
     def name
       _(@name)
+    end
+
+    alias_method :to_s, :value
+
+    # @return [Symbol]
+    def to_sym
+      value.to_sym
+    end
+
+    # Checks whether the object corresponds to any of the given enum values.
+    #
+    # By default, this will be the base comparison used in the case statements.
+    #
+    # @param names [#to_sym]
+    # @return [Boolean]
+    def is?(*names)
+      names.any? { |n| n.to_sym == to_sym }
+    end
+
+    # @return [Boolean]
+    def ==(other)
+      other.class == self.class && other.value == value
+    end
+
+    alias_method :eql?, :==
+
+    # @return [Boolean]
+    def ===(other)
+      other.instance_of?(self.class) && is?(other)
     end
   end
 end

--- a/src/lib/y2storage/pbkd_function.rb
+++ b/src/lib/y2storage/pbkd_function.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2021] SUSE LLC
+# Copyright (c) [2021-2022] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -18,9 +18,8 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "y2storage"
 
-module Y2Partitioner
+module Y2Storage
   # Class to represent each one of the possible values for {Y2Storage::Encryption#pbkdf}
   class PbkdFunction
     include Yast::I18n

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -46,6 +46,11 @@ module Y2Storage
       #   @return [String, nil] password used to encrypt the device.
       secret_attr :encryption_password
 
+      # PBKDF to use when encrypting the device if such property makes sense (eg. LUKS2)
+      #
+      # @return [PbkdFunction, nil] nil to use the default derivation function
+      attr_accessor :encryption_pbkdf
+
       # Initializations of the mixin, to be called from the class constructor.
       def initialize_can_be_encrypted; end
 
@@ -80,6 +85,7 @@ module Y2Storage
         if create_encryption?
           method = encryption_method || EncryptionMethod.find(:luks1)
           result = plain_device.encrypt(method: method, password: encryption_password)
+          result.pbkdf = encryption_pbkdf if encryption_pbkdf && result.supports_pbkdf?
           log.info "Device encrypted. Returning the new device #{result.inspect}"
         else
           log.info "No need to encrypt. Returning the existing device #{result.inspect}"

--- a/src/lib/y2storage/proposal/devices_planner.rb
+++ b/src/lib/y2storage/proposal/devices_planner.rb
@@ -160,8 +160,19 @@ module Y2Storage
         adjust_to_settings(lv, volume)
 
         planned_device = Planned::LvmVg.new(volume_group_name: volume.separate_vg_name, lvs: [lv])
-        planned_device.pvs_encryption_password = settings.encryption_password
+        adjust_pvs_encryption(planned_device)
         planned_device
+      end
+
+      # @see #planned_separate_vg
+      #
+      # @param vg [Planned::LvmVg]
+      def adjust_pvs_encryption(vg)
+        return unless settings.encryption_password
+
+        vg.pvs_encryption_password = settings.encryption_password
+        vg.pvs_encryption_method = settings.encryption_method
+        vg.pvs_encryption_pbkdf = settings.encryption_pbkdf
       end
 
       # Adjusts planned device values according to settings
@@ -195,8 +206,11 @@ module Y2Storage
       # @param _volume [VolumeSpecification]
       def adjust_encryption(planned_device, _volume)
         return unless planned_device.is_a?(Planned::Partition)
+        return unless settings.encryption_password
 
         planned_device.encryption_password = settings.encryption_password
+        planned_device.encryption_method = settings.encryption_method
+        planned_device.encryption_pbkdf = settings.encryption_pbkdf
       end
 
       # Adjusts planned device sizes according to settings

--- a/src/lib/y2storage/proposal/lvm_helper.rb
+++ b/src/lib/y2storage/proposal/lvm_helper.rb
@@ -111,6 +111,8 @@ module Y2Storage
         @reused_volume_group.lvs = planned_lvs
         @reused_volume_group.size_strategy = vg_strategy
         @reused_volume_group.pvs_encryption_password = settings.encryption_password
+        @reused_volume_group.pvs_encryption_method = settings.encryption_method
+        @reused_volume_group.pvs_encryption_pbkdf = settings.encryption_pbkdf
       end
 
       # Checks whether the passed device is the volume group to be reused
@@ -153,6 +155,8 @@ module Y2Storage
       def new_volume_group
         vg = Planned::LvmVg.new(volume_group_name: DEFAULT_VG_NAME, lvs: planned_lvs)
         vg.pvs_encryption_password = settings.encryption_password
+        vg.pvs_encryption_method = settings.encryption_method
+        vg.pvs_encryption_pbkdf = settings.encryption_pbkdf
         vg.size_strategy = vg_strategy
         vg
       end

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -25,6 +25,7 @@ require "y2storage/subvol_specification"
 require "y2storage/filesystems/type"
 require "y2storage/partitioning_features"
 require "y2storage/volume_specifications_set"
+require "y2storage/encryption_method"
 
 module Y2Storage
   # Class to manage settings used by the proposal (typically read from control.xml)
@@ -149,9 +150,22 @@ module Y2Storage
     # @return [Array<String>, nil]
     attr_reader :explicit_candidate_devices
 
+    # TODO: it makes sense to encapsulate #encryption_password, #encryption_method and
+    # #encryption_pbkdf in some new class (eg. EncryptionSettings), posponed for now
+
     # @!attribute encryption_password
     #   @return [String] password to use when creating new encryption devices
     secret_attr :encryption_password
+
+    # Encryption method to use if {#encryption_password} is set
+    #
+    # @return [EncryptionMethod::Base]
+    attr_accessor :encryption_method
+
+    # PBKDF to use if {#encryption_password} is set and {#encryption_method} is LUKS2
+    #
+    # @return [PbkdFunction, nil] nil to use the default
+    attr_accessor :encryption_pbkdf
 
     # @return [Boolean] whether to resize Windows systems if needed
     attr_accessor :resize_windows
@@ -384,6 +398,7 @@ module Y2Storage
       linux_delete_mode:          :ondemand,
       lvm:                        false,
       lvm_vg_strategy:            :use_available,
+      encryption_method:          EncryptionMethod::LUKS1,
       multidisk_first:            false,
       other_delete_mode:          :ondemand,
       resize_windows:             true,

--- a/test/support/boot_requirements_context.rb
+++ b/test/support/boot_requirements_context.rb
@@ -64,7 +64,8 @@ RSpec.shared_context "boot requirements" do
       esp_in_software_raid?:   false,
       esp_in_software_raid1?:  false,
       encrypted_esp?:          false,
-      boot_encryption_type:    boot_enc_type
+      boot_encryption_type:    boot_enc_type,
+      boot_luks2_pbkdf:        boot_pbkdf
     )
   end
 
@@ -80,6 +81,7 @@ RSpec.shared_context "boot requirements" do
   end
   let(:boot_ptable_type) { :msdos }
   let(:boot_enc_type) { Y2Storage::EncryptionType::NONE }
+  let(:boot_pbkdf) { nil }
 
   # Mocks for Raspberry Pi detection
   let(:raspi_system) { false }

--- a/test/y2partitioner/widgets/description_section/blk_device_test.rb
+++ b/test/y2partitioner/widgets/description_section/blk_device_test.rb
@@ -22,6 +22,7 @@ require_relative "../../test_helper"
 require_relative "help_fields_examples"
 
 require "y2partitioner/widgets/description_section/blk_device"
+require "y2storage/pbkd_function"
 
 describe Y2Partitioner::Widgets::DescriptionSection::BlkDevice do
   before { devicegraph_stub(scenario) }
@@ -73,7 +74,9 @@ describe Y2Partitioner::Widgets::DescriptionSection::BlkDevice do
       end
 
       context "if LUKS2 is used as encryption type" do
-        before { device.encrypt(method: :luks2, label: "something", pbkdf: "argon2i") }
+        before do
+          device.encrypt(method: :luks2, label: "something", pbkdf: Y2Storage::PbkdFunction::ARGON2I)
+        end
 
         it "includes an entry about the encryption including the encryption type" do
           expect(subject.value).to match(/Encrypted: Yes/)

--- a/test/y2partitioner/widgets/pbkdf_selector_test.rb
+++ b/test/y2partitioner/widgets/pbkdf_selector_test.rb
@@ -22,12 +22,15 @@ require_relative "../test_helper"
 
 require "cwm/rspec"
 require "y2partitioner/widgets/pbkdf_selector"
+require "y2storage/pbkd_function"
 
 describe Y2Partitioner::Widgets::PbkdfSelector do
   subject(:widget) { described_class.new(controller) }
 
-  let(:controller) { double("Controllers::Encryption", pbkdf: initial_pbkdf) }
   let(:initial_pbkdf) { "pbkdf2" }
+  let(:controller) do
+    double("Controllers::Encryption", pbkdf: Y2Storage::PbkdFunction.find(initial_pbkdf))
+  end
 
   include_examples "CWM::ComboBox"
 
@@ -71,7 +74,8 @@ describe Y2Partitioner::Widgets::PbkdfSelector do
     end
 
     it "sets the selected pbkdf" do
-      expect(controller).to receive(:pbkdf=).with(selected_pbkdf)
+      pbkdf = Y2Storage::PbkdFunction.find(selected_pbkdf)
+      expect(controller).to receive(:pbkdf=).with(pbkdf)
 
       widget.store
     end

--- a/test/y2storage/encryption_method_test.rb
+++ b/test/y2storage/encryption_method_test.rb
@@ -21,6 +21,7 @@
 
 require_relative "spec_helper"
 require "y2storage/encryption_method"
+require "y2storage/pbkd_function"
 
 describe Y2Storage::EncryptionMethod do
   describe ".all" do
@@ -274,10 +275,12 @@ describe Y2Storage::EncryptionMethod do
       it "sets the given label and PBKDF for the LUKS2 device" do
         expect(device.encrypted?).to eq(false)
 
-        subject.create_device(device, "cr_dev", label: "cool_luks", pbkdf: "argon2i")
+        subject.create_device(
+          device, "cr_dev", label: "cool_luks", pbkdf: Y2Storage::PbkdFunction::ARGON2I
+        )
 
         expect(device.encryption.label).to eq "cool_luks"
-        expect(device.encryption.pbkdf).to eq "argon2i"
+        expect(device.encryption.pbkdf.value).to eq "argon2i"
       end
     end
 

--- a/test/y2storage/pbkd_function_test.rb
+++ b/test/y2storage/pbkd_function_test.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage/pbkd_function"
+
+describe Y2Storage::PbkdFunction do
+  subject { Y2Storage::PbkdFunction::ARGON2I }
+
+  describe "#is?" do
+    it "returns true for an equivalent function object" do
+      expect(subject.is?(Y2Storage::PbkdFunction.find("argon2i"))).to eq true
+    end
+
+    it "returns false for a non-equivalent function object" do
+      expect(subject.is?(Y2Storage::PbkdFunction.find("pbkdf2"))).to eq false
+    end
+
+    it "returns true for a list of symbols including the equivalent one" do
+      expect(subject.is?(:argon2i, :pbkdf)).to eq true
+    end
+
+    it "returns false for list of symbols not including the equivalent one" do
+      expect(subject.is?(:argon2id, :pbkdf)).to eq false
+    end
+  end
+
+  describe "#===" do
+    it "returns true for the equivalent object" do
+      value =
+        case subject
+        when Y2Storage::PbkdFunction.find("argon2i")
+          true
+        else
+          false
+        end
+      expect(value).to eq true
+    end
+
+    it "returns false for the equivalent symbol" do
+      value =
+        case subject
+        when :argon2i
+          true
+        else
+          false
+        end
+      expect(value).to eq false
+    end
+  end
+end

--- a/test/y2storage/proposal_luks2_x86_test.rb
+++ b/test/y2storage/proposal_luks2_x86_test.rb
@@ -1,0 +1,175 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "storage"
+require "y2storage"
+require_relative "#{TEST_PATH}/support/proposal_examples"
+require_relative "#{TEST_PATH}/support/proposal_context"
+
+describe Y2Storage::GuidedProposal do
+  using Y2Storage::Refinements::SizeCasts
+
+  describe "#propose" do
+    include_context "proposal"
+
+    subject(:proposal) { described_class.new(settings: settings) }
+    let(:scenario) { "empty_hard_disk_50GiB" }
+    let(:architecture) { :x86 }
+    let(:control_file) { "legacy_settings.xml" }
+    let(:encrypt) { true }
+
+    before do
+      allow(Yast::Kernel).to receive(:propose_hibernation?).and_return(true)
+      allow(storage_arch).to receive(:efiboot?).and_return(efi)
+
+      settings.encryption_method = Y2Storage::EncryptionMethod::LUKS2
+      settings.encryption_pbkdf = pbkdf
+    end
+
+    # Helper method to check the properties of an encrypted filesystem
+    def expect_luks2_fs(mount_path, pbkdf)
+      fs = proposal.devices.filesystems.find { |i| i.mount_path == mount_path }
+      expect(fs.encrypted?).to eq true
+
+      enc = fs.blk_devices.first
+      expect(enc.type).to eq Y2Storage::EncryptionType::LUKS2
+      expect(enc.pbkdf).to eq pbkdf
+    end
+
+    # Helper method to check the properties of a filesystem inside an encrypted LVM
+    def expect_luks2_lvm_fs(mount_path, pbkdf)
+      fs = proposal.devices.filesystems.find { |i| i.mount_path == mount_path }
+      expect(fs.encrypted?).to eq false
+
+      lv = fs.blk_devices.first
+      expect(lv.is?(:lvm_lv)).to eq true
+
+      pvs = lv.lvm_vg.lvm_pvs
+      encs = pvs.map(&:blk_device)
+      expect(encs.map(&:type)).to all(eq Y2Storage::EncryptionType::LUKS2)
+      expect(encs.map(&:pbkdf)).to all(eq pbkdf)
+    end
+
+    RSpec.shared_examples "/boot unless PBKDF2" do
+      context "using Argon2id as key derivation function" do
+        let(:pbkdf) { Y2Storage::PbkdFunction::ARGON2ID }
+
+        it "proposes a separate unencrypted /boot partition" do
+          proposal.propose
+          boot_fs = proposal.devices.filesystems.find { |fs| fs.mount_path == "/boot" }
+          expect(boot_fs.encrypted?).to eq false
+        end
+      end
+
+      context "using PBKDF2 as key derivation function" do
+        let(:pbkdf) { Y2Storage::PbkdFunction::PBKDF2 }
+
+        it "does not propose a separate /boot partition" do
+          proposal.propose
+          boot_fs = proposal.devices.filesystems.find { |fs| fs.mount_path == "/boot" }
+          expect(boot_fs).to be_nil
+        end
+      end
+    end
+
+    RSpec.shared_examples "correct PBKDF encrypted partitions" do
+      context "using Argon2id as key derivation function" do
+        let(:pbkdf) { Y2Storage::PbkdFunction::ARGON2ID }
+
+        it "proposes LUKS2 encrypted partitions with Argon2 for all system partitions" do
+          proposal.propose
+          expect_luks2_fs("/", Y2Storage::PbkdFunction::ARGON2ID)
+          expect_luks2_fs("swap", Y2Storage::PbkdFunction::ARGON2ID)
+        end
+      end
+
+      context "using PBKDF2 as key derivation function" do
+        let(:pbkdf) { Y2Storage::PbkdFunction::PBKDF2 }
+
+        it "proposes LUKS2 encrypted partitions with PBKDF2 for all system partitions" do
+          proposal.propose
+          expect_luks2_fs("/", Y2Storage::PbkdFunction::PBKDF2)
+          expect_luks2_fs("swap", Y2Storage::PbkdFunction::PBKDF2)
+        end
+      end
+    end
+
+    RSpec.shared_examples "correct PBKDF encrypted LVM" do
+      context "using Argon2id as key derivation function" do
+        let(:pbkdf) { Y2Storage::PbkdFunction::ARGON2ID }
+
+        it "proposes LUKS2 encrypted LVM with Argon2 for all system volumes" do
+          proposal.propose
+          expect_luks2_lvm_fs("/", Y2Storage::PbkdFunction::ARGON2ID)
+          expect_luks2_lvm_fs("swap", Y2Storage::PbkdFunction::ARGON2ID)
+        end
+      end
+
+      context "using PBKDF2 as key derivation function" do
+        let(:pbkdf) { Y2Storage::PbkdFunction::PBKDF2 }
+
+        it "proposes LUKS2 encrypted LVM with PBKDF2 for all system volumes" do
+          proposal.propose
+          expect_luks2_lvm_fs("/", Y2Storage::PbkdFunction::PBKDF2)
+          expect_luks2_lvm_fs("swap", Y2Storage::PbkdFunction::PBKDF2)
+        end
+      end
+    end
+
+    context "In a UEFI system" do
+      let(:efi) { true }
+
+      context "proposing LVM" do
+        let(:lvm) { true }
+
+        # FIXME: commented out because the combination of LVM + LUKS2 with Argon2 doesn't work yet
+        # include_examples "/boot unless PBKDF2"
+        include_examples "correct PBKDF encrypted LVM"
+      end
+
+      context "proposing partitions (no LVM)" do
+        let(:lvm) { false }
+
+        include_examples "/boot unless PBKDF2"
+        include_examples "correct PBKDF encrypted partitions"
+      end
+    end
+
+    context "In a legacy BIOS boot system" do
+      let(:efi) { false }
+
+      context "proposing LVM" do
+        let(:lvm) { true }
+
+        # FIXME: commented out because the combination of LVM + LUKS2 with Argon2 doesn't work yet
+        # include_examples "/boot unless PBKDF2"
+        include_examples "correct PBKDF encrypted LVM"
+      end
+
+      context "proposing partitions (no LVM)" do
+        let(:lvm) { false }
+
+        include_examples "/boot unless PBKDF2"
+        include_examples "correct PBKDF encrypted partitions"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The `GuidedProposal` (and its variants) is the component responsible of calculating a good storage layout to install the system. So far it's used:

- By YaST to calculate the initial storage proposal
- By YaST if the option "Guided Setup" is used in the partitioning screen
- By AutoYaST if any of the options for [automatic partitioning](https://documentation.suse.com/sles/15-SP4/html/SLES-all/cha-configuration-installation-options.html#CreateProfile-Automatic-Partitioning) or for [guided partitioning](https://documentation.suse.com/sles/15-SP4/html/SLES-all/cha-configuration-installation-options.html#CreateProfile-Guided-Partitioning) is used
- By the current prototypes of D-Installer

For many reasons outlined in [this bugzilla comment](https://bugzilla.suse.com/show_bug.cgi?id=1185291#c1) and several other places, the `GuidedProposal` always uses LUKS1 to encrypt the devices.

But recent versions of openSUSE Tumbleweed and the ALP prototypes include a heavily patched version of Grub2 that can handle LUKS2 reasonably well as long as PBKDF2 is used as password-based key derivation function.

When installing any ALP-based product with D-Installer we want to make it possible to use TPM-based encryption. For that, LUKS2 is the only option, it cannot work with LUKS1.

## Solution

**Important:** this pull request also includes some previous commits to do some cleanup and refactor some parts. Review commit by commit.

Implement support for LUKS2 (with a configurable PBKDF) in the `GuidedProposal` so it can be used by D-Installer to implement TPM-based encryption.

There are no plans to use that capability from (Auto)YaST. Everything remains full backwards compatible using LUKS1 by default for any encryption done by the proposal.

The code assumes Grub2 can handle LUKS2 devices using PBKDF2. At the moment of writing, that is not true in the case of SLE-15-SP5 or any previous version of SLE or Leap. That implies we need to revisit that logic in the `BootRequirementsChecker` in the close future. On the bright side, Michael Chang commented he could make SLE-15-SP5 work just like TW in that regard. If that happens we would just need to remove the warning comments. :-)

`GuidedProposal` will always propose a separate unencrypted partition for `/boot` if LUKS2 is used with Argon2i or Argon2id, since Grub2 cannot handle those key derivation functions, not even in Tumbleweed or ALP-based systems. Due to a current bug, that's not true in the following case:  LVM with the physical volumes encrypted with LUKS2 using Argon2i or Argon2id. The plan is to fix that in an upcoming pull request, to not block the current one (LVM+LUKS2 with Argon is out of the scope of both YaST and D-Installer for now).

## Testing

- Tested manually. It works in a current Factory (and Grub2 indeed opens the LUKS2 device with PBKDF2)
- Created new unit tests and adapted the existing ones

## Pending for the future (after merging)

- Fix the LVM+Argon2 case - `BootRequirementsChecker` is not proposing a separate /boot
- As explained above, we need to re-evaluate the SLE-15-SP5 case in the following months. Very likely SP5 will be adapted and we will only need to delete the comments.
- As the number of parameters to configure encryption grows, it would make sense to reconsider how those parameters are passed `GuidedProposal`. We could likely add some kind of new class (eg. `EncryptionSettings`) to encapsulate that information instead of using three fields in the already overloaded `ProposalSettings`.