### PR TITLE
Correctly Identify Dell BOSS Storage Devices

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 17 14:32:36 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Extended regexp to identify Dell BOSS storage devices (bsc#1200975)
+- 4.4.42
+
+-------------------------------------------------------------------
 Tue Aug 30 10:06:43 UTC 2022 - José Iván López González <jlopez@suse.com>
 
 - Validate security policies in both guided proposal and

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.41
+Version:        4.4.42
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -658,7 +658,7 @@ module Y2Storage
     #   @return [Array<String>] empty if the driver is unknown
 
     # @see #boss?
-    BOSS_REGEXP = Regexp.new("dellboss", Regexp::IGNORECASE).freeze
+    BOSS_REGEXP = Regexp.new("dell.*boss", Regexp::IGNORECASE).freeze
     private_constant :BOSS_REGEXP
 
     # Whether this device is a Dell BOSS (Boot Optimized Storage Solution)


### PR DESCRIPTION
## Target Branch

This is for SLE-15 SP4.


## L3 / Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1200975


## Problem

In some cases, Dell BOSS NVMe drives were not correctly identified and shown as such to the user.


## Fix

Extended the regular expression for the check.

https://bugzilla.suse.com/show_bug.cgi?id=1200975#c87


## Related PR

Merge to _master_:

_to do_