### PR TITLE
Ruby 3.2 yast2-storage-ng sometimes fails to build, diff in Marshal.dump 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  2 10:13:14 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Fix comparing ProposalSettings in tests, avoid using Marshal
+  (bsc#1208259)
+- 4.5.17
+
+-------------------------------------------------------------------
 Tue Jan 17 14:32:36 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Extended regexp to identify Dell BOSS storage devices (bsc#1200975)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.16
+Version:        4.5.17
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/equal_by_instance_variables.rb
+++ b/src/lib/y2storage/equal_by_instance_variables.rb
@@ -1,0 +1,38 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Storage
+  # Define `==` by having the same class and same (==) instance variables.
+  #
+  # The strict comparison (`eql?`) is unchanged and will be `false`
+  # for different objects. See Yast2::Equatable which can also
+  # specify the instance variables used for the comparison:
+  # https://github.com/yast/yast-yast2/blob/master/library/general/src/lib/yast2/equatable.rb
+  module EqualByInstanceVariables
+    # TODO: move to base library?
+
+    def ==(other)
+      return false if other.class != self.class
+
+      instance_variables.all? do |iv|
+        instance_variable_get(iv) == other.instance_variable_get(iv)
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -26,6 +26,7 @@ require "y2storage/filesystems/type"
 require "y2storage/partitioning_features"
 require "y2storage/volume_specifications_set"
 require "y2storage/encryption_method"
+require "y2storage/equal_by_instance_variables"
 
 module Y2Storage
   # Class to manage settings used by the proposal (typically read from control.xml)
@@ -35,6 +36,7 @@ module Y2Storage
   class ProposalSettings
     include SecretAttributes
     include PartitioningFeatures
+    include EqualByInstanceVariables
 
     # @return [Boolean] whether to use LVM
     attr_accessor :use_lvm

--- a/src/lib/y2storage/secret_attributes.rb
+++ b/src/lib/y2storage/secret_attributes.rb
@@ -44,6 +44,15 @@ module Y2Storage
         # use deep instrospection
         []
       end
+
+      # Enable comparison
+      #
+      # The motivation for this is cooperation with EqualByInstanceVariables,
+      # and another way would be to simply include that mixin here,
+      # but it is more understandable to inline it like this.
+      def ==(other)
+        other.class == self.class && other.value == value
+      end
     end
 
     # Class methods for the mixin

--- a/src/lib/y2storage/subvol_specification.rb
+++ b/src/lib/y2storage/subvol_specification.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "y2storage/shadower"
+require "y2storage/equal_by_instance_variables"
 
 Yast.import "Arch"
 Yast.import "ProductFeatures"
@@ -29,6 +30,7 @@ module Y2Storage
   #
   class SubvolSpecification
     include Yast::Logger
+    include EqualByInstanceVariables
 
     attr_accessor :path, :copy_on_write, :archs, :referenced_limit
 

--- a/src/lib/y2storage/volume_specification.rb
+++ b/src/lib/y2storage/volume_specification.rb
@@ -20,6 +20,7 @@
 require "yast"
 require "y2storage/partitioning_features"
 require "y2storage/subvol_specification"
+require "y2storage/equal_by_instance_variables"
 
 Yast.import "Kernel"
 
@@ -27,6 +28,7 @@ module Y2Storage
   # Helper class to represent a volume specification as defined in control.xml
   class VolumeSpecification
     include PartitioningFeatures
+    include EqualByInstanceVariables
 
     # @return [PartitionId] when the volume needs to be a partition with a specific id
     attr_accessor :partition_id

--- a/test/y2storage/equal_by_instance_variables_test.rb
+++ b/test/y2storage/equal_by_instance_variables_test.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage/equal_by_instance_variables"
+
+# skeleton for the mixin
+class TestEquality
+  include Y2Storage::EqualByInstanceVariables
+
+  attr_accessor :a, :b
+
+  def initialize(aaa, bbb)
+    @a = aaa
+    @b = bbb
+  end
+end
+
+describe Y2Storage::EqualByInstanceVariables do
+  describe "#==" do
+    it "returns true for same class, same ivars" do
+      a = TestEquality.new(1, 2)
+      b = TestEquality.new(1, 2)
+
+      expect(a).to eq b
+    end
+
+    it "returns true for same class, different ivars" do
+      a = TestEquality.new(1, 2)
+      b = TestEquality.new(2, 1)
+
+      expect(a).to_not eq b
+    end
+
+    it "returns false for different class, same ivars" do
+      a = TestEquality.new(1, 2)
+      bb = Struct.new(:a, :b)
+      b = bb.new(1, 2)
+
+      expect(a).to_not eq b
+    end
+
+    it "returns false for a completely different class" do
+      a = TestEquality.new(1, 2)
+      b = Object.new
+
+      expect(a).to_not eq b
+    end
+  end
+end

--- a/test/y2storage/filesystems/btrfs_test.rb
+++ b/test/y2storage/filesystems/btrfs_test.rb
@@ -648,9 +648,13 @@ describe Y2Storage::Filesystems::Btrfs do
     end
 
     it "returns a copy of the stored objects instead of the original ones" do
-      filesystem.auto_deleted_subvolumes = [subvol1, subvol2]
+      subvols = [subvol1, subvol2]
+      filesystem.auto_deleted_subvolumes = subvols
+      returned_subvols = filesystem.auto_deleted_subvolumes
 
-      expect(filesystem.auto_deleted_subvolumes).to_not eq [subvol1, subvol2]
+      expect(returned_subvols).to_not equal subvols
+      expect(returned_subvols[0]).to_not equal subvols[0]
+      expect(returned_subvols[1]).to_not equal subvols[1]
     end
 
     it "shares the stored value with all the instances of the filesystem" do

--- a/test/y2storage/proposal/settings_generator_test.rb
+++ b/test/y2storage/proposal/settings_generator_test.rb
@@ -22,30 +22,6 @@
 require_relative "../../spec_helper"
 require "y2storage/proposal/settings_generator"
 
-# diff-friendly inspect
-def dinspect(obj)
-  obj.inspect.gsub(/0x00[0-9a-f]+/, "0x00(address)")
-end
-
-def peeker(blob, filename)
-  File.open(filename, "w") do |io|
-    peek = proc do |v|
-      io.puts "PEEK #{v.class}"
-
-      # NOTE: this gets called AFTER instance variables are declared with nil
-      # but BEFORE #initialize is called. Therefore:
-      # undefined * for nil in human_string_components
-      next if v.is_a? Y2Storage::DiskSize
-      io.puts(dinspect(v))
-    end
-    Marshal.load(blob, peek)
-    o = Marshal.load(blob)
-    io.puts "FINAL"
-    io.puts o.class
-    io.puts(dinspect(o))
-  end
-end
-
 describe Y2Storage::Proposal::SettingsGenerator do
   subject { described_class.new(settings) }
 
@@ -109,9 +85,6 @@ describe Y2Storage::Proposal::SettingsGenerator do
       it "returns the same values as the initial settings" do
         settings_values = Marshal.dump(settings)
         next_settings_values = Marshal.dump(subject.next_settings)
-
-        peeker(settings_values, "/tmp/dump1")
-        peeker(next_settings_values, "/tmp/dump2")
 
         expect(next_settings_values).to eq(settings_values)
       end

--- a/test/y2storage/proposal/settings_generator_test.rb
+++ b/test/y2storage/proposal/settings_generator_test.rb
@@ -83,10 +83,9 @@ describe Y2Storage::Proposal::SettingsGenerator do
 
     context "when called for first time" do
       it "returns the same values as the initial settings" do
-        settings_values = Marshal.dump(settings)
-        next_settings_values = Marshal.dump(subject.next_settings)
+        next_settings = subject.next_settings
 
-        expect(next_settings_values).to eq(settings_values)
+        expect(next_settings).to eq(settings)
       end
 
       it "creates an empty SettingsAdjustment object" do

--- a/test/y2storage/proposal/settings_generator_test.rb
+++ b/test/y2storage/proposal/settings_generator_test.rb
@@ -22,6 +22,30 @@
 require_relative "../../spec_helper"
 require "y2storage/proposal/settings_generator"
 
+# diff-friendly inspect
+def dinspect(obj)
+  obj.inspect.gsub(/0x00[0-9a-f]+/, "0x00(address)")
+end
+
+def peeker(blob, filename)
+  File.open(filename, "w") do |io|
+    peek = proc do |v|
+      io.puts "PEEK #{v.class}"
+
+      # NOTE: this gets called AFTER instance variables are declared with nil
+      # but BEFORE #initialize is called. Therefore:
+      # undefined * for nil in human_string_components
+      next if v.is_a? Y2Storage::DiskSize
+      io.puts(dinspect(v))
+    end
+    Marshal.load(blob, peek)
+    o = Marshal.load(blob)
+    io.puts "FINAL"
+    io.puts o.class
+    io.puts(dinspect(o))
+  end
+end
+
 describe Y2Storage::Proposal::SettingsGenerator do
   subject { described_class.new(settings) }
 
@@ -85,6 +109,9 @@ describe Y2Storage::Proposal::SettingsGenerator do
       it "returns the same values as the initial settings" do
         settings_values = Marshal.dump(settings)
         next_settings_values = Marshal.dump(subject.next_settings)
+
+        peeker(settings_values, "/tmp/dump1")
+        peeker(next_settings_values, "/tmp/dump2")
 
         expect(next_settings_values).to eq(settings_values)
       end

--- a/test/y2storage/proposal_settings_test.rb
+++ b/test/y2storage/proposal_settings_test.rb
@@ -68,10 +68,7 @@ describe Y2Storage::ProposalSettings do
     end
 
     it "creates an object with the same values" do
-      settings_values = Marshal.dump(settings)
-      settings_deep_copy_values = Marshal.dump(settings.deep_copy)
-
-      expect(settings_deep_copy_values).to eq(settings_values)
+      expect(settings.deep_copy).to eq(settings)
     end
 
     it "creates an object with different references" do

--- a/test/y2storage/secret_attributes_test.rb
+++ b/test/y2storage/secret_attributes_test.rb
@@ -21,6 +21,7 @@
 require_relative "spec_helper"
 require "y2storage"
 require "pp"
+require "y2storage/equal_by_instance_variables"
 
 describe Y2Storage::SecretAttributes do
   # Dummy test clase
@@ -35,6 +36,7 @@ describe Y2Storage::SecretAttributes do
   # Another dummy test clase
   class ClassWithData
     include Y2Storage::SecretAttributes
+    include Y2Storage::EqualByInstanceVariables
 
     attr_accessor :name
 
@@ -126,6 +128,30 @@ describe Y2Storage::SecretAttributes do
 
       expect(with_password2.name).to eq "data2X"
       expect(with_password2.password).to eq "xx2X"
+    end
+
+    context "when comparing (==) by instance variables" do
+      let(:with_data2) { ClassWithData.new }
+
+      it "compares as equal when the secret is equal" do
+        with_data.name = "name"
+        with_data.data = "data"
+
+        with_data2.name = "name"
+        with_data2.data = "data"
+
+        expect(with_data).to eq with_data2
+      end
+
+      it "compares as different when the secret is different" do
+        with_data.name = "name"
+        with_data.data = "data"
+
+        with_data2.name = "name"
+        with_data2.data = "somethingelse"
+
+        expect(with_data).to_not eq with_data2
+      end
     end
 
     context "when the attribute has never been set" do


### PR DESCRIPTION
## Problem

Ruby 3.2 yast2-storage-ng sometimes fails to build, diff in Marshal.dump

- https://bugzilla.suse.com/show_bug.cgi?id=1208259
- https://trello.com/c/jRe5bWVE/3249-ostumbleweed-1206419-staging-ruby-keyword-parameters-yast-stack-fails-to-build-against-ruby-32

The failing test means to check that a new `ProposalSettings` is in fact equal to the original one, and does so by dumping and reloading the two objects with `Marshal`. It fails in case the two objects differ in the order in which their instance variables were assigned.

## Solution

Instead of using `Marshal`, add `ProposalSettings#==`.

Do it by introducing a simple module, `EqualByInstanceVariables`, including it in that class and a couple of others that are used by it.

Gory details: everything I've learned about equality in Ruby along the way, very messy so far: https://gist.github.com/mvidner/eb10bf4d70f0df5c1073a2229fd4491e

## Testing

- Added new unit tests


## Screenshots

N/A