### PR TITLE
Fix a bug when formatting a full disk as Btrfs with snapshots

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,9 +1,15 @@
 -------------------------------------------------------------------
+Fri Jun 14 12:41:07 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed a problem when trying to locate a Btrfs root file-system
+  directly on top of a disk (gh#openSUSE/agama#1339).
+- 5.0.15
+
+-------------------------------------------------------------------
 Thu Jun 13 15:16:24 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Fix device description for encrypted PV
   (gh#yast/yast-storage-ng#1384).
-- 5.0.15
 
 -------------------------------------------------------------------
 Tue May  7 14:38:42 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.14
+Version:        5.0.15
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/proposal/devices_planner.rb
+++ b/src/lib/y2storage/proposal/devices_planner.rb
@@ -350,6 +350,7 @@ module Y2Storage
       # @param volume [VolumeSpecification]
       def adjust_btrfs_sizes(planned_device, volume)
         return if volume.ignore_snapshots_sizes?
+        return unless planned_device.respond_to?(:min_size)
 
         if volume.snapshots_size > DiskSize.zero
           planned_device.min_size += volume.snapshots_size


### PR DESCRIPTION
## Problem

This bug at Agama was reported https://github.com/openSUSE/agama/issues/1339

Turns out the root of the error was an uncaught exception at the GuidedProposal caused because YaST was trying to adjust the sizes of the root device to fulfill the Btrfs-related settings... but such a device was a disk instead of an LV or partition.

## Solution

Added the same guard we have in other parts of `DevicesPlanner` (eg. `adjust_sizes`).

## Testing

- Added a new unit test
- Tested manually with Agama. It solves the reported bug.

