### PR TITLE
Handling of YAST_REUSE_LVM linuxrc option

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Feb 14 09:11:06 UTC 2024 - Michal Filka <mfilka@suse.com>
+
+- jsc#PED-6407
+  - new env variable YAST_REUSE_LVM for reusing LVM in new
+    installation. It can be used as linuxrc boot param.
+- 4.6.15
+
+-------------------------------------------------------------------
 Wed Oct 11 08:41:15 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - New MdLevel value for linear RAIDs (bsc#1215022)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.6.14
+Version:        4.6.15
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/proposal/lvm_helper.rb
+++ b/src/lib/y2storage/proposal/lvm_helper.rb
@@ -21,7 +21,6 @@ require "fileutils"
 require "y2storage/disk_size"
 require "y2storage/exceptions"
 require "y2storage/planned/lvm_vg"
-require "y2storage/storage_env"
 
 module Y2Storage
   module Proposal

--- a/src/lib/y2storage/proposal/lvm_helper.rb
+++ b/src/lib/y2storage/proposal/lvm_helper.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2015] SUSE LLC
+#eCopyright (c) [2015] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -21,6 +21,7 @@ require "fileutils"
 require "y2storage/disk_size"
 require "y2storage/exceptions"
 require "y2storage/planned/lvm_vg"
+require "y2storage/storage_env"
 
 module Y2Storage
   module Proposal
@@ -166,9 +167,9 @@ module Y2Storage
       # @return [Boolean]
       def try_to_reuse?
         # Setting introduced to completely avoid LVM reusing in D-Installer.
-        # It's a new playground, so no need to carry YaST behaviors that have
-        # proven to be confusing.
-        return false if settings.lvm_vg_reuse == false
+        # However it happened to be handy even in old yast later on. Preset
+        # settings can get overwritten by Linuxrc boot param.
+        return false if StorageEnv.instance.reuse_lvm? == false || settings.lvm_vg_reuse == false
 
         # We introduced this when we still didn't have a mechanism to activate
         # existing LUKS. Now such mechanism exists but this check has never been

--- a/src/lib/y2storage/proposal/lvm_helper.rb
+++ b/src/lib/y2storage/proposal/lvm_helper.rb
@@ -167,9 +167,7 @@ module Y2Storage
       # @return [Boolean]
       def try_to_reuse?
         # Setting introduced to completely avoid LVM reusing in D-Installer.
-        # However it happened to be handy even in old yast later on. Preset
-        # settings can get overwritten by Linuxrc boot param.
-        return false if StorageEnv.instance.reuse_lvm? == false || settings.lvm_vg_reuse == false
+        return false if settings.lvm_vg_reuse == false
 
         # We introduced this when we still didn't have a mechanism to activate
         # existing LUKS. Now such mechanism exists but this check has never been

--- a/src/lib/y2storage/proposal/lvm_helper.rb
+++ b/src/lib/y2storage/proposal/lvm_helper.rb
@@ -1,4 +1,4 @@
-#eCopyright (c) [2015] SUSE LLC
+# Copyright (c) [2015] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -29,6 +29,7 @@ require "y2storage/volume_specifications_set"
 require "y2storage/encryption_method"
 require "y2storage/equal_by_instance_variables"
 require "y2storage/proposal_space_settings"
+require "y2storage/storage_env"
 
 module Y2Storage
   # Class to manage settings used by the proposal (typically read from control.xml)

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -424,7 +424,6 @@ module Y2Storage
       load_feature(:proposal, :other_delete_mode)
       load_feature(:proposal, :delete_resize_configurable)
       load_feature(:proposal, :lvm_vg_strategy)
-      load_feature(:proposal, :lvm_vg_reuse)
       load_feature(:proposal, :allocate_volume_mode)
       load_feature(:proposal, :multidisk_first)
       load_size_feature(:proposal, :lvm_vg_size)

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -236,6 +236,7 @@ module Y2Storage
     def for_current_product
       apply_defaults
       load_features
+      apply_user_enforced
     end
 
     # Produces a deep copy of settings
@@ -399,6 +400,14 @@ module Y2Storage
       DEFAULTS.each do |key, value|
         send(:"#{key}=", value) if send(key).nil?
       end
+    end
+
+    # Some values can be explicitly enforced by user
+    # This setting should have precendence over everything else
+    def apply_user_enforced
+      value = StorageEnv.instance.reuse_lvm?
+
+      send(:lvm_vg_reuse, StorageEnv.instance.reuse_lvm?) if !value.nil?
     end
 
     # Overrides the settings with values read from the YaST product features

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -414,6 +414,7 @@ module Y2Storage
       load_feature(:proposal, :other_delete_mode)
       load_feature(:proposal, :delete_resize_configurable)
       load_feature(:proposal, :lvm_vg_strategy)
+      load_feature(:proposal, :lvm_vg_reuse)
       load_feature(:proposal, :allocate_volume_mode)
       load_feature(:proposal, :multidisk_first)
       load_size_feature(:proposal, :lvm_vg_size)

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -406,9 +406,9 @@ module Y2Storage
     # Some values can be explicitly enforced by user
     # This setting should have precendence over everything else
     def apply_user_enforced
-      value = StorageEnv.instance.reuse_lvm?
+      value = StorageEnv.instance.requested_lvm_reuse
 
-      send(:lvm_vg_reuse, StorageEnv.instance.reuse_lvm?) if !value.nil?
+      send(:lvm_vg_reuse=, StorageEnv.instance.requested_lvm_reuse) if !value.nil?
     end
 
     # Overrides the settings with values read from the YaST product features

--- a/src/lib/y2storage/storage_env.rb
+++ b/src/lib/y2storage/storage_env.rb
@@ -100,9 +100,9 @@ module Y2Storage
     def requested_lvm_reuse
       value = read(ENV_REUSE_LVM)
 
-      return env_str_to_bool(value) if value
+      return nil if !value
 
-      nil
+      env_str_to_bool(value)
     end
 
     # Whether errors during libstorage probing should be ignored.

--- a/src/lib/y2storage/storage_env.rb
+++ b/src/lib/y2storage/storage_env.rb
@@ -96,9 +96,9 @@ module Y2Storage
     #
     # see jsc#PED-6407 or jsc#IBM-1315
     #
-    # @return [Boolean]
+    # @return [Boolean, nil] boolean as explicitly set by user, nil if user set nothing
     def reuse_lvm?
-      active?(ENV_REUSE_LVM, default: true)
+      active?(ENV_REUSE_LVM, default: nil)
     end
 
     # Whether errors during libstorage probing should be ignored.

--- a/src/lib/y2storage/storage_env.rb
+++ b/src/lib/y2storage/storage_env.rb
@@ -97,7 +97,7 @@ module Y2Storage
     # see jsc#PED-6407 or jsc#IBM-1315
     #
     # @return [Boolean, nil] boolean as explicitly set by user, nil if user set nothing
-    def reuse_lvm?
+    def requested_lvm_reuse
       active?(ENV_REUSE_LVM, default: nil)
     end
 

--- a/src/lib/y2storage/storage_env.rb
+++ b/src/lib/y2storage/storage_env.rb
@@ -36,8 +36,11 @@ module Y2Storage
 
     ENV_LIBSTORAGE_IGNORE_PROBE_ERRORS = "LIBSTORAGE_IGNORE_PROBE_ERRORS".freeze
 
+    ENV_REUSE_LVM = "YAST_REUSE_LVM".freeze
+
     private_constant :ENV_MULTIPATH, :ENV_BIOS_RAID, :ENV_ACTIVATE_LUKS, :ENV_LUKS2_AVAILABLE
     private_constant :ENV_LIBSTORAGE_IGNORE_PROBE_ERRORS
+    private_constant :ENV_REUSE_LVM
 
     def initialize
       reset_cache
@@ -87,6 +90,15 @@ module Y2Storage
     # @return [Boolean]
     def luks2_available?
       active?(ENV_LUKS2_AVAILABLE, default: false)
+    end
+
+    # Whether YaST should reuse existing LVM
+    #
+    # see jsc#PED-6407 or jsc#IBM-1315
+    #
+    # @return [Boolean]
+    def reuse_lvm?
+      active?(ENV_REUSE_LVM, default: true)
     end
 
     # Whether errors during libstorage probing should be ignored.

--- a/src/lib/y2storage/storage_env.rb
+++ b/src/lib/y2storage/storage_env.rb
@@ -98,7 +98,11 @@ module Y2Storage
     #
     # @return [Boolean, nil] boolean as explicitly set by user, nil if user set nothing
     def requested_lvm_reuse
-      active?(ENV_REUSE_LVM, default: nil)
+      value = read(ENV_REUSE_LVM)
+
+      return env_str_to_bool(value) if value
+
+      nil
     end
 
     # Whether errors during libstorage probing should be ignored.
@@ -118,6 +122,13 @@ module Y2Storage
 
     private
 
+    # Takes a string and translates it to bool in a similar way how linuxrc does
+    def env_str_to_bool(value)
+      # Similar to what linuxrc does, also consider the flag activated if the
+      # variable is used with no value or with "1"
+      value.casecmp?("on") || value.empty? || value == "1"
+    end
+
     # Whether the env variable is active
     #
     # @param variable [String]
@@ -128,9 +139,7 @@ module Y2Storage
 
       value = read(variable)
       result = if value
-        # Similar to what linuxrc does, also consider the flag activated if the
-        # variable is used with no value or with "1"
-        value.casecmp?("on") || value.empty? || value == "1"
+        env_str_to_bool(value)
       else
         default
       end

--- a/test/y2storage/storage_env_test.rb
+++ b/test/y2storage/storage_env_test.rb
@@ -80,6 +80,16 @@ describe Y2Storage::StorageEnv do
       end
     end
 
+    context "YAST_REUSE_LVM is set to '0'" do
+      let(:env_vars) do
+        { "YAST_REUSE_LVM" => "0" }
+      end
+
+      it "returns false" do
+        expect(Y2Storage::StorageEnv.instance.requested_lvm_reuse).to be false
+      end
+    end
+
     context "YAST_REUSE_LVM not set" do
       let(:env_vars) do
         {}

--- a/test/y2storage/storage_env_test.rb
+++ b/test/y2storage/storage_env_test.rb
@@ -68,4 +68,26 @@ describe Y2Storage::StorageEnv do
       end
     end
   end
+
+  describe "#requested_lvm_reuse" do
+    context "YAST_REUSE_LVM is set to '1'" do
+      let(:env_vars) do
+        { "YAST_REUSE_LVM" => "1" }
+      end
+
+      it "returns true" do
+        expect(Y2Storage::StorageEnv.instance.requested_lvm_reuse).to be true
+      end
+    end
+
+    context "YAST_REUSE_LVM not set" do
+      let(:env_vars) do
+        {}
+      end
+
+      it "returns nil" do
+        expect(Y2Storage::StorageEnv.instance.requested_lvm_reuse).to be nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

https://jira.suse.com/browse/PED-6407

The Storage Proposal in SLE 15 allows for creating a layout based on LVM. For historical reasons, it tries to reuse the existing LVM volume group for new installations. This sometimes produces a non-optimal, non-logical or even confusing disk setup.

## Solution

linuxrc option to disable lvm reuse


## Testing

- *Tested manually*

