### PR TITLE
Changes to allow automatic generation of LVM PVs at the AgamaProposal

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct  8 12:21:38 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- SpaceMaker: make it possible to generate physical volumes for
+  several volume groups (needed by gh#agama-project/agama#1655).
+- 5.0.20
+
+-------------------------------------------------------------------
 Mon Sep 23 11:27:55 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Use the newer exfatprogs instead of exfat-utils (bsc#1187854)

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.19
+Version:        5.0.20
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -28,10 +28,14 @@ module Y2Storage
     module CanBeEncrypted
       include SecretAttributes
 
-      # This value matches Storage::Luks.metadata_size, which is not exposed in
+      # This value matches Storage::Luks.v1_metadata_size, which is not exposed in
       # the libstorage API
-      ENCRYPTION_OVERHEAD = DiskSize.MiB(2)
-      private_constant :ENCRYPTION_OVERHEAD
+      LUKS1_OVERHEAD = DiskSize.MiB(2)
+      private_constant :LUKS1_OVERHEAD
+
+      # This value matches Storage::Luks.v2_metadata_size, see above
+      LUKS2_OVERHEAD = DiskSize.MiB(16)
+      private_constant :LUKS2_OVERHEAD
 
       # @!attribute encryption_method
       #   @return [EncryptionMethod::Base, nil] method used to encrypt the device. If is nil,
@@ -152,9 +156,13 @@ module Y2Storage
         # I.e. how much smaller will be an encrypted device compared to the plain
         # one.
         #
+        # @param type [EncryptionType]
         # @return [DiskSize]
-        def encryption_overhead
-          ENCRYPTION_OVERHEAD
+        def encryption_overhead(type = EncryptionType::LUKS1)
+          return LUKS1_OVERHEAD if type&.is?(:luks1)
+          return LUKS2_OVERHEAD if type&.is?(:luks2)
+
+          DiskSize.zero
         end
       end
     end

--- a/src/lib/y2storage/planned/lvm_vg.rb
+++ b/src/lib/y2storage/planned/lvm_vg.rb
@@ -323,7 +323,7 @@ module Y2Storage
       #
       # @return [DiskSize]
       def useless_pv_space
-        pvs_encrypt? ? USELESS_PV_SPACE + Planned::Partition.encryption_overhead : USELESS_PV_SPACE
+        pvs_encrypt? ? USELESS_PV_SPACE + encryption_overhead : USELESS_PV_SPACE
       end
 
       def substract_reused_vg_size(size)
@@ -332,6 +332,11 @@ module Y2Storage
         else
           DiskSize.zero
         end
+      end
+
+      # @return [DiskSize]
+      def encryption_overhead
+        Planned::Partition.encryption_overhead(pvs_encryption_method&.encryption_type)
       end
     end
   end

--- a/src/lib/y2storage/planned/lvm_vg.rb
+++ b/src/lib/y2storage/planned/lvm_vg.rb
@@ -83,6 +83,11 @@ module Y2Storage
       # @return [Symbol]
       attr_accessor :size_strategy
 
+      # Disks where the proposal can create extra physical volumes to honor {#size_strategy}
+      #
+      # @return [Array<String>] names of partitionable devices
+      attr_accessor :pvs_candidate_devices
+
       # Builds a new instance based on a real VG
       #
       # The new instance represents the intention to reuse the real VG, so the
@@ -111,6 +116,7 @@ module Y2Storage
         @pvs = pvs
         @pvs_encryption_password = nil
         @make_space_policy = :needed
+        @pvs_candidate_devices = []
       end
 
       # Initializes the object taking the values from a real volume group
@@ -258,13 +264,15 @@ module Y2Storage
       end
 
       # Device name of the disk-like device in which the volume group has to be
-      # physically located. If nil, the volume group can spread freely over any
-      # set of disks.
+      # physically located. If nil, the volume group can spread over a set of
+      # several disks (maybe even unlimited).
       #
       # @return [String, nil]
       def forced_disk_name
         forced_lv = lvs.find(&:disk)
-        forced_lv ? forced_lv.disk : nil
+        return forced_lv.disk if forced_lv
+
+        pvs_candidate_devices.size == 1 ? pvs_candidate_devices.first : nil
       end
 
       protected

--- a/src/lib/y2storage/planned/lvm_vg.rb
+++ b/src/lib/y2storage/planned/lvm_vg.rb
@@ -156,10 +156,12 @@ module Y2Storage
       #
       # This method is useful to generate a volume group with just one new PV.
       #
+      # @param target [DiskSize, nil] aim for the provided size, instead of
+      #   trying to provide the exact size needed by the volume group
       # @return [Planned::Partition]
-      def single_pv_partition
+      def single_pv_partition(target: nil)
         pv = minimal_pv_partition
-        pv.min_size = real_pv_size(missing_space)
+        pv.min_size = real_pv_size(target || missing_space)
         pv.max_size = real_pv_size(max_size)
         pv.weight = lvs_weight
         pv

--- a/src/lib/y2storage/proposal/autoinst_partitioner.rb
+++ b/src/lib/y2storage/proposal/autoinst_partitioner.rb
@@ -155,12 +155,21 @@ module Y2Storage
       def best_distribution(planned_partitions, devices)
         spaces = devices.map(&:free_spaces).flatten
 
-        calculator = Proposal::PartitionsDistributionCalculator.new
-        dist = calculator.best_distribution(planned_partitions, spaces)
+        dist = distribute_partitions(planned_partitions, spaces)
         return dist if dist
 
         # Second try with more flexible planned partitions
-        calculator.best_distribution(flexible_partitions(planned_partitions), spaces)
+        distribute_partitions(flexible_partitions(planned_partitions), spaces)
+      end
+
+      # @see #best_distribution
+      #
+      # @param partitions [Array<Planned::Partition>] list of planned partitions to create
+      # @param spaces [Array<FreeDiskSpace>] spaces to distribute the partitions
+      # @return [Planned::PartitionsDistribution, nil]
+      def distribute_partitions(partitions, spaces)
+        calculator = Proposal::PartitionsDistributionCalculator.new(partitions)
+        calculator.best_distribution(spaces)
       end
 
       # Checks whether (re)formatting the given device is acceptable

--- a/src/lib/y2storage/proposal/devicegraph_generator.rb
+++ b/src/lib/y2storage/proposal/devicegraph_generator.rb
@@ -167,14 +167,14 @@ module Y2Storage
         if settings.use_lvm
           provide_space_lvm(planned_partitions, devicegraph, lvm_helper)
         else
-          provide_space_no_lvm(planned_partitions, devicegraph, lvm_helper)
+          provide_space_no_lvm(planned_partitions, devicegraph)
         end
       end
 
       # Variant of #provide_space when LVM is not involved
       # @see #provide_space
-      def provide_space_no_lvm(planned_partitions, devicegraph, lvm_helper)
-        result = space_maker.provide_space(devicegraph, planned_partitions, lvm_helper)
+      def provide_space_no_lvm(planned_partitions, devicegraph)
+        result = space_maker.provide_space(devicegraph, planned_partitions)
         log.info "Found enough space"
         result
       end
@@ -194,7 +194,9 @@ module Y2Storage
           original_sids = space_maker.protected_sids
           space_maker.protected_sids += lvm_sids
 
-          result = space_maker.provide_space(devicegraph, planned_partitions, lvm_helper)
+          result = space_maker.provide_space(
+            devicegraph, planned_partitions, lvm_helper.volume_group
+          )
           log.info "Found enough space including LVM, reusing #{vg}"
           return result
         rescue Error
@@ -204,7 +206,7 @@ module Y2Storage
         end
 
         lvm_helper.reused_volume_group = nil
-        result = space_maker.provide_space(devicegraph, planned_partitions, lvm_helper)
+        result = space_maker.provide_space(devicegraph, planned_partitions, lvm_helper.volume_group)
         log.info "Found enough space including LVM"
 
         result

--- a/src/lib/y2storage/proposal/devicegraph_generator.rb
+++ b/src/lib/y2storage/proposal/devicegraph_generator.rb
@@ -190,7 +190,9 @@ module Y2Storage
       # Variant of #provide_space when LVM is not involved
       # @see #provide_space
       def provide_space_no_lvm(planned_partitions, devicegraph)
-        result = space_maker.provide_space(devicegraph, default_disks, planned_partitions)
+        result = space_maker.provide_space(
+          devicegraph, default_disks: default_disks, partitions: planned_partitions
+        )
         log.info "Found enough space"
         result
       end
@@ -211,7 +213,8 @@ module Y2Storage
           space_maker.protected_sids += lvm_sids
 
           result = space_maker.provide_space(
-            devicegraph, default_disks, planned_partitions, lvm_helper.volume_group
+            devicegraph, default_disks: default_disks,
+            partitions: planned_partitions, volume_groups: [lvm_helper.volume_group]
           )
           log.info "Found enough space including LVM, reusing #{vg}"
           return result
@@ -223,7 +226,8 @@ module Y2Storage
 
         lvm_helper.reused_volume_group = nil
         result = space_maker.provide_space(
-          devicegraph, default_disks, planned_partitions, lvm_helper.volume_group
+          devicegraph, default_disks: default_disks,
+          partitions: planned_partitions, volume_groups: [lvm_helper.volume_group]
         )
         log.info "Found enough space including LVM"
 

--- a/src/lib/y2storage/proposal/lvm_helper.rb
+++ b/src/lib/y2storage/proposal/lvm_helper.rb
@@ -111,16 +111,6 @@ module Y2Storage
         @reused_volume_group.pvs_encryption_pbkdf = settings.encryption_pbkdf
       end
 
-      # Checks whether the passed device is the volume group to be reused
-      #
-      # @param device [Device]
-      # @return [Boolean]
-      def vg_to_reuse?(device)
-        return false unless @reused_volume_group
-
-        device.is?(:lvm_vg) && @reused_volume_group.volume_group_name == device.vg_name
-      end
-
       # Returns the planned volume group
       #
       # If no volume group is set (see {#reused_volume_group=}), it will create

--- a/src/lib/y2storage/proposal/partitions_distribution_calculator.rb
+++ b/src/lib/y2storage/proposal/partitions_distribution_calculator.rb
@@ -30,8 +30,18 @@ module Y2Storage
     class PartitionsDistributionCalculator
       include Yast::Logger
 
-      def initialize(planned_vg = nil)
-        @planned_vg = planned_vg
+      # Constructor
+      #
+      # @param partitions [Array<Planned::Partition>] see {#planned_partitions}
+      # @param planned_vgs [Array<Planned::LvmVg>] see {#planned_vgs}
+      def initialize(partitions = [], planned_vgs = [], default_disks = nil)
+        @planned_partitions = partitions
+        # Always process first volume groups that are more limited in their usage of different
+        # disks. Use the name as second sort criteria for stable sorting between executions.
+        @planned_vgs = planned_vgs.sort_by do |vg|
+          [vg.pvs_candidate_devices.size, vg.volume_group_name]
+        end
+        @default_disks = default_disks
       end
 
       # Best possible distribution, nil if the planned partitions don't fit
@@ -41,30 +51,21 @@ module Y2Storage
       # the LVM physical volumes that need to be created in order to reach
       # that size (within the max limits defined for the planned VG).
       #
-      # @param partitions [Array<Planned::Partition>]
-      # @param spaces [Array<FreeDiskSpace>] spaces that can be used to allocate partitions targeted
-      #   to the corresponding disk but also partitions with no specific disk and partitions for LVM
-      # @param extra_spaces [Array<FreeDiskSpace>] spaces that can only be used to allocate
-      #   partitions explicitly targeted to the corresponding disk
-      #
-      # @return [Planned::PartitionsDistribution]
-      def best_distribution(partitions, spaces, extra_spaces = [])
-        log.info "Calculating best space distribution for #{partitions.inspect}"
+      # @param spaces [Array<FreeDiskSpace>] spaces that can be used to allocate partitions
+      # @return [Planned::PartitionsDistribution, nil]
+      def best_distribution(spaces)
+        log.info "Calculating best space distribution for #{planned_partitions.inspect}"
         # First, make sure the whole attempt makes sense
-        return nil if impossible?(partitions, spaces + extra_spaces)
+        return nil if impossible?(planned_partitions, spaces)
 
         begin
-          dist_hashes = distribute_partitions(partitions, spaces, extra_spaces)
+          dist_hashes = distribute_partitions(planned_partitions, spaces)
         rescue NoDiskSpaceError
           return nil
         end
         candidates = distributions_from_hashes(dist_hashes)
 
-        if lvm?
-          log.info "Calculate LVM posibilities for the #{candidates.size} candidate distributions"
-          pv_calculator = PhysVolCalculator.new(spaces, planned_vg)
-          candidates.map! { |dist| pv_calculator.add_physical_volumes(dist) }
-        end
+        add_physical_volumes(candidates, spaces)
         candidates.compact!
 
         best_candidate(candidates)
@@ -78,11 +79,9 @@ module Y2Storage
       # from the partition.
       #
       # @param partition [Partition] partition to resize
-      # @param planned_partitions [Array<Planned::Partition>] planned
-      #     partitions to make space for
       # @param free_spaces [Array<FreeDiskSpace>] all free spaces in the system
       # @return [DiskSize]
-      def resizing_size(partition, planned_partitions, free_spaces)
+      def resizing_size(partition, free_spaces)
         # This is far more complex than "needed_space - current_space" because
         # we really have to find a distribution that is valid.
         #
@@ -90,8 +89,10 @@ module Y2Storage
         # that would succeed, taking into account that resizing will introduce a
         # new space or make one of the existing spaces grow.
 
-        all_spaces = add_or_mark_growing_space(free_spaces, partition)
-        all_planned = all_planned_partitions(planned_partitions)
+        disk = partition.partitionable.name
+        all_spaces = free_spaces.select { |s| s.disk_name == disk }
+        all_spaces = add_or_mark_growing_space(all_spaces, partition)
+        all_planned = all_planned_partitions.select { |p| compatible_disk?(p, disk) }
 
         begin
           dist_hashes = distribute_partitions(all_planned, all_spaces)
@@ -100,11 +101,7 @@ module Y2Storage
           # reclaim as much space as possible.
           #
           # FIXME: using the partition size as fallback value in situations
-          # where resizing the partition cannot provide a valid solution makes
-          # sense because, with the current SpaceMaker algorithm, we will not
-          # have another chance of resizing this partition.
-          # Revisit this if the global proposal algorithm is changed in the
-          # future.
+          # where resizing the partition cannot provide a valid solution.
           return partition.size
         end
 
@@ -119,22 +116,21 @@ module Y2Storage
         end
       end
 
-      # Whether LVM should be taken into account
+      # When calculating an LVM proposal, this represents the projected volume groups for
+      # which is necessary to automatically allocate physical volumes (based on their respective
+      # values for {Planned::LvmVg#pvs_candidate_devices}.
       #
-      # @return [Boolean]
-      def lvm?
-        !!(planned_vg && planned_vg.missing_space > DiskSize.zero)
-      end
+      # Empty if LVM is not involved (partition-based proposal)
+      #
+      # @return [Array<Planned::LvmVg>]
+      attr_reader :planned_vgs
+
+      # @return [Array<Planned::Partition>] planned partitions to find space for
+      attr_reader :planned_partitions
+
+      attr_reader :default_disks
 
       protected
-
-      # When calculating an LVM proposal, this represents the projected "system"
-      # volume group to accommodate root and other volumes.
-      #
-      # Nil if LVM is not involved (partition-based proposal)
-      #
-      # @return [Planned::LvmVg, nil]
-      attr_reader :planned_vg
 
       # Checks whether there is any chance of producing a valid
       # PartitionsDistribution to accomodate the planned partitions and the
@@ -143,10 +139,8 @@ module Y2Storage
       # This check could be improved to detect more situations that make it impossible
       # to get a distribution, but the goal is to keep it relatively simple and fast.
       def impossible?(planned_partitions, free_spaces)
-        if lvm?
-          # Let's assume the best possible case - if we need to create a PV it will be only one
-          planned_partitions += [planned_vg.single_pv_partition]
-        end
+        # Let's assume the best possible case - if we need to create PVs it will be only one per VG
+        planned_partitions += single_pv_partitions
 
         # First, do the simplest calculation - checking total sizes
         needed = DiskSize.sum(planned_partitions.map(&:min))
@@ -169,6 +163,21 @@ module Y2Storage
         false
       end
 
+      # Planned volume groups that need some extra physical volume
+      #
+      # @return [Array<Planned::LvmVg]
+      def incomplete_planned_vgs
+        planned_vgs.select { |vg| vg.missing_space > DiskSize.zero }
+      end
+
+      # Simplest possible collection of missing physical volumes (only one per incomplete volume
+      # group)
+      #
+      # @return [Array<Planned::Partition>]
+      def single_pv_partitions
+        incomplete_planned_vgs.map(&:single_pv_partition)
+      end
+
       # Returns the sum of available spaces
       #
       # @param free_spaces [Array<FreeDiskSpace>] List of free disk spaces
@@ -184,17 +193,47 @@ module Y2Storage
       #
       # @param planned_partitions [Array<Planned::Partition>]
       # @param free_spaces [Array<FreeDiskSpace>]
-      # @param extra_spaces [Array<FreeDiskSpace>]
       # @return [Hash{Planned::Partition => Array<FreeDiskSpace>}]
-      def candidate_disk_spaces(planned_partitions, free_spaces, extra_spaces = [])
+      def candidate_disk_spaces(planned_partitions, free_spaces)
         planned_partitions.each_with_object({}) do |partition, hash|
-          spaces = partition_candidate_spaces(partition, free_spaces, extra_spaces)
+          spaces = partition_candidate_spaces(partition, free_spaces)
           if spaces.empty?
             log.error "No suitable free space for #{partition}"
             raise NoDiskSpaceError, "No suitable free space for the planned partition"
           end
           hash[partition] = spaces
         end
+      end
+
+      # @see #best_distribution
+      #
+      # @param candidates [Array<Planned::PartitionsDistribution>]
+      # @param spaces [Array<FreeDiskSpace>]
+      def add_physical_volumes(candidates, spaces)
+        candidates.map! do |dist|
+          incomplete_planned_vgs.inject(dist) do |res, planned_vg|
+            pv_spaces = spaces_for_vg(spaces, planned_vg)
+            pv_calculator = PhysVolCalculator.new(pv_spaces, planned_vg)
+            pv_calculator.add_physical_volumes(res)
+          end
+        end
+      end
+
+      # Subset of spaces that are located at devices that are acceptable for the given
+      # planed volume group
+      #
+      # @param all_spaces [Array<FreeDiskSpace>] full set of spaces
+      # @param volume_group [Planned::VolumeGroup]
+      # @return [Array<FreeDiskSpace>] subset of spaces that could contain a
+      #   physical volume
+      def spaces_for_vg(all_spaces, volume_group)
+        disk_name = volume_group.forced_disk_name
+        return all_spaces.select { |i| i.disk_name == disk_name } if disk_name
+
+        disk_names = volume_group.pvs_candidate_devices
+        disk_names = default_disks if disk_names.empty? && default_disks
+
+        all_spaces.select { |s| disk_names.include?(s.disk_name) }
       end
 
       # All possible combinations of spaces and planned partitions.
@@ -221,7 +260,7 @@ module Y2Storage
       #
       # @return [Boolean]
       def suitable_disk_space?(space, partition)
-        return false unless compatible_disk?(partition, space)
+        return false unless compatible_disk?(partition, space.disk_name)
         return false unless compatible_ptable?(partition, space)
         return false unless partition_fits_space?(partition, space)
 
@@ -235,19 +274,32 @@ module Y2Storage
       #
       # @param partition [Planned::Partition]
       # @param candidate_spaces [Array<FreeDiskSpace>]
-      # @param extra_spaces [Array<FreeDiskSpace>]
       # @return [Array<FreeDiskSpace>]
-      def partition_candidate_spaces(partition, candidate_spaces, extra_spaces)
-        spaces = partition.disk ? candidate_spaces + extra_spaces : candidate_spaces
-        spaces.select { |space| suitable_disk_space?(space, partition) }
+      def partition_candidate_spaces(partition, candidate_spaces)
+        candidate_spaces.select { |space| suitable_disk_space?(space, partition) }
       end
 
       # @param partition [Planned::Partition]
-      # @param space [FreeDiskSpace]
+      # @param disk_name [String]
       #
       # @return [Boolean]
-      def compatible_disk?(partition, space)
-        return true unless partition.disk && partition.disk != space.disk_name
+      def compatible_disk?(partition, disk_name)
+        return partition.disk == disk_name if partition.disk
+
+        pv_candidates = planned_vg_for(partition)&.pvs_candidate_devices
+        return pv_candidates.include?(disk_name) if pv_candidates&.any?
+
+        return true unless default_disks
+
+        default_disks.include?(disk_name)
+      end
+
+      # Planned volume group associated to the given partition, if any
+      #
+      # @param planned_partition [Planned::Partition]
+      # @return [Planned::LvmVg, nil] nil if the partition is not meant as an LVM PV
+      def planned_vg_for(planned_partition)
+        planned_vgs.find { |vg| vg.volume_group_name == planned_partition.lvm_volume_group_name }
       end
 
       # @param partition [Planned::Partition]
@@ -280,11 +332,10 @@ module Y2Storage
       #
       # @param partitions [Array<Planned::Partitions>]
       # @param spaces [Array<FreeDiskSpace>]
-      # @param extra_spaces [Array<FreeDiskSpace>]
       # @return [Array<Hash{FreeDiskSpace => Array<Planned::Partition>}>]
-      def distribute_partitions(partitions, spaces, extra_spaces = [])
+      def distribute_partitions(partitions, spaces)
         log.info "Selecting the candidate spaces for each planned partition"
-        disk_spaces_by_part = candidate_disk_spaces(partitions, spaces, extra_spaces)
+        disk_spaces_by_part = candidate_disk_spaces(partitions, spaces)
 
         log.info "Calculate all the possible distributions of planned partitions into spaces"
         dist_hashes = distribution_hashes(disk_spaces_by_part)
@@ -433,16 +484,12 @@ module Y2Storage
       #
       # @see #resizing_size
       #
-      # @param planned_partitions [Array<Planned::Partition>] original set of
-      #   partitions
       # @return [Array<Planned::Partition] original set (in the non-LVM case) or
       #   an extended set including partitions needed for LVM
-      def all_planned_partitions(planned_partitions)
-        return planned_partitions unless lvm?
-
+      def all_planned_partitions
         # In the LVM case, assume the worst case - that there will be only
-        # one big PV and we have to make room for it as well.
-        planned_partitions + [planned_vg.single_pv_partition]
+        # one big PV per volume group and we have to make room for them as well.
+        planned_partitions + single_pv_partitions
       end
 
       # Size that is missing in the space marked as "growing" in order to

--- a/src/lib/y2storage/proposal/phys_vol_calculator.rb
+++ b/src/lib/y2storage/proposal/phys_vol_calculator.rb
@@ -34,11 +34,11 @@ module Y2Storage
       # Initialize.
       #
       # @param all_spaces [Array<FreeDiskSpace>] Disk spaces that could
-      #     potentially contain physical volumes
+      #     potentially contain physical volumes for the given volume group
       # @param planned_vg [Planned::LvmVg] volume group to create the PVs for
       def initialize(all_spaces, planned_vg)
         @planned_vg = planned_vg
-        @all_spaces = spaces_in_valid_disks(all_spaces)
+        @all_spaces = all_spaces
 
         strategy = planned_vg.size_strategy
         if STRATEGIES[strategy]
@@ -63,24 +63,6 @@ module Y2Storage
       #     impossible to allocate all the needed physical volumes
       def add_physical_volumes(distribution)
         @strategy_class.new(distribution, @all_spaces, @planned_vg).add_physical_volumes
-      end
-
-      protected
-
-      # Subset of spaces that are located in acceptable devices
-      #
-      # Filters the original list to only include spaces in those disks that are
-      # acceptable for the planned VG. Usually that means simply returning the original
-      # list back.
-      #
-      # @param all_spaces [Array<FreeDiskSpace>] full set of spaces
-      # @return [Array<FreeDiskSpace>] subset of spaces that could contain a
-      #   physical volume
-      def spaces_in_valid_disks(all_spaces)
-        disk_name = @planned_vg.forced_disk_name
-        return all_spaces unless disk_name
-
-        all_spaces.select { |i| i.disk_name == disk_name }
       end
     end
   end

--- a/src/lib/y2storage/proposal/resize_phys_vol_calculator.rb
+++ b/src/lib/y2storage/proposal/resize_phys_vol_calculator.rb
@@ -1,0 +1,122 @@
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Storage
+  module Proposal
+    # Utility used by PartitionsDistributionCalculator to propose some potential LVM physical
+    # volumes during resize calculation, using a pessimistic heuristic.
+    class ResizePhysVolCalculator
+      # Initialize.
+      #
+      # @param disk_spaces [Array<FreeDiskSpace>] Spaces that could potentially contain physical
+      #   volumes for the volume groups and that are located at the same disk than the partition
+      #   being resized
+      # @param planned_vgs [Array<Planned::LvmVg>] volume group to create the PVs for
+      # @param disk_partitions [Array<Planned::Partition>] partitions (apart from the PVs) that
+      #   also need to be located at the given spaces
+      def initialize(disk_spaces, planned_vgs, disk_partitions)
+        @disk_spaces = disk_spaces
+        @planned_vgs = planned_vgs
+        @disk_partitions = disk_partitions
+      end
+
+      # Whether it makes sense to use the result of {#all_partitions}
+      #
+      # @return [Boolean] false if this heuristic would be equivalent to the simplest one of
+      #   adding one big PV per volume group
+      def useful?
+        space_sizes.any?
+      end
+
+      # A new set of planned partitions including physical volumes for the planned volume groups
+      #
+      # @return [Array<Planned::Partition>
+      def all_partitions
+        partitions = disk_partitions
+        spaces_idx = space_sizes.length - 1
+        space_remaining = space_sizes[spaces_idx]
+
+        sorted_vgs.each do |vg|
+          vg_missing = vg.missing_space
+
+          while spaces_idx >= 0 && vg_missing > Y2Storage::DiskSize.zero
+            useful_space = vg.useful_pv_space(space_remaining)
+
+            if useful_space <= Y2Storage::DiskSize.zero
+              spaces_idx -= 1
+              space_remaining = space_sizes[spaces_idx] if spaces_idx >= 0
+              next
+            end
+
+            assigned = [vg_missing, useful_space].min
+            partitions << vg.single_pv_partition(target: assigned)
+            vg_missing -= assigned
+            space_remaining -= vg.real_pv_size(assigned)
+
+            break if vg_missing.zero?
+          end
+
+          partitions << vg.single_pv_partition(target: vg_missing) unless vg_missing.zero?
+        end
+
+        partitions
+      end
+
+      private
+
+      # See documentation of the constructor
+      attr_reader :disk_spaces
+
+      # See documentation of the constructor
+      attr_reader :planned_vgs
+
+      # See documentation of the constructor
+      attr_reader :disk_partitions
+
+      # Parts of the disk spaces that can be used to allocate physical volumes
+      #
+      # @return [Array<DiskSize>]
+      def space_sizes
+        return @space_sizes if @space_sizes
+
+        # Use start_offset to ensure stable sorting
+        spaces = disk_spaces.reject(&:growing?).sort_by { |s| [s.disk_size, s.start_offset] }
+        parts_space = DiskSize.sum(disk_partitions.map(&:min), rounding: align_grain)
+
+        # Very pesimistic, substract the size of all partitions from ALL spaces
+        @space_sizes = spaces.map { |s| s.disk_size - parts_space }.reject(&:zero?)
+      end
+
+      # Alignment of the disk that is being processed
+      #
+      # @return [Array<DiskSize>]
+      def align_grain
+        disk_spaces.first.align_grain
+      end
+
+      # @see #all_partitions
+      #
+      # @return [Array<Planned::LvmVg>]
+      def sorted_vgs
+        # Use name to ensure stable sorting
+        planned_vgs.sort_by { |vg| [vg.missing_space, vg.volume_group_name] }
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/proposal/space_maker.rb
+++ b/src/lib/y2storage/proposal/space_maker.rb
@@ -64,11 +64,12 @@ module Y2Storage
       #   partitions and/or the physical volumes
       #
       # @param original_graph [Devicegraph] initial devicegraph
+      # @param partitions [Array<Planned::Partition>] set of partitions to make space for
+      # @param volume_groups [Planned::LvmVg] set of LVM volume groups for which is necessary to
+      #   allocate auto-calculated physical volumes
       # @param default_disks [Array<Strings>] disks that will be used to allocate those partitions
-      #   with no concrete disks and the physical volumes of the LVM volume group
-      # @param planned_partitions [Array<Planned::Partition>] set of partitions to make space for
-      # @param planned_vg [Planned::LvmVg, nil] planned system LVM volume group. Nil if there is no
-      #   need to create space for the system VG
+      #   with no concrete disks and the physical volumes for those volume groups with no concrete
+      #   candidate devices
       # @return [Hash] a hash with three elements:
       #   devicegraph: [Devicegraph] resulting devicegraph
       #   deleted_partitions: [Array<Partition>] partitions that
@@ -76,11 +77,10 @@ module Y2Storage
       #   partitions_distribution: [Planned::PartitionsDistribution] proposed
       #     distribution of partitions, including new PVs if necessary
       #
-      def provide_space(original_graph, default_disks, planned_partitions, planned_vg = nil)
+      def provide_space(original_graph, partitions: [], volume_groups: [], default_disks: [])
         @original_graph = original_graph
-        @dist_calculator = PartitionsDistributionCalculator.new(planned_vg)
 
-        calculate_new_graph(default_disks, planned_partitions, planned_vg)
+        calculate_new_graph(partitions, volume_groups, default_disks)
 
         {
           devicegraph:             new_graph,
@@ -99,7 +99,7 @@ module Y2Storage
 
         result = original_graph.dup
         actions = SpaceMakerActions::List.new(settings, disk_analyzer)
-        @candidate_disk_names = disks
+        @all_disk_names = disks
 
         disks.each do |disk_name|
           disk = result.find_by_name(disk_name)
@@ -121,12 +121,7 @@ module Y2Storage
 
       protected
 
-      attr_reader :disk_analyzer, :dist_calculator
-
-      # Disks that are not candidate devices but still must be considered because
-      # there are planned partitions explicitly targeted to those disks
-      # @return [Array<String>]
-      attr_reader :extra_disk_names
+      attr_reader :disk_analyzer
 
       # New devicegraph calculated by {#provide_space}
       # @return [Devicegraph]
@@ -139,8 +134,25 @@ module Y2Storage
       # @return [Array<Integer>]
       attr_reader :new_graph_deleted_sids
 
+      # @see #provide_space
+      #
       # @return [Array<String>]
-      attr_reader :candidate_disk_names
+      attr_reader :default_disk_names
+
+      # Names of all the disks that are involved in the current operation (ie. current call
+      # to {#prepare_devicegraph} or to {#provide_space})
+      #
+      # @return [Array<String>]
+      attr_reader :all_disk_names
+
+      # Auxiliary variable kept because some space strategies need to know whether some volume
+      # group is being reused (and which one).
+      #
+      # FIXME: keeping this internal variable is probably avoidable since it's used for a very
+      # concrete purpose
+      #
+      # @return [Array<Planned::LvmVg>]
+      attr_reader :all_volume_groups
 
       # Partitions from the original devicegraph that are not present in the
       # result of the last call to #provide_space
@@ -152,71 +164,110 @@ module Y2Storage
 
       # @see #provide_space
       #
-      # @param default_disk_names [Array<Strings>] see {#provide_space}
       # @param partitions [Array<Planned::Partition>] partitions to make space for
-      # @param volume_group [Planned::LvmVg, nil] planned system LVM volume group
-      def calculate_new_graph(default_disk_names, partitions, volume_group)
+      # @param volume_groups [Array<Planned::LvmVg>] volume groups to potentially create PVs for
+      # @param default_disk_names [Array<Strings>] disks that will be used to allocate partitions
+      #   with no disk and volume groups with no candidate devices
+      def calculate_new_graph(partitions, volume_groups, default_disk_names)
         @new_graph = original_graph.duplicate
         @new_graph_deleted_sids = []
-        @candidate_disk_names = default_disk_names
-        @extra_disk_names = partitions.map(&:disk).compact.uniq - candidate_disk_names
 
-        # To make sure we are not freeing space in useless places first
-        # restrict the operations to disks with particular disk
-        # requirements.
+        @all_volume_groups = volume_groups
+        @default_disk_names = default_disk_names
+        @all_disk_names = all_disks(partitions, volume_groups, default_disk_names)
+
+        # To make sure we are not freeing space in useless places first restrict the operations to
+        # disks with particular requirements (they are the only option for some partitions or VGs)
         #
-        # planned_partitions_by_disk() returns all partitions restricted to
-        # a certain disk. Most times partitions are free to be created
-        # anywhere but sometimes it is known in advance on which disk they
-        # should be created.
+        # planned_devices_by_disk() returns all partitions and VGs restricted to a certain disk
         #
-        # Doing something similar for #max_start_offset is more difficult and
-        # doesn't pay off (#max_start_offset is used just in one case)
+        # Doing something similar for #max_start_offset is more difficult and doesn't pay off
+        # (#max_start_offset is used just in one case)
 
-        parts_by_disk = planned_partitions_by_disk(partitions)
+        devs_by_disk = planned_devices_by_disk(partitions, volume_groups)
 
-        # In some cases (for example, if there is only one candidate disk),
-        # executing #resize_and_delete with a particular disk name and its
-        # restricted set of planned partitions brings no value. It just makes
-        # the whole thing harder to debug (bsc#1057436).
-        if several_passes?(parts_by_disk)
-          # Start by freeing space to the planned partitions that are restricted
-          # to a certain disk.
-          #
-          # The result (if successful) is kept in @distribution.
-          #
-          parts_by_disk.each do |disk, parts|
-            resize_and_delete(parts, volume_group, disk_name: disk)
+        # In some cases (for example, if there is only one candidate disk), executing
+        # #resize_and_delete with a particular disk name and its restricted set of planned devices
+        # brings no value. It just makes the whole thing harder to debug (bsc#1057436).
+        if several_passes?(devs_by_disk)
+          # Start by freeing space to the planned devices that are restricted to a certain disk.
+          devs_by_disk.each do |disk, devs|
+            parts, vgs = devs.partition { |d| d.is_a?(Planned::Partition) }
+            dist_calculator = dist_calculator_for(parts, volume_groups, disk)
+            resize_and_delete(dist_calculator, disk_name: disk)
           rescue Error
-            # If LVM was involved, maybe there is still hope if we don't abort on this error.
-            raise unless dist_calculator.lvm?
-
-            # dist_calculator tried to allocate the specific partitions for this disk but also
-            # all new physical volumes for the LVM. If the physical volumes were the culprit, we
-            # should keep trying to delete/resize stuff in other disks.
-            raise unless find_distribution(parts, ignore_lvm: true)
+            # The previously used dist_calculator tried to allocate the specific partitions for
+            # this disk but also all new physical volumes for any LVM which could use the disk.
+            # So a failure may not mean all hope is lost.
+            #
+            # Let's check if we can still find a distribution if we stick to the volume groups that
+            # are fully attached to this disk (ie. can use no other disk)
+            raise unless disk_still_fits?(dist_calculator, parts, vgs)
           end
         end
 
-        # Now repeat the process with the full set of planned partitions and all the candidate
-        # disks.
-        #
-        # Note that the result of the run above is not lost as already
-        # assigned partitions are taken into account.
-        #
-        resize_and_delete(partitions, volume_group)
+        # Now repeat the process with the full set of planned devices and disks
+        dist_calculator = dist_calculator_for(partitions, volume_groups)
+        resize_and_delete(dist_calculator)
 
         @all_deleted_sids.concat(new_graph_deleted_sids)
       end
 
-      # @return [Hash{String => Array<Planned::Partition>}]
-      def planned_partitions_by_disk(planned_partitions)
-        planned_partitions.each_with_object({}) do |partition, hash|
+      # @see #calculate_new_graph
+      #
+      # @return [Boolean]
+      def disk_still_fits?(previous_dist_calculator, disk_partitions, disk_vgs)
+        # The previous failed attempt was already the best for this disk
+        return false if previous_dist_calculator.planned_vgs == disk_vgs
+
+        # Let's make a new attempt restricting the volume groups
+        dist_calculator = dist_calculator_for(disk_partitions, disk_vgs)
+        success?(dist_calculator)
+      end
+
+      # @see #calculate_new_graph
+      #
+      # @return [Array<String>]
+      def all_disks(partitions, volume_groups, default_disks)
+        lvm_disks = volume_groups.flat_map(&:pvs_candidate_devices).uniq
+        partition_disks = partitions.map(&:disk).compact.uniq
+        (lvm_disks + partition_disks + default_disks).sort.uniq
+      end
+
+      # @return [Hash{String => Array<Planned::Partition, Planned::LvmVg>}]
+      def planned_devices_by_disk(planned_partitions, volume_groups)
+        result = planned_partitions.each_with_object({}) do |partition, hash|
           if partition.disk
             hash[partition.disk] ||= []
             hash[partition.disk] << partition
           end
         end
+        volume_groups.each_with_object(result) do |vg, hash|
+          if vg.forced_disk_name
+            hash[vg.forced_disk_name] ||= []
+            hash[vg.forced_disk_name] << vg
+          end
+        end
+      end
+
+      # Instantiates a PartitionsDistributionCalculator for the given set of planned devices
+      #
+      # @return [PartitionsDistributionCalculator]
+      def dist_calculator_for(partitions, volume_groups, disk_name = nil)
+        vgs = disk_name ? volume_groups_for(disk_name, volume_groups) : volume_groups
+        PartitionsDistributionCalculator.new(partitions, vgs, default_disk_names)
+      end
+
+      # @see #dist_calculator_for
+      def volume_groups_for(disk, volume_groups)
+        volume_groups.select { |vg| disks_for_vg(vg).any?(disk) }
+      end
+
+      # @see #volume_groups_for
+      def disks_for_vg(vg)
+        return default_disk_names if vg.pvs_candidate_devices.empty?
+
+        vg.pvs_candidate_devices
       end
 
       # Checks whether the goal has already being reached
@@ -225,9 +276,8 @@ module Y2Storage
       # that made it possible.
       #
       # @return [Boolean]
-      def success?(planned_partitions)
-        # Once a distribution has been found we don't have to look for another one.
-        @distribution ||= find_distribution(planned_partitions)
+      def success?(dist_calculator)
+        @distribution ||= dist_calculator.best_distribution(free_spaces)
         !!@distribution
       rescue Error => e
         log.info "Exception while trying to distribute partitions: #{e}"
@@ -235,50 +285,47 @@ module Y2Storage
         false
       end
 
-      # Finds the best distribution to allocate the given set of planned partitions
+      # Performs all the needed operations to make space for the partitions, including physical
+      # volumes
       #
-      # In case of an LVM-based proposal, the distribution will also include any needed physical
-      # volume for the system LVM. The argument ignore_lvm can be used to disable that requirement.
-      #
-      # @param planned_partitions [Array<Planned::Partition>]
-      # @param ignore_lvm [Boolean]
-      # @return [Planned::PartitionsDistribution, nil] nil if no valid distribution was found
-      def find_distribution(planned_partitions, ignore_lvm: false)
-        calculator = ignore_lvm ? non_lvm_dist_calculator : dist_calculator
-        calculator.best_distribution(planned_partitions, free_spaces, extra_free_spaces)
-      end
-
-      # Perform all the needed operations to make space for the partitions
-      #
-      # @param planned_partitions [Array<Planned::Partition>] partitions
-      #     to make space for
-      # @param volume_group [Planned::LvmVg, nil] planned system LVM volume group, if any
+      # @param dist_calculator [PartitionsDistributionCalculator]
       # @param disk_name [String, nil] optional disk name to restrict operations to
-      #
-      def resize_and_delete(planned_partitions, volume_group, disk_name: nil)
+      def resize_and_delete(dist_calculator, disk_name: nil)
         # Note that only the execution with disk_name == nil is the final one.
-        # In other words, if disk_name contains something, it means there will
-        # be at least a subsequent call to the method.
-        log.info "Resize and delete. disk_name: #{disk_name}, planned partitions:"
-        planned_partitions.each do |p|
-          log.info "  mount: #{p.mount_point}, disk: #{p.disk}, min: #{p.min}, max: #{p.max}"
-        end
+        # In other words, if disk_name contains something, it means there will be at least a
+        # subsequent call to the method if everything goes right and the process is not aborted
 
+        log_resize_and_delete(dist_calculator, disk_name)
         # restart evaluation
         @distribution = nil
-        force_ptables(planned_partitions)
+        force_ptables(dist_calculator.planned_partitions)
 
         actions = SpaceMakerActions::List.new(settings, disk_analyzer)
+
         disks_for(new_graph, disk_name).each do |disk|
-          actions.add_optional_actions(disk, volume_group)
+          actions.add_optional_actions(disk, all_volume_groups)
         end
         skip = all_protected_sids(new_graph)
 
-        until success?(planned_partitions)
-          break unless execute_next_action(actions, planned_partitions, skip, disk_name)
+        # rubocop:disable Style/WhileUntilModifier
+        # Moving the until at the end makes the 'break' hard to understand
+        until success?(dist_calculator)
+          break unless execute_next_action(actions, skip, dist_calculator)
         end
+        # rubocop:enable Style/WhileUntilModifier
 
         raise Error unless @distribution
+      end
+
+      # @see #resize_and_delete
+      def log_resize_and_delete(dist_calculator, disk_name)
+        log.info "Resize and delete. disk_name: #{disk_name}, planned_devices:"
+        dist_calculator.planned_partitions.each do |p|
+          log.info "  mount: #{p.mount_point}, disk: #{p.disk}, min: #{p.min}, max: #{p.max}"
+        end
+        dist_calculator.planned_vgs.each do |vg|
+          log.info "  vg_name: #{vg.volume_group_name}, disks: #{vg.pvs_candidate_devices}"
+        end
       end
 
       def force_ptables(planned_partitions)
@@ -303,19 +350,18 @@ module Y2Storage
       # Performs the next action of {#resize_and_delete}
       #
       # @param actions [SpaceMakerActions::List] set of actions that could be executed
-      # @param planned_partitions [Array<Planned::Partition>] set of partitions to make space for
       # @param skip [Array<Integer>] sids of devices that should not be modified
-      # @param disk_name [String] optional disk name to restrict operations to
+      # @param dist_calculator [PartitionsDistributionCalculator]
       # @return [Boolean] true if some operation was performed. False if nothing
       #   else could be done to reach the goal.
-      def execute_next_action(actions, planned_partitions, skip, disk_name = nil)
+      def execute_next_action(actions, skip, dist_calculator)
         action = actions.next
         if !action
-          log.info "No more actions for SpaceMaker (disk_name: #{disk_name})"
+          log.info "No more actions for this SpaceMaker iteration"
           return false
         end
 
-        sids = execute_action(action, new_graph, skip, planned_partitions, disk_name)
+        sids = execute_action(action, new_graph, skip, dist_calculator)
         actions.done(sids)
         new_graph_deleted_sids.concat(sids)
         true
@@ -326,12 +372,10 @@ module Y2Storage
       # @param action [SpaceMakerActions::Base] action to execute
       # @param graph [Devicegraph] devicegraph in which the action will be executed
       # @param skip [Array<Integer>] sids of devices that should not be modified
-      # @param planned_partitions [Array<Planned::Partition>, nil] set of partitions to make space
-      #   for, if known. Nil for mandatory operations executed during {#prepare_devicegraph}.
-      # @param disk_name [String, nil] optional disk name to restrict operations to
+      # @param dist_calculator [PartitionsDistributionCalculator]
       # @return [Array<Integer>] sids of the devices that has been deleted as a consequence
       #   of the action
-      def execute_action(action, graph, skip, planned_partitions = nil, disk_name = nil)
+      def execute_action(action, graph, skip, dist_calculator = nil)
         if skip.include?(action.sid)
           log.info "Skipping action on device #{action.sid} (#{action.class})"
           return []
@@ -339,7 +383,7 @@ module Y2Storage
 
         case action
         when SpaceMakerActions::Shrink
-          execute_shrink(action, graph, planned_partitions, disk_name)
+          execute_shrink(action, graph, dist_calculator)
         when SpaceMakerActions::Delete
           execute_delete(action, graph)
         else
@@ -353,16 +397,15 @@ module Y2Storage
       #
       # @param action [ProposalSpaceAction]
       # @param devicegraph [Devicegraph]
-      # @param planned_partitions [Array<Planned::Partition>, nil]
-      # @param disk_name [String, nil]
+      # @param dist_calculator [PartitionsDistributionCalculator]
       # @return [Array<Integer>]
-      def execute_shrink(action, devicegraph, planned_partitions, disk_name)
+      def execute_shrink(action, devicegraph, dist_calculator)
         log.info "SpaceMaker#execute_shrink - #{action}"
 
         if action.target_size.nil?
           part = devicegraph.find_device(action.sid)
-          if planned_partitions
-            resizing = resizing_size(part, planned_partitions, disk_name)
+          if dist_calculator
+            resizing = resizing_size(part, dist_calculator)
             action.target_size = resizing > part.size ? DiskSize.zero : part.size - resizing
           else
             # Mandatory resize
@@ -382,7 +425,7 @@ module Y2Storage
       # @return [Array<Integer>]
       def execute_delete(action, devicegraph)
         log.info "SpaceMaker#execute_delete - #{action}"
-        action.delete(devicegraph, candidate_disk_names)
+        action.delete(devicegraph, all_disk_names)
       end
 
       # Performs the action described by a {SpaceMakerActions::Wipe}
@@ -401,32 +444,17 @@ module Y2Storage
       # order to reach the goal
       #
       # @return [DiskSize]
-      def resizing_size(partition, planned_partitions, disk_name)
-        spaces = free_spaces(disk_name)
-        if disk_name && extra_disk_names.include?(disk_name)
-          # Operating in a disk that is not a candidate_device, no need to make extra space for LVM
-          return non_lvm_dist_calculator.resizing_size(partition, planned_partitions, spaces)
-        end
-
-        # As explained above, don't assume we will make space for LVM on non-candidate devices
-        partitions = planned_partitions.reject { |p| extra_disk_names.include?(p.disk) }
-        dist_calculator.resizing_size(partition, partitions, spaces)
+      def resizing_size(partition, dist_calculator)
+        dist_calculator.resizing_size(partition, free_spaces)
       end
 
-      # List of free spaces from the candidate devices in the new devicegraph
+      # List of free spaces from all the involved devices in the new devicegraph
       #
-      # @param disk [String, nil] optional disk name to restrict result to
       # @return [Array<FreeDiskSpace>]
-      def free_spaces(disk = nil)
-        disks_for(new_graph, disk).each_with_object([]) do |d, list|
+      def free_spaces
+        disks_for(new_graph).each_with_object([]) do |d, list|
           list.concat(d.as_not_empty { d.free_spaces })
         end
-      end
-
-      # List of free spaces from extra disks (see {#extra_disk_names})
-      # @return [Array<FreeDiskSpace>]
-      def extra_free_spaces
-        extra_disk_names.flat_map { |d| free_spaces(d) }
       end
 
       # List of candidate disk devices in the given devicegraph
@@ -436,38 +464,25 @@ module Y2Storage
       #
       # @return [Array<Dasd, Disk>]
       def disks_for(devicegraph, device_name = nil)
-        filter = device_name ? [device_name] : candidate_disk_names
+        filter = device_name ? [device_name] : all_disk_names
         devicegraph.blk_devices.select { |d| filter.include?(d.name) }
-      end
-
-      # Distribution calculator to use in special cases in which any implication related
-      # to LVM must be ignored
-      #
-      # Used for example when operating in extra (non-candidate) disks
-      #
-      # @return [PartitionsDistributionCalculator]
-      def non_lvm_dist_calculator
-        @non_lvm_dist_calculator ||= PartitionsDistributionCalculator.new
       end
 
       # Whether {#resize_and_delete} should be executed several times,
       # see {#calculate_new_graph} for details.
       #
-      # @param parts_by_disk [Hash{String => Array<Planned::Partition>}] see
-      #   {#planned_partitions_by_disk}
+      # @param devs_by_disk [Hash{String => Array<Planned::Device>}] see
+      #   {#planned_devices_by_disk}
       # @return [Boolean]
-      def several_passes?(parts_by_disk)
+      def several_passes?(devs_by_disk)
         # In this case the result is not much relevant since #resize_and_delete
         # wouldn't be executed for particular disks anyway
-        return false if parts_by_disk.empty?
+        return false if devs_by_disk.empty?
 
-        return true if parts_by_disk.size > 1
+        return true if devs_by_disk.size > 1
 
-        # In theory, the specific disk mentioned in the planned partitions
-        # (note that, at this point, we are sure there is only one) should be
-        # included in the set of candidate disks. Return false if that's not the
-        # case or if there is more than one candidate disk.
-        parts_by_disk.keys != candidate_disk_names
+        # Note that, at this point, we already know devs_by_disk.keys contains just one element
+        devs_by_disk.keys != all_disk_names
       end
     end
   end

--- a/src/lib/y2storage/proposal/space_maker_actions/auto_strategy.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions/auto_strategy.rb
@@ -53,9 +53,9 @@ module Y2Storage
         end
 
         # @param disk [Disk] see {List}
-        # @param volume_group [Planned::LvmVg, nil] system LVM VG to be created or reused, if any
-        def add_optional_actions(disk, volume_group)
-          prospects.add_prospects(disk, volume_group)
+        # @param volume_groups [Array<Planned::LvmVg>] LVM VGs to be potentially reused
+        def add_optional_actions(disk, volume_groups)
+          prospects.add_prospects(disk, volume_groups)
         end
 
         # @return [Action, nil] nil if there are no more actions in the list

--- a/src/lib/y2storage/proposal/space_maker_actions/auto_strategy.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions/auto_strategy.rb
@@ -53,9 +53,9 @@ module Y2Storage
         end
 
         # @param disk [Disk] see {List}
-        # @param lvm_helper [Proposal::LvmHelper] see {List}
-        def add_optional_actions(disk, lvm_helper)
-          prospects.add_prospects(disk, lvm_helper)
+        # @param volume_group [Planned::LvmVg, nil] system LVM VG to be created or reused, if any
+        def add_optional_actions(disk, volume_group)
+          prospects.add_prospects(disk, volume_group)
         end
 
         # @return [Action, nil] nil if there are no more actions in the list

--- a/src/lib/y2storage/proposal/space_maker_actions/list.rb
+++ b/src/lib/y2storage/proposal/space_maker_actions/list.rb
@@ -52,10 +52,9 @@ module Y2Storage
         # @see SpaceMaker#provide_space
         #
         # @param disk [Disk] disk to act upon
-        # @param lvm_helper [Proposal::LvmHelper] contains information about the
-        #     planned LVM logical volumes and how to make space for them
-        def add_optional_actions(disk, lvm_helper)
-          strategy.add_optional_actions(disk, lvm_helper)
+        # @param volume_group [Planned::LvmVg, nil] system LVM VG to be created or reused, if any
+        def add_optional_actions(disk, volume_group)
+          strategy.add_optional_actions(disk, volume_group)
         end
 
         # Next action to be performed by SpaceMaker

--- a/test/y2storage/proposal/space_maker_bigger_resize_test.rb
+++ b/test/y2storage/proposal/space_maker_bigger_resize_test.rb
@@ -187,7 +187,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 60.GiB) }
 
       it "raises an Error exception" do
-        expect { maker.provide_space(fake_devicegraph, disks, volumes) }
+        expect { maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks) }
           .to raise_error Y2Storage::Error
       end
     end
@@ -197,7 +197,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 40.GiB) }
 
       it "does not modify the disk" do
-        result = maker.provide_space(fake_devicegraph, disks, volumes)
+        result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
         disk = result[:devicegraph].disks.first
         expect(disk.partition_table).to be_nil
       end
@@ -207,7 +207,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         # The final 16.5 KiB are reserved by GPT
         gpt_final_space = 16.5.KiB
 
-        result = maker.provide_space(fake_devicegraph, disks, volumes)
+        result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
         space = result[:partitions_distribution].spaces.first
         expect(space.disk_size).to eq(50.GiB - gpt_size - gpt_final_space)
       end
@@ -220,7 +220,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       it "empties the disk deleting the LVM VG" do
         expect(fake_devicegraph.lvm_vgs.size).to eq 1
 
-        result = maker.provide_space(fake_devicegraph, disks, volumes)
+        result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
         disk = result[:devicegraph].disks.first
         expect(disk.has_children?).to eq false
         expect(result[:devicegraph].lvm_vgs).to be_empty
@@ -231,7 +231,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         # The final 16.5 KiB are reserved by GPT
         gpt_final_space = 16.5.KiB
 
-        result = maker.provide_space(fake_devicegraph, disks, volumes)
+        result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
         space = result[:partitions_distribution].spaces.first
         expect(space.disk_size).to eq(space.disk.size - gpt_size - gpt_final_space)
       end
@@ -246,7 +246,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       it "empties the device deleting the filesystem" do
         expect(fake_devicegraph.filesystems.size).to eq 1
 
-        result = maker.provide_space(fake_devicegraph, disks, volumes)
+        result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
         disk = result[:devicegraph].disk_devices.first
         expect(disk.has_children?).to eq false
         expect(result[:devicegraph].filesystems).to be_empty
@@ -257,7 +257,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         # The final 16.5 KiB are reserved by GPT
         gpt_final_space = 16.5.KiB
 
-        result = maker.provide_space(fake_devicegraph, disks, volumes)
+        result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
         space = result[:partitions_distribution].spaces.first
         expect(space.disk_size).to eq(space.disk.size - gpt_size - gpt_final_space)
       end
@@ -289,21 +289,21 @@ describe Y2Storage::Proposal::SpaceMaker do
           let(:volumes) { [vol1] }
 
           it "resizes the more 'productive' partition" do
-            result = maker.provide_space(fake_devicegraph, disks, volumes)
+            result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
             expect(result[:devicegraph].partitions).to include(
               an_object_having_attributes(filesystem_label: "windows", size: 210.GiB)
             )
           end
 
           it "does not delete any partition" do
-            result = maker.provide_space(fake_devicegraph, disks, volumes)
+            result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
             expect(result[:devicegraph].partitions.map(&:name)).to contain_exactly(
               "/dev/sda1", "/dev/sda2", "/dev/sda3", "/dev/sda4", "/dev/sda5"
             )
           end
 
           it "suggests a distribution using the freed space" do
-            result = maker.provide_space(fake_devicegraph, disks, volumes)
+            result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
             distribution = result[:partitions_distribution]
             expect(distribution.spaces.size).to eq 1
             expect(distribution.spaces.first.partitions).to eq volumes
@@ -314,7 +314,7 @@ describe Y2Storage::Proposal::SpaceMaker do
           let(:volumes) { [vol1, vol2] }
 
           it "resizes subsequent partitions" do
-            result = maker.provide_space(fake_devicegraph, disks, volumes)
+            result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
             expect(result[:devicegraph].partitions).to include(
               an_object_having_attributes(filesystem_label: "windows", size: 100.GiB),
               an_object_having_attributes(filesystem_label: "other", size: 110.GiB)
@@ -322,14 +322,14 @@ describe Y2Storage::Proposal::SpaceMaker do
           end
 
           it "does not delete any partition" do
-            result = maker.provide_space(fake_devicegraph, disks, volumes)
+            result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
             expect(result[:devicegraph].partitions.map(&:name)).to contain_exactly(
               "/dev/sda1", "/dev/sda2", "/dev/sda3", "/dev/sda4", "/dev/sda5"
             )
           end
 
           it "suggests a distribution using the freed space" do
-            result = maker.provide_space(fake_devicegraph, disks, volumes)
+            result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
             distribution = result[:partitions_distribution]
             expect(distribution.spaces.size).to eq 2
             expect(distribution.spaces.flat_map(&:partitions)).to contain_exactly(*volumes)
@@ -347,7 +347,7 @@ describe Y2Storage::Proposal::SpaceMaker do
           end
 
           it "resizes the more 'productive' partition taking restrictions into account" do
-            result = maker.provide_space(fake_devicegraph, disks, volumes)
+            result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
             expect(result[:devicegraph].partitions).to include(
               an_object_having_attributes(filesystem_label: "windows", size: 360.GiB),
               an_object_having_attributes(filesystem_label: "other", size: 110.GiB)
@@ -355,14 +355,14 @@ describe Y2Storage::Proposal::SpaceMaker do
           end
 
           it "does not delete any partition" do
-            result = maker.provide_space(fake_devicegraph, disks, volumes)
+            result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
             expect(result[:devicegraph].partitions.map(&:name)).to contain_exactly(
               "/dev/sda1", "/dev/sda2", "/dev/sda3", "/dev/sda4", "/dev/sda5"
             )
           end
 
           it "suggests a distribution using the freed space" do
-            result = maker.provide_space(fake_devicegraph, disks, volumes)
+            result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
             distribution = result[:partitions_distribution]
             expect(distribution.spaces.size).to eq 1
             expect(distribution.spaces.first.partitions).to eq volumes
@@ -373,7 +373,7 @@ describe Y2Storage::Proposal::SpaceMaker do
           let(:volumes) { [vol1, vol2, vol3] }
 
           it "resizes all allowed partitions to its minimum size" do
-            result = maker.provide_space(fake_devicegraph, disks, volumes)
+            result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
             expect(result[:devicegraph].partitions).to include(
               an_object_having_attributes(filesystem_label: "windows", size: 100.GiB),
               an_object_having_attributes(filesystem_label: "other", size: 100.GiB)
@@ -381,14 +381,14 @@ describe Y2Storage::Proposal::SpaceMaker do
           end
 
           it "deletes partitions starting with the one closer to the end of the disk" do
-            result = maker.provide_space(fake_devicegraph, disks, volumes)
+            result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
             expect(result[:devicegraph].partitions.map(&:name)).to contain_exactly(
               "/dev/sda1", "/dev/sda2", "/dev/sda3", "/dev/sda4"
             )
           end
 
           it "suggests a distribution using the freed space" do
-            result = maker.provide_space(fake_devicegraph, disks, volumes)
+            result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
             distribution = result[:partitions_distribution]
             expect(distribution.spaces.size).to eq 3
             expect(distribution.spaces.flat_map(&:partitions)).to contain_exactly(*volumes)
@@ -404,7 +404,7 @@ describe Y2Storage::Proposal::SpaceMaker do
             end
 
             it "resizes all allowed partitions their specified limits" do
-              result = maker.provide_space(fake_devicegraph, disks, volumes)
+              result = maker.provide_space(fake_devicegraph, partitions: volumes, default_disks: disks)
               expect(result[:devicegraph].partitions).to include(
                 an_object_having_attributes(filesystem_label: "windows", size: 150.GiB),
                 an_object_having_attributes(filesystem_label: "other", size: 110.GiB)

--- a/test/y2storage/proposal/space_maker_bigger_resize_test.rb
+++ b/test/y2storage/proposal/space_maker_bigger_resize_test.rb
@@ -31,20 +31,19 @@ describe Y2Storage::Proposal::SpaceMaker do
     fake_scenario(scenario)
   end
 
-  let(:settings) do
-    settings = Y2Storage::ProposalSettings.new_for_current_product
-    settings.candidate_devices = ["/dev/sda"]
-    settings.root_device = "/dev/sda"
-    settings.space_settings.strategy = :bigger_resize
-    settings.space_settings.actions = settings_actions
-    settings
+  let(:space_settings) do
+    Y2Storage::ProposalSpaceSettings.new.tap do |settings|
+      settings.strategy = :bigger_resize
+      settings.actions = settings_actions
+    end
   end
   let(:settings_actions) { [] }
   let(:analyzer) { Y2Storage::DiskAnalyzer.new(fake_devicegraph) }
   let(:delete) { Y2Storage::SpaceActions::Delete }
   let(:resize) { Y2Storage::SpaceActions::Resize }
+  let(:disks) { ["/dev/sda"] }
 
-  subject(:maker) { described_class.new(analyzer, settings) }
+  subject(:maker) { described_class.new(analyzer, space_settings) }
 
   describe "#prepare_devicegraph" do
     let(:scenario) { "complex-lvm-encrypt" }
@@ -53,7 +52,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:settings_actions) { [delete.new("/dev/sda1"), delete.new("/dev/sda2")] }
 
       it "does not delete any partition" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.size).to eq fake_devicegraph.partitions.size
       end
     end
@@ -63,7 +62,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:settings_actions) { [delete.new("/dev/sda", mandatory: true)] }
 
       it "does not delete any partition" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.size).to eq fake_devicegraph.partitions.size
       end
     end
@@ -74,13 +73,13 @@ describe Y2Storage::Proposal::SpaceMaker do
         [delete.new("/dev/sda2", mandatory: true), delete.new("/dev/sde1", mandatory: true)]
       end
 
-      it "does not delete partitions out of SpaceMaker#candidate_devices" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+      it "does not delete partitions out of SpaceMaker#default_disks" do
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to include "/dev/sde1"
       end
 
       it "deletes affected partitions within the candidate devices" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to_not include "/dev/sda2"
       end
     end
@@ -93,16 +92,13 @@ describe Y2Storage::Proposal::SpaceMaker do
         [delete.new("/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1", mandatory: true)]
       end
 
-      before do
-        settings.candidate_devices = ["/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"]
-        settings.root_device = "/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"
-      end
+      let(:disks) { ["/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"] }
 
       it "does not modify the content of the disk" do
         original_filesystems = fake_devicegraph.filesystems
         expect(original_filesystems.size).to eq 1
 
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         filesystems = result.filesystems
         expect(filesystems.size).to eq 1
         device = filesystems.first.blk_devices.first
@@ -115,12 +111,12 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:settings_actions) { [delete.new("/dev/sda1", mandatory: true)] }
 
       it "deletes the partitions explicitly mentioned in the settings" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to_not include "/dev/sda1"
       end
 
       it "does not delete other partitions constituting the same btrfs" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to include "/dev/sda2", "/dev/sda3", "/dev/sdb2"
       end
     end
@@ -130,12 +126,12 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:settings_actions) { [delete.new("/dev/sda1", mandatory: true)] }
 
       it "deletes the partitions explicitly mentioned in the settings" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to_not include "/dev/sda1"
       end
 
       it "does not delete other partitions constituting the same raid" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to include "/dev/sda2", "/dev/sda3", "/dev/sdb2"
       end
     end
@@ -145,12 +141,12 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:settings_actions) { [delete.new("/dev/sda1", mandatory: true)] }
 
       it "deletes the partitions explicitly mentioned in the settings" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to_not include "/dev/sda1"
       end
 
       it "does not delete other partitions constituting the same volume group" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to include "/dev/sda2", "/dev/sda3", "/dev/sdb2"
       end
     end
@@ -173,7 +169,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       end
 
       it "resizes the partition to the specified max if possible" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions).to include(
           an_object_having_attributes(filesystem_label: "other", size: 200.GiB)
         )
@@ -191,7 +187,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 60.GiB) }
 
       it "raises an Error exception" do
-        expect { maker.provide_space(fake_devicegraph, volumes) }
+        expect { maker.provide_space(fake_devicegraph, disks, volumes) }
           .to raise_error Y2Storage::Error
       end
     end
@@ -201,7 +197,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 40.GiB) }
 
       it "does not modify the disk" do
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         disk = result[:devicegraph].disks.first
         expect(disk.partition_table).to be_nil
       end
@@ -211,7 +207,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         # The final 16.5 KiB are reserved by GPT
         gpt_final_space = 16.5.KiB
 
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         space = result[:partitions_distribution].spaces.first
         expect(space.disk_size).to eq(50.GiB - gpt_size - gpt_final_space)
       end
@@ -224,7 +220,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       it "empties the disk deleting the LVM VG" do
         expect(fake_devicegraph.lvm_vgs.size).to eq 1
 
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         disk = result[:devicegraph].disks.first
         expect(disk.has_children?).to eq false
         expect(result[:devicegraph].lvm_vgs).to be_empty
@@ -235,7 +231,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         # The final 16.5 KiB are reserved by GPT
         gpt_final_space = 16.5.KiB
 
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         space = result[:partitions_distribution].spaces.first
         expect(space.disk_size).to eq(space.disk.size - gpt_size - gpt_final_space)
       end
@@ -245,15 +241,12 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:scenario) { "multipath-formatted.xml" }
       let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 5.GiB) }
 
-      before do
-        settings.candidate_devices = ["/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"]
-        settings.root_device = "/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"
-      end
+      let(:disks) { ["/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"] }
 
       it "empties the device deleting the filesystem" do
         expect(fake_devicegraph.filesystems.size).to eq 1
 
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         disk = result[:devicegraph].disk_devices.first
         expect(disk.has_children?).to eq false
         expect(result[:devicegraph].filesystems).to be_empty
@@ -264,7 +257,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         # The final 16.5 KiB are reserved by GPT
         gpt_final_space = 16.5.KiB
 
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         space = result[:partitions_distribution].spaces.first
         expect(space.disk_size).to eq(space.disk.size - gpt_size - gpt_final_space)
       end
@@ -296,21 +289,21 @@ describe Y2Storage::Proposal::SpaceMaker do
           let(:volumes) { [vol1] }
 
           it "resizes the more 'productive' partition" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:devicegraph].partitions).to include(
               an_object_having_attributes(filesystem_label: "windows", size: 210.GiB)
             )
           end
 
           it "does not delete any partition" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:devicegraph].partitions.map(&:name)).to contain_exactly(
               "/dev/sda1", "/dev/sda2", "/dev/sda3", "/dev/sda4", "/dev/sda5"
             )
           end
 
           it "suggests a distribution using the freed space" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             distribution = result[:partitions_distribution]
             expect(distribution.spaces.size).to eq 1
             expect(distribution.spaces.first.partitions).to eq volumes
@@ -321,7 +314,7 @@ describe Y2Storage::Proposal::SpaceMaker do
           let(:volumes) { [vol1, vol2] }
 
           it "resizes subsequent partitions" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:devicegraph].partitions).to include(
               an_object_having_attributes(filesystem_label: "windows", size: 100.GiB),
               an_object_having_attributes(filesystem_label: "other", size: 110.GiB)
@@ -329,14 +322,14 @@ describe Y2Storage::Proposal::SpaceMaker do
           end
 
           it "does not delete any partition" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:devicegraph].partitions.map(&:name)).to contain_exactly(
               "/dev/sda1", "/dev/sda2", "/dev/sda3", "/dev/sda4", "/dev/sda5"
             )
           end
 
           it "suggests a distribution using the freed space" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             distribution = result[:partitions_distribution]
             expect(distribution.spaces.size).to eq 2
             expect(distribution.spaces.flat_map(&:partitions)).to contain_exactly(*volumes)
@@ -354,7 +347,7 @@ describe Y2Storage::Proposal::SpaceMaker do
           end
 
           it "resizes the more 'productive' partition taking restrictions into account" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:devicegraph].partitions).to include(
               an_object_having_attributes(filesystem_label: "windows", size: 360.GiB),
               an_object_having_attributes(filesystem_label: "other", size: 110.GiB)
@@ -362,14 +355,14 @@ describe Y2Storage::Proposal::SpaceMaker do
           end
 
           it "does not delete any partition" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:devicegraph].partitions.map(&:name)).to contain_exactly(
               "/dev/sda1", "/dev/sda2", "/dev/sda3", "/dev/sda4", "/dev/sda5"
             )
           end
 
           it "suggests a distribution using the freed space" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             distribution = result[:partitions_distribution]
             expect(distribution.spaces.size).to eq 1
             expect(distribution.spaces.first.partitions).to eq volumes
@@ -380,7 +373,7 @@ describe Y2Storage::Proposal::SpaceMaker do
           let(:volumes) { [vol1, vol2, vol3] }
 
           it "resizes all allowed partitions to its minimum size" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:devicegraph].partitions).to include(
               an_object_having_attributes(filesystem_label: "windows", size: 100.GiB),
               an_object_having_attributes(filesystem_label: "other", size: 100.GiB)
@@ -388,14 +381,14 @@ describe Y2Storage::Proposal::SpaceMaker do
           end
 
           it "deletes partitions starting with the one closer to the end of the disk" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:devicegraph].partitions.map(&:name)).to contain_exactly(
               "/dev/sda1", "/dev/sda2", "/dev/sda3", "/dev/sda4"
             )
           end
 
           it "suggests a distribution using the freed space" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             distribution = result[:partitions_distribution]
             expect(distribution.spaces.size).to eq 3
             expect(distribution.spaces.flat_map(&:partitions)).to contain_exactly(*volumes)
@@ -411,7 +404,7 @@ describe Y2Storage::Proposal::SpaceMaker do
             end
 
             it "resizes all allowed partitions their specified limits" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               expect(result[:devicegraph].partitions).to include(
                 an_object_having_attributes(filesystem_label: "windows", size: 150.GiB),
                 an_object_having_attributes(filesystem_label: "other", size: 110.GiB)

--- a/test/y2storage/proposal/space_maker_lvm_test.rb
+++ b/test/y2storage/proposal/space_maker_lvm_test.rb
@@ -1,0 +1,82 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2024] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::Proposal::SpaceMaker do
+  # Partition from fake_devicegraph, fetched by name
+  def probed_partition(name)
+    fake_devicegraph.partitions.detect { |p| p.name == name }
+  end
+
+  before do
+    fake_scenario(scenario)
+  end
+
+  let(:space_settings) do
+    Y2Storage::ProposalSpaceSettings.new.tap do |settings|
+      settings.strategy = :bigger_resize
+      settings.actions = settings_actions
+    end
+  end
+  let(:settings_actions) { [] }
+  let(:analyzer) { Y2Storage::DiskAnalyzer.new(fake_devicegraph) }
+  let(:resize) { Y2Storage::SpaceActions::Resize }
+
+  subject(:maker) { described_class.new(analyzer, space_settings) }
+
+  describe "#provide_space" do
+    using Y2Storage::Refinements::SizeCasts
+
+    context "if some LVM physical volumes are needed and resizing a partition is possible" do
+      let(:scenario) { "space_22_extended" }
+
+      let(:vg) do
+        planned_vg(
+          volume_group_name: "system", pvs_candidate_devices: ["/dev/sda"],
+          lvs: volumes, size_strategy: :use_needed
+        )
+      end
+      let(:volumes) do
+        [planned_lv(mount_point: "/1", type: :ext4, logical_volume_name: "one", min: 50.GiB)]
+      end
+
+      let(:settings_actions) { [resize.new("/dev/sda1")] }
+      let(:resize_info) do
+        instance_double("ResizeInfo", resize_ok?: true, min_size: 10.GiB, max_size: 800.GiB)
+      end
+
+      before do
+        allow_any_instance_of(Y2Storage::Partition)
+          .to receive(:detect_resize_info).and_return(resize_info)
+      end
+
+      it "shrinks the partition by a sensible size" do
+        result = maker.provide_space(fake_devicegraph, volume_groups: [vg])
+        expect(result[:devicegraph].partitions).to include(
+          # 5 MiB due to several adjustments (LVM, logical partitions, etc.) But the result is
+          # just enough to fit the LVM without reclaiming any space that is actually not needed.
+          an_object_having_attributes(filesystem_label: "windows", size: 50.GiB - 5.MiB)
+        )
+      end
+    end
+  end
+end

--- a/test/y2storage/proposal/space_maker_test.rb
+++ b/test/y2storage/proposal/space_maker_test.rb
@@ -32,26 +32,25 @@ describe Y2Storage::Proposal::SpaceMaker do
     allow(analyzer).to receive(:windows_partitions).and_return windows_partitions
   end
 
-  let(:settings) do
-    settings = Y2Storage::ProposalSettings.new_for_current_product
-    settings.candidate_devices = ["/dev/sda"]
-    settings.root_device = "/dev/sda"
-    settings.resize_windows = resize_windows
-    settings.windows_delete_mode = delete_windows
-    settings.linux_delete_mode = delete_linux
-    settings.other_delete_mode = delete_other
-    settings
+  let(:space_settings) do
+    Y2Storage::ProposalSpaceSettings.new.tap do |settings|
+      settings.resize_windows = resize_windows
+      settings.windows_delete_mode = delete_windows
+      settings.linux_delete_mode = delete_linux
+      settings.other_delete_mode = delete_other
+    end
   end
   # Default values for settings
   let(:resize_windows) { true }
   let(:delete_windows) { :ondemand }
   let(:delete_linux) { :ondemand }
   let(:delete_other) { :ondemand }
+  let(:disks) { ["/dev/sda" ] }
 
   let(:analyzer) { Y2Storage::DiskAnalyzer.new(fake_devicegraph) }
   let(:windows_partitions) { [] }
 
-  subject(:maker) { described_class.new(analyzer, settings) }
+  subject(:maker) { described_class.new(analyzer, space_settings) }
 
   describe "#prepare_devicegraph" do
     let(:scenario) { "complex-lvm-encrypt" }
@@ -60,7 +59,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:delete_linux) { :none }
 
       it "does not delete the affected partitions" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.size).to eq fake_devicegraph.partitions.size
       end
     end
@@ -69,7 +68,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:delete_linux) { :ondemand }
 
       it "does not delete the affected partitions" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.size).to eq fake_devicegraph.partitions.size
       end
     end
@@ -78,12 +77,12 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:delete_linux) { :all }
 
       it "does not delete partitions out of SpaceMaker#candidate_devices" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to include "/dev/sde1", "/dev/sde2", "/dev/sdf1"
       end
 
       it "deletes affected partitions within the candidate devices" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to_not include "/dev/sda2", "/dev/sda3", "/dev/sda4"
       end
     end
@@ -91,20 +90,20 @@ describe Y2Storage::Proposal::SpaceMaker do
     context "when deleting Linux partitions" do
       let(:delete_linux) { :all }
 
-      before { settings.candidate_devices = fake_devicegraph.disks.map(&:name) }
+      let(:disks) { fake_devicegraph.disks.map(&:name) }
 
       it "deletes partitions with id linux" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to_not include "/dev/sda2", "/dev/sda4", "/dev/sde1"
       end
 
       it "deletes partitions with id swap" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to_not include "/dev/sde3"
       end
 
       it "deletes partitions with id lvm" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to_not include "/dev/sda3", "/dev/sde2"
       end
 
@@ -113,7 +112,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       end
 
       it "does not delete any other partition" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.size).to eq 2
       end
     end
@@ -124,22 +123,22 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:windows_partitions) { [partition_double("/dev/sda2")] }
 
       it "deletes partitions that seem to contain a Windows system" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to_not include "/dev/sda2"
       end
 
       it "does not delete NTFS/FAT partitions that don't look like a bootable Windows system" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to include "/dev/sda4"
       end
 
       it "does not delete Linux partitions" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to include "/dev/sda3"
       end
 
       it "does not delete other partitions like the Grub one" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to include "/dev/sda1"
       end
     end
@@ -150,7 +149,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:windows_partitions) { [partition_double("/dev/sda2")] }
 
       it "deletes all partitions except those included in the Windows or Linux definitions" do
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, disks)
         expect(result.partitions.map(&:name)).to contain_exactly "/dev/sda2", "/dev/sda3"
       end
     end
@@ -160,14 +159,12 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:delete_linux) { :all }
 
       it "deletes all partitions constituting this btrfs" do
-        settings.candidate_devices = ["/dev/sda", "/dev/sdb"]
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, ["/dev/sda", "/dev/sdb"])
         expect(result.partitions.map(&:name)).to be_empty
       end
 
       it "but deletes only partitions on candidate devices" do
-        settings.candidate_devices = ["/dev/sda"]
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, ["/dev/sda"])
         expect(result.partitions.map(&:name)).to contain_exactly "/dev/sdb1", "/dev/sdb2", "/dev/sdb3"
       end
     end
@@ -177,14 +174,12 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:delete_linux) { :all }
 
       it "deletes all partitions constituting this raid" do
-        settings.candidate_devices = ["/dev/sda", "/dev/sdb"]
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, ["/dev/sda", "/dev/sdb"])
         expect(result.partitions.map(&:name)).to be_empty
       end
 
       it "but deletes only partitions on candidate devices" do
-        settings.candidate_devices = ["/dev/sda"]
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, ["/dev/sda"])
         expect(result.partitions.map(&:name)).to contain_exactly "/dev/sdb1", "/dev/sdb2", "/dev/sdb3"
       end
     end
@@ -194,14 +189,12 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:delete_linux) { :all }
 
       it "deletes all partitions constituting this volume group" do
-        settings.candidate_devices = ["/dev/sda", "/dev/sdb"]
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, ["/dev/sda", "/dev/sdb"])
         expect(result.partitions.map(&:name)).to be_empty
       end
 
       it "but deletes only partitions on candidate devices" do
-        settings.candidate_devices = ["/dev/sda"]
-        result = maker.prepare_devicegraph(fake_devicegraph)
+        result = maker.prepare_devicegraph(fake_devicegraph, ["/dev/sda"])
         expect(result.partitions.map(&:name)).to contain_exactly "/dev/sdb1", "/dev/sdb2", "/dev/sdb3"
       end
     end
@@ -217,7 +210,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 60.GiB) }
 
       it "raises an Error exception" do
-        expect { maker.provide_space(fake_devicegraph, volumes) }
+        expect { maker.provide_space(fake_devicegraph, disks, volumes) }
           .to raise_error Y2Storage::Error
       end
     end
@@ -227,7 +220,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 40.GiB) }
 
       it "does not modify the disk" do
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         disk = result[:devicegraph].disks.first
         expect(disk.partition_table).to be_nil
       end
@@ -237,7 +230,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         # The final 16.5 KiB are reserved by GPT
         gpt_final_space = 16.5.KiB
 
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         space = result[:partitions_distribution].spaces.first
         expect(space.disk_size).to eq(50.GiB - gpt_size - gpt_final_space)
       end
@@ -250,7 +243,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       it "empties the disk deleting the LVM VG" do
         expect(fake_devicegraph.lvm_vgs.size).to eq 1
 
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         disk = result[:devicegraph].disks.first
         expect(disk.has_children?).to eq false
         expect(result[:devicegraph].lvm_vgs).to be_empty
@@ -261,7 +254,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         # The final 16.5 KiB are reserved by GPT
         gpt_final_space = 16.5.KiB
 
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         space = result[:partitions_distribution].spaces.first
         expect(space.disk_size).to eq(space.disk.size - gpt_size - gpt_final_space)
       end
@@ -271,15 +264,12 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:scenario) { "multipath-formatted.xml" }
       let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 5.GiB) }
 
-      before do
-        settings.candidate_devices = ["/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"]
-        settings.root_device = "/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"
-      end
+      let(:disks) { ["/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1"] }
 
       it "empties the device deleting the filesystem" do
         expect(fake_devicegraph.filesystems.size).to eq 1
 
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         disk = result[:devicegraph].disk_devices.first
         expect(disk.has_children?).to eq false
         expect(result[:devicegraph].filesystems).to be_empty
@@ -290,7 +280,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         # The final 16.5 KiB are reserved by GPT
         gpt_final_space = 16.5.KiB
 
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         space = result[:partitions_distribution].spaces.first
         expect(space.disk_size).to eq(space.disk.size - gpt_size - gpt_final_space)
       end
@@ -305,7 +295,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         let(:delete_linux) { :ondemand }
 
         it "deletes linux partitions as needed" do
-          result = maker.provide_space(fake_devicegraph, volumes)
+          result = maker.provide_space(fake_devicegraph, disks, volumes)
           expect(result[:devicegraph].partitions).to contain_exactly(
             an_object_having_attributes(filesystem_label: "windows", size: 250.GiB),
             an_object_having_attributes(filesystem_label: "swap", size: 2.GiB)
@@ -313,14 +303,14 @@ describe Y2Storage::Proposal::SpaceMaker do
         end
 
         it "stores the list of deleted partitions" do
-          result = maker.provide_space(fake_devicegraph, volumes)
+          result = maker.provide_space(fake_devicegraph, disks, volumes)
           expect(result[:deleted_partitions]).to contain_exactly(
             an_object_having_attributes(filesystem_label: "root", size: 248.GiB - 1.MiB)
           )
         end
 
         it "suggests a distribution using the freed space" do
-          result = maker.provide_space(fake_devicegraph, volumes)
+          result = maker.provide_space(fake_devicegraph, disks, volumes)
           distribution = result[:partitions_distribution]
           expect(distribution.spaces.size).to eq 1
           expect(distribution.spaces.first.partitions).to eq volumes
@@ -342,7 +332,7 @@ describe Y2Storage::Proposal::SpaceMaker do
             end
 
             it "resizes Windows partitions to free additional needed space" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               expect(result[:devicegraph].partitions).to contain_exactly(
                 an_object_having_attributes(filesystem_label: "windows", size: 200.GiB - 1.MiB)
               )
@@ -354,12 +344,12 @@ describe Y2Storage::Proposal::SpaceMaker do
             let(:delete_windows) { :ondemand }
 
             it "deletes Windows partitions as needed" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               expect(result[:devicegraph].partitions).to be_empty
             end
 
             it "stores the list of deleted partitions" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               expect(result[:deleted_partitions]).to contain_exactly(
                 an_object_having_attributes(name: "/dev/sda1"),
                 an_object_having_attributes(name: "/dev/sda2"),
@@ -368,7 +358,7 @@ describe Y2Storage::Proposal::SpaceMaker do
             end
 
             it "suggests a distribution using the freed space" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               distribution = result[:partitions_distribution]
               expect(distribution.spaces.size).to eq 1
               expect(distribution.spaces.first.partitions).to eq volumes
@@ -380,7 +370,7 @@ describe Y2Storage::Proposal::SpaceMaker do
             let(:delete_windows) { :none }
 
             it "raises an Error exception" do
-              expect { maker.provide_space(fake_devicegraph, volumes) }
+              expect { maker.provide_space(fake_devicegraph, disks, volumes) }
                 .to raise_error Y2Storage::Error
             end
           end
@@ -402,12 +392,12 @@ describe Y2Storage::Proposal::SpaceMaker do
           end
 
           it "does not delete the Linux partitions" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:devicegraph].partitions.map(&:filesystem_label)).to include("root", "swap")
           end
 
           it "resizes Windows partitions to free additional needed space" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             windows = result[:devicegraph].partitions.detect { |p| p.filesystem_label == "windows" }
             expect(windows.size).to eq 150.GiB
           end
@@ -418,18 +408,18 @@ describe Y2Storage::Proposal::SpaceMaker do
           let(:delete_windows) { :ondemand }
 
           it "does not delete the Linux partitions" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:devicegraph].partitions.map(&:filesystem_label)).to include("root", "swap")
           end
 
           it "deletes Windows partitions as needed" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             windows = result[:devicegraph].partitions.detect { |p| p.filesystem_label == "windows" }
             expect(windows).to be_nil
           end
 
           it "stores the list of deleted partitions" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:deleted_partitions]).to contain_exactly(
               an_object_having_attributes(name: "/dev/sda1")
             )
@@ -441,7 +431,7 @@ describe Y2Storage::Proposal::SpaceMaker do
           let(:delete_windows) { :none }
 
           it "raises an Error exception" do
-            expect { maker.provide_space(fake_devicegraph, volumes) }
+            expect { maker.provide_space(fake_devicegraph, disks, volumes) }
               .to raise_error Y2Storage::Error
           end
         end
@@ -468,13 +458,13 @@ describe Y2Storage::Proposal::SpaceMaker do
           let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 40.GiB) }
 
           it "shrinks the Windows partition by the required size" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             win_partition = Y2Storage::Partition.find_by_name(result[:devicegraph], "/dev/sda1")
             expect(win_partition.size).to eq 740.GiB
           end
 
           it "leaves other partitions untouched" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:devicegraph].partitions).to contain_exactly(
               an_object_having_attributes(filesystem_label: "windows"),
               an_object_having_attributes(filesystem_label: "recovery", size: 20.GiB - 1.MiB)
@@ -482,12 +472,12 @@ describe Y2Storage::Proposal::SpaceMaker do
           end
 
           it "leaves empty the list of deleted partitions" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:deleted_partitions]).to be_empty
           end
 
           it "suggests a distribution using the freed space" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             distribution = result[:partitions_distribution]
             expect(distribution.spaces.size).to eq 1
             expect(distribution.spaces.first.partitions).to eq volumes
@@ -501,27 +491,27 @@ describe Y2Storage::Proposal::SpaceMaker do
             let(:delete_other) { :ondemand }
 
             it "shrinks the Windows partition as much as possible" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               win_partition = Y2Storage::Partition.find_by_name(result[:devicegraph], "/dev/sda1")
               expect(win_partition.size).to eq 730.GiB
             end
 
             it "removes other (no Windows or Linux) partitions as needed" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               expect(result[:devicegraph].partitions).to contain_exactly(
                 an_object_having_attributes(filesystem_label: "windows")
               )
             end
 
             it "stores the list of deleted partitions" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               expect(result[:deleted_partitions]).to contain_exactly(
                 an_object_having_attributes(filesystem_label: "recovery", size: 20.GiB - 1.MiB)
               )
             end
 
             it "suggests a distribution using the freed space" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               distribution = result[:partitions_distribution]
               expect(distribution.spaces.size).to eq 1
               expect(distribution.spaces.first.partitions).to eq volumes
@@ -535,25 +525,25 @@ describe Y2Storage::Proposal::SpaceMaker do
               let(:delete_windows) { :ondemand }
 
               it "deletes Windows partitions as needed" do
-                result = maker.provide_space(fake_devicegraph, volumes)
+                result = maker.provide_space(fake_devicegraph, disks, volumes)
                 windows = result[:devicegraph].partitions.detect { |p| p.filesystem_label == "windows" }
                 expect(windows).to be_nil
               end
 
               it "does not remove other (no Windows or Linux) partitions" do
-                result = maker.provide_space(fake_devicegraph, volumes)
+                result = maker.provide_space(fake_devicegraph, disks, volumes)
                 expect(result[:devicegraph].partitions.map(&:filesystem_label)).to include "recovery"
               end
 
               it "stores the list of deleted partitions" do
-                result = maker.provide_space(fake_devicegraph, volumes)
+                result = maker.provide_space(fake_devicegraph, disks, volumes)
                 expect(result[:deleted_partitions]).to contain_exactly(
                   an_object_having_attributes(filesystem_label: "windows")
                 )
               end
 
               it "suggests a distribution using the freed space" do
-                result = maker.provide_space(fake_devicegraph, volumes)
+                result = maker.provide_space(fake_devicegraph, disks, volumes)
                 distribution = result[:partitions_distribution]
                 expect(distribution.spaces.size).to eq 1
                 expect(distribution.spaces.first.partitions).to eq volumes
@@ -564,7 +554,7 @@ describe Y2Storage::Proposal::SpaceMaker do
               let(:delete_windows) { :none }
 
               it "raises an Error exception" do
-                expect { maker.provide_space(fake_devicegraph, volumes) }
+                expect { maker.provide_space(fake_devicegraph, disks, volumes) }
                   .to raise_error Y2Storage::Error
               end
             end
@@ -580,21 +570,21 @@ describe Y2Storage::Proposal::SpaceMaker do
           let(:delete_other) { :ondemand }
 
           it "removes other (no Windows or Linux) partitions as needed" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:devicegraph].partitions).to contain_exactly(
               an_object_having_attributes(filesystem_label: "windows")
             )
           end
 
           it "stores the list of deleted partitions" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             expect(result[:deleted_partitions]).to contain_exactly(
               an_object_having_attributes(filesystem_label: "recovery", size: 20.GiB - 1.MiB)
             )
           end
 
           it "suggests a distribution using the freed space" do
-            result = maker.provide_space(fake_devicegraph, volumes)
+            result = maker.provide_space(fake_devicegraph, disks, volumes)
             distribution = result[:partitions_distribution]
             expect(distribution.spaces.size).to eq 1
             expect(distribution.spaces.first.partitions).to eq volumes
@@ -608,25 +598,25 @@ describe Y2Storage::Proposal::SpaceMaker do
             let(:delete_windows) { :ondemand }
 
             it "deletes Windows partition as needed" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               windows = result[:devicegraph].partitions.detect { |p| p.filesystem_label == "windows" }
               expect(windows).to be_nil
             end
 
             it "does not remove other (no Windows or Linux) partitions" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               expect(result[:devicegraph].partitions.map(&:filesystem_label)).to include "recovery"
             end
 
             it "stores the list of deleted partitions" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               expect(result[:deleted_partitions]).to contain_exactly(
                 an_object_having_attributes(filesystem_label: "windows")
               )
             end
 
             it "suggests a distribution using the freed space" do
-              result = maker.provide_space(fake_devicegraph, volumes)
+              result = maker.provide_space(fake_devicegraph, disks, volumes)
               distribution = result[:partitions_distribution]
               expect(distribution.spaces.size).to eq 1
               expect(distribution.spaces.first.partitions).to eq volumes
@@ -637,7 +627,7 @@ describe Y2Storage::Proposal::SpaceMaker do
             let(:delete_windows) { :none }
 
             it "raises an Error exception" do
-              expect { maker.provide_space(fake_devicegraph, volumes) }
+              expect { maker.provide_space(fake_devicegraph, disks, volumes) }
                 .to raise_error Y2Storage::Error
             end
           end
@@ -656,10 +646,9 @@ describe Y2Storage::Proposal::SpaceMaker do
       end
       let(:windows_partitions) { [partition_double("/dev/md0p1")] }
       let(:resize_windows) { true }
+      let(:disks) { ["/dev/md0"] }
 
       before do
-        settings.candidate_devices = ["/dev/md0"]
-        settings.root_device = "/dev/md0"
         allow_any_instance_of(Y2Storage::Partition).to receive(:detect_resize_info)
           .and_return(resize_info)
       end
@@ -668,13 +657,13 @@ describe Y2Storage::Proposal::SpaceMaker do
         let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 40.GiB) }
 
         it "shrinks the Windows partition by the required size" do
-          result = maker.provide_space(fake_devicegraph, volumes)
+          result = maker.provide_space(fake_devicegraph, disks, volumes)
           win_partition = Y2Storage::Partition.find_by_name(result[:devicegraph], "/dev/md0p1")
           expect(win_partition.size).to eq 20.GiB - 35.MiB
         end
 
         it "suggests a distribution using the freed space" do
-          result = maker.provide_space(fake_devicegraph, volumes)
+          result = maker.provide_space(fake_devicegraph, disks, volumes)
           distribution = result[:partitions_distribution]
           expect(distribution.spaces.size).to eq 1
           expect(distribution.spaces.first.partitions).to eq volumes
@@ -695,21 +684,21 @@ describe Y2Storage::Proposal::SpaceMaker do
         ]
       end
       let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 20.GiB) }
+      let(:disks) { ["/dev/sda", "/dev/sdb"] }
 
       before do
-        settings.candidate_devices = ["/dev/sda", "/dev/sdb"]
         allow_any_instance_of(Y2Storage::Partition).to receive(:detect_resize_info)
           .and_return(resize_info)
       end
 
       it "shrinks first the less full Windows partition" do
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         win2_partition = Y2Storage::Partition.find_by_name(result[:devicegraph], "/dev/sdb1")
         expect(win2_partition.size).to eq 160.GiB
       end
 
       it "leaves other partitions untouched if possible" do
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         expect(result[:devicegraph].partitions).to contain_exactly(
           an_object_having_attributes(filesystem_label: "windows1", size: 80.GiB),
           an_object_having_attributes(filesystem_label: "recovery1", size: 20.GiB - 1.MiB),
@@ -726,7 +715,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         vol = planned_vol(mount_point: "/1", type: :ext4, min: 700.GiB)
         volumes = [vol]
 
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         expect(result[:deleted_partitions]).to contain_exactly(
           an_object_having_attributes(name: "/dev/sda4", size: 900.GiB - 1.MiB),
           an_object_having_attributes(name: "/dev/sda5", size: 300.GiB),
@@ -743,7 +732,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         vol1 = planned_vol(mount_point: "/1", type: :ext4, min: 980.GiB)
         maker.protected_sids = [probed_partition("/dev/sda2").sid]
 
-        expect { maker.provide_space(fake_devicegraph, [vol1]) }
+        expect { maker.provide_space(fake_devicegraph, disks, [vol1]) }
           .to raise_error Y2Storage::Error
       end
 
@@ -755,7 +744,7 @@ describe Y2Storage::Proposal::SpaceMaker do
           planned_vol(mount_point: "/2", reuse_name: "/dev/sda3")
         ]
 
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         expect(result[:devicegraph].partitions).to contain_exactly(
           an_object_having_attributes(name: "/dev/sda1", size: 4.GiB),
           an_object_having_attributes(name: "/dev/sda2", size: 60.GiB),
@@ -779,7 +768,7 @@ describe Y2Storage::Proposal::SpaceMaker do
           probed_partition("/dev/sda6").sid
         ]
 
-        expect { maker.provide_space(fake_devicegraph, volumes) }
+        expect { maker.provide_space(fake_devicegraph, disks, volumes) }
           .to raise_error Y2Storage::Error
       end
     end
@@ -795,9 +784,9 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:vol2) { planned_vol(mount_point: "/2", type: :ext4, disk: "/dev/sda") }
       let(:vol3) { planned_vol(mount_point: "/3", type: :ext4) }
       let(:volumes) { [vol1, vol2, vol3] }
+      let(:disks) { ["/dev/sda", "/dev/sdb"] }
 
       before do
-        settings.candidate_devices = ["/dev/sda", "/dev/sdb"]
         allow_any_instance_of(Y2Storage::Partition).to receive(:detect_resize_info)
           .and_return(resize_info)
       end
@@ -810,7 +799,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         end
 
         it "raises an exception even if there is enough space in other disks" do
-          expect { maker.provide_space(fake_devicegraph, volumes) }
+          expect { maker.provide_space(fake_devicegraph, disks, volumes) }
             .to raise_error Y2Storage::Error
         end
       end
@@ -823,7 +812,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         end
 
         it "ensures disk restrictions are honored" do
-          result = maker.provide_space(fake_devicegraph, volumes)
+          result = maker.provide_space(fake_devicegraph, disks, volumes)
           distribution = result[:partitions_distribution]
           sda_space = distribution.spaces.detect { |i| i.disk_name == "/dev/sda" }
           # Without disk restrictions, it would have deleted linux partitions at /dev/sdb and
@@ -833,7 +822,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         end
 
         it "applies the usual criteria to allocate non-restricted volumes" do
-          result = maker.provide_space(fake_devicegraph, volumes)
+          result = maker.provide_space(fake_devicegraph, disks, volumes)
           distribution = result[:partitions_distribution]
           sdb_space = distribution.spaces.detect { |i| i.disk_name == "/dev/sdb" }
           # Default action: delete linux partitions at /dev/sdb and allocate volumes there
@@ -851,13 +840,11 @@ describe Y2Storage::Proposal::SpaceMaker do
 
       let(:partition) { dasda.partition_table.partition }
 
-      before do
-        settings.candidate_devices = ["/dev/dasda"]
-      end
+      let(:disks) { ["/dev/dasda"] }
 
       it "does not remove the partitition" do
         original_partition = partition
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         partitions = result[:devicegraph].partitions
 
         expect(partitions.map(&:sid)).to include original_partition.sid
@@ -871,7 +858,7 @@ describe Y2Storage::Proposal::SpaceMaker do
         it "wipes the partition" do
           expect(partition.has_children?).to eq(true)
 
-          result = maker.provide_space(fake_devicegraph, volumes)
+          result = maker.provide_space(fake_devicegraph, disks, volumes)
           dasda = result[:devicegraph].find_by_name("/dev/dasda")
           partition = dasda.partition_table.partition
 
@@ -886,7 +873,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       let(:volumes) { [planned_vol(mount_point: "/1", type: :ext4, min: 2.GiB)] }
 
       it "deletes also other partitions of the same volume group" do
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         partitions = result[:devicegraph].partitions
 
         expect(partitions.map(&:sid)).to_not include probed_partition("/dev/sda9").sid
@@ -894,13 +881,13 @@ describe Y2Storage::Proposal::SpaceMaker do
       end
 
       it "deletes the volume group itself" do
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
 
         expect(result[:devicegraph].lvm_vgs.map(&:vg_name)).to_not include "vg1"
       end
 
       it "does not affect partitions from other volume groups" do
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         devicegraph = result[:devicegraph]
 
         expect(devicegraph.partitions.map(&:name)).to include "/dev/sda7"
@@ -928,7 +915,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       # wrongly concluded that reducing "windows" was not enough and it ended up
       # deleting it.
       it "does not delete the Windows partition if resizing is enough" do
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         devicegraph = result[:devicegraph]
         expect(devicegraph.partitions.size).to eq 2
       end
@@ -940,7 +927,7 @@ describe Y2Storage::Proposal::SpaceMaker do
       # the partitions - the mandatory one that will reappear at the end of the disk
       # and the one at the end of the partition labeled "windows").
       it "aligns the new end of the partition" do
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         ptable = result[:devicegraph].disks.first.partition_table
         aligned = ptable.partitions.map { |part| part.region.end_aligned?(ptable.align_grain) }
         expect(aligned).to eq [true, true]
@@ -953,10 +940,10 @@ describe Y2Storage::Proposal::SpaceMaker do
     context "when a planned device needs to be created out of the candidate devices" do
       let(:scenario) { "empty-md_raid" }
       let(:vol1) { planned_vol(mount_point: "/1", type: :ext4, min: 200.GiB, disk: "/dev/sda") }
-      before { settings.candidate_devices = fake_devicegraph.raids }
+      let(:disks) { fake_devicegraph.raids }
 
       it "makes space for it" do
-        result = maker.provide_space(fake_devicegraph, volumes)
+        result = maker.provide_space(fake_devicegraph, disks, volumes)
         devicegraph = result[:devicegraph]
         expect(devicegraph.partitions.size).to eq 1
       end


### PR DESCRIPTION
We want to offer new possibilities with the so-called AgamaProposal (that will be used to implement all the features described at [this document](https://github.com/agama-project/agama/blob/master/doc/auto_storage.md).

For that we need a more powerful SpaceMaker that can automatically calculate physical volumes for an arbitrary number of LVM volume groups extended over different sets of disks.

This pull request generalizes the existing SpaceMaker to gain that capability and to be less coupled with the traditional YaST GuidedProposal.

Original API

```ruby
class Y2Storage::Proposal::SpaceMaker
  # @param settings [ProposalSettings] Note the class
  def initialize(disk_analyzer, settings); end

  # @param planned_partitions [Array<Planned::Partition>]
  # @param lvm_helper [Proposal::LvmHelper]
  def provide_space(original_graph, planned_partitions, lvm_helper); end

   # @param planned_partitions [Array<Planned::Partition>]
   def prepare_devicegraph(original_graph, planned_partitions = []); end
end
```

New API.

Does not use LvmHelper or ProposalSettings. Accepts different sets of partitions and/or volume groups. Many arguments can be omitted on the calls. The caller is more explicit about what to do instead of relying on SpaceMaker to take decisions (like which disks to clean) based on the proposal settings.

```ruby
class Y2Storage::Proposal::SpaceMaker
  # @param settings [ProposalSpaceSettings] Note the class
  def initialize(disk_analyzer, settings); end

  # @param partitions [Array<Planned::Partition>]
  # @param volume_groups [Array<Planned::LvmVg>]
  # @param default_disks [Array<String>]
  def provide_space(original_graph, partitions: [], volume_groups: [], default_disks: [])
  end

  # @param disks [Array<String>]
   def prepare_devicegraph(original_graph, disks); end
end
```

The behavior is unchanged except one corner case related to how it calculates the space needed to subtract from existing partitions in order to make space. The new behavior looks more correct. Anyways, that corner case should not affect YaST.

## Bonus

This also modifies the mentioned calculation of how much a partition must be resized.

The previous algorithm was quite aggressive when LVM is involved. A perfect size would be computationally too expensive to find, but now we do two attempts, one with the original logic and another one with a logic that can still succeed but is less aggressive when there are several spaces in the disk.

## Notes

As usual, this is structured in separate logical commits to easy review.