### PR TITLE
[SP5] Improve display of Dell BOSS

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 11 13:38:25 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adjusted detection of Dell BOSS devices (bsc#1200975).
+- Partitioner: improved column Type for disks (bsc#1200975).
+- 4.5.20
+
+-------------------------------------------------------------------
 Fri Mar 31 11:21:44 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the translation of widgets titles in the dialog to select

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.19
+Version:        4.5.20
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/widgets/columns/type.rb
+++ b/src/lib/y2partitioner/widgets/columns/type.rb
@@ -292,9 +292,11 @@ module Y2Partitioner
         #
         # @return [String]
         def default_unformatted_label(device)
-          data = [device.vendor, device.model].compact
+          # The "model" field from hwinfo is a combination of vendor + device with quite some added
+          # heuristics to make the result nice looking. See comment#66 at bsc#1200975.
+          model = device.model || ""
 
-          return data.join("-") unless data.empty?
+          return model unless model.empty?
           return device.id.to_human_string if device.respond_to?(:id)
 
           default_label(device)

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -665,16 +665,20 @@ module Y2Storage
     #   @return [Array<String>] empty if the driver is unknown
 
     # @see #boss?
-    BOSS_REGEXP = Regexp.new("dell.*boss", Regexp::IGNORECASE).freeze
+    DELL_REGEXP = Regexp.new("dell", Regexp::IGNORECASE).freeze
+    BOSS_REGEXP = Regexp.new("BOSS").freeze
+    private_constant :DELL_REGEXP
     private_constant :BOSS_REGEXP
 
     # Whether this device is a Dell BOSS (Boot Optimized Storage Solution)
     #
-    # See https://jira.suse.com/browse/SLE-17578
+    # See https://jira.suse.com/browse/SLE-17578 and bsc#1200975
     #
     # @return [Boolean]
     def boss?
-      !!model&.match?(BOSS_REGEXP)
+      return false unless model
+
+      model.match?(BOSS_REGEXP) && model.match?(DELL_REGEXP)
     end
 
     # Size of the space that could be theoretically reclaimed by shrinking the

--- a/test/y2storage/blk_device_test.rb
+++ b/test/y2storage/blk_device_test.rb
@@ -1186,6 +1186,71 @@ describe Y2Storage::BlkDevice do
     end
   end
 
+  describe "#boss?" do
+    let(:device_name) { "/dev/sda" }
+
+    before { allow(device).to receive(:model).and_return model }
+
+    context "when no model information is available" do
+      let(:model) { nil }
+
+      it "returns false" do
+        expect(device.boss?).to eq false
+      end
+    end
+
+    context "when the model information is empty" do
+      let(:model) { "" }
+
+      it "returns false" do
+        expect(device.boss?).to eq false
+      end
+    end
+
+    # Original criteria provided by Dell at jsc#SLE-17578
+    context "when the model contains DELLBOSS" do
+      let(:model) { "A DELLBOSS device" }
+
+      it "returns true" do
+        expect(device.boss?).to eq true
+      end
+    end
+
+    # Used in some models like the one reported as bsc#1200975
+    context "when the model contains 'Dell BOSS'" do
+      let(:model) { "Dell BOSS-N1 Modular" }
+
+      it "returns true" do
+        expect(device.boss?).to eq true
+      end
+    end
+
+    # Hypothetical string based on the criteria exposed at comment#84 of bsc#1200975
+    context "when the model contains first 'BOSS' and then 'Dell'" do
+      let(:model) { "Cool BOSS device by Dell" }
+
+      it "returns true" do
+        expect(device.boss?).to eq true
+      end
+    end
+
+    context "when the model contains 'Dell' but not 'BOSS'" do
+      let(:model) { "Dell controller" }
+
+      it "returns false" do
+        expect(device.boss?).to eq false
+      end
+    end
+
+    context "when the model contains 'BOSS' but not 'Dell'" do
+      let(:model) { "BOSS as Back Office Support System" }
+
+      it "returns false" do
+        expect(device.boss?).to eq false
+      end
+    end
+  end
+
   describe ".sorted_by_name" do
     let(:scenario) { "sorting/disks_and_dasds1" }
 


### PR DESCRIPTION
## Problem

Some things has changed regarding BOSS devices manufactured by Dell. That leaded to the creation of [bug#1200975](https://bugzilla.suse.com/show_bug.cgi?id=1200975).

From the discussions in the bug report, we identified two things that could be improved in the YaST side.

1. The regexp to detect a Dell BOSS disk needs to be updated. Originally Dell stated that all BOSS devices would contain the string "DELLBOSS" as part of the model (https://jira.suse.com/browse/SLE-17578). Looks like that's not true anymore. According to a comment at the mentioned [bug#1200975](https://bugzilla.suse.com/show_bug.cgi?id=1200975), the new criteria is "_the model string will always have both Dell and BOSS in some order_".
2. For a typical disk, the column "Type" in the Expert Partitioner is computed as `device.vendor + device.model` (both fields taken from hwinfo). But that's redundant because "model" in hwinfo is a combination of vendor + device with quite some added heuristics to make the result nice looking.

## Solution

- Extend the BOSS criteria to check for the presence of both "Dell" (checked in a case-insensitive way) and "BOSS" (checked case sensitive) in any order. That covers all the known models like "DELLBOSS VD" or "Dell BOSS-N1 Modular".
- Adjust the Type column. See screenshots below.

## Testing

Added new unit tests

## Screenshots

Type column before the change.

![before](https://user-images.githubusercontent.com/3638289/231178331-9355c23b-4e2c-4284-9020-ce5f34fdca54.png)

Type column after the change.

![after](https://user-images.githubusercontent.com/3638289/231178381-d21439b6-6a52-40c1-8b54-6b3f0f5d442f.png)
