### PR TITLE
Fix format of references to GitHub at changelog

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -2,14 +2,14 @@
 Wed May 17 11:45:26 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - GuidedProposal: allow Agama to configure exactly what to do with
-  every existing partition (gh#yast/yast-storage-ng/1337).
+  every existing partition (gh#yast/yast-storage-ng#1337).
 - 4.6.9
 
 -------------------------------------------------------------------
 Fri May  5 10:50:07 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Allow to pass commit callbacks to inst_prepdisk client.
-- Needed for Agama (gh#openSUSE/agama/558).
+- Needed for Agama (gh#openSUSE/agama#558).
 - 4.6.8
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## Problem

In my previous PR #1337 I copied from a previous entry the format of the reference to the github issue. But that's not the format recognized by the OBS and Jenkins cops.

That made the CI run fail. See https://ci.opensuse.org/job/yast-yast-storage-ng-master/464/console

## Solution

Use the right format, not only for my new entry but also for the previous one I copied.