### PR TITLE
Add internal setting to configure swap reusing in GuidedProposal

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Oct 19 14:46:45 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- GuidedProposal: new internal setting to control how existing
+  swap partitions are reused. Relevant for Agama and related to
+  bsc#1175535 and bsc#1215639.
+- 5.0.3
+
+-------------------------------------------------------------------
 Wed Oct 11 08:41:15 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - New MdLevel value for linear RAIDs (bsc#1215022)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.2
+Version:        5.0.3
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/proposal/devices_planner.rb
+++ b/src/lib/y2storage/proposal/devices_planner.rb
@@ -93,7 +93,7 @@ module Y2Storage
       # @param required_size [DiskSize]
       # @return [Partition]
       def reusable_swap(required_size)
-        return nil if skip_swap_reuse?
+        return nil unless try_to_reuse_swap?
 
         partitions = available_swap_partitions
         partitions.select! { |part| can_be_reused?(part, required_size) }
@@ -108,11 +108,11 @@ module Y2Storage
         devicegraph.partitions.select(&:swap?)
       end
 
-      # Whether reusing swap partitions is pointless
+      # Whether it makes sense to try to reuse existing swap partitions
       #
       # @return [Boolean]
-      def skip_swap_reuse?
-        settings.use_lvm || settings.use_encryption || settings.swap_reuse == :none
+      def try_to_reuse_swap?
+        !settings.use_lvm && !settings.use_encryption && settings.swap_reuse != :none
       end
 
       # Whether it is acceptable to reuse the given swap partition

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -62,6 +62,15 @@ module Y2Storage
     #   available candidate devices.
     attr_accessor :multidisk_first
 
+    # Criteria to use if it is possible to reuse an existing swap partition
+    #
+    #   * :any reuse a suitable swap partition from any disk, default historical behavior of YaST
+    #   * :none do not reuse existing swap partitions
+    #   * :candidate reuse a suitable partition only if it is located in a candidate disk
+    #
+    # @return [:any, :none, :candidate]
+    attr_accessor :swap_reuse
+
     # Device name of the disk in which '/' must be placed.
     #
     # If it's set to nil and {#allocate_volume_mode} is :auto, the proposal will try
@@ -388,6 +397,7 @@ module Y2Storage
       other_delete_mode:          :ondemand,
       resize_windows:             true,
       separate_vgs:               false,
+      swap_reuse:                 :any,
       volumes:                    [],
       windows_delete_mode:        :ondemand
     }

--- a/test/data/devicegraphs/autoyast_drive_examples.yml
+++ b/test/data/devicegraphs/autoyast_drive_examples.yml
@@ -40,9 +40,9 @@
     - partition:
         size:         1 GiB
         name:         /dev/dasdb1
+        id:           swap
         file_system:  swap
-        mount_point:  swap
-        label:        swap
+        label:        swap_dasdb
 
     - partition:
         size:         6 GiB
@@ -73,8 +73,7 @@
         name:         /dev/sdc2
         id:           swap
         file_system:  swap
-        mount_point:  swap
-        label:        swap
+        label:        swap_sdc
 
     - partition:
         size:         20 GiB
@@ -162,7 +161,7 @@
         type: logical
         id: swap
         file_system: swap
-        mount_point: swap
+        label: swap_sdd
 
     - partition:
         size: 10 GiB
@@ -215,6 +214,7 @@
         type: logical
         id: swap
         file_system: swap
+        label: swap_sdf
 
     - partition:
         size: 10 GiB
@@ -265,8 +265,7 @@
         name:         /dev/sdaa2
         id:           swap
         file_system:  swap
-        mount_point:  swap
-        label:        swap
+        label:        swap_sdaa
 
     - partition:
         size:         20 GiB
@@ -328,7 +327,7 @@
         name:         /dev/sdh3
         id:           swap
         file_system:  swap
-        mount_point:  swap
+        label:        swap_sdh
 
 # Btrfs with default_subvolume set to ""
 - disk:

--- a/test/y2storage/proposal_swap_reuse_test.rb
+++ b/test/y2storage/proposal_swap_reuse_test.rb
@@ -1,0 +1,147 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "storage"
+require "y2storage"
+require_relative "#{TEST_PATH}/support/proposal_examples"
+require_relative "#{TEST_PATH}/support/proposal_context"
+
+describe Y2Storage::GuidedProposal do
+  describe "#propose in a system with pre-existing swap partitions" do
+    subject(:proposal) { described_class.new(settings: settings) }
+
+    include_context "proposal"
+    let(:architecture) { :x86 }
+    let(:settings_format) { :ng }
+    let(:control_file_content) do
+      { "partitioning" => { "volumes" => volumes } }
+    end
+
+    let(:scenario) { "autoyast_drive_examples" }
+
+    let(:volumes) { [root_vol, swap_vol] }
+    let(:root_vol) do
+      { "mount_point" => "/", "fs_type" => "xfs", "min_size" => "5 GiB", "max_size" => "30 GiB" }
+    end
+    let(:swap_vol) do
+      { "mount_point" => "swap", "fs_type" => "swap", "min_size" => "500 MiB", "max_size" => "2 GiB" }
+    end
+
+    RSpec.shared_examples "reuse best swap" do
+      it "reuses the pre-existing swap with more suitable size" do
+        proposal.propose
+        dasdb1 = proposal.devices.find_by_name("/dev/dasdb1")
+        expect(dasdb1.exists_in_probed?).to eq true
+        expect(dasdb1).to have_attributes(
+          # This proves is mounted as swap
+          filesystem_mountpoint: "swap",
+          # This proves is not re-formatted
+          filesystem_label:      "swap_dasdb",
+          size:                  Y2Storage::DiskSize.GiB(1)
+        )
+      end
+    end
+
+    RSpec.shared_examples "new swap" do
+      it "creates a new swap partition" do
+        proposal.propose
+        swap = proposal.devices.partitions.find { |p| p.filesystem&.mount_path == "swap" }
+        expect(swap.exists_in_probed?).to eq false
+        # All preexisting partitions have some label
+        expect(swap.filesystem.label).to be_empty
+      end
+    end
+
+    before { settings.candidate_devices = [candidate] }
+
+    context "when swap_reuse is set to :any" do
+      before { settings.swap_reuse = :any }
+
+      context "and there is no swap in the candidate devices" do
+        let(:candidate) { "/dev/sda" }
+
+        include_examples "reuse best swap"
+      end
+
+      context "and there is a swap device (not the best regarding size) in the candidate devices" do
+        let(:candidate) { "/dev/sdc" }
+
+        include_examples "reuse best swap"
+      end
+
+      context "and the best swap device in the candidate devices" do
+        let(:candidate) { "/dev/dasdb" }
+
+        include_examples "reuse best swap"
+      end
+    end
+
+    context "when swap_reuse is set to :none" do
+      before { settings.swap_reuse = :none }
+
+      context "and there is no swap in the candidate devices" do
+        let(:candidate) { "/dev/sda" }
+
+        include_examples "new swap"
+      end
+
+      context "and there is a swap device (not the biggest one) in the candidate devices" do
+        let(:candidate) { "/dev/sdc" }
+
+        include_examples "new swap"
+      end
+
+      context "and the biggest swap device in the candidate devices" do
+        let(:candidate) { "/dev/dasdb" }
+
+        include_examples "new swap"
+      end
+    end
+
+    context "when swap_reuse is set to :candidate" do
+      before { settings.swap_reuse = :candidate }
+
+      context "and there is no swap in the candidate devices" do
+        let(:candidate) { "/dev/sda" }
+
+        include_examples "new swap"
+      end
+
+      context "and there is a swap device (not the biggest one) in the candidate devices" do
+        let(:candidate) { "/dev/sdc" }
+
+        it "reuses the swap partition from the candidate devices" do
+          proposal.propose
+          swap = proposal.devices.partitions.find { |p| p.filesystem&.mount_path == "swap" }
+          expect(swap.exists_in_probed?).to eq true
+          expect(swap.name).to eq "/dev/sdc2"
+          expect(swap.filesystem.label).to eq "swap_sdc"
+        end
+      end
+
+      context "and the biggest swap device in the candidate devices" do
+        let(:candidate) { "/dev/dasdb" }
+
+        include_examples "reuse best swap"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Currently YaST’s guided storage proposal reuses any available swap, even if that swap is not in the candidate devices.

That’s the traditional behavior inherited from the SLE-12 times. Although it has been reported as confusing at https://bugzilla.suse.com/show_bug.cgi?id=1175535 and https://bugzilla.suse.com/show_bug.cgi?id=1215639 .

It’s still not decided which possibilities we want to use regarding re-use of partitions at Agama. But while we decide what to do in Agama, the current behavior of reusing swap is confusing because it’s not clear what is happening looking at the UI.

## Solution

This implements a new setting at `ProposalSettings` to fine-tune swap reusing at the `GuidedProposal`. It has three possible values:

- `:any` Current behavior. For keeping compatibility in YaST.
- `:none` Simply don’t reuse any swap. This will be used by Agama while we decide what to do.
- `:candidate` Only reuse swaps that are in the candidate disks.

YaST keeps using `:any` and there is no plan to make that configurable in AutoYaST or in the YaST UI, although the modes `:none` and `:candidate` can easily be part of a future solution for the mentioned bug reports.

## Testing

Added new unit tests. Not tested with YaST in a real system, but the change looks safe enough.

Tested with a modified version of Agama that sets the new setting to `:none`. Works as expected.