### PR TITLE
Support probing of linear RAIDs

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep 13 08:41:15 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- New MdLevel value for linear RAIDs (bsc#1215022)
+- 4.4.46
+
+-------------------------------------------------------------------
 Wed Jul  5 13:42:12 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Ensure adding storage support software packages for MicroOS

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.4.45
+Version:        4.4.46
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/autoinst_profile/raid_options_section.rb
+++ b/src/lib/y2storage/autoinst_profile/raid_options_section.rb
@@ -90,11 +90,28 @@ module Y2Storage
       # @param md [Md] RAID device
       def init_from_raid(md)
         @raid_name = md.name unless md.numeric?
-        @raid_type = md.md_level.to_s
+        @raid_type = clone_md_level(md).to_s
         # A number will be interpreted as KB, so we explicitly set the unit.
         @chunk_size = "#{md.chunk_size.to_i}B"
         @parity_algorithm = md.md_parity.to_s
         @device_order = md.sorted_devices.map(&:name)
+      end
+
+      private
+
+      # MD level to be used at {#init_from_raid}
+      #
+      # This is a temporary method, created in the context of bsc#1215022, to avoid creating
+      # entries with "<raid_type>linear</raid_type>" in the AutoYaST profile when cloning the
+      # system. That may lead to the false impression that creation of linear RAIDs with YaST
+      # is supported.
+      #
+      # In more modern branches, the case of linear RAIDs will probably be handled differently.
+      #
+      # @param md [Md] RAID device
+      # @return [MdLevel]
+      def clone_md_level(md)
+        md.md_level.is?(:linear) ? MdLevel::UNKNOWN : md.md_level
       end
     end
   end

--- a/src/lib/y2storage/md_level.rb
+++ b/src/lib/y2storage/md_level.rb
@@ -38,7 +38,9 @@ module Y2Storage
       raid5:     N_("RAID5"),
       raid6:     N_("RAID6"),
       raid10:    N_("RAID10"),
-      container: N_("Container")
+      container: N_("Container"),
+      # TRANSLATOR: RAID level for linear RAIDs
+      linear:    N_("Linear")
     }
     private_constant :TRANSLATIONS
 


### PR DESCRIPTION
## Problem

libstorage-ng and YaST used to lack support for the RAID level "linear". That leaded to errors during probing in a system with such RAIDs. See [bsc#1215022](https://bugzilla.suse.com/show_bug.cgi?id=1215022).

To fix the problem, support for a new `MdLevel::LINEAR` was added to libstorage-ng. But yast2-storage-ng needs the corresponding adaptations to the new MD level.

To be precise, we want YaST to stop failing in presence of such a RAID, but we don't want to add support to create new ones.

## Solution

This targets SLE-15-SP4, only as a fix for the reported bug.

Adds the code needed to recognize the new level added to libstorage-ng, so probing works and the RAIDs are properly represented (eg. in the Expert Partitioner).

This also adds basic handling at AutoYaST. Basically preventing the `<raid_level>` to be cloned as "linear". If a linear RAID is detected in the system it will be exported with an unknown RAID level. That's a first step (the solution will be refined in subsequent versions) to clearly state that such a RAID level is not supported by (Auto)YaST.

## Testing

Tested manually with a patched SLE-15-SP4
