### PR TITLE
Fix device description of encrypted PV

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 13 15:16:24 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Fix device description for encrypted PV
+  (gh#yast/yast-storage-ng#1384).
+- 5.0.15
+
+-------------------------------------------------------------------
 Tue May  7 14:38:42 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Proposal: Make the encryption method and the key derivation

--- a/src/lib/y2storage/device_description.rb
+++ b/src/lib/y2storage/device_description.rb
@@ -206,7 +206,7 @@ module Y2Storage
 
       if encrypted && include_encryption
         # TRANSLATORS: %s is the volume group name. E.g., "vg0"
-        format(_("Encrypted PV of %s"), vg.basename)
+        return format(_("Encrypted PV of %s"), vg.basename)
       end
 
       # TRANSLATORS: %s is the volume group name. E.g., "vg0"

--- a/test/y2storage/device_description_test.rb
+++ b/test/y2storage/device_description_test.rb
@@ -190,6 +190,8 @@ describe Y2Storage::DeviceDescription do
             expect(description).to eq("PV of LVM")
           end
         end
+
+        include_examples "Encrypted device"
       end
 
       context "and it is an unused LVM physical volume" do


### PR DESCRIPTION
## Problem

The description of an encrypted physical volume is wrong: *PV of system* instead of *Encrypted PV of system*.

## Solution

Fix `ProductDescription`.

## Testing

* Added new unit test
* Tested manually

## Screenshots

![Screenshot from 2024-06-13 16-20-10](https://github.com/yast/yast-storage-ng/assets/1112304/9f4103d2-7f34-478d-847e-0eb026c41f31)
