### PR TITLE
Convert timestamp to UTC

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -2288,7 +2288,7 @@ Fri Oct 26 11:37:48 UTC 2018 - snwint@suse.com
   partitioner
 
 -------------------------------------------------------------------
-Sat Oct 20 22:10:48 WEST 2018 - igonzalezsosa@suse.com
+Sat Oct 20 21:10:48 UTC 2018 - igonzalezsosa@suse.com
 
 - Fixes and improvements to AutoYaST partitioning:
   - Improve support to reuse a disk as a PV (bsc#1107298).


### PR DESCRIPTION
Convert timestamp to UTC
to make parsing unambiguous.

Without this change, osc build mis-parsed this as another date
which breaks reproducible builds