### PR TITLE
Fixed crash in the proposal code (bsc#1209523)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 20 16:42:45 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed crash in the proposal code when the requested candidate
+  device does not exist (bsc#1209523)
+- 4.6.2
+
+-------------------------------------------------------------------
 Mon Mar 13 12:04:07 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Removed unnecessary executable flags from files (bsc#1209094)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.6.1
+Version:        4.6.2
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/guided_proposal.rb
+++ b/src/lib/y2storage/guided_proposal.rb
@@ -271,7 +271,7 @@ module Y2Storage
     def candidate_devices_with_empty_partition_table(devicegraph)
       device_names = settings.candidate_devices
       devices = device_names.map { |n| devicegraph.find_by_name(n) }
-      devices.select { |d| d.partition_table && d.partitions.empty? }
+      devices.select { |d| d&.partition_table && d.partitions.empty? }
     end
 
     # Candidate devices to make a proposal

--- a/src/lib/y2storage/guided_proposal.rb
+++ b/src/lib/y2storage/guided_proposal.rb
@@ -270,8 +270,8 @@ module Y2Storage
     # @return [Array<Y2Storage::BlkDevice>]
     def candidate_devices_with_empty_partition_table(devicegraph)
       device_names = settings.candidate_devices
-      devices = device_names.map { |n| devicegraph.find_by_name(n) }
-      devices.select { |d| d&.partition_table && d.partitions.empty? }
+      devices = device_names.map { |n| devicegraph.find_by_name(n) }.compact
+      devices.select { |d| d.partition_table && d.partitions.empty? }
     end
 
     # Candidate devices to make a proposal

--- a/test/y2storage/guided_proposal_test.rb
+++ b/test/y2storage/guided_proposal_test.rb
@@ -112,6 +112,16 @@ describe Y2Storage::GuidedProposal do
       end
     end
 
+    context "when the candidate devices are invalid" do
+      include_context "candidate devices"
+
+      let(:candidate_devices) { ["/dev/invalid_device"] }
+
+      it "raises Y2Storage::NoDiskSpaceError exception" do
+        expect { proposal.propose }.to raise_error(Y2Storage::NoDiskSpaceError)
+      end
+    end
+
     context "when the candidate devices are not given" do
       include_context "candidate devices"
 


### PR DESCRIPTION
## Problem

Changing the candidate device in the D-Installer to a non-existing device caused a crash `undefined method 'partition_table' for nil:NilClass`:

```
# dinstallerctl storage selected_devices /dev/sdb
/usr/share/YaST2/lib/y2storage/guided_proposal.rb:274:in `block in candidate_devices_with_empty_partition_table': undefined method `partition_table' for nil:NilClass; caused by 1 sender=:1.0 -> dest=org.opensuse.DInstaller.Storage serial=12 reply_serial= path=/org/opensuse/DInstaller/Storage1; interface=org.opensuse.DInstaller.Storage1.Proposal.Calculator; member=Calculate error_name=; caused by 3 sender=:1.4 -> dest=:1.0 serial=36 reply_serial=12 path=; interface=; member= error_name=org.freedesktop.DBus.Error.Failed (DBus::Error)
```

## Solution

- Added a `nil` check

## Testing

- Added a new unit test, the code now raises `Y2Storage::NoDiskSpaceError` instead of  `NoMethodError`
- Tested manually, now it does not crash
