### PR TITLE
Fix bsc#1233095

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov  8 13:02:58 UTC 2024 - José Iván López González <jlopez@suse.com>
+
+- Fix failing test (bsc#1233095).
+- 5.0.21
+
+-------------------------------------------------------------------
 Tue Oct  8 12:21:38 UTC 2024 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - SpaceMaker: make it possible to generate physical volumes for

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.20
+Version:        5.0.21
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/test/y2partitioner/widgets/pages/disks_test.rb
+++ b/test/y2partitioner/widgets/pages/disks_test.rb
@@ -89,11 +89,11 @@ describe Y2Partitioner::Widgets::Pages::Disks do
       end
 
       context "and the Btrfs is multidevice" do
-        let(:scenario) { "btrfs-multidevice-over-partitions.xml" }
+        let(:scenario) { "btrfs2-devicegraph.xml" }
 
         it "does not include its Btrfs subvolumes in the table" do
-          sda2 = device_graph.find_by_name("/dev/sda2")
-          subvolumes = btrfs_subvolumes(sda2).map(&:path)
+          sdb1 = device_graph.find_by_name("/dev/sdb1")
+          subvolumes = btrfs_subvolumes(sdb1).map(&:path)
 
           expect(items).to_not include(*subvolumes)
         end


### PR DESCRIPTION
## Problem

There is a wrong test in which no value was passed to the `#include` matcher. This raises an error with *rspec-expectations 3.13.2*.

https://github.com/rspec/rspec-expectations/blob/838952dc1416c943e7933684c47249a77481e7f5/Changelog.md

3.13.2 / 2024-08-20
Bug Fixes:
    Raise an error when passing no arguments to the include matcher. (Eric Mueller, #1479)

## Solution

Fix tests by using correct data and passing a value to `#include`.

## Testing

- Updated unit test.
