### PR TITLE
Fix unlimited-sized fake device graphs (bsc#1221222)  [SLE-15-SP6 Backport]

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr  3 11:23:01 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fix unlimited-sized fake device graphs (bsc#1221222)
+- 4.6.17
+
+-------------------------------------------------------------------
 Thu Feb 22 08:32:24 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added new libstorage enum value UF_BCACHEFS to fix build failure

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.6.16
+Version:        4.6.17
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/test/data/devicegraphs/autoyast_drive_examples.yml
+++ b/test/data/devicegraphs/autoyast_drive_examples.yml
@@ -416,7 +416,7 @@
           blk_device: /dev/sdj1
     lvm_lvs:
       - lvm_lv:
-          size:         unlimited
+          size:         1 TiB
           lv_name:      lv1
           file_system:  btrfs
           mount_point:  /
@@ -435,7 +435,7 @@
           blk_device: /dev/sdj2
     lvm_lvs:
       - lvm_lv:
-          size:         unlimited
+          size:         1 TiB
           lv_name:      lv1
           file_system:  btrfs
           mount_point:  /

--- a/test/data/devicegraphs/dos_lvm.yml
+++ b/test/data/devicegraphs/dos_lvm.yml
@@ -19,7 +19,7 @@
 
     lvm_lvs:
         - lvm_lv:
-            size:         unlimited
+            size:         200 GiB
             lv_name:      lv1
             file_system:  btrfs
             mount_point:  /

--- a/test/data/devicegraphs/dos_lvm_boot_partition.yml
+++ b/test/data/devicegraphs/dos_lvm_boot_partition.yml
@@ -25,7 +25,7 @@
 
     lvm_lvs:
         - lvm_lv:
-            size:         unlimited
+            size:         200 GiB
             lv_name:      lv1
             file_system:  btrfs
             mount_point:  /

--- a/test/data/devicegraphs/lvm-striped-lvs.yml
+++ b/test/data/devicegraphs/lvm-striped-lvs.yml
@@ -31,7 +31,7 @@
             blk_device: /dev/sdb1
     lvm_lvs:
         - lvm_lv:
-            size:         unlimited
+            size:         100 GiB
             lv_name:      lv1
             file_system:  btrfs
             mount_point:  /

--- a/test/data/devicegraphs/lvm-two-disks.yml
+++ b/test/data/devicegraphs/lvm-two-disks.yml
@@ -31,7 +31,7 @@
 
     lvm_lvs:
         - lvm_lv:
-            size:         unlimited
+            size:         400 GiB
             lv_name:      lv1
             file_system:  btrfs
             mount_point:  /

--- a/test/data/devicegraphs/lvm_with_bios_boot.yml
+++ b/test/data/devicegraphs/lvm_with_bios_boot.yml
@@ -23,7 +23,7 @@
 
     lvm_lvs:
         - lvm_lv:
-            size:         unlimited
+            size:         200 GiB
             lv_name:      lv1
             file_system:  btrfs
             mount_point:  /

--- a/test/data/devicegraphs/lvm_with_boot.yml
+++ b/test/data/devicegraphs/lvm_with_boot.yml
@@ -24,7 +24,7 @@
 
     lvm_lvs:
         - lvm_lv:
-            size:         unlimited
+            size:         200 GiB
             lv_name:      lv1
             file_system:  btrfs
             mount_point:  /

--- a/test/data/devicegraphs/prep_lvm.yml
+++ b/test/data/devicegraphs/prep_lvm.yml
@@ -23,7 +23,7 @@
 
     lvm_lvs:
         - lvm_lv:
-            size:         unlimited
+            size:         200 GiB
             lv_name:      lv1
             file_system:  btrfs
             mount_point:  /

--- a/test/data/devicegraphs/trivial_lvm.yml
+++ b/test/data/devicegraphs/trivial_lvm.yml
@@ -18,7 +18,7 @@
 
     lvm_lvs:
         - lvm_lv:
-            size:         unlimited
+            size:         200 GiB
             lv_name:      lv1
             file_system:  btrfs
             mount_point:  /

--- a/test/data/devicegraphs/trivial_lvm_and_other_partitions.yml
+++ b/test/data/devicegraphs/trivial_lvm_and_other_partitions.yml
@@ -53,7 +53,7 @@
 
     lvm_lvs:
         - lvm_lv:
-            size:         unlimited
+            size:         200 GiB
             lv_name:      lv1
             file_system:  btrfs
             mount_point:  /


### PR DESCRIPTION
## Target Branch

This is a backport of PR #1375 to **SLE-15-SP6**.


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1221222


## Problem

Build failure of yast-storage-ng with the latest SWIG bindings.


## Cause

The unit tests use `DiskSize::unlimited` in the YAML files for many test scenarios for LVs, and that results in a value -1 which clashes with the libstorage function prototype that expects `unsigned long long` for `create_lvm_lv()`.

Obviously SWIG decides at runtime (!) which C++ function to call, and now the checks appear to be stricter: A -1 worked well until this version; it had obviously converted it to the bit pattern of the expected unsigned type, in this case resulting in 16 EiB - 1. Now that doesn't work anymore.


## Fix

Don't use _unlimited_ for LVM LVs in the YAML fake device graphs; that's unrealistic and not possible in real life anyway.

This fix is limited purely to unit test data. There is no code change.
