### PR TITLE
bsc#1209697: fix widgets titles in the dialog to select a partitioning schema

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 31 11:21:44 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the translation of widgets titles in the dialog to select
+  a partitioning scheme (bsc#1209697).
+- 4.5.19
+
+-------------------------------------------------------------------
 Fri Mar 10 16:35:10 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Removed unnecessary executable flags from files (bsc#1209094)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.18
+Version:        4.5.19
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -109,10 +109,8 @@ module Y2Storage
               CheckBox(
                 Id(:separate_vgs),
                 format(
-                  # TRANSLATORS: %{widget_label} refers to the label of the widget. %{paths} is a
-                  # comma separated list of paths
-                  _("%{widget_label}\n(%{paths})"),
-                  widget_label: WIDGET_LABELS[:use_separate_vgs],
+                  "%{widget_label}\n(%{paths})",
+                  widget_label: _(WIDGET_LABELS[:use_separate_vgs]),
                   paths:        separated_volume_groups.map(&:mount_point).join(", ")
                 )
               )
@@ -123,7 +121,7 @@ module Y2Storage
 
         def enable_disk_encryption
           VBox(
-            Left(CheckBox(Id(:encryption), Opt(:notify), WIDGET_LABELS[:enable_disk_encryption])),
+            Left(CheckBox(Id(:encryption), Opt(:notify), _(WIDGET_LABELS[:enable_disk_encryption]))),
             VSpacing(0.2),
             Left(
               HBox(
@@ -201,7 +199,7 @@ module Y2Storage
               "so make sure not to lose it!</i>" \
               "</p>"
             ),
-            disk_encryption_label: WIDGET_LABELS[:use_disk_encryption]
+            disk_encryption_label: _(WIDGET_LABELS[:use_disk_encryption])
           )
           # rubocop:enable Metrics/MethodLength
         end
@@ -211,7 +209,7 @@ module Y2Storage
           format(
             _("<p><b>%{widget_label}:</b> indicates to the <i>Guided Setup</i> that you want " \
               "to put some of those special paths in an isolated Volume Group.</p>"),
-            widget_label: WIDGET_LABELS[:use_separate_vgs]
+            widget_label: _(WIDGET_LABELS[:use_separate_vgs])
           )
         end
 


### PR DESCRIPTION
## Problem

Although strings are marked for translation, they are not properly translated later.

https://bugzilla.suse.com/show_bug.cgi?id=1209697

## Solution

Fix the calls to `_` to act on the marked test.

## Testing

- Tested manually

## Screenshots

![translated-partitioning-scheme](https://user-images.githubusercontent.com/15836/229109147-3732e7e0-7be3-4cd1-8063-c201ee1ea6f5.png)
