### PR TITLE
Optionally include the encryption status in the device description

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 17 15:56:25 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Optionally add the encryption status in the device description
+  (gh#openSUSE/agama#1155)
+- 5.0.12
+
+-------------------------------------------------------------------
 Wed Apr  3 09:52:32 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - GuidedProposal: fixed a problem related to the :bigger_resize

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.11
+Version:        5.0.12
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/device_description.rb
+++ b/src/lib/y2storage/device_description.rb
@@ -100,7 +100,7 @@ module Y2Storage
 
     # Filesystem name
     #
-    # @param filesystem [Y2Storage::BlkFilesystem]
+    # @param filesystem [Y2Storage::Filesystems::Base]
     # @return [String]
     def filesystem_label(filesystem)
       label = filesystem.type.to_human_string
@@ -223,14 +223,14 @@ module Y2Storage
           if lvm_snapshot.encrypted? && include_encryption
             # TRANSLATORS: %{origin} is replaced by an LVM logical volume name
             # (e.g., /dev/vg0/user-data)
-            _("Encrypted thin Snapshot of %{origin}")
+            _("Encrypted Thin Snapshot of %{origin}")
           else
             # TRANSLATORS: %{origin} is replaced by an LVM logical volume name
             # (e.g., /dev/vg0/user-data)
             _("Thin Snapshot of %{origin}")
           end
         elsif lvm_snapshot.encrypted? && include_encryption
-          _("Encrypted snapshot of %{origin}")
+          _("Encrypted Snapshot of %{origin}")
         # TRANSLATORS: %{origin} is replaced by an LVM logical volume name
         # (e.g., /dev/vg0/user-data)
         else


### PR DESCRIPTION
## Problem

- The device labels in Agama do not include the encryption status
- In YaST it is OK because it has a dedicated column with encryption status
- In Agama we would like to have the status included directly in the label

## Solution

- Adapt the code to include the encryption status in the label

## Notes

- The encryption status is included only when explicitly requested. That allows to keep the backward compatibility with YaST and show it only in Agama.
- See related https://github.com/openSUSE/agama/pull/1155

## Testing

- Tested manually

## Screenshots

![agama_encrypted_disk](https://github.com/yast/yast-storage-ng/assets/907998/2dd4a605-7cdd-4684-977b-027397f596ca)
