### PR TITLE
New strategy for SpaceMaker

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 17 11:45:26 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- GuidedProposal: allow Agama to configure exactly what to do with
+  every existing partition (gh#yast/yast-storage-ng/1337).
+- 4.6.9
+
+-------------------------------------------------------------------
 Fri May  5 10:50:07 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Allow to pass commit callbacks to inst_prepdisk client.

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.6.8
+Version:        4.6.9
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/guided_proposal.rb
+++ b/src/lib/y2storage/guided_proposal.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2016-2021] SUSE LLC
+# Copyright (c) [2016-2023] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2storage/guided_proposal.rb
+++ b/src/lib/y2storage/guided_proposal.rb
@@ -249,7 +249,7 @@ module Y2Storage
       # the end of the process for those devices that were not used (as soon as libstorage-ng
       # allows us to copy sub-graphs).
       remove_empty_partition_tables(new_devicegraph)
-      @clean_graph = space_maker.delete_unwanted_partitions(new_devicegraph)
+      @clean_graph = space_maker.prepare_devicegraph(new_devicegraph)
     end
 
     # Removes partition tables from candidate devices with empty partition table

--- a/src/lib/y2storage/proposal/space_maker.rb
+++ b/src/lib/y2storage/proposal/space_maker.rb
@@ -104,7 +104,7 @@ module Y2Storage
         log.info "BEGIN SpaceMaker#prepare_devicegraph"
 
         result = original_graph.dup
-        actions = SpaceMakerActions::List.new(settings, disk_analyzer)
+        actions = SpaceMakerActions::List.new(settings.space_settings, disk_analyzer)
         disks_for(result).each { |d| actions.add_mandatory_actions(d) }
 
         while (action = actions.next)
@@ -265,7 +265,7 @@ module Y2Storage
         @distribution = nil
         force_ptables(planned_partitions)
 
-        actions = SpaceMakerActions::List.new(settings, disk_analyzer)
+        actions = SpaceMakerActions::List.new(settings.space_settings, disk_analyzer)
         disks_for(new_graph, disk_name).each do |disk|
           actions.add_optional_actions(disk, keep, lvm_helper)
         end

--- a/src/lib/y2storage/proposal/space_maker_actions.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -17,24 +17,15 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2storage/proposal/space_maker_prospects/base"
-
 module Y2Storage
   module Proposal
+    # Namespace for the classes used to represent the actions performed by SpaceMaker
     module SpaceMakerProspects
-      # Represents the prospect action of deleting the content of a disk with no
-      # partition table (i.e. a disk that is directly formatted or is a
-      # component of a software RAID or an LVM).
-      #
-      # @see Base
-      class WipeDisk < Base
-        protected
-
-        # @see #action
-        def action_class
-          SpaceMakerActions::Wipe
-        end
-      end
     end
   end
 end
+
+require "y2storage/proposal/space_maker_actions/delete"
+require "y2storage/proposal/space_maker_actions/wipe"
+require "y2storage/proposal/space_maker_actions/shrink"
+require "y2storage/proposal/space_maker_actions/list"

--- a/src/lib/y2storage/proposal/space_maker_actions/auto_strategy.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions/auto_strategy.rb
@@ -1,0 +1,95 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/proposal/space_maker_prospects"
+
+module Y2Storage
+  module Proposal
+    module SpaceMakerActions
+      # Classical YaST strategy for {SpaceMakerActions::List}, used by default and if the strategy
+      # is configured as :auto.
+      #
+      # This is basically a wrapper around {SpaceMakerProspects::List}, since the original logic
+      # was implemented there.
+      class AutoStrategy
+        # Constructor
+        #
+        # @param settings [ProposalSpaceSettings] proposal settings
+        # @param disk_analyzer [DiskAnalyzer] information about existing partitions
+        def initialize(settings, disk_analyzer)
+          @settings = settings
+          @disk_analyzer = disk_analyzer
+          @prospects = SpaceMakerProspects::List.new(settings, disk_analyzer)
+          @mandatory = []
+        end
+
+        # In the case of the traditional YaST strategy for making space, this corresponds to
+        # deleting all partitions explicitly marked for removal in the proposal settings, i.e.
+        # all the partitions belonging to one of the types with delete_mode set to :all.
+        #
+        # @see ProposalSettings#windows_delete_mode
+        # @see ProposalSettings#linux_delete_mode
+        # @see ProposalSettings#other_delete_mode
+        #
+        # @param disk [Disk] see {List}
+        def add_mandatory_actions(disk)
+          mandatory.concat(prospects.unwanted_partition_prospects(disk))
+        end
+
+        # @param disk [Disk] see {List}
+        # @param keep [Array<Integer>] see {List}
+        # @param lvm_helper [Proposal::LvmHelper] see {List}
+        def add_optional_actions(disk, keep, lvm_helper)
+          prospects.add_prospects(disk, lvm_helper, keep)
+        end
+
+        # @return [Action, nil] nil if there are no more actions in the list
+        def next
+          next_prospect&.action
+        end
+
+        # @param deleted_sids [Array<Integer>] see {List}
+        def done(deleted_sids)
+          if mandatory.any?
+            mandatory.shift
+            return
+          end
+
+          prospects.next_available_prospect.available = false
+          prospects.mark_deleted(deleted_sids)
+        end
+
+        private
+
+        # @return [Array<Action>] list of mandatory actions to be executed
+        attr_reader :mandatory
+
+        # @return [SpaceMakerProspects::List] optional actions to be executed if needed
+        attr_reader :prospects
+
+        # @see #next
+        def next_prospect
+          return @mandatory.first unless @mandatory.empty?
+
+          prospects.next_available_prospect
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/space_maker_actions/base.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions/base.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -17,22 +17,22 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2storage/proposal/space_maker_prospects/base"
-
 module Y2Storage
   module Proposal
-    module SpaceMakerProspects
-      # Represents the prospect action of deleting the content of a disk with no
-      # partition table (i.e. a disk that is directly formatted or is a
-      # component of a software RAID or an LVM).
+    module SpaceMakerActions
+      # Class to represent an action to be performed by SpaceMaker on the system
       #
-      # @see Base
-      class WipeDisk < Base
-        protected
+      # Objects of this class can be originated from SpaceMaker prospects (if the actions
+      # are calculated by the YaST proposal) or from objects of class ProposalSpaceAction
+      # (if the concrete actions are already specified at the proposal settings).
+      class Base
+        # Identifier of the target device
+        # @return [Integer]
+        attr_reader :sid
 
-        # @see #action
-        def action_class
-          SpaceMakerActions::Wipe
+        # @param device [Integer, Y2Storage::Device] sid or device
+        def initialize(device)
+          @sid = device.respond_to?(:sid) ? device.sid : device.to_i
         end
       end
     end

--- a/src/lib/y2storage/proposal/space_maker_actions/bigger_resize_strategy.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions/bigger_resize_strategy.rb
@@ -1,0 +1,172 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/proposal/space_maker_actions/shrink"
+require "y2storage/proposal/space_maker_actions/delete"
+require "y2storage/proposal/space_maker_actions/wipe"
+
+module Y2Storage
+  module Proposal
+    module SpaceMakerActions
+      # Strategy for {SpaceMakerActions::List} used for the case in which the actions to perform are
+      # explicitly configured as part of the proposal settings.
+      class BiggerResizeStrategy
+        # Constructor
+        #
+        # @param settings [ProposalSpaceSettings] proposal settings
+        def initialize(settings, _disk_analyzer)
+          @settings = settings
+          @to_delete_mandatory = []
+          @to_delete_optional = []
+          @to_resize = []
+        end
+
+        # @param disk [Disk] see {List}
+        def add_mandatory_actions(disk)
+          devices = disk.partition_table? ? partitions(disk) : [disk]
+          devices.select! { |d| configured?(d, :force_delete) }
+          to_delete_mandatory.concat(devices)
+        end
+
+        # @param disk [Disk] see {List}
+        # @param keep [Array<Integer>] see {List}
+        def add_optional_actions(disk, keep, _lvm_helper)
+          add_resize(disk)
+          add_optional_delete(disk, keep)
+        end
+
+        # @return [Action, nil] nil if there are no more actions in the list
+        def next
+          source = source_for_next
+          dev = send(source).first
+          return unless dev
+
+          return Shrink.new(dev) if source == :to_resize
+
+          dev.is?(:partition) ? Delete.new(dev, related_partitions: false) : Wipe.new(dev)
+        end
+
+        # @param deleted_sids [Array<Integer>] see {List}
+        def done(deleted_sids)
+          send(source_for_next).shift
+          cleanup(to_delete_mandatory, deleted_sids)
+          cleanup(to_delete_optional, deleted_sids)
+          cleanup(to_resize, deleted_sids)
+        end
+
+        private
+
+        # @return [ProposalSpaceSettings] proposal settings for making space
+        attr_reader :settings
+
+        # @return [Array<BlkDevice>] list of devices to be deleted or emptied (mandatory)
+        attr_reader :to_delete_mandatory
+
+        # @return [Array<BlkDevice>] list of devices to be deleted or emptied (optionally)
+        attr_reader :to_delete_optional
+
+        # @return [Array<Partition>] list of partitions to be shrunk
+        attr_reader :to_resize
+
+        # @see #add_optional_actions
+        # @param disk [Disk]
+        def add_resize(disk)
+          return unless disk.partition_table?
+
+          partitions = partitions(disk).select { |p| configured?(p, :resize) }
+          return if partitions.empty?
+
+          @to_resize = (to_resize + partitions).sort { |a, b| preferred_resize(a, b) }
+        end
+
+        # Compares two partitions to decide which one should be resized first
+        #
+        # @param part1 [Partition]
+        # @param part2 [Partition]
+        def preferred_resize(part1, part2)
+          result = part2.recoverable_size <=> part1.recoverable_size
+          return result unless result.zero?
+
+          # Just to ensure stable sorting between different executions in case of draw
+          part1.name <=> part2.name
+        end
+
+        # @see #add_optional_actions
+        #
+        # @param disk [Disk]
+        # @param keep [Array<Integer>]
+        def add_optional_delete(disk, keep)
+          if disk.partition_table?
+            partitions = partitions(disk).select { |p| configured?(p, :delete) }
+            partitions.reject! { |p| keep.include?(p.sid) }
+            to_delete_optional.concat(partitions.sort { |a, b| preferred_delete(a, b) })
+          elsif configured?(disk, :delete)
+            to_delete_optional << disk
+          end
+        end
+
+        # Compares two partitions to decide which one should be deleted first
+        #
+        # @param part1 [Partition]
+        # @param part2 [Partition]
+        def preferred_delete(part1, part2)
+          # Mimic order from the auto strategy. We might consider other approaches in the future.
+          part2.region.start <=> part1.region.start
+        end
+
+        # Whether the given action is configured for the given device at the proposal settings
+        #
+        # @see ProposalSpaceSettings#actions
+        #
+        # @param device [BlkDevice]
+        # @param action [Symbol] :force_delete, :delete or :resize
+        # @return [Boolean]
+        def configured?(device, action)
+          settings.actions[device.name]&.to_sym == action
+        end
+
+        # Removes devices with the given sids from a collection
+        #
+        # @param collection [Array<BlkDevice>]
+        # @param deleted_sids [Array<Integer>]
+        def cleanup(collection, deleted_sids)
+          collection.delete_if { |d| deleted_sids.include?(d.sid) }
+        end
+
+        # Collection for the next action
+        #
+        # @return [Symbol]
+        def source_for_next
+          if to_delete_mandatory.any?
+            :to_delete_mandatory
+          elsif to_resize.any?
+            :to_resize
+          else
+            :to_delete_optional
+          end
+        end
+
+        # Relevant partitions for the given disk
+        def partitions(disk)
+          disk.partitions.reject { |part| part.type.is?(:extended) }
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/space_maker_actions/delete.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions/delete.rb
@@ -27,11 +27,20 @@ module Y2Storage
       #
       # @see Base
       class Delete < Base
+        # @return [Boolean] see {PartitionKiller#delete_by_sid}
+        attr_reader :related_partitions
+
+        # Constructor
+        def initialize(device, related_partitions: true)
+          super(device)
+          @related_partitions = related_partitions
+        end
+
         # @param devicegraph [Devicegraph]
         # @param disk_names [Array<String>] collateral actions are restricted to these disks
         def delete(devicegraph, disk_names)
           killer = PartitionKiller.new(devicegraph, disk_names)
-          killer.delete_by_sid(sid)
+          killer.delete_by_sid(sid, delete_related_partitions: related_partitions)
         end
       end
     end

--- a/src/lib/y2storage/proposal/space_maker_actions/delete.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions/delete.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -17,22 +17,21 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2storage/proposal/space_maker_prospects/base"
+require "y2storage/proposal/space_maker_actions/base"
+require "y2storage/proposal/partition_killer"
 
 module Y2Storage
   module Proposal
-    module SpaceMakerProspects
-      # Represents the prospect action of deleting the content of a disk with no
-      # partition table (i.e. a disk that is directly formatted or is a
-      # component of a software RAID or an LVM).
+    module SpaceMakerActions
+      # Action for deleting a given partition
       #
       # @see Base
-      class WipeDisk < Base
-        protected
-
-        # @see #action
-        def action_class
-          SpaceMakerActions::Wipe
+      class Delete < Base
+        # @param devicegraph [Devicegraph]
+        # @param disk_names [Array<String>] collateral actions are restricted to these disks
+        def delete(devicegraph, disk_names)
+          killer = PartitionKiller.new(devicegraph, disk_names)
+          killer.delete_by_sid(sid)
         end
       end
     end

--- a/src/lib/y2storage/proposal/space_maker_actions/list.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions/list.rb
@@ -1,0 +1,113 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/proposal/space_maker_prospects"
+
+module Y2Storage
+  module Proposal
+    module SpaceMakerActions
+      # A set of actions to be executed by SpaceMaker
+      #
+      # This class is responsible of selecting which prospect action would be the next to be
+      # performed by SpaceMaker, both at the beginning of the process (mandatory actions) and during
+      # the iterative process done to find enough space (optional actions).
+      #
+      # In this original implementation is basically a wrapper around {SpaceMakerProspects::List},
+      # but in the future it will implement different strategies to calculate and sort the actions.
+      class List
+        # Initialize.
+        #
+        # @param settings [ProposalSettings] proposal settings
+        # @param disk_analyzer [DiskAnalyzer] information about existing partitions
+        def initialize(settings, disk_analyzer)
+          @settings = settings
+          @disk_analyzer = disk_analyzer
+          @prospects = SpaceMakerProspects::List.new(settings, disk_analyzer)
+          @mandatory = []
+        end
+
+        # Adds mandatory actions to be performed at the beginning of the process
+        #
+        # @see SpaceMaker#prepare_devicegraph
+        #
+        # In the case of the traditional YaST strategy for making space, that corresponds to
+        # deleting all partitions explicitly marked for removal in the proposal settings, i.e.
+        # all the partitions belonging to one of the types with delete_mode set to :all.
+        #
+        # @see ProposalSettings#windows_delete_mode
+        # @see ProposalSettings#linux_delete_mode
+        # @see ProposalSettings#other_delete_mode
+        #
+        # @param disk [Disk] disk to act upon
+        def add_mandatory_actions(disk)
+          mandatory.concat(prospects.unwanted_partition_prospects(disk))
+        end
+
+        # Adds optional actions to be performed if needed until the goal is reached
+        #
+        # @see SpaceMaker#provide_space
+        #
+        # @param disk [Disk] disk to act upon
+        # @param keep [Array<Integer>] sids of partitions that should not be deleted
+        # @param lvm_helper [Proposal::LvmHelper] contains information about the
+        #     planned LVM logical volumes and how to make space for them
+        def add_optional_actions(disk, keep, lvm_helper)
+          prospects.add_prospects(disk, lvm_helper, keep)
+        end
+
+        # Next action to be performed by SpaceMaker
+        #
+        # @return [Action, nil] nil if there are no more actions in the list
+        def next
+          next_prospect&.action
+        end
+
+        # Marks the action currently reported by {#next} as completed, so it will not be longer
+        # returned by subsequent calls to {#next}
+        #
+        # @param deleted_sids [Array<Integer>] sids of devices that are not longer available as
+        #   a side effect of completing the action
+        def done(deleted_sids = [])
+          if mandatory.any?
+            mandatory.shift
+            return
+          end
+
+          prospects.next_available_prospect.available = false
+          prospects.mark_deleted(deleted_sids)
+        end
+
+        private
+
+        # @return [Array<Action>] list of mandatory actions to be executed
+        attr_reader :mandatory
+
+        # @return [SpaceMakerProspects::List] optional actions to be executed if needed
+        attr_reader :prospects
+
+        # @see #next
+        def next_prospect
+          return @mandatory.first unless @mandatory.empty?
+
+          prospects.next_available_prospect
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/space_maker_actions/list.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions/list.rb
@@ -33,7 +33,7 @@ module Y2Storage
       class List
         # Initialize.
         #
-        # @param settings [ProposalSettings] proposal settings
+        # @param settings [ProposalSpaceSettings] proposal settings
         # @param disk_analyzer [DiskAnalyzer] information about existing partitions
         def initialize(settings, disk_analyzer)
           @settings = settings

--- a/src/lib/y2storage/proposal/space_maker_actions/shrink.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions/shrink.rb
@@ -1,0 +1,58 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/proposal/space_maker_actions/base"
+
+module Y2Storage
+  module Proposal
+    module SpaceMakerActions
+      # Action for resizing a given partition
+      #
+      # @see Base
+      class Shrink < Base
+        # @return [DiskSize] size of the space to substract ideally
+        attr_accessor :shrink_size
+
+        # Reduces the size of the target partition
+        #
+        # If possible, it reduces the size of the partition by {#shrink_size}.
+        # Otherwise, it reduces the size as much as possible.
+        #
+        # This method does not take alignment into account.
+        #
+        # @param devicegraph [Devicegraph]
+        # @return [Array<Integer>] always empty, resizing should not cause deletion of devices
+        def shrink(devicegraph)
+          partition = devicegraph.find_device(sid)
+          shrink_partition(partition)
+          []
+        end
+
+        protected
+
+        # @param partition [Partition]
+        def shrink_partition(partition)
+          target = shrink_size.unlimited? ? DiskSize.zero : partition.size - shrink_size
+          # Explicitly avoid alignment to keep current behavior (to be reconsidered)
+          partition.resize(target, align_type: nil)
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/space_maker_actions/wipe.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions/wipe.rb
@@ -1,0 +1,51 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/proposal/space_maker_actions/base"
+
+module Y2Storage
+  module Proposal
+    module SpaceMakerActions
+      # Action for clearing up the content of a block device
+      #
+      # @see Base
+      class Wipe < Base
+        # @param devicegraph [Devicegraph]
+        def wipe(devicegraph)
+          disk = devicegraph.find_device(sid)
+          remove_content(disk)
+          []
+        end
+
+        private
+
+        # Remove descendants of a disk and also partitions from other disks that
+        # are not longer useful afterwards
+        #
+        # TODO: delete partitions that were part of the removed VG and/or RAID
+        #
+        # @param disk [Partitionable] disk-like device to cleanup. It must not be
+        #   part of a multipath device or a BIOS RAID.
+        def remove_content(disk)
+          disk.remove_descendants
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/space_maker_prospects/base.rb
+++ b/src/lib/y2storage/proposal/space_maker_prospects/base.rb
@@ -17,17 +17,17 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "y2storage/proposal/space_maker_actions"
+
 module Y2Storage
   module Proposal
     module SpaceMakerProspects
       # Abstract class to represent a possible action to be performed by
       # SpaceMaker on the system.
       #
-      # The SpaceMakerProspects classes are NOT responsible for actually
-      # performing the corresponding changes in the devicegraph (that's done by
-      # SpaceMaker itself), they just provide information about the prospect
-      # actions. SpaceMaker can then use such information to take decisions
-      # about what to do next.
+      # This class (and its descendants) are used by the YaST GuidedProposal as a mechanism to
+      # generate the real list of actions (SpaceMakerActions) that will executed. Not all prospects
+      # will end up being translated into an action and consumed by SpaceMaker.
       class Base
         include Yast::Logger
 
@@ -47,6 +47,13 @@ module Y2Storage
           @sid = device.sid
           @device_name = device.name
           @available = true
+        end
+
+        # Corresponding action that would be consumed by SpaceMaker
+        #
+        # @return [SpaceMakerActions::Base]
+        def action
+          @action ||= action_class.new(sid)
         end
 
         # Whether the prospect action is still possible

--- a/src/lib/y2storage/proposal/space_maker_prospects/base.rb
+++ b/src/lib/y2storage/proposal/space_maker_prospects/base.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2023] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2storage/proposal/space_maker_prospects/delete_partition.rb
+++ b/src/lib/y2storage/proposal/space_maker_prospects/delete_partition.rb
@@ -86,15 +86,6 @@ module Y2Storage
           "<#{sid} (#{device_name}) - #{partition_type}>"
         end
 
-        # @return [Symbol]
-        def action_type
-          :delete
-        end
-
-        def action_optional?
-          !for_delete_all
-        end
-
         private
 
         # @return [PartitionId]

--- a/src/lib/y2storage/proposal/space_maker_prospects/delete_partition.rb
+++ b/src/lib/y2storage/proposal/space_maker_prospects/delete_partition.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2023] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2storage/proposal/space_maker_prospects/delete_partition.rb
+++ b/src/lib/y2storage/proposal/space_maker_prospects/delete_partition.rb
@@ -28,8 +28,12 @@ module Y2Storage
       class DeletePartition < PartitionProspect
         # @param partition [Partition] partition to delete
         # @param disk_analyzer [DiskAnalyzer] see {#analyzer}
-        def initialize(partition, disk_analyzer)
-          super
+        # @param for_delete_all [Boolean] if the permissions are being checked
+        #   as part of the first step which deletes unwanted partitions when the
+        #   corresponding delete_mode is :all
+        def initialize(partition, disk_analyzer, for_delete_all)
+          @for_delete_all = for_delete_all
+          super(partition, disk_analyzer)
           @partition_id = partition.id
         end
 
@@ -51,18 +55,15 @@ module Y2Storage
         #
         # @param settings [ProposalSettings]
         # @param keep [Array<Integer>] list of sids of partitions that should be kept
-        # @param for_delete_all [Boolean] if the permissions are being checked
-        #   as part of the first step which deletes unwanted partitions when the
-        #   corresponding delete_mode is :all
         # @return [Boolean]
-        def allowed?(settings, keep, for_delete_all)
+        def allowed?(settings, keep)
           return false if keep.include?(sid)
 
-          allowed = allowed_type?(settings, partition_type, for_delete_all)
+          allowed = allowed_type?(settings, partition_type)
           if irst? && windows_in_disk? && allowed
             # Second line of defense for IRST partitions
             log.info "#{device_name} seems to be used by a Windows installation, double-checking"
-            allowed_type?(settings, :windows, for_delete_all)
+            allowed_type?(settings, :windows)
           else
             allowed
           end
@@ -86,14 +87,20 @@ module Y2Storage
         end
 
         # @return [Symbol]
-        def to_sym
-          :delete_partition
+        def action_type
+          :delete
+        end
+
+        def action_optional?
+          !for_delete_all
         end
 
         private
 
         # @return [PartitionId]
         attr_reader :partition_id
+
+        attr_reader :for_delete_all
 
         # Whether the partition is an Intel Rapid Start Technology partition
         #
@@ -103,12 +110,17 @@ module Y2Storage
         end
 
         # @see #allowed?
-        def allowed_type?(settings, type, for_delete_all)
+        def allowed_type?(settings, type)
           if for_delete_all
             settings.delete_forced?(type)
           else
             !settings.delete_forbidden?(type)
           end
+        end
+
+        # @see #action
+        def action_class
+          SpaceMakerActions::Delete
         end
       end
     end

--- a/src/lib/y2storage/proposal/space_maker_prospects/list.rb
+++ b/src/lib/y2storage/proposal/space_maker_prospects/list.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2023] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2storage/proposal/space_maker_prospects/list.rb
+++ b/src/lib/y2storage/proposal/space_maker_prospects/list.rb
@@ -26,8 +26,9 @@ module Y2Storage
     module SpaceMakerProspects
       # A set of prospect actions SpaceMaker can perform to reach its goal
       #
-      # This class is responsible of selecting which prospect action would be
-      # the next to be performed by SpaceMaker.
+      # @see SpaceMakerActions::List
+      #
+      # This class implements the logic followed by the traditional YaST GuidedProposal.
       class List
         include Yast::Logger
 
@@ -50,10 +51,11 @@ module Y2Storage
 
         # Adds to the set all the prospect actions for the given disk
         #
-        # @param disk [Disk] disk to act upon
-        # @param lvm_helper [Proposal::LvmHelper] contains information about the
-        #     planned LVM logical volumes and how to make space for them
-        # @param keep [Array<Integer>] sids of partitions that should not be deleted
+        # @see SpaceMakerActions::List#add_optional_actions
+        #
+        # @param disk [Disk]
+        # @param lvm_helper [Proposal::LvmHelper]
+        # @param keep [Array<Integer>]
         def add_prospects(disk, lvm_helper, keep = [])
           add_delete_partition_prospects(disk, keep)
           add_resize_prospects(disk)
@@ -102,7 +104,7 @@ module Y2Storage
         # Prospects actions for deleting the unwanted partitions (i.e. when one
         # of the delete modes is set to :all) for the given disk
         #
-        # @see SpaceMaker#delete_unwanted_partitions
+        # @see SpaceMakerActions::List#add_mandatory_actions
         #
         # @param disk [Disk] disk to act upon
         # @return [Array<DeletePartition>]
@@ -247,11 +249,11 @@ module Y2Storage
           partitions = disk.partitions.reject { |part| part.type.is?(:extended) }
 
           prospects = partitions.map do |part|
-            SpaceMakerProspects::DeletePartition.new(part, analyzer)
+            SpaceMakerProspects::DeletePartition.new(part, analyzer, for_delete_all)
           end
 
           prospects.select do |action|
-            allowed = action.allowed?(settings, keep, for_delete_all)
+            allowed = action.allowed?(settings, keep)
             log.info "SpaceMakerProspects::DeletePartition allowed? #{allowed} -> #{action}"
             allowed
           end

--- a/src/lib/y2storage/proposal/space_maker_prospects/resize_partition.rb
+++ b/src/lib/y2storage/proposal/space_maker_prospects/resize_partition.rb
@@ -54,9 +54,11 @@ module Y2Storage
           settings.resize_windows
         end
 
-        # @return [Symbol]
-        def to_sym
-          :resize_partition
+        protected
+
+        # @see #action
+        def action_class
+          SpaceMakerActions::Shrink
         end
       end
     end

--- a/src/lib/y2storage/proposal/space_maker_prospects/resize_partition.rb
+++ b/src/lib/y2storage/proposal/space_maker_prospects/resize_partition.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2023] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2storage/proposal/space_maker_prospects/wipe_disk.rb
+++ b/src/lib/y2storage/proposal/space_maker_prospects/wipe_disk.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2018] SUSE LLC
+# Copyright (c) [2018-2023] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "forwardable"
 require "y2storage/disk_size"
 require "y2storage/secret_attributes"
 require "y2storage/volume_specification"
@@ -27,6 +28,7 @@ require "y2storage/partitioning_features"
 require "y2storage/volume_specifications_set"
 require "y2storage/encryption_method"
 require "y2storage/equal_by_instance_variables"
+require "y2storage/proposal_space_settings"
 
 module Y2Storage
   # Class to manage settings used by the proposal (typically read from control.xml)
@@ -37,6 +39,7 @@ module Y2Storage
     include SecretAttributes
     include PartitioningFeatures
     include EqualByInstanceVariables
+    extend Forwardable
 
     # @return [Boolean] whether to use LVM
     attr_accessor :use_lvm
@@ -169,39 +172,6 @@ module Y2Storage
     # @return [PbkdFunction, nil] nil to use the default
     attr_accessor :encryption_pbkdf
 
-    # @return [Boolean] whether to resize Windows systems if needed
-    attr_accessor :resize_windows
-
-    # What to do regarding removal of existing partitions hosting a Windows system.
-    #
-    # Options:
-    #
-    # * :none Never delete a Windows partition.
-    # * :ondemand Delete Windows partitions as needed by the proposal.
-    # * :all Delete all Windows partitions, even if not needed.
-    #
-    # @raise ArgumentError if any other value is assigned
-    #
-    # @return [Symbol]
-    attr_reader :windows_delete_mode
-
-    # @return [Symbol] what to do regarding removal of existing Linux
-    #   partitions. See {DiskAnalyzer} for the definition of "Linux partitions".
-    #   @see #windows_delete_mode for the possible values and exceptions
-    attr_reader :linux_delete_mode
-
-    # @return [Symbol] what to do regarding removal of existing partitions that
-    #   don't fit in #windows_delete_mode or #linux_delete_mode.
-    #   @see #windows_delete_mode for the possible values and exceptions
-    attr_reader :other_delete_mode
-
-    # Whether the delete mode of the partitions and the resize option for windows can be
-    # configured. When this option is set to `false`, the {#windows_delete_mode}, {#linux_delete_mode},
-    # {#other_delete_mode} and {#resize_windows} options cannot be modified by the user.
-    #
-    # @return [Boolean]
-    attr_accessor :delete_resize_configurable
-
     # When the user decides to use LVM, strategy to decide the size of the volume
     # group (and, thus, the number and size of created physical volumes).
     #
@@ -232,6 +202,14 @@ module Y2Storage
 
     alias_method :lvm, :use_lvm
     alias_method :lvm=, :use_lvm=
+
+    # @return [ProposalSpaceSettings]
+    attr_reader :space_settings
+
+    # Constructor
+    def initialize
+      @space_settings = ProposalSpaceSettings.new
+    end
 
     # Volumes grouped by their location in the disks.
     #
@@ -273,44 +251,48 @@ module Y2Storage
       !encryption_password.nil?
     end
 
-    # Whether the settings disable deletion of a given type of partitions
-    #
-    # @see #windows_delete_mode
-    # @see #linux_delete_mode
-    # @see #other_delete_mode
-    #
-    # @param type [#to_s] :linux, :windows or :other
-    # @return [Boolean]
-    def delete_forbidden(type)
-      send(:"#{type}_delete_mode") == :none
-    end
+    def_delegators :@space_settings,
+      :windows_delete_mode, :linux_delete_mode, :other_delete_mode, :resize_windows,
+      :resize_windows=, :delete_resize_configurable, :delete_resize_configurable=,
+      :delete_forbidden, :delete_forbidden?, :delete_forced, :delete_forced?
 
-    alias_method :delete_forbidden?, :delete_forbidden
+    # @!attribute windows_delete_mode
+    #   @see ProposalSpaceSettings
 
-    # Whether the settings enforce deletion of a given type of partitions
-    #
-    # @see #windows_delete_mode
-    # @see #linux_delete_mode
-    # @see #other_delete_mode
-    #
-    # @param type [#to_s] :linux, :windows or :other
-    # @return [Boolean]
-    def delete_forced(type)
-      send(:"#{type}_delete_mode") == :all
-    end
+    # @!attribute linux_delete_mode
+    #   @see ProposalSpaceSettings
 
-    alias_method :delete_forced?, :delete_forced
+    # @!attribute other_delete_mode
+    #   @see ProposalSpaceSettings
+
+    # @!attribute resize_windows
+    #   @see ProposalSpaceSettings
+
+    # @!attribute delete_resize_configurable
+    #   @see ProposalSpaceSettings
+
+    # @!method delete_forbidden
+    #   @see ProposalSpaceSettings
+
+    # @!method delete_forbidden?
+    #   @see ProposalSpaceSettings
+
+    # @!method delete_forced
+    #   @see ProposalSpaceSettings
+
+    # @!method delete_forced?
+    #   @see ProposalSpaceSettings
 
     def windows_delete_mode=(mode)
-      @windows_delete_mode = validated_delete_mode(mode)
+      space_settings.windows_delete_mode = validated_delete_mode(mode)
     end
 
     def linux_delete_mode=(mode)
-      @linux_delete_mode = validated_delete_mode(mode)
+      space_settings.linux_delete_mode = validated_delete_mode(mode)
     end
 
     def other_delete_mode=(mode)
-      @other_delete_mode = validated_delete_mode(mode)
+      space_settings.other_delete_mode = validated_delete_mode(mode)
     end
 
     def lvm_vg_strategy=(strategy)
@@ -388,11 +370,6 @@ module Y2Storage
       volumes.find(&:root?)
     end
 
-    # List of possible delete strategies.
-    # TODO: enum?
-    DELETE_MODES = [:none, :all, :ondemand]
-    private_constant :DELETE_MODES
-
     # List of possible VG strategies.
     # TODO: enum?
     LVM_VG_STRATEGIES = [:use_available, :use_needed, :use_vg_size]
@@ -444,7 +421,7 @@ module Y2Storage
     end
 
     def validated_delete_mode(mode)
-      validated_feature_value(mode, DELETE_MODES)
+      validated_feature_value(mode, ProposalSpaceSettings.delete_modes)
     end
 
     def validated_lvm_vg_strategy(strategy)

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2015-2019] SUSE LLC
+# Copyright (c) [2015-2023] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2storage/proposal_space_settings.rb
+++ b/src/lib/y2storage/proposal_space_settings.rb
@@ -1,0 +1,100 @@
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage/equal_by_instance_variables"
+
+module Y2Storage
+  # Class to encapsulate all the GuidedProposal settings related to the process of making space
+  # to allocate the new operating system
+  class ProposalSpaceSettings
+    include EqualByInstanceVariables
+
+    # @see .delete_modes
+    # TODO: enum?
+    DELETE_MODES = [:none, :all, :ondemand].freeze
+    private_constant :DELETE_MODES
+
+    # @return [Array<String>] list of possible delete strategies
+    def self.delete_modes
+      DELETE_MODES
+    end
+
+    # @return [Boolean] whether to resize Windows systems if needed
+    attr_accessor :resize_windows
+
+    # What to do regarding removal of existing partitions hosting a Windows system.
+    #
+    # Options:
+    #
+    # * :none Never delete a Windows partition.
+    # * :ondemand Delete Windows partitions as needed by the proposal.
+    # * :all Delete all Windows partitions, even if not needed.
+    #
+    # @raise ArgumentError if any other value is assigned
+    #
+    # @return [Symbol]
+    attr_accessor :windows_delete_mode
+
+    # @return [Symbol] what to do regarding removal of existing Linux
+    #   partitions. See {DiskAnalyzer} for the definition of "Linux partitions".
+    #   @see #windows_delete_mode for the possible values and exceptions
+    attr_accessor :linux_delete_mode
+
+    # @return [Symbol] what to do regarding removal of existing partitions that
+    #   don't fit in #windows_delete_mode or #linux_delete_mode.
+    #   @see #windows_delete_mode for the possible values and exceptions
+    attr_accessor :other_delete_mode
+
+    # Whether the delete mode of the partitions and the resize option for windows can be
+    # configured. When this option is set to `false`, the {#windows_delete_mode}, {#linux_delete_mode},
+    # {#other_delete_mode} and {#resize_windows} options cannot be modified by the user.
+    #
+    # @return [Boolean]
+    attr_accessor :delete_resize_configurable
+
+    # Whether the settings disable deletion of a given type of partitions
+    #
+    # @see #windows_delete_mode
+    # @see #linux_delete_mode
+    # @see #other_delete_mode
+    #
+    # @param type [#to_s] :linux, :windows or :other
+    # @return [Boolean]
+    def delete_forbidden(type)
+      send(:"#{type}_delete_mode") == :none
+    end
+
+    alias_method :delete_forbidden?, :delete_forbidden
+
+    # Whether the settings enforce deletion of a given type of partitions
+    #
+    # @see #windows_delete_mode
+    # @see #linux_delete_mode
+    # @see #other_delete_mode
+    #
+    # @param type [#to_s] :linux, :windows or :other
+    # @return [Boolean]
+    def delete_forced(type)
+      send(:"#{type}_delete_mode") == :all
+    end
+
+    alias_method :delete_forced?, :delete_forced
+  end
+end

--- a/src/lib/y2storage/proposal_space_settings.rb
+++ b/src/lib/y2storage/proposal_space_settings.rb
@@ -36,6 +36,19 @@ module Y2Storage
       DELETE_MODES
     end
 
+    # Strategy followed to calculate the actions executed while making space and to
+    # decide in which order execute those actions.
+    #
+    #   - :auto is the traditional YaST approach. The actions and the moment to execute them are
+    #     auto-calculated based on settings like {#resize_windows}, {#windows_delete_mode},
+    #     {#linux_delete_mode} and {#other_delete_mode}.
+    #   - :bigger_resize uses the actions from {#actions}, executing the optional actions in a
+    #     simple order. First it executes the resize actions (sorted by "recoverable" size) and
+    #     then the more destructive ones.
+    #
+    # @return [Symbol] :auto is the default
+    attr_accessor :strategy
+
     # @return [Boolean] whether to resize Windows systems if needed
     attr_accessor :resize_windows
 
@@ -68,6 +81,32 @@ module Y2Storage
     #
     # @return [Boolean]
     attr_accessor :delete_resize_configurable
+
+    # What to do with existing partitions and disks if they are involved in the process of making
+    # space.
+    #
+    # Keys are device names (like in BlkDevice#name, no alternative names) that correspond to a
+    # partition or to a disk with no partitions.
+    #
+    # The value for each key specifies what to do with the corresponding device if the storage
+    # proposal needs to process the corresponding disk. If the device is not explicitly mentioned,
+    # nothing will be done. Possible values are :resize, :delete and :force_delete.
+    #
+    # Entries for devices that are not involved in the proposal are ignored. For example, if all
+    # the volumes are configured to be placed at /dev/sda but there is an entry like
+    # `{"/dev/sdb1" => :force_delete}`, the corresponding /dev/sdb1 partition will NOT be deleted
+    # because there is no reason for the proposal to process the disk /dev/sdb.
+    #
+    # Device names corresponding to extended partitions are also ignored. The storage proposal only
+    # considers actions for primary and logical partitions.
+    #
+    # @return [Hash{String => Symbol}]
+    attr_accessor :actions
+
+    def initialize
+      @strategy = :auto
+      @actions = []
+    end
 
     # Whether the settings disable deletion of a given type of partitions
     #

--- a/test/data/devicegraphs/irst-windows-linux-gpt.yml
+++ b/test/data/devicegraphs/irst-windows-linux-gpt.yml
@@ -1,0 +1,36 @@
+---
+- disk:
+    name: /dev/sda
+    size: 800 GiB
+    partition_table:  gpt
+    partitions:
+
+    - partition:
+        size:         8 GiB
+        name:         /dev/sda1
+        id:           irst
+
+    - partition:
+        size:         360 GiB
+        name:         /dev/sda2
+        id:           windows_basic_data
+        file_system:  ntfs
+        label:        windows
+
+    - partition:
+        size:         260 GiB
+        name:         /dev/sda3
+        id:           windows_basic_data
+        file_system:  vfat
+        label:        other
+
+    - partition:
+        size:         1 GiB
+        name:         /dev/sda4
+        id:           swap
+        file_system:  swap
+
+    - partition:
+        size:         unlimited
+        name:         /dev/sda5
+        file_system:  ext4

--- a/test/y2storage/proposal/space_maker_bigger_resize_test.rb
+++ b/test/y2storage/proposal/space_maker_bigger_resize_test.rb
@@ -1,0 +1,364 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::Proposal::SpaceMaker do
+  # Partition from fake_devicegraph, fetched by name
+  def probed_partition(name)
+    fake_devicegraph.partitions.detect { |p| p.name == name }
+  end
+
+  before do
+    fake_scenario(scenario)
+  end
+
+  let(:settings) do
+    settings = Y2Storage::ProposalSettings.new_for_current_product
+    settings.candidate_devices = ["/dev/sda"]
+    settings.root_device = "/dev/sda"
+    settings.space_settings.strategy = :bigger_resize
+    settings.space_settings.actions = settings_actions
+    settings
+  end
+  let(:settings_actions) { {} }
+  let(:analyzer) { Y2Storage::DiskAnalyzer.new(fake_devicegraph) }
+
+  subject(:maker) { described_class.new(analyzer, settings) }
+
+  describe "#prepare_devicegraph" do
+    let(:scenario) { "complex-lvm-encrypt" }
+
+    context "if no device is set as :force_delete " do
+      let(:settings_actions) { { "/dev/sda1" => :delete, "/dev/sda2" => :delete } }
+
+      it "does not delete any partition" do
+        result = maker.prepare_devicegraph(fake_devicegraph)
+        expect(result.partitions.size).to eq fake_devicegraph.partitions.size
+      end
+    end
+
+    context "if :force_delete is specified for a disk that contains partitions" do
+      let(:settings_actions) { { "/dev/sda" => :force_delete } }
+
+      it "does not delete any partition" do
+        result = maker.prepare_devicegraph(fake_devicegraph)
+        expect(result.partitions.size).to eq fake_devicegraph.partitions.size
+      end
+    end
+
+    context "if :force_delete is specified for several partitions" do
+      let(:settings_actions) { { "/dev/sda2" => :force_delete, "/dev/sde1" => :force_delete } }
+
+      it "does not delete partitions out of SpaceMaker#candidate_devices" do
+        result = maker.prepare_devicegraph(fake_devicegraph)
+        expect(result.partitions.map(&:name)).to include "/dev/sde1"
+      end
+
+      it "deletes affected partitions within the candidate devices" do
+        result = maker.prepare_devicegraph(fake_devicegraph)
+        expect(result.partitions.map(&:name)).to_not include "/dev/sda2"
+      end
+    end
+
+    context "if :force_delete is specified for a directly formatted disk (no partition table)" do
+      let(:scenario) { "multipath-formatted.xml" }
+
+      let(:settings_actions) { { "/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1" => :force_delete } }
+      before do
+        settings.candidate_devices = ["/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"]
+        settings.root_device = "/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"
+      end
+
+      it "empties the device deleting the filesystem" do
+        expect(fake_devicegraph.filesystems.size).to eq 1
+
+        result = maker.prepare_devicegraph(fake_devicegraph)
+        disk = result.disk_devices.first
+        expect(disk.has_children?).to eq false
+        expect(result.filesystems).to be_empty
+      end
+    end
+
+    context "when deleting a btrfs partition that is part of a multidevice btrfs" do
+      let(:scenario) { "btrfs-multidevice-over-partitions.xml" }
+      let(:settings_actions) { { "/dev/sda1" => :force_delete } }
+
+      it "deletes the partitions explicitly mentioned in the settings" do
+        result = maker.prepare_devicegraph(fake_devicegraph)
+        expect(result.partitions.map(&:name)).to_not include "/dev/sda1"
+      end
+
+      it "does not delete other partitions constituting the same btrfs" do
+        result = maker.prepare_devicegraph(fake_devicegraph)
+        expect(result.partitions.map(&:name)).to include "/dev/sda2", "/dev/sda3", "/dev/sdb2"
+      end
+    end
+
+    context "when deleting a partition that is part of a raid" do
+      let(:scenario) { "raid0-over-partitions.xml" }
+      let(:settings_actions) { { "/dev/sda1" => :force_delete } }
+
+      it "deletes the partitions explicitly mentioned in the settings" do
+        result = maker.prepare_devicegraph(fake_devicegraph)
+        expect(result.partitions.map(&:name)).to_not include "/dev/sda1"
+      end
+
+      it "does not delete other partitions constituting the same raid" do
+        result = maker.prepare_devicegraph(fake_devicegraph)
+        expect(result.partitions.map(&:name)).to include "/dev/sda2", "/dev/sda3", "/dev/sdb2"
+      end
+    end
+
+    context "when deleting a partition that is part of a lvm volume group" do
+      let(:scenario) { "lvm-over-partitions.xml" }
+      let(:settings_actions) { { "/dev/sda1" => :force_delete } }
+
+      it "deletes the partitions explicitly mentioned in the settings" do
+        result = maker.prepare_devicegraph(fake_devicegraph)
+        expect(result.partitions.map(&:name)).to_not include "/dev/sda1"
+      end
+
+      it "does not delete other partitions constituting the same volume group" do
+        result = maker.prepare_devicegraph(fake_devicegraph)
+        expect(result.partitions.map(&:name)).to include "/dev/sda2", "/dev/sda3", "/dev/sdb2"
+      end
+    end
+  end
+
+  describe "#provide_space" do
+    using Y2Storage::Refinements::SizeCasts
+
+    let(:volumes) { [vol1] }
+    let(:lvm_helper) { Y2Storage::Proposal::LvmHelper.new([], settings) }
+
+    context "if the only disk is not big enough" do
+      let(:scenario) { "empty_hard_disk_mbr_50GiB" }
+      let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 60.GiB) }
+
+      it "raises an Error exception" do
+        expect { maker.provide_space(fake_devicegraph, volumes, lvm_helper) }
+          .to raise_error Y2Storage::Error
+      end
+    end
+
+    context "if the only disk has no partition table and is not used in any other way" do
+      let(:scenario) { "empty_hard_disk_50GiB" }
+      let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 40.GiB) }
+
+      it "does not modify the disk" do
+        result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+        disk = result[:devicegraph].disks.first
+        expect(disk.partition_table).to be_nil
+      end
+
+      it "assumes a (future) GPT partition table" do
+        gpt_size = 1.MiB
+        # The final 16.5 KiB are reserved by GPT
+        gpt_final_space = 16.5.KiB
+
+        result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+        space = result[:partitions_distribution].spaces.first
+        expect(space.disk_size).to eq(50.GiB - gpt_size - gpt_final_space)
+      end
+    end
+
+    context "if the only disk is directly used as PV (no partition table)" do
+      let(:scenario) { "lvm-disk-as-pv.xml" }
+      let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 5.GiB) }
+
+      context "and the disk is not mentioned in the settings" do
+        let(:settings_actions) { { "/dev/sda1" => :delete } }
+
+        it "raises an Error exception" do
+          expect { maker.provide_space(fake_devicegraph, volumes, lvm_helper) }
+            .to raise_error Y2Storage::Error
+        end
+      end
+
+      context "and the disk is marked to be deleted" do
+        let(:settings_actions) { { "/dev/sda" => :delete } }
+
+        it "empties the disk deleting the LVM VG" do
+          expect(fake_devicegraph.lvm_vgs.size).to eq 1
+
+          result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+          disk = result[:devicegraph].disks.first
+          expect(disk.has_children?).to eq false
+          expect(result[:devicegraph].lvm_vgs).to be_empty
+        end
+
+        it "assumes a (future) GPT partition table" do
+          gpt_size = 1.MiB
+          # The final 16.5 KiB are reserved by GPT
+          gpt_final_space = 16.5.KiB
+
+          result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+          space = result[:partitions_distribution].spaces.first
+          expect(space.disk_size).to eq(space.disk.size - gpt_size - gpt_final_space)
+        end
+      end
+    end
+
+    context "if the only available device is directly formatted (no partition table)" do
+      let(:scenario) { "multipath-formatted.xml" }
+      let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 5.GiB) }
+
+      before do
+        settings.candidate_devices = ["/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"]
+        settings.root_device = "/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"
+      end
+
+      context "and the device is not mentioned in the settings" do
+        let(:settings_actions) { {} }
+
+        it "raises an Error exception" do
+          expect { maker.provide_space(fake_devicegraph, volumes, lvm_helper) }
+            .to raise_error Y2Storage::Error
+        end
+      end
+
+      context "and the disk is marked to be deleted" do
+        let(:settings_actions) { { "/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1" => :delete } }
+
+        it "empties the device deleting the filesystem" do
+          expect(fake_devicegraph.filesystems.size).to eq 1
+
+          result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+          disk = result[:devicegraph].disk_devices.first
+          expect(disk.has_children?).to eq false
+          expect(result[:devicegraph].filesystems).to be_empty
+        end
+
+        it "assumes a (future) GPT partition table" do
+          gpt_size = 1.MiB
+          # The final 16.5 KiB are reserved by GPT
+          gpt_final_space = 16.5.KiB
+
+          result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+          space = result[:partitions_distribution].spaces.first
+          expect(space.disk_size).to eq(space.disk.size - gpt_size - gpt_final_space)
+        end
+      end
+    end
+
+    context "with one disk containing several partitions" do
+      let(:scenario) { "irst-windows-linux-gpt" }
+      let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 150.GiB) }
+      let(:vol2) { planned_vol(mount_point: "/2", type: :ext4, min: 150.GiB) }
+      let(:vol3) { planned_vol(mount_point: "/3", type: :ext4, min: 150.GiB) }
+      let(:resize_info) do
+        instance_double("ResizeInfo", resize_ok?: true, min_size: 100.GiB, max_size: 800.GiB)
+      end
+
+      before do
+        allow_any_instance_of(Y2Storage::Partition)
+          .to receive(:detect_resize_info).and_return(resize_info)
+      end
+
+      context "if resizing some partitions and deleting others is allowed" do
+        let(:settings_actions) do
+          {
+            "/dev/sda2" => :resize, "/dev/sda3" => :resize,
+            "/dev/sda5" => :delete, "/dev/sda6" => :delete
+          }
+        end
+
+        context "and resizing one partition is enough" do
+          let(:volumes) { [vol1] }
+
+          it "resizes the more 'productive' partition" do
+            result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+            expect(result[:devicegraph].partitions).to include(
+              an_object_having_attributes(filesystem_label: "windows", size: 210.GiB)
+            )
+          end
+
+          it "does not delete any partition" do
+            result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+            expect(result[:devicegraph].partitions.map(&:name)).to contain_exactly(
+              "/dev/sda1", "/dev/sda2", "/dev/sda3", "/dev/sda4", "/dev/sda5"
+            )
+          end
+
+          it "suggests a distribution using the freed space" do
+            result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+            distribution = result[:partitions_distribution]
+            expect(distribution.spaces.size).to eq 1
+            expect(distribution.spaces.first.partitions).to eq volumes
+          end
+        end
+
+        context "and resizing one partition is not enough" do
+          let(:volumes) { [vol1, vol2] }
+
+          it "resizes subsequent partitions" do
+            result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+            expect(result[:devicegraph].partitions).to include(
+              an_object_having_attributes(filesystem_label: "windows", size: 100.GiB),
+              an_object_having_attributes(filesystem_label: "other", size: 110.GiB)
+            )
+          end
+
+          it "does not delete any partition" do
+            result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+            expect(result[:devicegraph].partitions.map(&:name)).to contain_exactly(
+              "/dev/sda1", "/dev/sda2", "/dev/sda3", "/dev/sda4", "/dev/sda5"
+            )
+          end
+
+          it "suggests a distribution using the freed space" do
+            result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+            distribution = result[:partitions_distribution]
+            expect(distribution.spaces.size).to eq 2
+            expect(distribution.spaces.flat_map(&:partitions)).to contain_exactly(*volumes)
+          end
+        end
+
+        context "and resizing all the allowed partitions is not enough" do
+          let(:volumes) { [vol1, vol2, vol3] }
+
+          it "resizes all allowed partitions to its minimum size" do
+            result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+            expect(result[:devicegraph].partitions).to include(
+              an_object_having_attributes(filesystem_label: "windows", size: 100.GiB),
+              an_object_having_attributes(filesystem_label: "other", size: 100.GiB)
+            )
+          end
+
+          it "deletes partitions starting with the one closer to the end of the disk" do
+            result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+            expect(result[:devicegraph].partitions.map(&:name)).to contain_exactly(
+              "/dev/sda1", "/dev/sda2", "/dev/sda3", "/dev/sda4"
+            )
+          end
+
+          it "suggests a distribution using the freed space" do
+            result = maker.provide_space(fake_devicegraph, volumes, lvm_helper)
+            distribution = result[:partitions_distribution]
+            expect(distribution.spaces.size).to eq 3
+            expect(distribution.spaces.flat_map(&:partitions)).to contain_exactly(*volumes)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/y2storage/proposal/space_maker_test.rb
+++ b/test/y2storage/proposal/space_maker_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2016] SUSE LLC
+# Copyright (c) [2016-2023] SUSE LLC
 #
 # All Rights Reserved.
 #


### PR DESCRIPTION
## Problem

The traditional behavior of `Y2Storage::Proposal::SpaceMaker` is coupled to the options offered by YaST in that regard. Somehow summarized in this screenshot.

![auto](https://github.com/yast/yast-storage-ng/assets/3638289/0eda2740-932c-4ab8-aa12-4cacace409de)

But for Agama we want to offer other options.

First of all, we want to stop making a difference for partitions of type Windows/Linux/other. The criteria for classifying a partition in one group or the other is not so clear.

On the other hand, we want to make it possible for Agama to specify any of the four modes described at [storage_ui.md](https://github.com/openSUSE/agama/blob/master/doc/storage_ui.md). That is:

 - Delete everything in the disk(s).
 - Resize existing partition(s).
 - Do not modify existing partition(s).
 - Custom, with the user specifying what to do with every individual partition in the affected disks: resize it, delete it or keep it as it is.

## Solution

This adds to the `ProposalSetting` the concept of different strategies for making space.

The default strategy is the classic one, now called `auto` and based on the known settings `resize_windows`, `windows_delete_mode`, `linux_delete_mode` and `other_delete_mode`.

A new strategy called `bigger_resize` is added. This strategy ignores the settings previously mentioned and works with a explicit list of actions specified in the proposal settings. Thus, the caller is responsible for deciding what to do with each partition or disk (`:force_delete`, `:delete` or `:resize`). Omitted devices are kept without modification. The only decision taken by `SpaceMaker` itself is the order in which those actions must be applied while looking for valid layout. As the name of the strategy suggests, it first executes all the `:force_delete` actions, then the `:resize` ones (sorted by "recoverable size") and finally the `:delete` ones.

With this solution, all the mentioned Agama modes can be easily implemented.

 - Delete everything in the disk(s). Settings with `:force_delete` for all partitions in the affected disks.
 - Resize existing partition(s).  Settings with `:resize` for all partitions in the affected disks.
 - Do not modify existing partition(s). Settings with an empty list of actions.
 - Custom. Settings describing the exact actions decided by the user.

## Implementation

The pull request is divided into several commits because the code was refactored into small steps before implementing the strategy support at SpaceMaker. Our comprehensive battery of unit tests survived all those reorganizations.

## Testing

Added new unit tests.
