### PR TITLE
Use the newer exfatprogs instead of exfat-utils [master]

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 23 11:27:55 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Use the newer exfatprogs instead of exfat-utils (bsc#1187854)
+- 5.0.19
+
+-------------------------------------------------------------------
 Fri Sep 20 13:06:00 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Extend the API to resize partitions during a proposal (required

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.18
+Version:        5.0.19
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/storage_feature.rb
+++ b/src/lib/y2storage/storage_feature.rb
@@ -75,7 +75,7 @@ module Y2Storage
         UF_NFS:              "nfs-client",
         UF_NTFS:             ["ntfs-3g", "ntfsprogs"],
         UF_VFAT:             "dosfstools",
-        UF_EXFAT:            "exfat-utils",
+        UF_EXFAT:            "exfatprogs",
         UF_F2FS:             "f2fs-tools",
         UF_UDF:              "udftools",
         UF_JFS:              "jfsutils",


### PR DESCRIPTION
## Target Branch

**This the merge of #1389 / #1390 into _master_ / _Factory_.**

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1187854


## Trello

https://trello.com/c/N7gz5WP0


## Problem

When determining what additional software packages are needed for a storage operation, e.g. in the expert partitioner, we still requested the old _exfat-utils_ instead of the newer _exfatprogs_.

This can be relevant if the user wants to format e.g. a USB stick with the ExFAT filesystem, and the support package for that filesystem is not yet installed.


## Fix

Add _exfatprogs_ to the list of needed packages for the storage operations, not _exfat-utils_.


## What about libstorage?

libstorage-ng has been using the binary from _exfatprogs_ for quite a while already. But the user had to make sure manually that this package was installed.


## Related PRs

- Original PR for SLE-15-SP6: #1389 
- Merge to SLE-15-SP7: #1390
