### PR TITLE
Speed-up tests a bit in systems with slow hwinfo

### DIFF
--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -136,6 +136,9 @@ RSpec.configure do |c|
       end
     end
 
+    allow(Y2Storage::HWInfoReader.instance).to receive(:for_device)
+      .and_return Y2Storage::HWInfoDisk.new
+
     # Bcache is only supported for x86_64 architecture. Probing the devicegraph complains if Bcache is
     # used with another architecture. Bcache error is avoided here. Otherwise, x86_84 architecture must
     # to be set for every test using Bcache (which has demonstrated to be quite error prone).

--- a/test/y2storage/hwinfo_reader_test.rb
+++ b/test/y2storage/hwinfo_reader_test.rb
@@ -29,6 +29,9 @@ describe Y2Storage::HWInfoReader do
   let(:hwinfo_file) { "hwinfo.txt" }
 
   before do
+    # Disable the global mock that normally prevents calls to hwinfo
+    allow(reader).to receive(:for_device).and_call_original
+
     allow(Yast::Execute).to receive(:on_target!)
       .with(/hwinfo/, anything, anything, anything).and_return(hwinfo_output)
     reader.reset


### PR DESCRIPTION
## Problem

The testsuite used to run in around 2-4 minutes in my personal system.

We have always known that we should be more aggressive mocking calls to `hwinfo` and some libstorage-ng operations (mostly those that result in calls to `udevadm --settle`). But even without that mocking, the situation was still acceptable.

Recently things became MUCH worse. Now the testsuite is much slower. I was not able to find what caused it. No luck bisecting the changes in the repository, so I guess the problem is somewhere else (some combination of changes in libstorage-ng or another YaST package, Ruby, the Tumbleweed kernel, udev and whatnot).

## Solution

Even if the source of the recent slow-down is still there, I decided to introduce the long-overdue mocking for `hwinfo` in order to mitigate the problem.

Now the execution time is acceptable again, even if there is still room for improvement (if someone can find why/how at some point we went from a couple of minutes to ~10mins).