### PR TITLE
Fix drive section

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 26 14:47:40 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- AutoYaST: small fix to ensure symbol for the drive type when
+  importing from a hash (required by gh#openSUSE/agama#1471).
+- 5.0.17
+
+-------------------------------------------------------------------
 Wed Aug 21 12:03:30 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Tiny internal code reorganization to ease Agama development at

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.16
+Version:        5.0.17
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/autoinst_profile/drive_section.rb
+++ b/src/lib/y2storage/autoinst_profile/drive_section.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2019] SUSE LLC
+# Copyright (c) [2017-2024] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -137,6 +137,7 @@ module Y2Storage
       def init_from_hashes(hash)
         super
         @type ||= default_type_for(hash)
+        @type = @type.to_sym
         @use = use_value_from_string(hash["use"]) if hash["use"]
         @partitions = partitions_from_hash(hash)
         @skip_list = SkipListSection.new_from_hashes(hash.fetch("skip_list", []), self)


### PR DESCRIPTION
## Problem

Agama calculates an AutoYaST proposal from a given JSON config file. Such a config file is a direct conversion from XML to JSON. This implies that some symbol attributes (e.g., [type](https://doc.opensuse.org/projects/autoyast/#id-1.9.5.2.10.8.7.4) from *drive* section) are converted to string (JSON does not support symbols).

The AutoYaST proposal code works fine with strings instead of symbols, for example for the fileystem type, encryption method, etc. Except for the `type` attribute, which must be a symbol.

## Solution

Ensure the *type* attribute is a symbol when importing a hash. 

Required by https://github.com/openSUSE/agama/pull/1471.
