### PR TITLE
Guided Setup: display a hint for disks with sensible transports

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 24 14:47:33 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Guided Setup: display a hint for disks with sensible data
+  transports like FCoE or NVMe/oF (bsc#1209588).
+- 4.5.22
+
+-------------------------------------------------------------------
 Tue Apr 18 08:23:44 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - AutoYaST: correctly import legacy values for parity_algorithm.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.21
+Version:        4.5.22
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/dialogs/guided_setup/helpers/disk.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/helpers/disk.rb
@@ -98,6 +98,10 @@ module Y2Storage
               _("USB")
             elsif transport.is?(:sbp)
               _("IEEE 1394")
+            # FIXME: Find alternative ways to represent these transports with better support for
+            # i18n, etc. This implementation is the bare minimum for bsc#1209588.
+            elsif transport.is?(:iscsi, :fcoe, :tcp, :fc, :rdma)
+              transport.to_s
             else
               ""
             end

--- a/test/y2storage/dialogs/guided_setup/helpers/disk_test.rb
+++ b/test/y2storage/dialogs/guided_setup/helpers/disk_test.rb
@@ -37,20 +37,14 @@ describe Y2Storage::Dialogs::GuidedSetup::Helpers::Disk do
       allow(disk).to receive(:transport).and_return(transport)
       allow(disk).to receive(:sd_card?).and_return(sd_card)
       allow(disk).to receive(:boss?).and_return(boss)
-
-      allow(transport).to receive(:is?).with(:usb).and_return(usb)
-      allow(transport).to receive(:is?).with(:sbp).and_return(sbp)
-
       allow(analyzer).to receive(:installed_systems).with(disk).and_return(installed_systems)
     end
 
     let(:disk) { instance_double(Y2Storage::Disk) }
 
-    let(:transport) { instance_double(Y2Storage::DataTransport) }
+    let(:transport) { Y2Storage::DataTransport::UNKNOWN }
 
     let(:name) { "/dev/sda" }
-    let(:usb) { false }
-    let(:sbp) { false }
     let(:sd_card) { false }
     let(:boss) { false }
     let(:installed_systems) { [] }
@@ -76,7 +70,7 @@ describe Y2Storage::Dialogs::GuidedSetup::Helpers::Disk do
     end
 
     context "when the disk transport is usb" do
-      let(:usb) { true }
+      let(:transport) { Y2Storage::DataTransport::USB }
 
       it "includes the 'USB' label" do
         expect(subject.label(disk)).to match(/USB/)
@@ -84,10 +78,26 @@ describe Y2Storage::Dialogs::GuidedSetup::Helpers::Disk do
     end
 
     context "when the disk transport is sbp" do
-      let(:sbp) { true }
+      let(:transport) { Y2Storage::DataTransport::SBP }
 
       it "includes the 'IEEE 1394' label" do
         expect(subject.label(disk)).to match(/IEEE 1394/)
+      end
+    end
+
+    context "when the disk transport is FCoE" do
+      let(:transport) { Y2Storage::DataTransport::FCOE }
+
+      it "includes the raw transport name" do
+        expect(subject.label(disk)).to match(/fcoe/)
+      end
+    end
+
+    context "when the disk transport is sata" do
+      let(:transport) { Y2Storage::DataTransport::SATA }
+
+      it "does not include any reference to the transport" do
+        expect(subject.label(disk)).to_not match(/sata/i)
       end
     end
 


### PR DESCRIPTION
## Problem

Described and discussed at https://bugzilla.suse.com/show_bug.cgi?id=1209588

The screen of the Guided Setup used to select the target disk(s) shows some information about each disk to make it possible to identify them.

![sles-bfs-1](https://user-images.githubusercontent.com/3638289/234025708-359fc654-5e3d-4749-a34b-f64b6bcc7975.PNG)

But deciding which information to display is VERY tricky:

- YaST interface is designed to fit perfectly in text mode with 80 columns and 24 lines. That implies a lot of text and space economy.
- Many systems contains dozens of disks.
- Although some advanced users may appreciate details about the model of the disk or the controller, those are long and complex strings that are meaningless for most users.
- ...and many other considerations...

As a reasonable compromise, YaST displays the following information for each disk:

- The device name
- The total size
- The list of operating systems installed into it
- Whether the disk is removable (USB, Firewire or SD Card)
- A specific label if the disk is a DELL BOSS device

That was reported to not be enough in the case in which both local and remote NVMe disks are present in the system. There is nothing in the previous list that would allow to distinguish the remote from the local ones.

## Solution

As a quick fix for SLE-15-SP5, just display the data transport in some special cases.

This displays the internal identifier of the transport, that is something like `fcoe` or `tcp`. Nothing too nice. Eg.

- /dev/sda, 500 GiB, iscsi, SLES-12

## Testing

Extended unit tests