### PR TITLE
Adaptations to have more flexible proposal (useful for Agama)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May  3 11:51:09 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- GuidedProposal adapted to support assigning volumes to specific
+  devices when volumes_allocate_mode is :auto (useful for Agama).
+
+-------------------------------------------------------------------
 Mon Apr 24 14:47:33 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Guided Setup: display a hint for disks with sensible data

--- a/src/lib/y2storage/proposal/devices_planner.rb
+++ b/src/lib/y2storage/proposal/devices_planner.rb
@@ -298,14 +298,12 @@ module Y2Storage
       # @param planned_device [Planned::Device]
       # @param volume [VolumeSpecification]
       def adjust_device(planned_device, volume)
-        if settings.allocate_mode?(:device)
-          planned_device.disk = volume.device if planned_device.respond_to?(:disk=)
-        elsif planned_device.root?
-          # Forcing this when planned_device is a LV would imply the new VG
-          # can only be located in that disk (preventing it to spread over
-          # several disks). We likely don't want that.
-          planned_device.disk = settings.root_device if planned_device.is_a?(Planned::Partition)
-        end
+        planned_device.disk = volume.device if planned_device.respond_to?(:disk=)
+        return unless settings.allocate_mode?(:auto) && planned_device.root?
+
+        # Forcing this when planned_device is a LV would imply the new VG can only be located
+        # in that disk (preventing it to spread over several disks). We likely don't want that.
+        planned_device.disk ||= settings.root_device if planned_device.is_a?(Planned::Partition)
       end
 
       # Adjusts values when planned device is swap

--- a/src/lib/y2storage/proposal/partitions_distribution_calculator.rb
+++ b/src/lib/y2storage/proposal/partitions_distribution_calculator.rb
@@ -181,13 +181,11 @@ module Y2Storage
       #
       # @param planned_partitions [Array<Planned::Partition>]
       # @param free_spaces [Array<FreeDiskSpace>]
-      # @param raise_if_empty [Boolean] raise a {NoDiskSpaceError} if there is
-      #   any planned partition that doesn't fit in any of the spaces
       # @return [Hash{Planned::Partition => Array<FreeDiskSpace>}]
-      def candidate_disk_spaces(planned_partitions, free_spaces, raise_if_empty: true)
+      def candidate_disk_spaces(planned_partitions, free_spaces)
         planned_partitions.each_with_object({}) do |partition, hash|
           spaces = free_spaces.select { |space| suitable_disk_space?(space, partition) }
-          if spaces.empty? && raise_if_empty
+          if spaces.empty?
             log.error "No suitable free space for #{partition}"
             raise NoDiskSpaceError, "No suitable free space for the planned partition"
           end

--- a/src/lib/y2storage/proposal/space_maker.rb
+++ b/src/lib/y2storage/proposal/space_maker.rb
@@ -131,6 +131,11 @@ module Y2Storage
 
       attr_reader :disk_analyzer, :dist_calculator
 
+      # Disks that are not candidate devices but still must be considered because
+      # there are planned partitions explicitly targeted to those disks
+      # @return [Array<String>]
+      attr_reader :extra_disk_names
+
       # New devicegraph calculated by {#provide_space}
       # @return [Devicegraph]
       attr_reader :new_graph
@@ -164,6 +169,7 @@ module Y2Storage
         @new_graph = original_graph.duplicate
         @new_graph_part_killer = PartitionKiller.new(@new_graph, candidate_disk_names)
         @new_graph_deleted_sids = []
+        @extra_disk_names = partitions.map(&:disk).compact.uniq - settings.candidate_devices
 
         # To make sure we are not freeing space in useless places first
         # restrict the operations to disks with particular disk
@@ -191,6 +197,14 @@ module Y2Storage
           #
           parts_by_disk.each do |disk, parts|
             resize_and_delete(parts, keep, lvm_helper, disk_name: disk)
+          rescue Error
+            # If LVM was involved, maybe there is still hope if we don't abort on this error.
+            raise unless dist_calculator.lvm?
+
+            # dist_calculator tried to allocate the specific partitions for this disk but also
+            # all new physical volumes for the LVM. If the physical volumes were the culprit, we
+            # should keep trying to delete/resize stuff in other disks.
+            raise unless find_distribution(parts, ignore_lvm: true)
           end
         end
 
@@ -223,15 +237,26 @@ module Y2Storage
       # @return [Boolean]
       def success?(planned_partitions)
         # Once a distribution has been found we don't have to look for another one.
-        if !@distribution
-          spaces = free_spaces(new_graph)
-          @distribution = dist_calculator.best_distribution(planned_partitions, spaces)
-        end
+        @distribution ||= find_distribution(planned_partitions)
         !!@distribution
       rescue Error => e
         log.info "Exception while trying to distribute partitions: #{e}"
         @distribution = nil
         false
+      end
+
+      # Finds the best distribution to allocate the given set of planned partitions
+      #
+      # In case of an LVM-based proposal, the distribution will also include any needed physical
+      # volume for the system LVM. The argument ignore_lvm can be used to disable that requirement.
+      #
+      # @param planned_partitions [Array<Planned::Partition>]
+      # @param ignore_lvm [Boolean]
+      # @return [Planned::PartitionsDistribution, nil] nil if no valid distribution was found
+      def find_distribution(planned_partitions, ignore_lvm: false)
+        spaces = free_spaces(new_graph)
+        calculator = ignore_lvm ? non_lvm_dist_calculator : dist_calculator
+        calculator.best_distribution(planned_partitions, spaces, extra_free_spaces)
       end
 
       # Perform all the needed operations to make space for the partitions
@@ -379,10 +404,17 @@ module Y2Storage
       # @return [DiskSize]
       def resizing_size(partition, planned_partitions, disk_name)
         spaces = free_spaces(new_graph, disk_name)
-        dist_calculator.resizing_size(partition, planned_partitions, spaces)
+        if disk_name && extra_disk_names.include?(disk_name)
+          # Operating in a disk that is not a candidate_device, no need to make extra space for LVM
+          return non_lvm_dist_calculator.resizing_size(partition, planned_partitions, spaces)
+        end
+
+        # As explained above, don't assume we will make space for LVM on non-candidate devices
+        partitions = planned_partitions.reject { |p| extra_disk_names.include?(p.disk) }
+        dist_calculator.resizing_size(partition, partitions, spaces)
       end
 
-      # List of free spaces in the given devicegraph
+      # List of free spaces from the candidate devices in the given devicegraph
       #
       # @param graph [Devicegraph]
       # @param disk [String, nil] optional disk name to restrict result to
@@ -391,6 +423,12 @@ module Y2Storage
         disks_for(graph, disk).each_with_object([]) do |d, list|
           list.concat(d.as_not_empty { d.free_spaces })
         end
+      end
+
+      # List of free spaces from extra disks (see {#extra_disk_names})
+      # @return [Array<FreeDiskSpace>]
+      def extra_free_spaces
+        extra_disk_names.flat_map { |d| free_spaces(new_graph, d) }
       end
 
       # List of candidate disk devices in the given devicegraph
@@ -407,6 +445,16 @@ module Y2Storage
       # @return [Array<String>]
       def candidate_disk_names
         settings.candidate_devices
+      end
+
+      # Distribution calculator to use in special cases in which any implication related
+      # to LVM must be ignored
+      #
+      # Used for example when operating in extra (non-candidate) disks
+      #
+      # @return [PartitionsDistributionCalculator]
+      def non_lvm_dist_calculator
+        @non_lvm_dist_calculator ||= PartitionsDistributionCalculator.new
       end
 
       # Whether {#resize_and_delete} should be executed several times,

--- a/src/lib/y2storage/volume_specification.rb
+++ b/src/lib/y2storage/volume_specification.rb
@@ -140,11 +140,8 @@ module Y2Storage
     # @return [String]
     attr_accessor :separate_vg_name
 
-    # Device name of the disk (DiskDevice to be precise) in which the volume
-    # must be located. If nil, there are no restrictions allocating the volume.
-    #
-    # Note this is only relevant when {ProposalSettings#allocate_volume_mode} is
-    # set to :device.
+    # Optional device name of the disk (DiskDevice to be precise) in which the volume
+    # must be located.
     #
     # @return [String, nil]
     attr_accessor :device

--- a/test/data/devicegraphs/output/agama-basis-distributed.yml
+++ b/test/data/devicegraphs/output/agama-basis-distributed.yml
@@ -1,0 +1,64 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sda1
+        size:         1033215 MiB (0.99 TiB)
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        name:         /dev/sda2
+        id:           linux
+        file_system:  xfs
+        mount_point:  /home
+
+- disk:
+    name: /dev/sdb
+    size: 400 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        name:         /dev/sdb1
+        size:         398332 MiB (389.00 GiB)
+        id: windows_basic_data
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        size:         2 MiB
+        name:         /dev/sdb2
+        id:           bios_boot
+    - partition:
+        size:         10 GiB
+        name:         /dev/sdb3
+        id:           linux
+        file_system:  xfs
+        mount_point:  /
+    - partition:
+        name:         /dev/sdb4
+        id:           swap
+        file_system:  swap
+        mount_point:  swap
+
+- disk:
+    name: /dev/sdc
+    size: 400 GiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        size:         404479 MiB (395.00 GiB)
+        name:         /dev/sdc1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        name:         /dev/sdc2
+        id:           linux
+        file_system:  xfs
+        mount_point:  /srv

--- a/test/data/devicegraphs/output/agama-basis-lvm-distributed.yml
+++ b/test/data/devicegraphs/output/agama-basis-lvm-distributed.yml
@@ -1,0 +1,93 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sda1
+        size:         1033214 MiB (0.99 TiB)
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        name:         /dev/sda2
+        id:           lvm
+
+- disk:
+    name: /dev/sdb
+    size: 400 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        name:         /dev/sdb1
+        size:         398331 MiB (389.00 GiB)
+        id:           windows_basic_data
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        size:         2 MiB
+        name:         /dev/sdb2
+        id:           bios_boot
+    - partition:
+        name:         /dev/sdb3
+        id:           lvm
+
+- disk:
+    name: /dev/sdc
+    size: 400 GiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sdc1
+        size:         404478 MiB (395.00 GiB)
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        name:         /dev/sdc2
+        id:           lvm
+
+- lvm_vg:
+    vg_name: system
+    lvm_lvs:
+    - lvm_lv:
+        lv_name:     root
+        size:        10 GiB
+        file_system: xfs
+        mount_point: /
+    - lvm_lv:
+        lv_name:     swap
+        size:        1 GiB
+        file_system: swap
+        mount_point: swap
+    lvm_pvs:
+    - lvm_pv:
+        blk_device:  /dev/sdb3
+
+- lvm_vg:
+    vg_name: home
+    lvm_lvs:
+    - lvm_lv:
+        lv_name:     home
+        size:        15 GiB
+        file_system: xfs
+        mount_point: /home
+    lvm_pvs:
+    - lvm_pv:
+        blk_device:  /dev/sda2
+
+- lvm_vg:
+    vg_name: srv
+    lvm_lvs:
+    - lvm_lv:
+        lv_name:     srv
+        size:        5 GiB
+        file_system: xfs
+        mount_point: /srv
+    lvm_pvs:
+    - lvm_pv:
+        blk_device:  /dev/sdc2

--- a/test/data/devicegraphs/output/agama-basis-lvm-separate_boot.yml
+++ b/test/data/devicegraphs/output/agama-basis-lvm-separate_boot.yml
@@ -1,0 +1,71 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sda1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+
+- disk:
+    name: /dev/sdb
+    size: 400 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        name:         /dev/sdb1
+        size:         409596 MiB (400.00 GiB)
+        id:           windows_basic_data
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        name:         /dev/sdb2
+        id:           bios_boot
+
+- disk:
+    name: /dev/sdc
+    size: 400 GiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sdc1
+        size:         377854 MiB (369.00 GiB)
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        name:         /dev/sdc2
+        id:           lvm
+
+- lvm_vg:
+    vg_name: system
+    lvm_lvs:
+    - lvm_lv:
+        lv_name:     root
+        size:        10 GiB
+        file_system: xfs
+        mount_point: /
+    - lvm_lv:
+        lv_name:     srv
+        size:        5 GiB
+        file_system: xfs
+        mount_point: /srv
+    - lvm_lv:
+        lv_name:     swap
+        size:        1 GiB
+        file_system: swap
+        mount_point: swap
+    - lvm_lv:
+        lv_name:     home
+        size:        15 GiB
+        file_system: xfs
+        mount_point: /home
+    lvm_pvs:
+    - lvm_pv:
+        blk_device:  /dev/sdc2

--- a/test/data/devicegraphs/output/agama-basis-lvm-several_disks.yml
+++ b/test/data/devicegraphs/output/agama-basis-lvm-several_disks.yml
@@ -1,0 +1,77 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sda1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+
+- disk:
+    name: /dev/sdb
+    size: 400 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        name:         /dev/sdb1
+        size:         40 GiB
+        id:           windows_basic_data
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        size:         2 MiB
+        name:         /dev/sdb2
+        id: bios_boot
+    - partition:
+        name:         /dev/sdb3
+        id: lvm
+
+- disk:
+    name: /dev/sdc
+    size: 400 GiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sdc1
+        size:         40 GiB
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        name:         /dev/sdc2
+        id: lvm
+
+- lvm_vg:
+    vg_name: system
+    lvm_lvs:
+    - lvm_lv:
+        lv_name:     root
+        size:        380 GiB
+        file_system: xfs
+        mount_point: /
+    - lvm_lv:
+        lv_name:     srv
+        size:        10 GiB
+        file_system: xfs
+        mount_point: /srv
+    - lvm_lv:
+        lv_name:     swap
+        size:        2 GiB
+        file_system: swap
+        mount_point: swap
+    - lvm_lv:
+        lv_name:     home
+        size:        335860 MiB (327.99 GiB)
+        file_system: xfs
+        mount_point: /home
+    lvm_pvs:
+    - lvm_pv:
+        blk_device:  /dev/sdb3
+    - lvm_pv:
+        blk_device:  /dev/sdc2

--- a/test/data/devicegraphs/output/agama-basis-lvm-single_disk.yml
+++ b/test/data/devicegraphs/output/agama-basis-lvm-single_disk.yml
@@ -1,0 +1,71 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sda1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+
+- disk:
+    name: /dev/sdb
+    size: 400 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        name:         /dev/sdb1
+        size:         377851 MiB (369.00 GiB)
+        id:           windows_basic_data
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        size:         2 MiB
+        name:         /dev/sdb2
+        id: bios_boot
+    - partition:
+        name:         /dev/sdb3
+        id: lvm
+
+- disk:
+    name: /dev/sdc
+    size: 400 GiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sdc1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+
+- lvm_vg:
+    vg_name: system
+    lvm_lvs:
+    - lvm_lv:
+        lv_name:     root
+        size:        10 GiB
+        file_system: xfs
+        mount_point: /
+    - lvm_lv:
+        lv_name:     srv
+        size:        5 GiB
+        file_system: xfs
+        mount_point: /srv
+    - lvm_lv:
+        lv_name:     swap
+        size:        1 GiB
+        file_system: swap
+        mount_point: swap
+    - lvm_lv:
+        lv_name:     home
+        size:        15 GiB
+        file_system: xfs
+        mount_point: /home
+    lvm_pvs:
+    - lvm_pv:
+        blk_device:  /dev/sdb3

--- a/test/data/devicegraphs/output/agama-basis-separate_boot.yml
+++ b/test/data/devicegraphs/output/agama-basis-separate_boot.yml
@@ -1,0 +1,70 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        size:         1016829 MiB (0.97 TiB)
+        name:         /dev/sda1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        size:         10 GiB
+        name:         /dev/sda2
+        id:           linux
+        file_system:  xfs
+        mount_point:  /
+    - partition:
+        size:         15 GiB
+        name:         /dev/sda3
+        id:           linux
+        file_system:  xfs
+        mount_point:  /home
+    - partition:
+        name:         /dev/sda4
+        type:         extended
+        id:           extended
+    - partition:
+        size:         5 GiB
+        name:         /dev/sda5
+        type:         logical
+        id:           linux
+        file_system:  xfs
+        mount_point:  /srv
+    - partition:
+        name:         /dev/sda6
+        id:           swap
+        type:         logical
+        file_system:  swap
+        mount_point:  swap
+
+- disk:
+    name: /dev/sdb
+    size: 400 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        name:         /dev/sdb1
+        size:         409596 MiB (400.00 GiB)
+        id:           windows_basic_data
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        name:         /dev/sdb2
+        id:           bios_boot
+
+- disk:
+    name: /dev/sdc
+    size: 400 GiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sdc1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows

--- a/test/data/devicegraphs/output/agama-basis-single_disk.yml
+++ b/test/data/devicegraphs/output/agama-basis-single_disk.yml
@@ -1,0 +1,64 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sda1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+
+- disk:
+    name: /dev/sdb
+    size: 400 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        name:         /dev/sdb1
+        size:         377852 MiB (369.00 GiB)
+        id:           windows_basic_data
+        file_system:  ntfs
+        label:        windows
+    - partition:
+        size:         2 MiB
+        name:         /dev/sdb2
+        id:           bios_boot
+    - partition:
+        size:         10 GiB
+        name:         /dev/sdb3
+        id:           linux
+        file_system:  xfs
+        mount_point:  /
+    - partition:
+        size:         15 GiB
+        name:         /dev/sdb4
+        id:           linux
+        file_system:  xfs
+        mount_point:  /home
+    - partition:
+        size:         5 GiB
+        name:         /dev/sdb5
+        id:           linux
+        file_system:  xfs
+        mount_point:  /srv
+    - partition:
+        name:         /dev/sdb6
+        id:           swap
+        file_system:  swap
+        mount_point:  swap
+
+- disk:
+    name: /dev/sdc
+    size: 400 GiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sdc1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows

--- a/test/data/devicegraphs/windows_disks.yml
+++ b/test/data/devicegraphs/windows_disks.yml
@@ -1,0 +1,36 @@
+---
+- disk:
+    name: /dev/sda
+    size: 1 TiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sda1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows
+
+- disk:
+    name: /dev/sdb
+    size: 400 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        name:         /dev/sdb1
+        id: windows_basic_data
+        file_system:  ntfs
+        label:        windows
+
+- disk:
+    name: /dev/sdc
+    size: 400 GiB
+    partition_table:  ms-dos
+    partitions:
+
+    - partition:
+        name:         /dev/sdc1
+        id:           0x7
+        file_system:  ntfs
+        label:        windows

--- a/test/support/proposal_context.rb
+++ b/test/support/proposal_context.rb
@@ -93,7 +93,7 @@ RSpec.shared_context "proposal" do
   end
 
   let(:expected_scenario) { scenario }
-  let(:expected) do
+  let(:expected_scenario_filename) do
     file_name = expected_scenario
     file_name.concat("-enc") if encrypt
     if lvm
@@ -101,7 +101,10 @@ RSpec.shared_context "proposal" do
       file_name.concat("-#{lvm_strategy}") if lvm_strategy
     end
     file_name.concat("-sep-home") if separate_home
-    full_path = output_file_for(file_name)
+    file_name
+  end
+  let(:expected) do
+    full_path = output_file_for(expected_scenario_filename)
     devicegraph = Y2Storage::Devicegraph.new_from_file(full_path)
     log.info("Expected devicegraph from file\n#{full_path}:\n\n#{devicegraph.to_str}\n")
     devicegraph

--- a/test/y2storage/proposal/space_maker_test.rb
+++ b/test/y2storage/proposal/space_maker_test.rb
@@ -1039,16 +1039,17 @@ describe Y2Storage::Proposal::SpaceMaker do
     end
 
     # Test for bug#1161331 found in the beta versions of SLE-15-SP2. Instead of just
-    # reporting the error (like SLE-15-SP1 used to do), this scenario made SpaceMaker
-    # enter an infinite loop trying to delete sda1 over and over again.
+    # doing its work, this scenario made SpaceMaker enter an infinite loop trying to
+    # delete sda1 over and over again.
     context "when a planned device needs to be created out of the candidate devices" do
       let(:scenario) { "empty-md_raid" }
-      let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 1.GiB, disk: "/dev/sda") }
+      let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 200.GiB, disk: "/dev/sda") }
       before { settings.candidate_devices = fake_devicegraph.raids }
 
-      it "raises an Error exception" do
-        expect { maker.provide_space(fake_devicegraph, volumes, lvm_helper) }
-          .to raise_error Y2Storage::Error
+      it "makes space for it" do
+        result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+        devicegraph = result[:devicegraph]
+        expect(devicegraph.partitions.size).to eq 1
       end
     end
   end

--- a/test/y2storage/proposal_agama_basis_test.rb
+++ b/test/y2storage/proposal_agama_basis_test.rb
@@ -1,0 +1,181 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "storage"
+require "y2storage"
+require_relative "#{TEST_PATH}/support/proposal_examples"
+require_relative "#{TEST_PATH}/support/proposal_context"
+
+describe Y2Storage::MinGuidedProposal do
+  describe "#propose with settings in the Agama style" do
+    subject(:proposal) { described_class.new(settings: settings) }
+
+    include_context "proposal"
+    let(:architecture) { :x86 }
+    let(:settings_format) { :ng }
+    let(:separate_home) { true }
+    let(:control_file_content) do
+      { "partitioning" => { "proposal" => { "windows_delete_mode" => :none }, "volumes" => volumes } }
+    end
+
+    # Several disks fully used by Windows partitions
+    let(:scenario) { "windows_disks" }
+    let(:resize_info) do
+      instance_double("Y2Storage::ResizeInfo", resize_ok?: true, reasons: 0, reason_texts: [],
+        min_size: Y2Storage::DiskSize.GiB(40), max_size: Y2Storage::DiskSize.TiB(2))
+    end
+
+    # Let's define some volumes to shuffle them around among the disks
+    let(:volumes) { [root_vol, home_vol, srv_vol, swap_vol] }
+    let(:root_vol) do
+      { "mount_point" => "/", "fs_type" => "xfs", "min_size" => "10 GiB", "max_size" => "30 GiB" }
+    end
+    let(:home_vol) do
+      { "mount_point" => "/home", "fs_type" => "xfs", "min_size" => "15 GiB" }
+    end
+    let(:srv_vol) do
+      { "mount_point" => "/srv", "fs_type" => "xfs", "min_size" => "5 GiB", "max_size" => "10 GiB" }
+    end
+    let(:swap_vol) do
+      { "mount_point" => "swap", "fs_type" => "swap", "min_size" => "1 GiB", "max_size" => "2 GiB" }
+    end
+
+    before do
+      # Speed-up things by avoiding calls to hwinfo
+      allow_any_instance_of(Y2Storage::Disk).to receive(:hwinfo).and_return(Y2Storage::HWInfoDisk.new)
+
+      # Install into /dev/sdb by default
+      settings.candidate_devices = ["/dev/sdb"]
+      settings.root_device = "/dev/sdb"
+
+      # Agama uses homogeneous weights for all volumes
+      settings.volumes.each { |v| v.weight = 100 }
+      # Activate support for separate LVM VGs
+      settings.separate_vgs = true
+    end
+
+    context "when ProposalSettings#lvm is set to false" do
+      let(:lvm) { false }
+
+      context "if no alternative disks are specified for any of the volumes" do
+        let(:expected_scenario_filename) { "agama-basis-single_disk" }
+
+        # Creates all partitions in the target disk and leaves everything else untouched
+        include_examples "proposed layout"
+      end
+
+      context "if some partitions are assigned to different disks" do
+        let(:expected_scenario_filename) { "agama-basis-distributed" }
+
+        before do
+          settings.volumes.each do |vol|
+            vol.device = "/dev/sda" if vol.mount_point == "/home"
+            vol.device = "/dev/sdc" if vol.mount_point == "/srv"
+          end
+        end
+
+        # Creates default partitions in the target disk and special ones at sda and sdc as requested
+        include_examples "proposed layout"
+      end
+
+      context "if all partitions (even the root one) are assigned to a different disk" do
+        let(:expected_scenario_filename) { "agama-basis-separate_boot" }
+
+        before { settings.volumes.each { |v| v.device = "/dev/sda" } }
+
+        # Creates all partitions at sda except the bios_boot one (at sdb)
+        include_examples "proposed layout"
+      end
+    end
+
+    context "when ProposalSettings#lvm is set to true" do
+      let(:lvm) { true }
+
+      context "if all volumes must be located in the system VG" do
+        before do
+          settings.volumes.each { |v| v.separate_vg_name = nil }
+        end
+
+        context "and the system VG must be located in the boot disk" do
+          let(:expected_scenario_filename) { "agama-basis-lvm-single_disk" }
+
+          # Creates the boot partition and the system VG with all volumes at the target disk
+          include_examples "proposed layout"
+        end
+
+        context "and the system VG is allowed to use several disks" do
+          before { settings.candidate_devices = ["/dev/sdb", "/dev/sdc"] }
+
+          context "if all volumes fit when using only a disk" do
+            let(:expected_scenario_filename) { "agama-basis-lvm-single_disk" }
+
+            # Creates the boot partition and the system VG with all volumes at the target disk
+            include_examples "proposed layout"
+          end
+
+          context "if several disks must be used for the volumes to fit" do
+            before do
+              root = settings.volumes.find { |v| v.mount_point == "/" }
+              root.min_size = Y2Storage::DiskSize.GiB(380)
+              root.max_size = Y2Storage::DiskSize.GiB(380)
+            end
+
+            let(:expected_scenario_filename) { "agama-basis-lvm-several_disks" }
+
+            # Creates the system VG with all volumes over the needed candidate disks
+            # FIXME: due to bsc#1211041, this resizes sdc1 to its minimum and consequently creates
+            # bigger LVs for swap, /srv or /home than the other LVM-based contexts
+            include_examples "proposed layout"
+          end
+        end
+
+        context "and the system VG must be located in another disk (not the boot one)" do
+          before { settings.candidate_devices = ["/dev/sdc"] }
+
+          let(:expected_scenario_filename) { "agama-basis-lvm-separate_boot" }
+
+          # Creates the system VG at sdc and the partition needed for booting at sdb
+          include_examples "proposed layout"
+        end
+      end
+
+      context "if some volumes must be located in their own separate VG" do
+        before do
+          settings.volumes.each do |vol|
+            case vol.mount_point
+            when "/home"
+              vol.separate_vg_name = "home"
+              vol.device = "/dev/sda"
+            when "/srv"
+              vol.separate_vg_name = "srv"
+              vol.device = "/dev/sdc"
+            end
+          end
+        end
+
+        let(:expected_scenario_filename) { "agama-basis-lvm-distributed" }
+
+        # Creates the system VG in the target disk and separate ones at sda and sdc as requested
+        include_examples "proposed layout"
+      end
+    end
+  end
+end

--- a/test/y2storage/proposal_agama_basis_test.rb
+++ b/test/y2storage/proposal_agama_basis_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2023] SUSE LLC
 #
 # All Rights Reserved.
 #


### PR DESCRIPTION
## Problem

We are re-using the YaST `GuidedProposal` at Agama (to be precise, we use `MinGuidedProposal` which is identical but ignores `desired_size` and performs only one attempt with the minimum).

The `GuidedProposal` can find the best location for every requested volumes within a set of candidate devices. It also allows to specify that a given volume must be placed in a specific disk. But turns out it was not able to do both things at the same time!

If a setting called `allocate_volume_mode` was set to `auto` (which is the default), assignations of volume to specific disks were ignored and the proposal freely allocated all the volumes within the designated candidate devices. If `allocate_volume_mode` was set to `device` then the proposal calculated the candidate devices as the sum of all devices already assigned to a particular volume.

In other words, the proposal was not able to handle requirements like "allocate all volumes at sda except for volume `/home` that should go alone to sdb".

## Solution

Now when the allocate mode is `auto`, the proposal still honors when a volume is assigned to a specific device, no matter if that device is part of `candidate_devices` or not.

That allows us to offer the following options at Agama proposal configuration.

### Agama's partition-based proposal

- All partitions are created in the boot disk by default.
- It's possible to override that for a particular volume and specify a target disk for it

That can be achieved by setting the following `Y2Storage::Settings`

- root_device -> boot disk
- candidate_devices -> [boot_disk]
- Assign `device` to volumes that don't go to the boot disk

### Agama's LVM-based proposal

- The system VG is created by default in the boot disk
- It's possible to specify a set of several disks if we want the system VG to (potentially) extend over them (will do it only if necessary). It's even possible to select a disk or set of disks that do not include the boot disk.
- All LVs are created by default in the system VG
- It's possible to override that for a particular volume and specify an alternative VG name and a target disk (only one) for it

That can be achieved by setting the following `Y2Storage::Settings`

- root_device -> boot disk
- candidate_devices -> disks to be used to allocate the system VG
- separate_vgs -> true
- Assign `separate_vg_name` and `device` to volumes that don't go to the system VG

## Testing

Added unit tests to demonstrate all that is possible now

## Review

Better review commit by commit. This also includes a couple of clean-up commits.