### PR TITLE
Ensure adding Storage Support Software Packages for MicroOS [SLE-15-SP5]

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -4,7 +4,7 @@ Wed Jul  5 13:42:12 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 - Ensure adding storage support software packages for MicroOS
   which uses its custom partitions_proposal client, not the 
   standard inst_disk_proposal client (bsc#1212452)
-  https://github.com/yast/yast-storage-ng/pull/1347
+  https://github.com/yast/yast-storage-ng/pull/1350
 - 4.5.24
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,19 @@
 -------------------------------------------------------------------
+Wed Jul  5 13:42:12 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Ensure adding storage support software packages for MicroOS
+  which uses its custom partitions_proposal client, not the 
+  standard inst_disk_proposal client (bsc#1212452)
+  https://github.com/yast/yast-storage-ng/pull/1347
+- 4.5.24
+
+-------------------------------------------------------------------
+Thu Jun 29 11:42:21 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Honor encryption settings if they are set into ProductFeatures
+  by the Common Critera role (jsc#PED-4166, jsc#PED-4474).
+
+-------------------------------------------------------------------
 Wed Jun  7 08:03:52 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Prevent setting the volume label for a mounted btrfs or swap

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.5.23
+Version:        4.5.24
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/clients/inst_disk_proposal.rb
+++ b/src/lib/y2storage/clients/inst_disk_proposal.rb
@@ -158,23 +158,7 @@ module Y2Storage
       # Add storage-related software packages (filesystem tools etc.) to the
       # set of packages to be installed.
       def add_storage_packages
-        features = storage_manager.staging.used_features
-        required_features = storage_manager.staging.used_features(required_only: true)
-
-        required_packages = required_features.pkg_list
-        optional_packages = features.pkg_list - required_packages
-
-        set_proposal_packages(required_packages, false)
-        set_proposal_packages(optional_packages, true)
-      end
-
-      # @see #add_storage_packages
-      #
-      # @param pkgs [Array<String>] list of packages
-      # @param optional [Boolean] whether the packages in the list are optional
-      def set_proposal_packages(pkgs, optional)
-        pkg_handler = Y2Storage::PackageHandler.new(pkgs, optional: optional)
-        pkg_handler.set_proposal_packages
+        Y2Storage::PackageHandler.set_proposal_packages_for(storage_manager.staging)
       end
 
       # Save the list of filesystem to /etc/sysconfig/storage.

--- a/src/lib/y2storage/clients/partitions_proposal.rb
+++ b/src/lib/y2storage/clients/partitions_proposal.rb
@@ -116,8 +116,9 @@ module Y2Storage
           staging = storage_manager.staging
           actiongraph = staging ? staging.actiongraph : nil
           self.actions_presenter = ActionsPresenter.new(actiongraph)
-          Y2Storage::DumpManager.dump(staging)
-          Y2Storage::DumpManager.dump(actions_presenter)
+          DumpManager.dump(staging)
+          DumpManager.dump(actions_presenter)
+          PackageHandler.set_proposal_packages_for(staging)
         end
       end
 

--- a/src/lib/y2storage/devicegraph.rb
+++ b/src/lib/y2storage/devicegraph.rb
@@ -612,6 +612,23 @@ module Y2Storage
       StorageFeaturesList.from_bitfield(storage_used_features(type))
     end
 
+    # List of required (mandatory) storage features used by the devicegraph
+    #
+    # @return [StorageFeaturesList]
+    def required_used_features
+      used_features(required_only: true)
+    end
+
+    # List of optional storage features used by the devicegraph
+    #
+    # @return [StorageFeaturesList]
+    def optional_used_features
+      all = storage_used_features(Storage::UsedFeaturesDependencyType_SUGGESTED)
+      required = storage_used_features(Storage::UsedFeaturesDependencyType_REQUIRED)
+      # Using binary XOR in those bit fields to calculate the difference
+      StorageFeaturesList.from_bitfield(all ^ required)
+    end
+
     private
 
     # Copy of a device tree where hashes have been substituted by sorted

--- a/src/lib/y2storage/package_handler.rb
+++ b/src/lib/y2storage/package_handler.rb
@@ -112,6 +112,21 @@ module Y2Storage
       success
     end
 
+    # Add the proposal packages for storage that are needed for the specified
+    # devicegraph's used features. This marks the packages for installation;
+    # it does not install them yet.
+    #
+    # @param devicegraph [Devicegraph] usually StorageManager.instance.staging
+    # @param optional
+    def self.set_proposal_packages_for(devicegraph, optional: true)
+      required_packages = devicegraph.required_used_features.pkg_list
+      PackageHandler.new(required_packages, optional: false).set_proposal_packages
+      return unless optional
+
+      optional_packages = devicegraph.optional_used_features.pkg_list
+      PackageHandler.new(optional_packages, optional: true).set_proposal_packages
+    end
+
     private
 
     # Whether the packages should be considered as optional when adding them to the

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -441,6 +441,23 @@ module Y2Storage
       load_feature(:proposal, :multidisk_first)
       load_size_feature(:proposal, :lvm_vg_size)
       load_volumes_feature(:volumes)
+      load_encryption
+    end
+
+    # Loads the default encryption settings
+    #
+    # The encryption settings are not part of control.xml, but can be injected by a previous step of
+    # the installation, eg. the dialog of the Common Criteria system role
+    def load_encryption
+      enc = feature(:proposal, :encryption)
+
+      return unless enc
+      return unless enc.respond_to?(:password)
+
+      passwd = enc.password.to_s
+      return if passwd.nil? || passwd.empty?
+
+      self.encryption_password = passwd
     end
 
     def validated_delete_mode(mode)

--- a/src/lib/y2storage/storage_feature.rb
+++ b/src/lib/y2storage/storage_feature.rb
@@ -125,6 +125,14 @@ module Y2Storage
       end
     end
 
+    # Drop the cache of storage packages that are available.
+    #
+    # This is only ever needed if the available packages might have changed
+    # since the last use of this class.
+    def self.drop_cache
+      @all = nil
+    end
+
     # Constructor
     #
     # This looks up a constant in the ::Storage namespace to make sure the id

--- a/test/y2storage/devicegraph_test.rb
+++ b/test/y2storage/devicegraph_test.rb
@@ -1319,4 +1319,54 @@ describe Y2Storage::Devicegraph do
       end
     end
   end
+
+  describe "#required_used_features" do
+    before { fake_scenario(scenario) }
+
+    context "with local devices combining several filesystem types" do
+      let(:scenario) { "mixed_disks" }
+
+      it "returns only the features for mounted filesystems" do
+        features = fake_devicegraph.required_used_features
+        expect(features).to be_a Y2Storage::StorageFeaturesList
+        expect(features.map(&:id))
+          .to contain_exactly(:UF_BTRFS, :UF_XFS, :UF_SWAP)
+      end
+    end
+
+    context "with an empty disk" do
+      let(:scenario) { "empty_disks" }
+
+      it "Survives not having any storage features" do
+        features = fake_devicegraph.required_used_features
+        expect(features).to be_a Y2Storage::StorageFeaturesList
+        expect(features.map(&:id)).to be == []
+      end
+    end
+  end
+
+  describe "#optional_used_features" do
+    before { fake_scenario(scenario) }
+
+    context "with local devices combining several filesystem types" do
+      let(:scenario) { "mixed_disks" }
+
+      it "returns only the features for filesystems that are not mounted" do
+        features = fake_devicegraph.optional_used_features
+        expect(features).to be_a Y2Storage::StorageFeaturesList
+        expect(features.map(&:id))
+          .to contain_exactly(:UF_EXT4, :UF_NTFS)
+      end
+    end
+
+    context "with an empty disk" do
+      let(:scenario) { "empty_disks" }
+
+      it "Survives not having any storage features" do
+        features = fake_devicegraph.optional_used_features
+        expect(features).to be_a Y2Storage::StorageFeaturesList
+        expect(features.map(&:id)).to be == []
+      end
+    end
+  end
 end

--- a/test/y2storage/proposal_settings_test.rb
+++ b/test/y2storage/proposal_settings_test.rb
@@ -35,6 +35,19 @@ describe Y2Storage::ProposalSettings do
     stub_features("partitioning" => initial_partitioning_features.merge(features))
   end
 
+  # Used to test the mechanism to inject an encryption password into the settings
+  class TestInjectedPassword
+    include Y2Storage::SecretAttributes
+
+    # Real password
+    secret_attr :password
+
+    # Constructor
+    def initialize(passwd)
+      self.password = passwd
+    end
+  end
+
   before do
     Y2Storage::StorageManager.create_test_instance
   end
@@ -331,6 +344,15 @@ describe Y2Storage::ProposalSettings do
       expect(settings.lvm).to eq true
       read_feature("lvm", false)
       expect(settings.lvm).to eq false
+    end
+
+    it "sets 'encryption_password' based on the 'encryption' feature in the 'proposal' section" do
+      read_feature("encryption", "SuperSecret")
+      expect(settings.use_encryption).to eq false
+      expect(settings.encryption_password).to eq nil
+      read_feature("encryption", TestInjectedPassword.new("SuperSecret"))
+      expect(settings.use_encryption).to eq true
+      expect(settings.encryption_password).to eq "SuperSecret"
     end
 
     it "sets 'delete_resize_configurable' based on the feature in the 'proposal' section" do

--- a/test/y2storage/storage_features_list_test.rb
+++ b/test/y2storage/storage_features_list_test.rb
@@ -22,6 +22,7 @@
 # find current contact information at www.suse.com.
 
 require_relative "spec_helper"
+require "y2storage/storage_feature"
 require "y2storage/storage_features_list"
 
 describe Y2Storage::StorageFeaturesList do
@@ -84,6 +85,7 @@ describe Y2Storage::StorageFeaturesList do
       let(:bits) { Storage::UF_NTFS | Storage::UF_EXT3 }
 
       before do
+        Y2Storage::StorageFeature.drop_cache
         allow(Yast::Package).to receive(:Available).and_return false
         allow(Yast::Package).to receive(:Available).with("ntfsprogs").and_return true
       end


### PR DESCRIPTION
## Target Branch / Product

_This is the merge to **SLE-15-SP5** of #1346 ._


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1212452


## Trello

https://trello.com/c/T9nqET80/


## Problem

On an system with a multipath storage setup, the reboot after the installation failed. It turned out that the _multipath-tools_ package was not installed.


## Cause 

A regular SLE-15-SPx or Leap 15.x or Tumbleweed installation uses the _inst_disk_proposal_ client in the installation workflow which at its end determines which storage features (e.g. Btrfs, XFS, LVM, multipath) are used and adds the software packages that are needed for those technologies to the pool of packages that are going to be installed.

But MicroOS has a different installation workflow, and it doesn't use that default _inst_disk_proposal_ client at all; instead, it uses a custom _partitions_proposal_ client to handle the storage proposal. And in that client, the packages handling was missing.


## Fix

Added the packages handling to that _partitions_proposal_ client.

To avoid code duplication, that handling was factored out from the _inst_disk_proposal_ client: It is now done by a new `PackageHandler::set_proposal_packages_for(devicegraph)` method which is now called from both clients.


## Test

- New unit tests for that new method and for fringe cases

- Manual test in a Leap 15.5 VM with the changed files to test against regressions

- Manual test in a MicroOS 5.3 VM to check if the support packages are added; changed the storage setup between the default Btrfs to a nonstandard XFS and observed the log file if the packages were added correctly.


## Installer Self-Update / Maintenance Update

- No self-update needed for SLE-15-SP5 / Leap 15.5

- The change can wait for the next QU for SLE-15-SP5 / Leap 15.5


## Related PRs

- Original PR for _SLE-15-SP4:_ #1346 
- Merge to _master_ / _Factory_: TBD