### PR TITLE
Add commit callbacks to inst_prepdisk

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May  5 10:50:07 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Allow to pass commit callbacks to inst_prepdisk client.
+- Needed for Agama (gh#openSUSE/agama/558).
+- 4.6.8
+
+-------------------------------------------------------------------
 Wed May  3 11:51:09 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - GuidedProposal adapted to support assigning volumes to specific

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.6.7
+Version:        4.6.8
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2015-2016] SUSE LLC
+# Copyright (c) [2015-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -38,8 +38,12 @@ module Y2Storage
 
       EFIVARS_PATH = "/sys/firmware/efi/efivars".freeze
 
-      def initialize
+      # Constructor
+      #
+      # @param commit_callbacks [Storage::CommitCallbacks, nil]
+      def initialize(commit_callbacks: nil)
         textdomain "storage"
+        @commit_callbacks = commit_callbacks
       end
 
       def run
@@ -58,13 +62,18 @@ module Y2Storage
 
       protected
 
+      # Callbacks to use for commit
+      #
+      # @return [Storage::CommitCallbacks, nil]
+      attr_reader :commit_callbacks
+
       # Commits the actions to disk
       #
       # @return [Boolean] true if everything went fine, false if the user
       #   decided to abort
       def commit
         manager.rootprefix = Yast::Installation.destdir
-        return false unless manager.commit(force_rw: true)
+        return false unless manager.commit(force_rw: true, callbacks: commit_callbacks)
 
         mount_in_target("/dev", "devtmpfs", "-t devtmpfs")
         mount_in_target("/proc", "proc", "-t proc")

--- a/src/lib/y2storage/storage_manager.rb
+++ b/src/lib/y2storage/storage_manager.rb
@@ -315,7 +315,7 @@ module Y2Storage
     # The user is asked whether to continue on each error reported by libstorage-ng.
     #
     # @param force_rw [Boolean] if mount points should be forced to have read/write permissions.
-    # @param callbacks [Y2Storage::Callbacks::Commit]
+    # @param callbacks [Storage::CommitCallbacks]
     #
     # @return [Boolean] whether commit was successful, false if libstorage-ng found a problem and it was
     #   decided to abort.


### PR DESCRIPTION
## Problem

Agama uses the *inst_prepdisk* client to perform the required storage actions. That client calls to the storage commit action, which uses the default commit callbacks from YaST to report the errors.

Agama needs to provide its own callbacks, see https://github.com/openSUSE/agama/pull/558.

## Solution

Allows to pass commit callbacks to the *inst_prepdisk* client.
