### PR TITLE
Don't pass -1 to unsigned long long in swig bindings (bsc#1221222)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Mar 12 11:52:40 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed build failure with latest SWIG:
+  Make sure not to pass -1 to unsigned long long value in libstorage-ng
+  (bsc#1221222)
+- 5.0.9
+
+-------------------------------------------------------------------
 Thu Mar  7 16:26:04 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Share the logic for generating the description of a device and

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.8
+Version:        5.0.9
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -769,7 +769,7 @@ module Y2Storage
       size = args["size"] || DiskSize.zero
       raise ArgumentError, "\"size\" missing for lvm_lv #{lv_name}" unless args.key?("size")
 
-      size = DiskSize.EiB(4) if size.unlimited? # bsc#1221222
+      size = DiskSize.EiB(4) if size.unlimited? # (2^62 bytes) bsc#1221222
 
       lvm_lv = parent.create_lvm_lv(lv_name, size)
       create_lvm_lv_stripe_parameters(lvm_lv, args)

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -768,6 +768,7 @@ module Y2Storage
 
       size = args["size"] || DiskSize.zero
       raise ArgumentError, "\"size\" missing for lvm_lv #{lv_name}" unless args.key?("size")
+
       size = DiskSize.EiB(4) if size.unlimited? # bsc#1221222
 
       lvm_lv = parent.create_lvm_lv(lv_name, size)

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -768,6 +768,7 @@ module Y2Storage
 
       size = args["size"] || DiskSize.zero
       raise ArgumentError, "\"size\" missing for lvm_lv #{lv_name}" unless args.key?("size")
+      size = DiskSize.EiB(4) if size.unlimited? # bsc#1221222
 
       lvm_lv = parent.create_lvm_lv(lv_name, size)
       create_lvm_lv_stripe_parameters(lvm_lv, args)


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1221222


## Problem

Build failure of yast-storage-ng with the latest SWIG bindings.


## Cause

The unit tests use `DiskSize::unlimited` in the YAML files for many test scenarios for LVs, and that results in a value -1 which clashes with the libstorage function prototype that expects `unsigned long long` for `create_lvm_lv()`.

Obviously SWIG decides at runtime (!) which C++ function to call, and now the checks appear to be stricter: A -1 worked well until this version; it had obviously converted it to the bit pattern of the expected unsigned type, in this case resulting in 16 EiB - 1. Now that doesn't work anymore.


## Fix

If `DiskSize::unlimited` (-1) is detected in the `FakeDeviceFactory` for that function, use a very large `unsigned long long` value instead (4 EiB).