### PR TITLE
Add env variables to enforce test mode

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Apr  4 07:00:19 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- New environment variables YAST_STORAGE_TEST_MODE and
+  YAST_DEVICEGRAPH_FILE to ease development of YaST and Agama
+  (gh#yast/yast-storage-ng#1407).
+- 5.0.28
+
+-------------------------------------------------------------------
 Mon Feb 24 15:11:04 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Discarded RAM disks as candidate for installation

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.27
+Version:        5.0.28
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/clients/manual_test.rb
+++ b/src/lib/y2storage/clients/manual_test.rb
@@ -143,11 +143,7 @@ module Y2Storage
 
       # @see #mock
       def load_devicegraph
-        if devicegraph_path =~ /.ya?ml$/
-          Y2Storage::StorageManager.instance(mode: :rw).probe_from_yaml(devicegraph_path)
-        else
-          Y2Storage::StorageManager.instance(mode: :rw).probe_from_xml(devicegraph_path)
-        end
+        Y2Storage::StorageManager.instance(mode: :rw).probe_from_file(devicegraph_path)
       end
 
       # @see #mock

--- a/src/lib/y2storage/device_finder.rb
+++ b/src/lib/y2storage/device_finder.rb
@@ -20,6 +20,7 @@
 require "pathname"
 require "y2storage/storage_manager"
 require "y2storage/blk_device"
+require "y2storage/storage_env"
 
 module Y2Storage
   # Utility class to find devices in a devicegraph
@@ -61,7 +62,7 @@ module Y2Storage
     # * It uses a system lookup only when necessary (i.e. all the cheaper
     #   methods for finding the device have been unsuccessful).
     # * It avoids system lookup in potentially risky scenarios (like an outdated
-    #   {StorageManager#probed}).
+    #   {StorageManager#probed} or when running in test mode).
     #
     # In case of LUKSes and MDs, the device might be found by using an alternative name,
     # see {#alternative_names}.
@@ -173,6 +174,8 @@ module Y2Storage
     #
     # @return [Boolean]
     def udev_lookup_possible?
+      return false if StorageEnv.instance.test_mode?
+
       # Checking when the operation is safe is quite tricky, since we must
       # ensure than the list of block devices in #probed matches 1:1 the list
       # of block devices in the system.

--- a/src/lib/y2storage/storage_env.rb
+++ b/src/lib/y2storage/storage_env.rb
@@ -38,9 +38,14 @@ module Y2Storage
 
     ENV_NO_BLS_BOOT = "YAST_NO_BLS_BOOT".freeze
 
+    ENV_TEST_MODE = "YAST_STORAGE_TEST_MODE".freeze
+
+    ENV_DEVICEGRAPH = "YAST_DEVICEGRAPH_FILE".freeze
+
     private_constant :ENV_MULTIPATH, :ENV_BIOS_RAID, :ENV_ACTIVATE_LUKS
     private_constant :ENV_LIBSTORAGE_IGNORE_PROBE_ERRORS
     private_constant :ENV_REUSE_LVM, :ENV_NO_BLS_BOOT
+    private_constant :ENV_TEST_MODE, :ENV_DEVICEGRAPH
 
     def initialize
       reset_cache
@@ -72,6 +77,29 @@ module Y2Storage
     # @return [Boolean]
     def forced_bios_raid?
       active?(ENV_BIOS_RAID)
+    end
+
+    # Whether operations on the system should be avoided, including those for
+    # reading
+    #
+    # This implies creating a test instance of the libstorage-ng manager (instead
+    # of a regular one) and also avoiding queries to the system to search for
+    # devices or to analyze them.
+    #
+    # @return [Boolean]
+    def test_mode?
+      active?(ENV_TEST_MODE)
+    end
+
+    # Location of a file (XML or YAML) containing a devicegraph that must be
+    # used to mock the libstorage-ng probing.
+    #
+    # @return [String, nil]
+    def devicegraph_file
+      filename = read(ENV_DEVICEGRAPH)
+      return nil if filename&.strip&.empty?
+
+      filename
     end
 
     # Whether LUKSes could be activated

--- a/test/y2storage/clients/manual_test_test.rb
+++ b/test/y2storage/clients/manual_test_test.rb
@@ -31,7 +31,7 @@ describe Y2Storage::Clients::ManualTest do
       allow(Y2Storage::StorageManager).to receive(:instance).and_return storage_manager
     end
 
-    let(:storage_manager) { double("StorageManager", probe_from_yaml: nil, probe_from_xml: nil) }
+    let(:storage_manager) { double("StorageManager", probe_from_file: nil) }
     let(:partitioner_client) { double("Main", run: :next) }
     let(:proposal_client) { double("InstDiskProposal", run: :next) }
 
@@ -48,7 +48,7 @@ describe Y2Storage::Clients::ManualTest do
 
     RSpec.shared_examples "mock devicegraph" do
       it "mocks the devicegraph with the given file" do
-        expect(storage_manager).to receive(:probe_from_xml).with(args[1])
+        expect(storage_manager).to receive(:probe_from_file).with(args[1])
         described_class.run
       end
     end
@@ -97,7 +97,7 @@ describe Y2Storage::Clients::ManualTest do
       let(:args) { ["partitioner", "devicegraph.xml"] }
 
       it "mocks the devicegraph with the xml file" do
-        expect(storage_manager).to receive(:probe_from_xml).with("devicegraph.xml")
+        expect(storage_manager).to receive(:probe_from_file).with("devicegraph.xml")
         described_class.run
       end
 
@@ -111,7 +111,7 @@ describe Y2Storage::Clients::ManualTest do
       let(:args) { ["partitioner", "/path/to/devicegraph.yaml"] }
 
       it "mocks the devicegraph with the YAML file" do
-        expect(storage_manager).to receive(:probe_from_yaml).with("/path/to/devicegraph.yaml")
+        expect(storage_manager).to receive(:probe_from_file).with("/path/to/devicegraph.yaml")
         described_class.run
       end
 

--- a/test/y2storage/device_test.rb
+++ b/test/y2storage/device_test.rb
@@ -161,18 +161,42 @@ describe Y2Storage::Device do
         reasons: 0, reason_texts: [])
     end
 
-    before { allow(device).to receive(:detect_resize_info).and_return resize_info }
+    before { allow(device).to receive(:storage_detect_resize_info).and_return resize_info }
 
-    context "if libstorage-nd reports that resizing is possible" do
+    context "if not in test mode and libstorage-ng reports that resizing is possible" do
       let(:resize_ok) { true }
+
+      it "invokes the corresponding libstorage-ng method" do
+        expect(device).to receive(:storage_detect_resize_info)
+        device.can_resize?
+      end
 
       it "returns true" do
         expect(device.can_resize?).to eq true
       end
     end
 
-    context "if libstorage-ng reports that resizing is not possible" do
+    context "if not in test mode and libstorage-ng reports that resizing is not possible" do
       let(:resize_ok) { false }
+
+      it "invokes the corresponding libstorage-ng method" do
+        expect(device).to receive(:storage_detect_resize_info)
+        device.can_resize?
+      end
+
+      it "returns false" do
+        expect(device.can_resize?).to eq false
+      end
+    end
+
+    context "if in test mode" do
+      before { allow(Y2Storage::StorageEnv.instance).to receive(:test_mode?).and_return(true) }
+      let(:resize_ok) { true }
+
+      it "does not check with libstorage-ng" do
+        expect(device).to_not receive(:storage_detect_resize_info)
+        device.can_resize?
+      end
 
       it "returns false" do
         expect(device.can_resize?).to eq false

--- a/test/y2storage/storage_env_test.rb
+++ b/test/y2storage/storage_env_test.rb
@@ -100,4 +100,78 @@ describe Y2Storage::StorageEnv do
       end
     end
   end
+
+  describe "#test_mode?" do
+    context "YAST_STORAGE_TEST_MODE is not set" do
+      let(:env_vars) do
+        {}
+      end
+
+      it "returns false" do
+        expect(Y2Storage::StorageEnv.instance.test_mode?).to be false
+      end
+    end
+
+    context "YAST_STORAGE_TEST_MODE is empty" do
+      let(:env_vars) do
+        { "YAST_STORAGE_TEST_MODE" => "" }
+      end
+
+      it "returns true" do
+        expect(Y2Storage::StorageEnv.instance.test_mode?).to be true
+      end
+    end
+
+    context "YAST_STORAGE_TEST_MODE is set to '1'" do
+      let(:env_vars) do
+        { "YAST_STORAGE_TEST_MODE" => "1" }
+      end
+
+      it "returns true" do
+        expect(Y2Storage::StorageEnv.instance.test_mode?).to be true
+      end
+    end
+
+    context "YAST_STORAGE_TEST_MODE is set to '0'" do
+      let(:env_vars) do
+        { "YAST_STORAGE_TEST_MODE" => "0" }
+      end
+
+      it "returns false" do
+        expect(Y2Storage::StorageEnv.instance.test_mode?).to be false
+      end
+    end
+  end
+
+  describe "#devicegraph_file" do
+    context "YAST_DEVICEGRAPH_FILE is not set" do
+      let(:env_vars) do
+        {}
+      end
+
+      it "returns nil" do
+        expect(Y2Storage::StorageEnv.instance.devicegraph_file).to be_nil
+      end
+    end
+
+    context "YAST_DEVICEGRAPH_FILE is empty" do
+      let(:env_vars) do
+        { "YAST_DEVICEGRAPH_FILE" => "" }
+      end
+
+      it "returns nil" do
+        expect(Y2Storage::StorageEnv.instance.devicegraph_file).to be_nil
+      end
+    end
+
+    context "YAST_DEVICEGRAPH_FILE contains a file path" do
+      let(:env_vars) do
+        { "YAST_DEVICEGRAPH_FILE" => "/tmp/mock.xml" }
+      end
+
+      it "returns the path" do
+        expect(Y2Storage::StorageEnv.instance.devicegraph_file).to eq "/tmp/mock.xml"
+      end
+    end
+  end
 end

--- a/test/y2storage/storage_manager_test.rb
+++ b/test/y2storage/storage_manager_test.rb
@@ -783,6 +783,18 @@ describe Y2Storage::StorageManager do
     let(:devicegraph) { Y2Storage::Devicegraph.new(st_staging) }
     let(:proposal) { double("Y2Storage::GuidedProposal", devices: devicegraph, failed?: false) }
 
+    context "when a devicegraph file is set via environment variables" do
+      before do
+        allow(Y2Storage::StorageEnv.instance).to receive(:devicegraph_file).and_return(mock_path)
+      end
+      let(:mock_path) { File.join(DATA_PATH, "devicegraphs", "empty_disks.yml") }
+
+      it "does not execute a real probing" do
+        expect(manager.storage).to_not receive(:probe)
+        manager.probe!
+      end
+    end
+
     it "refreshes #probed" do
       expect(manager.probed.disks.size).to eq 6
       # Calling twice (or more) does not result in a refresh
@@ -998,6 +1010,43 @@ describe Y2Storage::StorageManager do
       manager.proposal = proposal
       manager.probe_from_xml(input_file_for("md2-devicegraph", suffix: "xml"))
       expect(manager.proposal).to be_nil
+    end
+  end
+
+  describe "#probe_from_file" do
+    subject(:manager) { described_class.create_test_instance }
+
+    context "when called with a file name ending in .xml" do
+      let(:filename) { "devicegraph.xml" }
+
+      it "mocks the devicegraph using probe_from_xml" do
+        expect(manager).to receive(:probe_from_xml).with(filename)
+        expect(manager).to_not receive(:probe_from_yaml).with(filename)
+
+        manager.probe_from_file(filename)
+      end
+    end
+
+    context "when called with a file name ending in .yml" do
+      let(:filename) { "devicegraph.yml" }
+
+      it "mocks the devicegraph using probe_from_yaml" do
+        expect(manager).to receive(:probe_from_yaml).with(filename)
+        expect(manager).to_not receive(:probe_from_xml).with(filename)
+
+        manager.probe_from_file(filename)
+      end
+    end
+
+    context "when called with a file name ending in .YAML" do
+      let(:filename) { "devicegraph.YAML" }
+
+      it "mocks the devicegraph using probe_from_yaml" do
+        expect(manager).to receive(:probe_from_yaml).with(filename)
+        expect(manager).to_not receive(:probe_from_xml).with(filename)
+
+        manager.probe_from_file(filename)
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

To ease development of Agama, it would be really useful to have a way to fake the storage setup using a devicegraph stored in a file.

## Solution

Introduce two new environment variables that will be honored by yast-storage-ng:

- YAST_TEST_MODE limits the access to the system. YaST will create a test libstorage-ng instance instead of real one and will not try to read information from the system when asked for resize information or when searching a device.
- YAST_DEVICEGRAPH_FILE allows to specify a mocked devicegraph.

## Testing

- Tested manually during Agama development
- Unit tests adapted and expanded
