### PR TITLE
Console: LUKS2 support it no longer experimental

### DIFF
--- a/src/lib/installation/console/plugins/luks2_checkbox.rb
+++ b/src/lib/installation/console/plugins/luks2_checkbox.rb
@@ -36,7 +36,7 @@ module Installation
 
         def label
           # TRANSLATORS: check box label
-          _("Enable Experimental LUKS2 Encryption Support")
+          _("Enable LUKS2 Encryption Support")
         end
 
         def store


### PR DESCRIPTION
## Problem

While working on the LUKS2 documentation ([PED-3882](https://jira.suse.com/browse/PED-3882)), I noticed the checkbox in the YaST console still reads "Enable Experimental LUKS2 Encryption Support". I guess with the latest work around [PED-3878](https://jira.suse.com/browse/PED-3878), we can remove the 'experimental' state.

