### PR TITLE
Improvements to allow more flexible resize of partitions (needed by Agama)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 20 13:06:00 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Extend the API to resize partitions during a proposal (required
+  by gh#openSUSE/agama#1599).
+- 5.0.18
+
+-------------------------------------------------------------------
 Mon Aug 26 14:47:40 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - AutoYaST: small fix to ensure symbol for the drive type when

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.17
+Version:        5.0.18
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/free_disk_space.rb
+++ b/src/lib/y2storage/free_disk_space.rb
@@ -95,6 +95,10 @@ module Y2Storage
 
     # Whether the region belongs to a partition that is going to be reused
     #
+    # This only makes sense in the case of DASD devices with an implicit partition table,
+    # partitions are never deleted there, but 'reused' (nothing to do with the 'reuse' flag of
+    # planned devices).
+    #
     # @return [Boolean]
     def reused_partition?
       return false if growing?

--- a/src/lib/y2storage/planned/assigned_space.rb
+++ b/src/lib/y2storage/planned/assigned_space.rb
@@ -161,6 +161,15 @@ module Y2Storage
         end
       end
 
+      # Space that can be sustracted from the start of the region without invalidating this
+      # valid assignation
+      #
+      # @return [DiskSize]
+      def disposable_size
+        # FIXME: This is more based on trial and error than on a real rationale
+        usable_extra_size - align_grain
+      end
+
       # Space consumed by the EBR of one logical partition in a given disk
       # See https://en.wikipedia.org/wiki/Extended_boot_record
       #

--- a/src/lib/y2storage/planned/assigned_space.rb
+++ b/src/lib/y2storage/planned/assigned_space.rb
@@ -208,6 +208,14 @@ module Y2Storage
         @disk_size ||= @disk_space.disk_size
       end
 
+      # Recalculates the information about the available space, in case it has been modified
+      def update_disk_space
+        @region = nil
+        @disk_size = nil
+        @space_start = nil
+        @disk_space = @disk_space.updated_free_space(devicegraph)
+      end
+
       protected
 
       # Checks whether the disk space is inside an extended partition
@@ -322,6 +330,11 @@ module Y2Storage
         partitions.reverse.detect do |partition|
           partition.min_size.ceil(align_grain) - missing >= partition.min_size
         end
+      end
+
+      # @return [Devicegraph] devicegraph in which the space is defined
+      def devicegraph
+        disk_space.disk.devicegraph
       end
 
       def partitions_sorted_by_attr(*attrs, nils_first: false, descending: false)

--- a/src/lib/y2storage/planned/can_be_resized.rb
+++ b/src/lib/y2storage/planned/can_be_resized.rb
@@ -44,6 +44,15 @@ module Y2Storage
         max_size <= device_to_reuse(devicegraph).size
       end
 
+      # Limit the max size to ensure the device does not grow more than a give margin
+      #
+      # @param max_grow [DiskSize] max margin to grow the device
+      # @param devicegraph [Devicegraph]
+      def limit_grow(max_grow, devicegraph)
+        limit = device_to_reuse(devicegraph).size + max_grow
+        self.max_size = [max_size, limit].min
+      end
+
       protected
 
       # Implements reuse_device! hook

--- a/src/lib/y2storage/planned/has_size.rb
+++ b/src/lib/y2storage/planned/has_size.rb
@@ -200,7 +200,7 @@ module Y2Storage
           devices.map(&:weight).reduce(0, :+)
         end
 
-        # Checks if there are eough space at all
+        # Checks if there are enough space at all
         # @raise RuntimeError if there is not enough space
         def check_size(devices, space_size)
           needed_size = DiskSize.sum(devices.map(&:min))

--- a/src/lib/y2storage/planned/partition.rb
+++ b/src/lib/y2storage/planned/partition.rb
@@ -87,6 +87,19 @@ module Y2Storage
         @primary = false
       end
 
+      # Whether this corresponds to a reused partition that is located right before the given
+      # assigned space
+      #
+      # @param assigned_space [AssignedSpace]
+      # @return [Boolean]
+      def subsequent_slot?(assigned_space)
+        devicegraph = assigned_space.disk_space.disk.devicegraph
+        dev = device_to_reuse(devicegraph)
+        return false unless dev
+
+        dev.subsequent_slot?(assigned_space.disk_space)
+      end
+
       def self.to_string_attrs
         [
           :mount_point, :reuse_name, :reuse_sid, :min_size, :max_size,

--- a/src/lib/y2storage/proposal/space_maker.rb
+++ b/src/lib/y2storage/proposal/space_maker.rb
@@ -361,14 +361,17 @@ module Y2Storage
       def execute_shrink(action, devicegraph, planned_partitions, disk_name)
         log.info "SpaceMaker#execute_shrink - #{action}"
 
-        if action.shrink_size.nil?
+        if action.target_size.nil?
+          part = devicegraph.find_device(action.sid)
           if planned_partitions
-            part = devicegraph.find_device(action.sid)
-            action.shrink_size = resizing_size(part, planned_partitions, disk_name)
+            resizing = resizing_size(part, planned_partitions, disk_name)
+            action.target_size = resizing > part.size ? DiskSize.zero : part.size - resizing
           else
-            action.shrink_size = DiskSize.Unlimited
+            # Mandatory resize
+            action.target_size = part.size
           end
         end
+
         action.shrink(devicegraph)
       end
 

--- a/src/lib/y2storage/proposal_space_settings.rb
+++ b/src/lib/y2storage/proposal_space_settings.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "y2storage/equal_by_instance_variables"
+require "y2storage/space_actions"
 
 module Y2Storage
   # Class to encapsulate all the GuidedProposal settings related to the process of making space
@@ -84,27 +85,20 @@ module Y2Storage
 
     # What to do with existing partitions if they are involved in the process of making space.
     #
-    # Keys are device names (like in BlkDevice#name, no alternative names) that correspond to a
-    # partition.
-    #
-    # The value for each key specifies what to do with the corresponding partition if the storage
-    # proposal needs to process the corresponding disk. If the device is not explicitly mentioned,
-    # nothing will be done. Possible values are :resize, :delete and :force_delete.
-    #
     # Entries for devices that are not involved in the proposal are ignored. For example, if all
     # the volumes are configured to be placed at /dev/sda but there is an entry like
-    # `{"/dev/sdb1" => :force_delete}`, the corresponding /dev/sdb1 partition will NOT be deleted
-    # because there is no reason for the proposal to process the disk /dev/sdb.
+    # Delete<device: "/dev/sdb1", mandatory: true>, the corresponding /dev/sdb1 partition will NOT
+    # be deleted because there is no reason for the proposal to process the disk /dev/sdb.
     #
     # Device names corresponding to extended partitions are also ignored. The storage proposal only
     # considers actions for primary and logical partitions.
     #
-    # @return [Hash{String => Symbol}]
+    # @return [Array<SpaceActions::Base>]
     attr_accessor :actions
 
     def initialize
       @strategy = :auto
-      @actions = {}
+      @actions = []
     end
 
     # Whether the settings disable deletion of a given type of partitions

--- a/src/lib/y2storage/space_actions.rb
+++ b/src/lib/y2storage/space_actions.rb
@@ -1,0 +1,27 @@
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Storage
+  # Namespace for the objects representing the actions of the bigger_resize SpaceMaker strategy
+  module SpaceActions
+  end
+end
+
+require "y2storage/space_actions/delete"
+require "y2storage/space_actions/resize"

--- a/src/lib/y2storage/space_actions/base.rb
+++ b/src/lib/y2storage/space_actions/base.rb
@@ -1,0 +1,46 @@
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/equal_by_instance_variables"
+
+module Y2Storage
+  module SpaceActions
+    # Base class for representing the actions of the bigger_resize SpaceMaker strategy
+    class Base
+      include EqualByInstanceVariables
+      attr_reader :device
+
+      # Constructor
+      def initialize(device)
+        @device = device
+      end
+
+      # Checks whether this is a concrete kind(s) of action
+      # @return [Boolean]
+      def is?(*types)
+        (types.map(&:to_sym) & types_for_is).any?
+      end
+
+      # @see #is?
+      def types_for_is
+        []
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/space_actions/delete.rb
+++ b/src/lib/y2storage/space_actions/delete.rb
@@ -1,0 +1,42 @@
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/space_actions/base"
+
+module Y2Storage
+  module SpaceActions
+    # Delete action to configure the bigger_resize SpaceMaker strategy
+    class Delete < Base
+      # Whether the delete action must always be executed (if the involved disk is processed)
+      # @return [Boolean]
+      attr_reader :mandatory
+
+      # Constructor
+      def initialize(device, mandatory: false)
+        super(device)
+        @mandatory = mandatory
+      end
+
+      # @see #is?
+      def types_for_is
+        [:delete]
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/space_actions/resize.rb
+++ b/src/lib/y2storage/space_actions/resize.rb
@@ -1,0 +1,53 @@
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/space_actions/base"
+
+module Y2Storage
+  module SpaceActions
+    # Resize action to configure the bigger_resize SpaceMaker strategy
+    class Resize < Base
+      # Min size the device should have.
+      #
+      # Nil is equivalent to the initial size of the device (no shrinking, only growing).
+      #
+      # @return [DiskSize, nil]
+      attr_reader :min_size
+
+      # Max size the device should have.
+      #
+      # Nil is equivalent to the initial size of the device (no growing, only shrinking).
+      #
+      # @return [DiskSize, nil]
+      attr_reader :max_size
+
+      # Constructor
+      def initialize(device, min_size: DiskSize.zero, max_size: nil)
+        super(device)
+        @min_size = min_size
+        @max_size = max_size
+      end
+
+      # @see #is?
+      def types_for_is
+        [:resize]
+      end
+    end
+  end
+end

--- a/test/y2storage/planned/assigned_space_test.rb
+++ b/test/y2storage/planned/assigned_space_test.rb
@@ -179,4 +179,25 @@ describe Y2Storage::Planned::AssignedSpace do
       end
     end
   end
+
+  describe "#update_disk_space" do
+    before { fake_scenario("mixed_disks") }
+    let(:disk) { fake_devicegraph.find_by_name("/dev/sda") }
+    subject(:assigned) { described_class.new(disk.free_spaces.first, []) }
+
+    it "refreshes all the information related to the available space" do
+      expect(assigned.region.start).to eq 209717248
+      expect(assigned.disk_size).to eq 2.GiB
+
+      disk.partition_table.create_partition(
+        "/dev/sda3",
+        Y2Storage::Region.create(assigned.region.start, 1048576, 512),
+        Y2Storage::PartitionType::PRIMARY
+      )
+      assigned.update_disk_space
+
+      expect(assigned.region.start).to eq(209717248 + 1048576)
+      expect(assigned.disk_size).to eq 1.5.GiB
+    end
+  end
 end

--- a/test/y2storage/planned/can_be_resized_test.rb
+++ b/test/y2storage/planned/can_be_resized_test.rb
@@ -172,4 +172,18 @@ describe Y2Storage::Planned::CanBeResized do
       end
     end
   end
+
+  describe "#limit_grow" do
+    before { planned.max_size = 70.GiB }
+
+    it "limits the max size if the sum of the new limit and the original size is smaller" do
+      planned.limit_grow(5.GiB, devicegraph)
+      expect(planned.max_size).to eq 55.GiB
+    end
+
+    it "leaves the max size untouched if the sum of original size and limit is bigger" do
+      planned.limit_grow(50.GiB, devicegraph)
+      expect(planned.max_size).to eq 70.GiB
+    end
+  end
 end

--- a/test/y2storage/proposal_agama_advanced_test.rb
+++ b/test/y2storage/proposal_agama_advanced_test.rb
@@ -42,6 +42,9 @@ describe Y2Storage::MinGuidedProposal do
       { "mount_point" => "swap", "fs_type" => "swap", "min_size" => "1 GiB", "max_size" => "2 GiB" }
     end
 
+    let(:delete) { Y2Storage::SpaceActions::Delete }
+    let(:resize) { Y2Storage::SpaceActions::Resize }
+
     let(:scenario) { "mixed_disks" }
 
     before do
@@ -70,7 +73,7 @@ describe Y2Storage::MinGuidedProposal do
       before do
         settings.candidate_devices = ["/dev/sdb"]
         settings.root_device = "/dev/sda"
-        settings.space_settings.actions = { "/dev/sda1" => :resize, "/dev/sda2" => :resize }
+        settings.space_settings.actions = [resize.new("/dev/sda1"), resize.new("/dev/sda2")]
         allow(storage_arch).to receive(:efiboot?).and_return(true)
       end
 
@@ -127,7 +130,7 @@ describe Y2Storage::MinGuidedProposal do
         it "tries to use the formatted disk before trying an optional delete" do
           sda1_sid = fake_devicegraph.find_by_name("/dev/sda1").sid
 
-          settings.space_settings.actions = { "/dev/sda1" => :delete }
+          settings.space_settings.actions = [delete.new("/dev/sda1")]
           proposal.propose
           expect(proposal.failed?).to eq false
 
@@ -141,7 +144,7 @@ describe Y2Storage::MinGuidedProposal do
         it "tries to use the formatted disk before trying an optional resize" do
           orig_sda1 = fake_devicegraph.find_by_name("/dev/sda1")
 
-          settings.space_settings.actions = { "/dev/sda1" => :resize }
+          settings.space_settings.actions = [resize.new("/dev/sda1")]
           proposal.propose
           expect(proposal.failed?).to eq false
 

--- a/test/y2storage/proposal_agama_basis_test.rb
+++ b/test/y2storage/proposal_agama_basis_test.rb
@@ -252,11 +252,11 @@ describe Y2Storage::MinGuidedProposal do
 
       before do
         settings.space_settings.strategy = :bigger_resize
-        settings.space_settings.actions = {
-          "/dev/sda1" => :resize,
-          "/dev/sdb1" => :resize,
-          "/dev/sdc1" => :resize
-        }
+        settings.space_settings.actions = [
+          Y2Storage::SpaceActions::Resize.new("/dev/sda1"),
+          Y2Storage::SpaceActions::Resize.new("/dev/sdb1"),
+          Y2Storage::SpaceActions::Resize.new("/dev/sdc1")
+        ]
       end
 
       include_examples "resize volume combinations"
@@ -275,11 +275,11 @@ describe Y2Storage::MinGuidedProposal do
 
       before do
         settings.space_settings.strategy = :bigger_resize
-        settings.space_settings.actions = {
-          "/dev/sda1" => :force_delete,
-          "/dev/sdb1" => :force_delete,
-          "/dev/sdc1" => :force_delete
-        }
+        settings.space_settings.actions = [
+          Y2Storage::SpaceActions::Delete.new("/dev/sda1", mandatory: true),
+          Y2Storage::SpaceActions::Delete.new("/dev/sdb1", mandatory: true),
+          Y2Storage::SpaceActions::Delete.new("/dev/sdc1", mandatory: true)
+        ]
       end
 
       include_examples "delete volume combinations"

--- a/test/y2storage/proposal_agama_reuse_test.rb
+++ b/test/y2storage/proposal_agama_reuse_test.rb
@@ -34,7 +34,7 @@ describe Y2Storage::MinGuidedProposal do
     let(:settings_format) { :ng }
     let(:separate_home) { true }
     let(:control_file_content) { { "partitioning" => { "volumes" => volumes } } }
-    let(:space_actions) { {} }
+    let(:space_actions) { [] }
 
     let(:scenario) { "lvm-two-vgs" }
     let(:resize_info) do
@@ -56,6 +56,9 @@ describe Y2Storage::MinGuidedProposal do
     let(:swap_vol) do
       { "mount_point" => "swap", "fs_type" => "swap", "min_size" => "2 GiB", "max_size" => "6 GiB" }
     end
+
+    let(:delete) { Y2Storage::SpaceActions::Delete }
+    let(:resize) { Y2Storage::SpaceActions::Resize }
 
     before do
       # Speed-up things by avoiding calls to hwinfo
@@ -82,7 +85,9 @@ describe Y2Storage::MinGuidedProposal do
         srv.reformat = reformat
       end
 
-      let(:space_actions) { { "/dev/sda1" => :delete, "/dev/sda2" => :delete, "/dev/sda8" => :delete } }
+      let(:space_actions) do
+        [delete.new("/dev/sda1"), delete.new("/dev/sda2"), delete.new("/dev/sda8")]
+      end
       let(:original_sda8) { fake_devicegraph.find_by_name("/dev/sda8") }
 
       context "keeping its filesystem" do
@@ -129,7 +134,7 @@ describe Y2Storage::MinGuidedProposal do
         srv.reformat = reformat
       end
 
-      let(:space_actions) { { "/dev/sda1" => :delete, "/dev/sda4" => :delete } }
+      let(:space_actions) { [delete.new("/dev/sda1"), delete.new("/dev/sda4")] }
       let(:original_sda4) { fake_devicegraph.find_by_name("/dev/sda4") }
 
       context "keeping its filesystem" do
@@ -178,7 +183,9 @@ describe Y2Storage::MinGuidedProposal do
         srv.reformat = reformat
       end
 
-      let(:space_actions) { { "/dev/sda1" => :delete, "/dev/sda2" => :delete, "/dev/sda5" => :delete } }
+      let(:space_actions) do
+        [delete.new("/dev/sda1"), delete.new("/dev/sda2"), delete.new("/dev/sda5")]
+      end
       let(:original_sda5) { fake_devicegraph.find_by_name("/dev/sda5") }
 
       context "keeping its filesystem" do
@@ -316,7 +323,7 @@ describe Y2Storage::MinGuidedProposal do
           srv.reuse_name = "/dev/md1"
         end
 
-        let(:space_actions) { { "/dev/sda2" => :delete, "/dev/sdb2" => :delete } }
+        let(:space_actions) { [delete.new("/dev/sda2"), delete.new("/dev/sdb2")] }
 
         let(:original_sda2) { fake_devicegraph.find_by_name("/dev/sda2") }
         let(:original_sdb2) { fake_devicegraph.find_by_name("/dev/sdb2") }
@@ -345,7 +352,7 @@ describe Y2Storage::MinGuidedProposal do
           srv.reuse_name = "/dev/md0"
         end
 
-        let(:space_actions) { { "/dev/sda1" => :delete, "/dev/sdb1" => :delete } }
+        let(:space_actions) { [delete.new("/dev/sda1"), delete.new("/dev/sdb1")] }
 
         let(:original_sda1) { fake_devicegraph.find_by_name("/dev/sda1") }
         let(:original_sdb1) { fake_devicegraph.find_by_name("/dev/sdb1") }
@@ -383,7 +390,7 @@ describe Y2Storage::MinGuidedProposal do
         srv.reformat = false
       end
 
-      let(:space_actions) { { "/dev/sda2" => :delete, "/dev/sdb2" => :delete } }
+      let(:space_actions) { [delete.new("/dev/sda2"), delete.new("/dev/sdb2")] }
 
       let(:original_sda2) { fake_devicegraph.find_by_name("/dev/sda2") }
       let(:original_sdb2) { fake_devicegraph.find_by_name("/dev/sdb2") }
@@ -413,7 +420,7 @@ describe Y2Storage::MinGuidedProposal do
         srv.reformat = false
       end
 
-      let(:space_actions) { { "/dev/sda2" => :delete, "/dev/sdb2" => :delete } }
+      let(:space_actions) { [delete.new("/dev/sda2"), delete.new("/dev/sdb2")] }
 
       let(:original_sda2) { fake_devicegraph.find_by_name("/dev/sda2") }
       let(:original_sdb2) { fake_devicegraph.find_by_name("/dev/sdb2") }
@@ -477,10 +484,10 @@ describe Y2Storage::MinGuidedProposal do
       end
 
       let(:space_actions) do
-        {
-          "/dev/sda1" => :delete, "/dev/sda2" => :delete, "/dev/sda3" => :delete,
-          "/dev/sdb1" => :delete, "/dev/sdb2" => :delete
-        }
+        [
+          delete.new("/dev/sda1"), delete.new("/dev/sda2"), delete.new("/dev/sda3"),
+          delete.new("/dev/sdb1"), delete.new("/dev/sdb2")
+        ]
       end
 
       let(:original_sdb1) { fake_devicegraph.find_by_name("/dev/sdb1") }


### PR DESCRIPTION
Agama allows to specify what to do with the existing partitions during installation in a quite flexible way. That includes deleting, deleting if needed or resizing (both shrinking and growing) within certain min and max sizes.

The initial support for that is implemented at https://github.com/openSUSE/agama/pull/1599

This pull request includes all the changes needed to make that implementation possible.

