### PR TITLE
Add bus_id for DASD

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 19 15:36:55 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Add bus_id for DASD (gh#yast/yast-storage-ng#1339,
+  gh#openSUSE/agama#578).
+- 4.6.10
+
+-------------------------------------------------------------------
 Wed May 17 11:45:26 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - GuidedProposal: allow Agama to configure exactly what to do with

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.6.9
+Version:        4.6.10
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/dasd.rb
+++ b/src/lib/y2storage/dasd.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2023] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -32,6 +32,10 @@ module Y2Storage
     # @!method rotational?
     #   @return [Boolean] whether this is a rotational device
     storage_forward :rotational?
+
+    # @!method bus_id
+    #   @return [String] The bus ID of the DASD (e.g., "0.0.0150")
+    storage_forward :bus_id
 
     # @!method type
     #   @return [DasdType]


### PR DESCRIPTION
## Problem

Agama needs to show the Bus Id of a DASD in order to help to indentify the device, see https://github.com/openSUSE/agama/pull/578. 

## Solution

Add `#bus_id` to `Dasd` class.
