### PR TITLE
explicitelly mount /mnt/run as private to avoid mount point propagations

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov 29 10:23:28 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Mount '/mnt/run' as private to avoid mount points propagation
+  (gh#yast/yast-storage-ng#1395)
+- 5.0.22
+
+-------------------------------------------------------------------
 Fri Nov  8 13:02:58 UTC 2024 - José Iván López González <jlopez@suse.com>
 
 - Fix failing test (bsc#1233095).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.21
+Version:        5.0.22
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -79,9 +79,9 @@ module Y2Storage
         mount_in_target("/proc", "proc", "-t proc")
         mount_in_target("/sys", "sysfs", "-t sysfs")
         mount_in_target(EFIVARS_PATH, "efivarfs", "-t efivarfs") if mount_efivars?
-        # systemd makes default for mount bind sharable, but it cause trouble with
-        # systemd credentials that created another mount point undef /run when someone
-        # login. Result is that later /run cannot be unmounted. There is no benefit now
+        # systemd makes default for mount bind sharable, but it causes troubles with
+        # systemd credentials that created another mount point under /run when someone
+        # logs in. Result is that later /run cannot be unmounted. There is no benefit now
         # to have /mnt/run sharable mounted with propagation of mount points.
         # For defaults see https://lwn.net/Articles/689856/
         mount_in_target("/run", "/run", "--bind --make-private")

--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -79,7 +79,12 @@ module Y2Storage
         mount_in_target("/proc", "proc", "-t proc")
         mount_in_target("/sys", "sysfs", "-t sysfs")
         mount_in_target(EFIVARS_PATH, "efivarfs", "-t efivarfs") if mount_efivars?
-        mount_in_target("/run", "/run", "--bind")
+        # systemd makes default for mount bind sharable, but it cause trouble with
+        # systemd credentials that created another mount point undef /run when someone
+        # login. Result is that later /run cannot be unmounted. There is no benefit now
+        # to have /mnt/run sharable mounted with propagation of mount points.
+        # For defaults see https://lwn.net/Articles/689856/
+        mount_in_target("/run", "/run", "--bind --make-private")
 
         true
       end


### PR DESCRIPTION
## Problem

In agama where is systemd root is mounted as sharable and it affects also default for nested mounts. Result is that default mount bind is also sharable. As consequence systemd credentials creates under /run its own mount point when user login and this mount point is as long busy as long user is logged in. Result is that /mnt cannot be clearly unmounted.

trello card: https://trello.com/c/4YxqRmZF/3944-3-agama-could-not-umount-mnt-run-after-the-installation-systemd-creds
lwn article about topic: https://lwn.net/Articles/689856/

## Solution

Make mount --bind explcitely private to avoid propagation of mount points.


## Testing

- *Tested manually*

