### PR TITLE
AutoYaST (SLE-15-SP5): support for advanced LUKS(2) settings

### DIFF
--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -402,6 +402,11 @@ module Y2Storage
         @loop_fs = true
         @crypt_method = method.id
         @crypt_key = CRYPT_KEY_VALUE if method.password_required?
+        enc = partition.encryption
+        @crypt_pbkdf = enc.pbkdf&.to_sym if enc.supports_pbkdf?
+        @crypt_label = enc.label if enc.supports_label? && !enc.label.empty?
+        @crypt_cipher = enc.cipher if enc.supports_cipher? && !enc.cipher.empty?
+        @crypt_key_size = enc.key_size * 8 if enc.supports_key_size? && !enc.key_size.zero?
       end
 
       def init_filesystem_fields(partition)

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -65,6 +65,10 @@ module Y2Storage
         { name: :loop_fs },
         { name: :crypt_method },
         { name: :crypt_key },
+        { name: :crypt_pbkdf },
+        { name: :crypt_label },
+        { name: :crypt_cipher },
+        { name: :crypt_key_size },
         { name: :raid_name },
         { name: :raid_options },
         { name: :mkfs_options },
@@ -103,6 +107,22 @@ module Y2Storage
 
       # @!attribute crypt_key
       #   @return [String] encryption key
+
+      # @!attribute crypt_pbkdf
+      #   @return [Symbol,nil] password-based derivation function for LUKS2 (:pbkdf2, :argon2i,
+      #     :argon2id). See {Y2Storage::PbkdFunction}.
+
+      # @!attribute crypt_label
+      #   @return [String,nil] LUKS label if LUKS2 is going to be used
+
+      # @!attribute crypt_cipher
+      #   @return [String,nil] specific cipher if LUKS is going to be used
+      #
+      # @!attribute crypt_key_size
+      #   Specific key size (in bits) if LUKS is going to be used
+      #
+      #   @return [Integer,nil] If nil, the default key size will be used. If an integer
+      #     value is used, it has to be a multiple of 8.
 
       # @!attribute filesystem
       #   @return [Symbol] file system type to use in the partition, it also

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -63,9 +63,25 @@ module Y2Storage
     storage_forward :key_file=
 
     # @!attribute cipher
-    #   @return [String] the encryption cipher
+    #   The encryption cipher
+    #
+    #   Currently only supported for LUKS
+    #
+    #   @return [String] if empty, the default of cryptsetup will be used during creation
     storage_forward :cipher
     storage_forward :cipher=
+
+    # @!attribute key_size
+    #   The key size in bytes
+    #
+    #   Currently only supported for LUKS
+    #
+    #   Note the value is expressed in bytes. That's dictated by libstorage-ng, even when cryptsetup
+    #   and all the LUKS-related documentation use bits for expressing the key size.
+    #
+    #   @return [Integer] if zero, the default of cryptsetup will be used during creation
+    storage_forward :key_size
+    storage_forward :key_size=
 
     # @!attribute pbkdf_value
     #   String representation of {#pbkdf}, an empty string is equivalent to a nil value on {#pbkdf}
@@ -427,6 +443,27 @@ module Y2Storage
     # @return [Boolean]
     def supports_pbkdf?
       type.is?(:luks2)
+    end
+
+    # Whether the attribute #label makes sense for this object
+    #
+    # @return [Boolean]
+    def supports_label?
+      type.is?(:luks2)
+    end
+
+    # Whether the attribute #cipher makes sense for this object
+    #
+    # @return [Boolean]
+    def supports_cipher?
+      type.is?(:luks1, :luks2)
+    end
+
+    # Whether the attribute #key_size makes sense for this object
+    #
+    # @return [Boolean]
+    def supports_key_size?
+      type.is?(:luks1, :luks2)
     end
 
     protected

--- a/src/lib/y2storage/encryption_method/luks2.rb
+++ b/src/lib/y2storage/encryption_method/luks2.rb
@@ -23,6 +23,8 @@ require "y2storage/encryption_method/pervasive_luks2"
 require "y2storage/encryption_processes/luks"
 require "y2storage/pbkd_function"
 
+Yast.import "Mode"
+
 module Y2Storage
   module EncryptionMethod
     # The encryption method that allows to create and identify an encrypted device using regular
@@ -60,7 +62,8 @@ module Y2Storage
 
       # @see Base#available?
       def available?
-        StorageEnv.instance.luks2_available?
+        # jsc#PED-3878 and jsc#GEHC-6
+        Yast::Mode.auto || StorageEnv.instance.luks2_available?
       end
 
       private

--- a/test/y2storage/autoinst_proposal_encryption_test.rb
+++ b/test/y2storage/autoinst_proposal_encryption_test.rb
@@ -1,0 +1,248 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+
+describe Y2Storage::AutoinstProposal do
+  before do
+    fake_scenario(scenario)
+
+    allow(Yast::Mode).to receive(:auto).and_return(true)
+  end
+
+  subject(:proposal) do
+    described_class.new(
+      partitioning: partitioning, devicegraph: fake_devicegraph, issues_list: issues_list
+    )
+  end
+
+  let(:scenario) { "empty_disks" }
+  let(:issues_list) { ::Installation::AutoinstIssues::List.new }
+
+  let(:partitioning) do
+    [
+      {
+        "device" => "/dev/sda",
+        "type" => :CT_DISK, "use" => "all", "initialize" => true, "disklabel" => "gpt",
+        "partitions" => partitions
+      }
+    ]
+  end
+
+  let(:partitions) { [partition] }
+
+  describe "#propose" do
+    context "when creating a LUKS2 device with default options" do
+      let(:partition) do
+        { "mount" => "/", "crypt_key" => "s3cr3t", "crypt_method" => :luks2 }
+      end
+
+      it "encrypts the device with LUKS2 as encryption method" do
+        proposal.propose
+        enc = proposal.devices.encryptions.first
+        expect(enc.method).to eq Y2Storage::EncryptionMethod::LUKS2
+      end
+
+      it "does not set any LUKS label" do
+        proposal.propose
+        enc = proposal.devices.encryptions.first
+        expect(enc.label).to eq ""
+      end
+
+      it "does not set any derivation function, cipher or key size" do
+        proposal.propose
+        enc = proposal.devices.encryptions.first
+        expect(enc.pbkdf).to be_nil
+        expect(enc.cipher).to eq ""
+        expect(enc.key_size).to be_zero
+      end
+
+      it "does not register any issue" do
+        proposal.propose
+        expect(issues_list).to be_empty
+      end
+    end
+
+    context "when creating a LUKS2 device with a given password derivation function" do
+      let(:partition) do
+        { "mount" => "/", "crypt_key" => "s3cr3t", "crypt_method" => :luks2, "crypt_pbkdf" => :argon2i }
+      end
+
+      it "uses the corresponding derivation function" do
+        proposal.propose
+        enc = proposal.devices.encryptions.first
+        expect(enc.pbkdf).to eq Y2Storage::PbkdFunction::ARGON2I
+      end
+
+      it "does not register any issue" do
+        proposal.propose
+        expect(issues_list).to be_empty
+      end
+    end
+
+    context "when creating a LUKS2 device with an unsupported password derivation function" do
+      let(:partition) do
+        { "mount" => "/", "crypt_key" => "s3cr3t", "crypt_method" => :luks2, "crypt_pbkdf" => :wrong }
+      end
+
+      it "does not enforce any derivation function" do
+        proposal.propose
+        enc = proposal.devices.encryptions.first
+        expect(enc.pbkdf).to be_nil
+      end
+
+      it "register an AutoinstIssues::InvalidValue warning" do
+        proposal.propose
+        expect(issues_list).to_not be_empty
+        issue = issues_list.first
+        expect(issue.class).to eq Y2Storage::AutoinstIssues::InvalidValue
+        expect(issue.attr).to eq :crypt_pbkdf
+      end
+    end
+
+    context "when creating a LUKS2 device with given cipher and key size" do
+      let(:partition) do
+        {
+          "mount" => "/", "crypt_key" => "s3cr3t", "crypt_method" => :luks2,
+          "crypt_cipher" => "aes-xts-plain64", "crypt_key_size" => 512
+        }
+      end
+
+      it "uses the corresponding cipher and key size" do
+        proposal.propose
+        enc = proposal.devices.encryptions.first
+        expect(enc.cipher).to eq "aes-xts-plain64"
+        # libstorage-ng uses bytes instead of bits to represent the key size, contrary to all LUKS
+        # documentation and to cryptsetup
+        expect(enc.key_size).to eq 64
+      end
+
+      it "does not register any issue" do
+        proposal.propose
+        expect(issues_list).to be_empty
+      end
+    end
+
+    context "when creating a LUKS2 device with an invalid key size" do
+      let(:partition) do
+        { "mount" => "/", "crypt_key" => "s3cr3t", "crypt_method" => :luks2, "crypt_key_size" => 12 }
+      end
+
+      it "does not enforce any key size" do
+        proposal.propose
+        enc = proposal.devices.encryptions.first
+        expect(enc.key_size).to be_zero
+      end
+
+      it "register an AutoinstIssues::InvalidValue warning" do
+        proposal.propose
+        expect(issues_list).to_not be_empty
+        issue = issues_list.first
+        expect(issue.class).to eq Y2Storage::AutoinstIssues::InvalidValue
+        expect(issue.attr).to eq :crypt_key_size
+      end
+    end
+
+    context "when creating a LUKS2 device with a given LUKS label" do
+      let(:partition) do
+        { "mount" => "/", "crypt_key" => "s3cr3t", "crypt_method" => :luks2, "crypt_label" => "crpt" }
+      end
+
+      it "sets the label in the LUKS device" do
+        proposal.propose
+        enc = proposal.devices.encryptions.first
+        expect(enc.label).to eq "crpt"
+      end
+
+      it "does not register any issue" do
+        proposal.propose
+        expect(issues_list).to be_empty
+      end
+    end
+
+    context "when creating a LUKS1 device with a given password derivation function" do
+      let(:partition) do
+        { "mount" => "/", "crypt_key" => "s3cr3t", "crypt_method" => :luks1, "crypt_pbkdf" => :argon2i }
+      end
+
+      it "does not enforce any derivation function" do
+        proposal.propose
+        enc = proposal.devices.encryptions.first
+        expect(enc.method).to eq Y2Storage::EncryptionMethod::LUKS1
+        expect(enc.pbkdf).to be_nil
+      end
+
+      it "does not register any issue" do
+        proposal.propose
+        expect(issues_list).to be_empty
+      end
+    end
+
+    context "when creating a LUKS1 device with a LUKS label" do
+      let(:partition) do
+        { "mount" => "/", "crypt_key" => "s3cr3t", "crypt_method" => :luks1, "crypt_label" => "crpt" }
+      end
+
+      it "does not set the label" do
+        proposal.propose
+        enc = proposal.devices.encryptions.first
+        expect(enc.method).to eq Y2Storage::EncryptionMethod::LUKS1
+        expect(enc.label).to be_empty
+      end
+
+      it "does not register any issue" do
+        proposal.propose
+        expect(issues_list).to be_empty
+      end
+    end
+
+    context "when creating a SECURE_SWAP device with given cipher and key size" do
+      before do
+        allow_any_instance_of(Y2Storage::EncryptionMethod::SecureSwap).to receive(:available?)
+          .and_return(true)
+      end
+
+      let(:partitions) do
+        [
+          { "mount" => "/" },
+          {
+            "mount" => "swap", "crypt_method" => :secure_swap,
+            "crypt_cipher" => "aes-xts-plain64", "crypt_key_size" => 512
+          }
+        ]
+      end
+
+      it "ignores the given cipher and key size" do
+        proposal.propose
+        enc = proposal.devices.encryptions.first
+        expect(enc.method).to eq Y2Storage::EncryptionMethod::SECURE_SWAP
+        expect(enc.cipher).to eq ""
+        expect(enc.key_size).to be_zero
+      end
+
+      it "does not register any issue" do
+        proposal.propose
+        expect(issues_list).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

AutoYaST does not officially support LUKS2 or setting any of its advanced options.

In fact, preliminary support for LUKS2 was added to YaST at SLE-15-SP4 targeting only the interactive installation. That's explained at the description of #1245. Since there was no feedback about it, the feature was not developed any further.

As a consequence, LUKS2 works partially in AutoYaST if the boot argument `YAST_LUKS2_AVAILABLE` is used during installation. But there is no way to configure via AutoYaST some of the parameters than can be tweaked in the UI (like the PBKDF or the LUKS2 label). LUKS2 support for AutoYaST is not even officially documented.

But some SUSE customers want to configure LUKS2 devices during installation using AutoYaST, tweaking some of the luksFormat parameters. Even on already released versions of SLE.

## Solution

This pull request removes the need to use `YAST_LUKS2_AVAILABLE` for using LUKS2 with AutoYaST. It's still needed in interactive installation or the UI corresponding to LUKS2 will be hidden.

This also adds support for four new attributes in a `<partition>` section of AutoYaST: `<crypt_pbkdf>`, `<crypt_label>`, `<crypt_cipher>` and `<crypt_key_size>`.

Those new attributes are honored when present in an AutoYaST profile (in those cases that make sense) and are also exported to the generated AutoYaST profile when cloning the system.

This pull request targets SLE-15-SP5, but it's still not clear for which version of SLES/Leap will this finally be released (there are security and testing implications).

## Extra

This pull request also includes a relatively big commit to refactor a bit the class `Y2Storage::AutoinstProfile::PartitionSection`, encapsulating the logic for exporting (ie. cloning the system) into an new inner class `PartitionExporter`.

That was triggered by Rubocop complaining about `PartitionSection` being too long and complex.

The refactoring is far from being a final solution, but it's likely a step into the right direction without introducing much disruption (despite its size, the commit actually just relocates and reorganizes existing code well covered by unit tests).

## Testing

This pull request includes automated unit tests to verify the following aspects:

- The new attributes `<crypt_cipher>` and `<crypt_key_size>` are honored for devices encrypted with the LUKS1 and LUKS2 encryption methods.
- The new attributes `<crypt_pbkdf>` and `<crypt_label>` are honored for devices encrypted with the LUKS2 encryption method.
- The four attributes are ignored for all other encryptions methods (like SECURE_SWAP).
- AutoYaST suggests to create an extra unencrypted `/boot` partition if LUKS2 is used for root with a password-based key derivation function not supported by Grub2.
- AutoYaST does not suggest a separate `/boot`  if root is encrypted with LUKS2 using PBKDF2 as derivation function.
- Cloning a system writes the new attributes to the AutoYaST profile if they are known and make sense.

But apart from all those unit tests, this pull request has been successfully tested in a patched SLE-15-SP5 with the following AutoYaST definition. The result looks as expected.

```xml
<partitions t="list">
  <partition>
    <create t="boolean">true</create>
    <filesystem t="symbol">xfs</filesystem>
    <format t="boolean">true</format>
    <mount>/</mount>
    <size>12G</size>
  </partition>
  <partition>
    <create t="boolean">true</create>
    <filesystem t="symbol">xfs</filesystem>
    <mount>/home/crypt1</mount>
    <size>3G</size>
    <crypt_method t="symbol">luks2</crypt_method>
    <crypt_key>linuxlinux</crypt_key>
    <crypt_label>aesPBKDF2</crypt_label>
    <crypt_pbkdf t="symbol">pbkdf2</crypt_pbkdf>
  </partition>
  <partition>
    <create t="boolean">true</create>
    <filesystem t="symbol">xfs</filesystem>
    <mount>/home/crypt2</mount>
    <size>3G</size>
    <crypt_method t="symbol">luks2</crypt_method>
    <crypt_key>linuxlinux</crypt_key>
    <crypt_cipher>capi:xts(aes)-plain64</crypt_cipher>
  </partition>
  <partition>
    <create t="boolean">true</create>
    <filesystem t="symbol">xfs</filesystem>
    <mount>/home/crypt3</mount>
    <size>3G</size>
    <crypt_method t="symbol">luks2</crypt_method>
    <crypt_key>linuxlinux</crypt_key>
    <crypt_key_size t="integer">256</crypt_key_size>
  </partition>
  <partition>
    <create t="boolean">true</create>
    <filesystem t="symbol">xfs</filesystem>
    <mount>/home/crypt4</mount>
    <size>3G</size>
    <crypt_method t="symbol">luks2</crypt_method>
    <crypt_key>linuxlinux</crypt_key>
    <crypt_pbkdf t="symbol">argon2i</crypt_pbkdf>
    <crypt_label>twoFish512</crypt_label>
    <crypt_cipher>twofish-xts-plain64</crypt_cipher>
    <crypt_key_size t="integer">512</crypt_key_size>
  </partition>
  <partition>
    <create t="boolean">true</create>
    <filesystem t="symbol">xfs</filesystem>
    <mount>/home/crypt5</mount>
    <size>3G</size>
    <crypt_method t="symbol">luks1</crypt_method>
    <crypt_key>linuxlinux</crypt_key>
  </partition>
</partitions>
```

## Dependencies

This depends on the corresponding updates on two other repositories: yast-autoyast and yast-schema.