### PR TITLE
Honor proposal encryption from ProductFeatures

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 29 11:42:21 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Honor encryption settings if they are set into ProductFeatures
+  by the Common Critera role (jsc#PED-4166, jsc#PED-4474).
+- 4.4.44
+
+-------------------------------------------------------------------
 Wed Jun  7 08:03:52 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Prevent setting the volume label for a mounted btrfs or swap

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.43
+Version:        4.4.44
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -426,10 +426,15 @@ module Y2Storage
     # The encryption settings are not part of control.xml, but can be injected by a previous step of
     # the installation, eg. the dialog of the Common Criteria system role
     def load_encryption
-      load_feature(:proposal, :encryption_password)
-      return if encryption_password.nil?
+      enc = feature(:proposal, :encryption)
 
-      @encryption_password = nil if encryption_password.empty?
+      return unless enc
+      return unless enc.respond_to?(:password)
+
+      passwd = enc.password.to_s
+      return if passwd.nil? || passwd.empty?
+
+      self.encryption_password = passwd
     end
 
     def validated_delete_mode(mode)

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -418,6 +418,16 @@ module Y2Storage
       load_feature(:proposal, :multidisk_first)
       load_size_feature(:proposal, :lvm_vg_size)
       load_volumes_feature(:volumes)
+      load_encryption
+    end
+
+    # Loads the default encryption settings
+    #
+    # The encryption settings are not part of control.xml, but can be injected by a previous step of
+    # the installation, eg. the dialog of the Common Criteria system role
+    def load_encryption
+      load_feature(:proposal, :encryption_password)
+      @encryption_password = nil if encryption_password&.empty?
     end
 
     def validated_delete_mode(mode)

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -427,7 +427,9 @@ module Y2Storage
     # the installation, eg. the dialog of the Common Criteria system role
     def load_encryption
       load_feature(:proposal, :encryption_password)
-      @encryption_password = nil if encryption_password&.empty?
+      return if encryption_password.nil?
+
+      @encryption_password = nil if encryption_password.empty?
     end
 
     def validated_delete_mode(mode)

--- a/test/y2storage/proposal_settings_test.rb
+++ b/test/y2storage/proposal_settings_test.rb
@@ -35,6 +35,19 @@ describe Y2Storage::ProposalSettings do
     stub_features("partitioning" => initial_partitioning_features.merge(features))
   end
 
+  # Used to test the mechanism to inject an encryption password into the settings
+  class TestInjectedPassword
+    include Y2Storage::SecretAttributes
+
+    # Real password
+    secret_attr :password
+
+    # Constructor
+    def initialize(passwd)
+      self.password = passwd
+    end
+  end
+
   before do
     Y2Storage::StorageManager.create_test_instance
   end
@@ -336,11 +349,11 @@ describe Y2Storage::ProposalSettings do
       expect(settings.lvm).to eq false
     end
 
-    it "sets 'encryption_password' based on the feature in the 'proposal' section" do
-      read_feature("encryption_password", "")
+    it "sets 'encryption_password' based on the 'encryption' feature in the 'proposal' section" do
+      read_feature("encryption", "SuperSecret")
       expect(settings.use_encryption).to eq false
       expect(settings.encryption_password).to eq nil
-      read_feature("encryption_password", "SuperSecret")
+      read_feature("encryption", TestInjectedPassword.new("SuperSecret"))
       expect(settings.use_encryption).to eq true
       expect(settings.encryption_password).to eq "SuperSecret"
     end

--- a/test/y2storage/proposal_settings_test.rb
+++ b/test/y2storage/proposal_settings_test.rb
@@ -336,6 +336,15 @@ describe Y2Storage::ProposalSettings do
       expect(settings.lvm).to eq false
     end
 
+    it "sets 'encryption_password' based on the feature in the 'proposal' section" do
+      read_feature("encryption_password", "")
+      expect(settings.use_encryption).to eq false
+      expect(settings.encryption_password).to eq nil
+      read_feature("encryption_password", "SuperSecret")
+      expect(settings.use_encryption).to eq true
+      expect(settings.encryption_password).to eq "SuperSecret"
+    end
+
     it "sets 'delete_resize_configurable' based on the feature in the 'proposal' section" do
       read_feature("delete_resize_configurable", true)
       expect(settings.delete_resize_configurable).to eq true


### PR DESCRIPTION
## Problem

We want to make it possible for the Common Criteria role to provide an encryption password, so the partitioning proposal uses encryption by default.

And we want to do so in the less intrusive possible way, since we want the change to land at already released branches like 15.4 and 15.5.

## Solution

On the one hand, we implemented https://github.com/yast/system-role-common-criteria/pull/10, to make the Common Criteria role dialog ask for the encryption password and store it at the field `encryption` of the `ProductFeatures`.

On this pull request, we make sure the storage `GuidedProposal` honors the mentioned field. The storage proposal already took all its default settings from the `ProductFeatures`, but encryption was not previously considered because it makes no sense to define a given password for all the installations of a product. But `ProductFeatures` is actually a very handy mechanism to store this value without affecting any other part of the code.

## Testing

- Added a new unit test
- Tested manually together with https://github.com/yast/system-role-common-criteria/pull/10
