### PR TITLE
Set different encryption types (luks1, luks2) via product proposal/encryption settings

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb 20 12:50:08 UTC 2024 - Stefan Schubert <schubi@suse.com>
+
+- Set different encryption types (luks1, luks2), password and pbkdf
+  via product proposal/encryption settings.
+  (jsc#PED-1906)
+- 5.0.7
+
+-------------------------------------------------------------------
 Wed Feb 14 09:11:06 UTC 2024 - Michal Filka <mfilka@suse.com>
 
 - jsc#PED-6407

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.6
+Version:        5.0.7
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/installation/console/plugins/luks2_checkbox.rb
+++ b/src/lib/installation/console/plugins/luks2_checkbox.rb
@@ -20,7 +20,7 @@ require "y2storage/storage_env"
 module Installation
   module Console
     module Plugins
-      # define a checkbox for enabling the experimental LUKS2 support in the installer
+      # define a checkbox for enabling the LUKS2 support in the installer
       class LUKS2CheckBox < CWM::CheckBox
         include Yast::Logger
 
@@ -36,7 +36,7 @@ module Installation
 
         def label
           # TRANSLATORS: check box label
-          _("Enable Experimental LUKS2 Encryption Support")
+          _("Enable LUKS2 Encryption Support")
         end
 
         def store
@@ -53,7 +53,7 @@ module Installation
 
         def help
           # TRANSLATORS: help text for the checkbox enabling LUKS2 support
-          _("<p>You can enable experimental LUKS2 encryption support in "\
+          _("<p>You can enable LUKS2 encryption support in "\
             "the YaST partitioner. It is not supported and is designed as a " \
             "technology preview only.</p>")
         end

--- a/test/y2storage/proposal_settings_test.rb
+++ b/test/y2storage/proposal_settings_test.rb
@@ -355,6 +355,13 @@ describe Y2Storage::ProposalSettings do
       expect(settings.encryption_password).to eq "SuperSecret"
     end
 
+    it "sets 'encryption_password' based on the 'encryption' selection configurartion dialog" do
+      read_feature("encryption", { "type" => "luks2", "pbkdf" => "argon2id",
+                                   "password" => "SuperSecret" })
+      expect(settings.use_encryption).to eq true
+      expect(settings.encryption_password).to eq "SuperSecret"
+    end
+
     it "sets 'delete_resize_configurable' based on the feature in the 'proposal' section" do
       read_feature("delete_resize_configurable", true)
       expect(settings.delete_resize_configurable).to eq true


### PR DESCRIPTION
Due
https://github.com/yast/yast-installation/pull/1109
the user can set systemd-boot und luks2 for the proposal.
The communication will be done via the product description (partitioning/proposal/encryption)
This has the advantage that the product can also define partitions which are encrypted.

Other associated PRs :
https://github.com/yast/yast-installation-control/pull/125
https://github.com/yast/yast-bootloader/pull/694
