### PR TITLE
AutoYaST part of pervasive encryption

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 21 13:30:05 UTC 2025 - Knut Anderssen <kanderssen@suse.com>
+
+- Added AutoYaST support for selecting the APQNs and pervasive
+  encryption key type (jsc#PED-10950).
+- 4.7.3
+
+-------------------------------------------------------------------
 Tue Jan 21 09:43:35 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Pervasive encryption: support for AES-CIPHER and EP11 and better

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        4.7.2
+Version:        4.7.3
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2partitioner/actions/controllers/encryption.rb
+++ b/src/lib/y2partitioner/actions/controllers/encryption.rb
@@ -52,7 +52,7 @@ module Y2Partitioner
 
         # Selected APQNs to generate a new secure key for pervasive encryption
         #
-        # @return [Array<Y2Storage:.EncryptionProcesses::Apqn>]
+        # @return [Array<Y2Storage::EncryptionProcesses::Apqn>]
         attr_accessor :apqns
 
         # @return [String] Type for the new secure key for pervasive encryption

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -54,6 +54,8 @@ module Y2Storage
         { name: :crypt_label },
         { name: :crypt_cipher },
         { name: :crypt_key_size },
+        { name: :crypt_pervasive_apqns },
+        { name: :crypt_pervasive_key_type },
         { name: :raid_name },
         { name: :raid_options },
         { name: :mkfs_options },
@@ -108,6 +110,12 @@ module Y2Storage
       #
       #   @return [Integer,nil] If nil, the default key size will be used. If an integer
       #     value is used, it has to be a multiple of 8.
+
+      # @!attribute crypt_pervasive_apqns
+      #   @return [Array<String>,nil] items like "01.0001"
+      #
+      # @!attribute crypt_pervasive_key_type
+      #   @return [String,nil] "CCA-AESCIPHER" or "CCA-AESDATA"
 
       # @!attribute filesystem
       #   @return [Symbol] file system type to use in the partition, it also
@@ -449,6 +457,7 @@ module Y2Storage
           section.crypt_method = method.id
           section.crypt_key = CRYPT_KEY_VALUE if method.password_required?
           init_luks_fields(section)
+          init_pervasive_fields(section)
         end
 
         # @param section [PartitionSection] section object to modify based on the device
@@ -458,6 +467,12 @@ module Y2Storage
           section.crypt_label = enc.label if enc.supports_label? && !enc.label.empty?
           section.crypt_cipher = enc.cipher if enc.supports_cipher? && !enc.cipher.empty?
           section.crypt_key_size = enc.key_size * 8 if enc.supports_key_size? && !enc.key_size.zero?
+        end
+
+        # @param section [PartitionSection] section object to modify based on the device
+        def init_pervasive_fields(section)
+          section.crypt_pervasive_apqns =  fail "TODO" if todo
+          section.crypt_pervasive_key_type = fail "TODO" if todo
         end
 
         # @param section [PartitionSection] section object to modify based on the device

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -195,6 +195,8 @@ module Y2Storage
           @raid_options = RaidOptionsSection.new_from_hashes(hash["raid_options"], self)
         end
 
+        @crypt_pervasive_apqns = hash["crypt_pervasive_apqns"] if hash["crypt_pervasive_apqns"]
+
         @subvolumes_prefix = hash["subvolumes_prefix"]
         @create_subvolumes = hash.fetch("create_subvolumes", true)
         @subvolumes = subvolumes_from_hashes(hash["subvolumes"]) if hash["subvolumes"]

--- a/src/lib/y2storage/autoinst_profile/partition_section.rb
+++ b/src/lib/y2storage/autoinst_profile/partition_section.rb
@@ -457,7 +457,6 @@ module Y2Storage
           section.crypt_method = method.id
           section.crypt_key = CRYPT_KEY_VALUE if method.password_required?
           init_luks_fields(section)
-          init_pervasive_fields(section)
         end
 
         # @param section [PartitionSection] section object to modify based on the device
@@ -467,12 +466,6 @@ module Y2Storage
           section.crypt_label = enc.label if enc.supports_label? && !enc.label.empty?
           section.crypt_cipher = enc.cipher if enc.supports_cipher? && !enc.cipher.empty?
           section.crypt_key_size = enc.key_size * 8 if enc.supports_key_size? && !enc.key_size.zero?
-        end
-
-        # @param section [PartitionSection] section object to modify based on the device
-        def init_pervasive_fields(section)
-          section.crypt_pervasive_apqns =  fail "TODO" if todo
-          section.crypt_pervasive_key_type = fail "TODO" if todo
         end
 
         # @param section [PartitionSection] section object to modify based on the device

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -57,6 +57,16 @@ module Y2Storage
       # @return [String, nil] nil or empty string to use the default cipher
       attr_accessor :encryption_cipher
 
+      # Selected APQNs to generate a new security key for pervasive encryption
+      #
+      # @return [Array<String>]
+      attr_accessor :encryption_pervasive_apqns
+
+      # Pervasive key key_type
+      #
+      # @return [String, nil] nil or empty string to use the default key type
+      attr_accessor :encryption_pervasive_key_type
+
       # Key size (in bits) to use when encrypting a LUKS device
       #
       # Any positive value must be a multiple of 8.
@@ -70,7 +80,9 @@ module Y2Storage
       attr_accessor :encryption_key_size
 
       # Initializations of the mixin, to be called from the class constructor.
-      def initialize_can_be_encrypted; end
+      def initialize_can_be_encrypted
+        self.encryption_pervasive_apqns = []
+      end
 
       # Checks whether the resulting device must be encrypted
       #
@@ -102,7 +114,12 @@ module Y2Storage
         result = super
         if create_encryption?
           method = encryption_method || EncryptionMethod.find(:luks1)
-          result = plain_device.encrypt(method: method, password: encryption_password)
+          args = {}
+          if method.is?(:pervasive_luks2)
+            args[:apqns] = encryption_pervasive_apqns
+            args[:key_type] = encryption_pervasive_key_type
+          end
+          result = plain_device.encrypt(method: method, password: encryption_password, **args)
           assign_enc_attr(result, :pbkdf)
           assign_enc_attr(result, :label)
           assign_enc_attr(result, :cipher)

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -115,6 +115,9 @@ module Y2Storage
         if create_encryption?
           method = encryption_method || EncryptionMethod.find(:luks1)
           args = {}
+          # FIXME: For pervasive_luks2 the arguments need to be passed directly at #encrypt
+          # instead of being able to assign them afterwards. That's a defect on the API of
+          # that encryption method that should be fixed
           if method.is?(:pervasive_luks2)
             args[:apqns] = encryption_pervasive_apqns
             args[:key_type] = encryption_pervasive_key_type

--- a/src/lib/y2storage/proposal/autoinst_drive_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_drive_planner.rb
@@ -147,9 +147,22 @@ module Y2Storage
         device.encryption_label = partition_section.crypt_label
         device.encryption_cipher = partition_section.crypt_cipher
         device.encryption_key_size = encryption_key_size_for(partition_section)
+        if device.encryption_method.is?(:pervasive_luks2)
+          device.encryption_pervasive_apqns = apqns_for(partition_section)
+          device.encryption_pervasive_key_type = partition_section.crypt_pervasive_key_type
+        end
         return unless device.encryption_method&.password_required?
 
         device.encryption_password = find_encryption_password(partition_section)
+      end
+
+      # Obtains the online APQNs for a partition section
+      #
+      # @param partition_section [AutoinstProfile::PartitionSection] AutoYaST specification
+      # @return [Array<EncryptionProcesses::Apqn>]
+      def apqns_for(partition_section)
+        apqns = partition_section.crypt_pervasive_apqns || []
+        Y2Storage::EncryptionProcesses::Apqn.online.select { |a| apqns.include? a.name }
       end
 
       # Determines the encryption method for a partition section

--- a/src/lib/y2storage/proposal/autoinst_drive_planner.rb
+++ b/src/lib/y2storage/proposal/autoinst_drive_planner.rb
@@ -149,7 +149,7 @@ module Y2Storage
         device.encryption_label = partition_section.crypt_label
         device.encryption_cipher = partition_section.crypt_cipher
         device.encryption_key_size = encryption_key_size_for(partition_section)
-        if device.encryption_method.is?(:pervasive_luks2)
+        if device.encryption_method&.is?(:pervasive_luks2)
           device.encryption_pervasive_apqns = apqns_for(partition_section)
           device.encryption_pervasive_key_type = partition_section.crypt_pervasive_key_type
         end

--- a/test/y2storage/autoinst_proposal_encryption_test.rb
+++ b/test/y2storage/autoinst_proposal_encryption_test.rb
@@ -36,7 +36,7 @@ describe Y2Storage::AutoinstProposal do
   end
 
   let(:scenario) { "empty_disks" }
-  let(:issues_list) { ::Installation::AutoinstIssues::List.new }
+  let(:issues_list) { Installation::AutoinstIssues::List.new }
 
   let(:partitioning) do
     [
@@ -282,14 +282,61 @@ describe Y2Storage::AutoinstProposal do
     end
 
     context "when using pervasive LUKS2 method" do
-      let(:partition) do
-        { "mount" => "/", "crypt_key" => "s3cr3t", "crypt_method" => :pervasive_luks2, "..." => :todo }
+      before do
+        allow(Yast::Execute).to receive(:locally).with(/zkey/, any_args)
+        allow_any_instance_of(Y2Storage::EncryptionMethod::PervasiveLuks2).to receive(:available?)
+          .and_return(true)
+
+        allow(Y2Storage::EncryptionProcesses::Apqn).to receive(:all).and_return(apqns)
       end
 
-      xit "does not register any issue" do
+      let(:apqns) { [apqn1, apqn2, apqn3] }
+      let(:apqn1) do
+        instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "01.0001", type: "CEX5C",
+          mode: "CCA_Coproc", status: "online", master_key_pattern: "0x654478", online?: true)
+      end
+      let(:apqn2) do
+        instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "02.0001", status: "offline",
+          master_key_pattern: nil, online?: false)
+      end
+      let(:apqn3) do
+        instance_double(Y2Storage::EncryptionProcesses::Apqn, name: "02.0002", status: "online",
+          mode: "EP11-Coproc", master_key_pattern: nil, online?: true)
+      end
+
+      let(:password) { "s3cr3t" }
+      let(:method) { Y2Storage::EncryptionMethod::PERVASIVE_LUKS2 }
+      let(:apqn_name) { "01.0001" }
+
+      let(:partition) do
+        { "mount" => "/", "crypt_key" => password, "crypt_method" => method.id,
+"crypt_pervasive_apqns" => [apqn_name] }
+      end
+
+      it "encrypts the device with PERVASIVE LUKS2 as encryption method" do
         proposal.propose
-        # TODO: fails as the method is unavailable, I haven't mocked any apqns
-        expect(issues_list).to be_empty
+        enc = proposal.devices.encryptions.first
+        expect(enc.method).to eq method
+      end
+
+      context "when an apqn is specified" do
+        context "and the selected APNs are online and with a proper master key pattern configured" do
+          it "encrypts the device with the selected apqn" do
+            expect_any_instance_of(Y2Storage::BlkDevice).to receive(:encrypt).with(method: method,
+              password: password, apqns: [apqn1], key_type: nil).and_call_original
+            proposal.propose
+          end
+        end
+
+        context "and the selected APNs are not valid candidates to be used" do
+          let(:apqn_name) { "02.0001" }
+
+          it "encrypts the device with no APQNs selected explicitly" do
+            expect_any_instance_of(Y2Storage::BlkDevice).to receive(:encrypt).with(method: method,
+              password: password, apqns: [], key_type: nil).and_call_original
+            proposal.propose
+          end
+        end
       end
     end
   end

--- a/test/y2storage/autoinst_proposal_encryption_test.rb
+++ b/test/y2storage/autoinst_proposal_encryption_test.rb
@@ -288,7 +288,7 @@ describe Y2Storage::AutoinstProposal do
 
       xit "does not register any issue" do
         proposal.propose
-        # todo: fails as the method is unavailable, I haven't mocked any apqns
+        # TODO: fails as the method is unavailable, I haven't mocked any apqns
         expect(issues_list).to be_empty
       end
     end

--- a/test/y2storage/autoinst_proposal_encryption_test.rb
+++ b/test/y2storage/autoinst_proposal_encryption_test.rb
@@ -280,5 +280,17 @@ describe Y2Storage::AutoinstProposal do
         expect(mount_points).to contain_exactly("/boot", "/")
       end
     end
+
+    context "when using pervasive LUKS2 method" do
+      let(:partition) do
+        { "mount" => "/", "crypt_key" => "s3cr3t", "crypt_method" => :pervasive_luks2, "..." => :todo }
+      end
+
+      xit "does not register any issue" do
+        proposal.propose
+        # todo: fails as the method is unavailable, I haven't mocked any apqns
+        expect(issues_list).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

Recently was added support for PAES-encrypted volumes but only selecting the apqns and key type to be used manually.  Therefore, would be nice to be able to select the apqns and key type through the AutoYaST profile.

- https://trello.com/c/Ffc1JCwe

## Solution

Added AutoYaST support for selecting in the profile the APQNs and the pervasive encryption key type to be used.

## Testing

- *Tested manually*
- Added unit test

