### PR TITLE
Release version 4.5.15

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec  7 14:26:51 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Allow reusing LVM volume groups
+- 4.5.15
+
+-------------------------------------------------------------------
 Tue Nov 29 15:07:25 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Proposal: new setting to prevent reusing LVM volume groups

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.14
+Version:        4.5.15
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only


### PR DESCRIPTION
## Problem

https://github.com/yast/yast-storage-ng/pull/1316 introduced a small change in the API allowing to reuse the LVM volume groups. However, the version was not bumped and, accordingly, the code has not been _released_ yet to Factory.

## Solution

Bump version from 4.5.14 to 4.5.15