### PR TITLE
Require libstorage bindings for the current Ruby version (bsc#1235598)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 12 11:01:03 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Require libstorage bindings for the current Ruby version (bsc#1235598)
+- 5.0.25
+
+-------------------------------------------------------------------
 Tue Jan 21 10:00:00 UTC 2025 - Stefan Schubert <schubi@suse.de>
 
 - Reserve 1GiB boot partition for grub2-bls bootloader (jsc#PED-10703).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.24
+Version:        5.0.25
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only
@@ -49,6 +49,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 Requires:       findutils
 # Encryption#use_key_file_in_commit
 Requires:       libstorage-ng-ruby >= 4.5.144
+# Require libstorage bindings for the current Ruby version (bsc#1235598)
+Requires:       libstorage-ng-ruby-%{rb_ver}
 # Replace PackageSystem with Package
 Requires:       yast2 >= 4.4.38
 # Y2Packager::Repository


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1235598


## Problem

Package or dist upgrades may lead to confusion what Ruby version to use and break YaST.


## Fix

Require bindings for the current Ruby version