### PR TITLE
Fix Build Failure: New libstorage-ng enum [SLE-15-SP6]

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 22 08:32:24 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added new libstorage enum value UF_BCACHEFS to fix build failure
+  (bsc#1219804)
+- 4.6.16
+
+-------------------------------------------------------------------
 Wed Feb 14 09:11:06 UTC 2024 - Michal Filka <mfilka@suse.com>
 
 - jsc#PED-6407

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.6.15
+Version:        4.6.16
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/storage_feature.rb
+++ b/src/lib/y2storage/storage_feature.rb
@@ -98,6 +98,7 @@ module Y2Storage
         # Other
         UF_QUOTA:            "quota",
         UF_BCACHE:           "bcache-tools",
+        UF_BCACHEFS:         [], # When implemented: "bcachefs-tools"
         UF_SNAPSHOTS:        "snapper"
       }
 


### PR DESCRIPTION
## Target Branch

This is a **backport  to SLE-15-SP6** of PR #1367.

It was a bit unexpected to see this new libstorage-ng feature appear in SP6, hence this backport and not our usual procedure to change the oldest affected branch first and then merge that forward until _master_.


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1219804


## Problem

Build failure with latest libstorage-ng:

```
13) Y2Storage::StorageFeature.all contains one entry for each feature from libstorage-ng
    Failure/Error: expect(described_class.all.map(&:to_sym)).to contain_exactly(*constants)

      expected collection contained:  [:UF_BCACHE, :UF_BCACHEFS, :UF_BITLOCKER, :UF_BTRFS, :UF_DASD, :UF_DMRAID, :UF_EXFAT, :UF_EXT2, :UF_E..._ENCRYPTION, :UF_PMEM, :UF_QUOTA, :UF_REISERFS, :UF_SNAPSHOTS, :UF_SWAP, :UF_UDF, :UF_VFAT, :UF_XFS]
      actual collection contained:    [:UF_BCACHE, :UF_BITLOCKER, :UF_BTRFS, :UF_DASD, :UF_DMRAID, :UF_EXFAT, :UF_EXT2, :UF_EXT3, :UF_EXT4,..._ENCRYPTION, :UF_PMEM, :UF_QUOTA, :UF_REISERFS, :UF_SNAPSHOTS, :UF_SWAP, :UF_UDF, :UF_VFAT, :UF_XFS]
      the missing elements were:      [:UF_BCACHEFS]
# ./test/y2storage/storage_feature_test.rb:33:in `block (3 levels) in <top (required)>'
```

## Cause

libstorage-ng now has support for _bcachefs_, including  a new enum value `BCACHEFS`.

We have a unit test to check if all values of this C++ libstorage-ng enum for storage features are covered on the Ruby side in yast-storage-ng in this map:

https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2storage/storage_feature.rb#L55-L102

The map contains support packages for each storage feature; packages that need to be installed when the feature is used.


## Fix

Added a map entry for this new enum value.


## What Support Packages are Needed?

Right now none since there is no support for _bcachefs_ in yast-storage-ng for the time being. libstorage may detect it during storage probing, but we will not propose it, and the expert partitioner does not support adding it.


### Future Support Packages

There is package _bcachefs-tools_ which will be needed when this is implemented on the Ruby side (in yast-storage-ng), too.

https://build.opensuse.org/package/show/openSUSE:Factory/bcache-tools


### Add this Immediately?

No, this might lead to unrecoverable situations if a _bcachefs_ is detected during storage probing, so that package would be requested from the libzypp pool, but it might not be available for the current product.

We would have to add it to `OPTIONAL_PACKAGES`  as well for the time being, but it might be left over there when the feature is implemented, leading to more obscure problems.

https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2storage/storage_feature.rb#L112

For now, it's just in a comment as a reminder to add it in the future.


## Related PR

Original for _master_: PR #1367
