### PR TITLE
[Proposal] New setting to not reuse LVM volume groups

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 29 15:07:25 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Proposal: new setting to prevent reusing LVM volume groups
+  (related to gh#yast/d-installer#264).
+
+-------------------------------------------------------------------
 Mon Nov 21 11:33:52 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - GuidedProposal: support for LUKS2 encryption with a configurable

--- a/src/lib/y2storage/proposal/lvm_helper.rb
+++ b/src/lib/y2storage/proposal/lvm_helper.rb
@@ -169,6 +169,11 @@ module Y2Storage
       #
       # @return [Boolean]
       def try_to_reuse?
+        # Setting introduced to completely avoid LVM reusing in D-Installer.
+        # It's a new playground, so no need to carry YaST behaviors that have
+        # proven to be confusing.
+        return false if settings.lvm_vg_reuse == false
+
         # We introduced this when we still didn't have a mechanism to activate
         # existing LUKS. Now such mechanism exists but this check has never been
         # removed. Nobody complained so far.

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -219,6 +219,11 @@ module Y2Storage
     #   specify the predefined size of the LVM volume group.
     attr_accessor :lvm_vg_size
 
+    # @return [Boolean] whether a pre-existing LVM volume group should be reused if
+    #   the conditions to do so are met. That is the historical YaST behavior, which
+    #   can be inhibited by setting this to false.
+    attr_accessor :lvm_vg_reuse
+
     # @return [Array<VolumeSpecification>] list of volumes specifications used during
     #   the proposal
     attr_accessor :volumes
@@ -398,6 +403,7 @@ module Y2Storage
       linux_delete_mode:          :ondemand,
       lvm:                        false,
       lvm_vg_strategy:            :use_available,
+      lvm_vg_reuse:               true,
       encryption_method:          EncryptionMethod::LUKS1,
       multidisk_first:            false,
       other_delete_mode:          :ondemand,

--- a/test/data/devicegraphs/output/windows-linux-lvm-noreuse-lvm-sep-home.yml
+++ b/test/data/devicegraphs/output/windows-linux-lvm-noreuse-lvm-sep-home.yml
@@ -1,0 +1,44 @@
+---
+- disk:
+    name: "/dev/sda"
+    size: 800 GiB
+    partition_table: msdos
+    partitions:
+
+    - partition:
+        size: 730 GiB
+        name: /dev/sda1
+        id: ntfs
+        file_system: ntfs
+        label: windows
+
+    - partition:
+        size: unlimited
+        name: /dev/sda2
+        id: lvm
+
+- lvm_vg:
+    vg_name: system
+    lvm_lvs:
+
+    - lvm_lv:
+        lv_name: root
+        size: 40 GiB
+        file_system: btrfs
+        mount_point: "/"
+
+    - lvm_lv:
+        lv_name: home
+        size: 28668 MiB
+        file_system: xfs
+        mount_point: "/home"
+
+    - lvm_lv:
+        lv_name: swap
+        size: 2 GiB
+        file_system: swap
+        mount_point: swap
+
+    lvm_pvs:
+    - lvm_pv:
+        blk_device: /dev/sda2

--- a/test/data/devicegraphs/output/windows-linux-lvm-noreuse-lvm.yml
+++ b/test/data/devicegraphs/output/windows-linux-lvm-noreuse-lvm.yml
@@ -1,0 +1,45 @@
+---
+- disk:
+    name: "/dev/sda"
+    size: 800 GiB
+    partition_table: msdos
+    partitions:
+
+    - partition:
+        size: 730 GiB
+        name: /dev/sda1
+        id: ntfs
+        file_system: ntfs
+        label: windows
+
+    - partition:
+        size: 50 GiB
+        name: /dev/sda2
+        id: lvm
+
+    - partition:
+        size: unlimited
+        name: /dev/sda3
+        id: 0xb
+        file_system: vfat
+        label: recovery
+
+- lvm_vg:
+    vg_name: system
+    lvm_lvs:
+
+    - lvm_lv:
+        lv_name: root
+        size: 40 GiB
+        file_system: btrfs
+        mount_point: "/"
+
+    - lvm_lv:
+        lv_name: swap
+        size: 2 GiB
+        file_system: swap
+        mount_point: swap
+
+    lvm_pvs:
+    - lvm_pv:
+        blk_device: /dev/sda2

--- a/test/y2storage/proposal/lvm_helper_test.rb
+++ b/test/y2storage/proposal/lvm_helper_test.rb
@@ -64,6 +64,14 @@ describe Y2Storage::Proposal::LvmHelper do
           expect(helper.reusable_volume_groups(fake_devicegraph)).to eq []
         end
       end
+
+      context "and ProposalSettings#lvm_vg_reuse is set to false" do
+        before { settings.lvm_vg_reuse = false }
+
+        it "returns an empty array" do
+          expect(helper.reusable_volume_groups(fake_devicegraph)).to eq []
+        end
+      end
     end
 
     context "if some volume groups are big enough" do
@@ -97,6 +105,14 @@ describe Y2Storage::Proposal::LvmHelper do
 
       context "and the logical volumes are assigned to a concrete disk" do
         before { volumes.first.disk = "/dev/sda" }
+
+        it "returns an empty array" do
+          expect(helper.reusable_volume_groups(fake_devicegraph)).to eq []
+        end
+      end
+
+      context "and ProposalSettings#lvm_vg_reuse is set to false" do
+        before { settings.lvm_vg_reuse = false }
 
         it "returns an empty array" do
           expect(helper.reusable_volume_groups(fake_devicegraph)).to eq []

--- a/test/y2storage/proposal_scenarios_x86_test.rb
+++ b/test/y2storage/proposal_scenarios_x86_test.rb
@@ -84,6 +84,13 @@ describe Y2Storage::GuidedProposal do
       let(:scenario) { "windows-linux-lvm-pc" }
       include_examples "LVM-based proposed layouts"
       include_examples "partition-based proposed layouts"
+
+      context "if the proposal is configured to not reuse volume groups" do
+        before { settings.lvm_vg_reuse = false }
+
+        let(:expected_scenario) { "windows-linux-lvm-noreuse" }
+        include_examples "LVM-based proposed layouts"
+      end
     end
 
     context "in a windows-only PC with GPT partition table" do


### PR DESCRIPTION
## Problem

For historical reasons, YaST tries to reuse existing LVM volume groups when making a proposal.

That behavior can be very confusing in many situations. Some of the associated problems and historical factors are described here:
https://trello.com/c/Ib7QC298/19-proposal-strategy-for-reusing-stuff-in-proposal-bug1091998-and-others

Now `Y2Storage::GuidedProposal` is also used by D-Installer and we don't want to follow the YaST approach for reusing stuff. Since D-Installer represents a new playground, we don't need to play by the old rules and expectations.

 ## Solution

Introduce a new setting into `Y2Storage::ProposalSettings` that will be used only by D-Installer (for the time being) and that will inhibit the mechanism to reuse existing LVM volume groups.

## Testing

Added unit tests. Backwards compatibility ensured because all the previous tests keep working with no modification.

## Note about the version

Version of the package not bumped because we are not in a hurry to submit this to Factory and @jreidinger is already working on another change for yast-storage-ng.