### PR TITLE
Fine tuning BLS boot strategy proposal

### DIFF
--- a/src/lib/y2storage/boot_requirements_checker.rb
+++ b/src/lib/y2storage/boot_requirements_checker.rb
@@ -23,6 +23,7 @@ require "y2storage/storage_manager"
 require "y2storage/storage_env"
 
 Yast.import "Arch"
+Yast.import "Product"
 
 module Y2Storage
   #
@@ -139,6 +140,11 @@ module Y2Storage
     #
     # @return [Boolean]
     def bls_boot?
+        # BLS is only for TW or Slowroll
+        return false if !Yast::Product.FindBaseProducts.any? do |p|
+          p.display_name =~ /Tumbleweed/ || p.display_name =~ /Slowroll/
+        end
+
         # BLS is for x86_64 and aarch64 only
         !StorageEnv.instance.no_bls_bootloader && (arch.x86? || Yast::Arch.aarch64)
     end

--- a/src/lib/y2storage/boot_requirements_checker.rb
+++ b/src/lib/y2storage/boot_requirements_checker.rb
@@ -143,7 +143,7 @@ module Y2Storage
       # BLS is only for TW or Slowroll
       return false if Yast::Product.FindBaseProducts.none? do |p|
         # this should match "openSUSE Tumbleweed" even "openSUSE Tumbleweed-Slowroll"
-        p.display_name =~ /Tumbleweed/
+        p["display_name"] =~ /Tumbleweed/
       end
 
       # BLS is for x86_64 and aarch64 only

--- a/src/lib/y2storage/boot_requirements_checker.rb
+++ b/src/lib/y2storage/boot_requirements_checker.rb
@@ -135,16 +135,22 @@ module Y2Storage
       end
     end
 
+    # Says whether BLS boot should be used
+    #
+    # @return [Boolean]
+    def bls_boot?
+        # BLS is for x86_64 and aarch64 only
+        !StorageEnv.instance.no_bls_bootloader && (arch.x86? || Yast::Arch.aarch64)
+    end
+
     # @see #strategy
     #
     # @return [BootRequirementsStrategies::Base]
     def arch_strategy_class
       if arch.efiboot?
-        if StorageEnv.instance.no_bls_bootloader ||
-            (!arch.x86? && !Yast::Arch.aarch64)
+        if !bls_boot?
           BootRequirementsStrategies::UEFI
         else
-          # BLS is for x86_64 and aarch64 only
           BootRequirementsStrategies::BLS
         end
       elsif arch.s390?

--- a/src/lib/y2storage/boot_requirements_checker.rb
+++ b/src/lib/y2storage/boot_requirements_checker.rb
@@ -140,13 +140,14 @@ module Y2Storage
     #
     # @return [Boolean]
     def bls_boot?
-        # BLS is only for TW or Slowroll
-        return false if !Yast::Product.FindBaseProducts.any? do |p|
-          p.display_name =~ /Tumbleweed/ || p.display_name =~ /Slowroll/
-        end
+      # BLS is only for TW or Slowroll
+      return false if Yast::Product.FindBaseProducts.none? do |p|
+        # this should match "openSUSE Tumbleweed" even "openSUSE Tumbleweed-Slowroll"
+        p.display_name =~ /Tumbleweed/
+      end
 
-        # BLS is for x86_64 and aarch64 only
-        !StorageEnv.instance.no_bls_bootloader && (arch.x86? || Yast::Arch.aarch64)
+      # BLS is for x86_64 and aarch64 only
+      !StorageEnv.instance.no_bls_bootloader && (arch.x86? || Yast::Arch.aarch64)
     end
 
     # @see #strategy
@@ -154,10 +155,10 @@ module Y2Storage
     # @return [BootRequirementsStrategies::Base]
     def arch_strategy_class
       if arch.efiboot?
-        if !bls_boot?
-          BootRequirementsStrategies::UEFI
-        else
+        if bls_boot?
           BootRequirementsStrategies::BLS
+        else
+          BootRequirementsStrategies::UEFI
         end
       elsif arch.s390?
         BootRequirementsStrategies::ZIPL


### PR DESCRIPTION
## Problem

Folowup of https://github.com/yast/yast-storage-ng/pull/1396/files#diff-d0c8ea3d63135679325c6c61b13d11f85edc06bbb141d983037c55846699e125R143

The above proposal intoduced BLS boot proposal. Only limitation was target architecture, but it doesn't fit for conservative products like SLE for now.

## Solution

Added product based condition into BLS decision proposal. BLS is proposed only for tumbleweed (including Slowroll)


## Testing

- TBD: *Added a new unit test*
- *Tested manually*
