### PR TITLE
Use the newer exfatprogs instead of exfat-utils [SLE-15-SP7]

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,7 +1,13 @@
+Thu Sep 19 13:42:45 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Use the newer exfatprogs instead of exfat-utils (bsc#1187854)
+- 4.7.1
+
 -------------------------------------------------------------------
 Fri Sep 06 06:47:30 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Branch package for SP7 (bsc#1230201)
+- 4.7.0
 
 -------------------------------------------------------------------
 Wed Apr  3 11:23:01 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.7.0
+Version:        4.7.1
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/storage_feature.rb
+++ b/src/lib/y2storage/storage_feature.rb
@@ -76,7 +76,7 @@ module Y2Storage
         UF_NFS:              "nfs-client",
         UF_NTFS:             ["ntfs-3g", "ntfsprogs"],
         UF_VFAT:             "dosfstools",
-        UF_EXFAT:            "exfat-utils",
+        UF_EXFAT:            "exfatprogs",
         UF_F2FS:             "f2fs-tools",
         UF_UDF:              "udftools",
         UF_JFS:              "jfsutils",


### PR DESCRIPTION
## Target Branch

**This the merge of #1389 into SLE-15-SP7.**

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1187854


## Trello

https://trello.com/c/N7gz5WP0


## Problem

When determining what additional software packages are needed for a storage operation, e.g. in the expert partitioner, we still requested the old _exfat-utils_ instead of the newer _exfatprogs_.

This can be relevant if the user wants to format e.g. a USB stick with the ExFAT filesystem, and the support package for that filesystem is not yet installed.


## Fix

Add _exfatprogs_ to the list of needed packages for the storage operations, not _exfat-utils_.


## What about libstorage?

libstorage-ng has been using the binary from _exfatprogs_ for quite a while already. But the user had to make sure manually that this package was installed.


## Related PRs

-Original PR for SLE-15-SP6: #1389 
- Merge to _master_ / _Factory_: _TBD_

