### PR TITLE
Fix Build Failure: New libstorage-ng enum

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 12 15:18:51 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added new libstorage enum value UF_BCACHEFS to fix build failure
+  (bsc#1219804)
+- 5.0.5
+
+-------------------------------------------------------------------
 Thu Nov  2 13:52:11 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Encryption method TpmFde to be used by Agama (and later by YaST)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.4
+Version:        5.0.5
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/storage_feature.rb
+++ b/src/lib/y2storage/storage_feature.rb
@@ -98,6 +98,7 @@ module Y2Storage
         # Other
         UF_QUOTA:            "quota",
         UF_BCACHE:           "bcache-tools",
+        UF_BCACHEFS:         [], # When implemented: "bcachefs-tools"
         UF_SNAPSHOTS:        "snapper"
       }
 


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1219804


## Problem

Build failure with latest libstorage-ng:

```
13) Y2Storage::StorageFeature.all contains one entry for each feature from libstorage-ng
    Failure/Error: expect(described_class.all.map(&:to_sym)).to contain_exactly(*constants)

      expected collection contained:  [:UF_BCACHE, :UF_BCACHEFS, :UF_BITLOCKER, :UF_BTRFS, :UF_DASD, :UF_DMRAID, :UF_EXFAT, :UF_EXT2, :UF_E..._ENCRYPTION, :UF_PMEM, :UF_QUOTA, :UF_REISERFS, :UF_SNAPSHOTS, :UF_SWAP, :UF_UDF, :UF_VFAT, :UF_XFS]
      actual collection contained:    [:UF_BCACHE, :UF_BITLOCKER, :UF_BTRFS, :UF_DASD, :UF_DMRAID, :UF_EXFAT, :UF_EXT2, :UF_EXT3, :UF_EXT4,..._ENCRYPTION, :UF_PMEM, :UF_QUOTA, :UF_REISERFS, :UF_SNAPSHOTS, :UF_SWAP, :UF_UDF, :UF_VFAT, :UF_XFS]
      the missing elements were:      [:UF_BCACHEFS]
# ./test/y2storage/storage_feature_test.rb:33:in `block (3 levels) in <top (required)>'
```

## Cause

libstorage-ng now has support for _bcachefs_, including  a new enum value `BCACHEFS`.

We have a unit test to check if all values of this C++ libstorage-ng enum for storage features are covered on the Ruby side in yast-storage-ng in this map:

https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2storage/storage_feature.rb#L55-L102

The map contains support packages for each storage feature; packages that need to be installed when the feature is used.


## Fix

Added a map entry for this new enum value.


## What Support Packages are Needed?

Right now none since there is no support for _bcachefs_ in yast-storage-ng for the time being. libstorage may detect it during storage probing, but we will not propose it, and the expert partitioner does not support adding it.


### Future Support Packages

There is package _bcachefs-tools_ which will be needed when this is implemented on the Ruby side (in yast-storage-ng), too.

https://build.opensuse.org/package/show/openSUSE:Factory/bcache-tools


### Add this Immediately?

No, this might lead to unrecoverable situations if a _bcachefs_ is detected during storage probing, so that package would be requested from the libzypp pool, but it might not be available for the current product.

We would have to add it to `OPTIONAL_PACKAGES`  as well for the time being, but it might be left over there when the feature is implemented, leading to more obscure problems.

https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2storage/storage_feature.rb#L112

For now, it's just in a comment as a reminder to add it in the future.