### PR TITLE
Improve the :bigger_resize SpaceMaker strategy

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Apr 24 07:48:08 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- GuidedProposal: refine the :bigger_resize SpaceMaker strategy
+  (gh#openSUSE/agama#1164).
+- Fixed a bug related to the calculation of partitions required
+  for booting when RAID is involved.
+- 5.0.13
+
+-------------------------------------------------------------------
 Wed Apr 17 15:56:25 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Optionally add the encryption status in the device description

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.12
+Version:        5.0.13
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/analyzer.rb
@@ -85,6 +85,8 @@ module Y2Storage
         return @boot_disk if @boot_disk
 
         @boot_disk = devicegraph.find_by_name(boot_disk_name) if boot_disk_name
+        # If the disk was explicitly chosen via boot_disk_name, we are all set
+        return @boot_disk if @boot_disk
 
         @boot_disk ||= boot_disk_from_planned_dev
         @boot_disk ||= boot_disk_from_devicegraph

--- a/src/lib/y2storage/proposal_space_settings.rb
+++ b/src/lib/y2storage/proposal_space_settings.rb
@@ -82,13 +82,12 @@ module Y2Storage
     # @return [Boolean]
     attr_accessor :delete_resize_configurable
 
-    # What to do with existing partitions and disks if they are involved in the process of making
-    # space.
+    # What to do with existing partitions if they are involved in the process of making space.
     #
     # Keys are device names (like in BlkDevice#name, no alternative names) that correspond to a
-    # partition or to a disk with no partitions.
+    # partition.
     #
-    # The value for each key specifies what to do with the corresponding device if the storage
+    # The value for each key specifies what to do with the corresponding partition if the storage
     # proposal needs to process the corresponding disk. If the device is not explicitly mentioned,
     # nothing will be done. Possible values are :resize, :delete and :force_delete.
     #

--- a/test/y2storage/proposal_agama_advanced_test.rb
+++ b/test/y2storage/proposal_agama_advanced_test.rb
@@ -155,5 +155,24 @@ describe Y2Storage::MinGuidedProposal do
         end
       end
     end
+
+    context "when installing on a disk that previously contained a RAID1" do
+      let(:scenario) { "windows-pc-raid1.xml" }
+
+      before do
+        settings.candidate_devices = ["/dev/sda"]
+        settings.root_device = "/dev/sda"
+        # Let's ensure a bios_boot partition is needed
+        allow(storage_arch).to receive(:efiboot?).and_return(false)
+      end
+
+      # In the past, the pre-existing RAID1 was considered to be the booting disk due to some
+      # false asumptions made by the BootRequirementsChecker.
+      it "creates the partitions needed for booting in the correct disk" do
+        proposal.propose
+        disk = proposal.devices.find_by_name("/dev/sda")
+        expect(disk.partitions.map(&:id)).to include Y2Storage::PartitionId::BIOS_BOOT
+      end
+    end
   end
 end


### PR DESCRIPTION
**IMPORTANT:** This should be merged in sync with https://github.com/openSUSE/agama/pull/1164, which includes the needed adaptations in the Agama side to keep everything consistent.

## Problem

The `:bigger_resize` strategy was added to give Agama a more fine-grained control of the actions to be performed by the SpaceMaker.

But we found several inconsistencies in the way we originally defined `:bigger_resize`.

Before this change, the SpaceMaker strategy expected a list like this.

- For non-partitioned disks (for example, disks directly formatted or acting as LVM PV) it expected one of the following actions:
  - none (ie. keep the content)
  - `:delete` or `:force_delete` (ie. wipe the content).
- For partitions it expected one of the following:
  - none (ie. keep the partition as-is),
  - `:delete or `:force_delete` (ie. remove the partition)
  - `:resize` (ie. shrinking the partition)

### First problem

The behavior described above turned out to be quite confusing since actions on non-partitioned disks are about the content (filesystems, PVs, etc.) and actions on partitions are about the devices themselves, offering no option for things like keeping the device but allowing to destroy the content.

### Second problem

The first problem refers to disks that are part of the candidate devices or are selected as root disk. But the situation of disks or RAIDs that were chosen to be formatted (ie. reused by a volume) also needed clarification.

### Additional unrelated problem

While testing this I found that installing on a disk that previously contained a RAID could result in a proposal that didn't include the partitions needed for booting.  After some debugging, turns out the culprit was some code introduced many years ago in order to support non-standard RAID1 setups (https://github.com/yast/yast-storage-ng/pull/788).

## Solution

### Solution to the first problem

We agreed that having explicit actions for non-partitioned disks has very little value. If a non-partitioned device is selected to be formatted or to be a candidate disk or root disk, it’s content will be deleted if needed no matter whether there is such action. In other words, actions refer to the devices themselves, not to their content. As such, actions only make sense for partitions and maybe for other devices that can be destroyed (like logical volumes if we implement reusing of LVM VGs in the future).

### Solution to the second problem

We came to the conclusion that selecting a disk to be directly formatted (or any other partitionable device like a RAID) already implies an statement about deleting all its content (partitions or whatever is there). There is no need to have space actions for those cases (they would be an open door for conflicts). Space actions only make sense for candidate disks and for the root disk. They are not needed for reused devices or its descendants.

### Solution to the additional problem

If the root device is explicitly set (something that always happens in the Agama proposals), that value is now honored, ignoring any possible RAID consideration.

## Testing

- Unit tests adapted and expanded
- Tested manually together with https://github.com/openSUSE/agama/pull/1164