### PR TITLE
Prevent setting the Volume Label for a Mounted Btrfs or Swap [SLE-15-SP5]

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun  7 08:03:52 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Prevent setting the volume label for a mounted btrfs or swap
+  (bsc#1211337)
+- 4.5.23
+
+-------------------------------------------------------------------
 Mon Apr 24 14:47:33 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Guided Setup: display a hint for disks with sensible data

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.22
+Version:        4.5.23
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/filesystem.rb
+++ b/src/lib/y2partitioner/actions/controllers/filesystem.rb
@@ -175,6 +175,14 @@ module Y2Partitioner
           mount_point.path
         end
 
+        # Check if the filesystem is currently mounted in the system device graph.
+        #
+        # @return [Boolean]
+        def mounted_in_system_graph?
+          sys_fs = system_device(filesystem)
+          sys_fs&.active_mount_point?
+        end
+
         # Partition id of the block device if it is a partition
         #
         # @return [Y2Storage::PartitionId, nil] nil if there is no block device or the


### PR DESCRIPTION
## Target Branch

**This is the merge of #1340  for _SLE-15-SP4_**


## Bugzilla

**L3:** https://bugzilla.suse.com/show_bug.cgi?id=1211337


## Trello

https://trello.com/c/0ASTpHRy


## Problem

Trying to change the volume label of a mounted Btrfs or swap partition in the YaST partitioner fails with an error message

  _Setting label of btrfs on /dev/sda2 (57.50 GiB) to root Unexpected situation found in the system._

The "Details" button shows

  _Caught signal #127: "/sbin/btrfs filesystem label '/dev/sda2' 'root'_

which is scary and confusing and does not give the user any hint what's actually wrong.

![Unexpected_situation](https://github.com/yast/yast-storage-ng/assets/11538225/4a8e2e42-1a5e-491b-8767-63eb6d49b176)

![Caught_signal](https://github.com/yast/yast-storage-ng/assets/11538225/9121a2fb-995a-4a7c-bdd0-d62d62e34428)

In the case of a root Btrfs, it even hangs later because subvolumes cannot be mounted.


## Cause

Even though some filesystem types do support changing the volume label while mounted, in our context this has implications with the subvolumes. Handling the subvolumes properly very likely requires a very intrusive code change which involves quite some risk.


## Fix

So we chose the less intrusive approach to disable it on the UI level: When we detect that the filesystem or swap space is actively mounted, we are now disabling the "Volume Label" field in the "Fstab Options" dialog.


## Screenshots

![partitioner-btrfs](https://github.com/yast/yast-storage-ng/assets/11538225/4352e08f-9d08-41a9-b004-0872e069ea05)
_Partitioner with a mounted Btrfs on /dev/sdb1_

![partitioner-edit](https://github.com/yast/yast-storage-ng/assets/11538225/7ddedce7-4cf8-4525-b88b-dc5b2526b05b)
_Editing /dev/sdb1_

![btrfs-mounted](https://github.com/yast/yast-storage-ng/assets/11538225/63ebee88-b650-4ec0-a8f4-26b5d573c8b6)
_"Volume Label" field disabled because the filesystem is mounted, so changing it would fail._


![partitioner-edit-after-unmount](https://github.com/yast/yast-storage-ng/assets/11538225/f10ecc76-8b52-42f8-b9fe-e42e3581931b)
_After unmounting, saving the changes and entering the partitioner again, the volume label can now be changed._


## Test

Extensive manual tests in a VM with a second virtual disk where partitions can be easily added and changed.


## Related PRs

- Original PR for _SLE-15-SP4_: #1340 
- Merge to _master_: TBD

