### PR TITLE
Manage /etc/lvm/devices

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 10 11:30:44 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Create /etc/lvm/devices if needed (jsc#PED-7355, jsc#PED-12241).
+- 5.0.29
+
+-------------------------------------------------------------------
 Fri Apr  4 07:00:19 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - New environment variables YAST_STORAGE_TEST_MODE and

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.28
+Version:        5.0.29
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# LvmDevicesFile
-BuildRequires:	libstorage-ng-ruby >= 4.5.234
+# RB_FILESYSTEM_MOUNT_READ_ONLY
+BuildRequires:	libstorage-ng-ruby >= 4.5.246
 BuildRequires:  update-desktop-files
 # Replace PackageSystem with Package
 BuildRequires:  yast2 >= 4.4.38
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# LvmDevicesFile
-Requires:       libstorage-ng-ruby >= 4.5.234
+# RB_FILESYSTEM_MOUNT_READ_ONLY
+Requires:       libstorage-ng-ruby >= 4.5.246
 # Require libstorage bindings for the current Ruby version (bsc#1235598)
 Requires:       libstorage-ng-ruby-%{rb_ver}
 # Replace PackageSystem with Package

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -25,8 +25,8 @@ Url:            https://github.com/yast/yast-storage-ng
 
 Source:         %{name}-%{version}.tar.bz2
 
-# Encryption#use_key_file_in_commit
-BuildRequires:	libstorage-ng-ruby >= 4.5.144
+# LvmDevicesFile
+BuildRequires:	libstorage-ng-ruby >= 4.5.234
 BuildRequires:  update-desktop-files
 # Replace PackageSystem with Package
 BuildRequires:  yast2 >= 4.4.38
@@ -47,8 +47,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:parallel_tests)
 
 # findutils for xargs
 Requires:       findutils
-# Encryption#use_key_file_in_commit
-Requires:       libstorage-ng-ruby >= 4.5.144
+# LvmDevicesFile
+Requires:       libstorage-ng-ruby >= 4.5.234
 # Require libstorage bindings for the current Ruby version (bsc#1235598)
 Requires:       libstorage-ng-ruby-%{rb_ver}
 # Replace PackageSystem with Package

--- a/src/lib/y2storage/resize_info.rb
+++ b/src/lib/y2storage/resize_info.rb
@@ -57,7 +57,8 @@ module Y2Storage
         RB_NO_SPACE_IN_LVM_VG:                             N_("No space left in the LVM volume group."),
         RB_MIN_SIZE_FOR_LVM_LV:                            N_("The LVM logical volume already has the minimum possible size."),
         RB_MAX_SIZE_FOR_LVM_LV_THIN:                       N_("The LVM thin logical volume already has the maximum size."),
-        RB_PASSWORD_REQUIRED:                              N_("The encryption password is required.")
+        RB_PASSWORD_REQUIRED:                              N_("The encryption password is required."),
+        RB_FILESYSTEM_MOUNT_READ_ONLY:                     N_("Filesystem mounted in read-only mode.")
       }.freeze
     # rubocop:enable Layout/LineLength
 


### PR DESCRIPTION
## Problem

It was decided that lvm2 should use system/devices feature by default in all (open)SUSE distributions (openSUSE Tumbleweed, SLES 16 and Leap 16).

Libstorage-ng was already adapted to handle that, but some adaptations were still missing in the installer.

- https://jira.suse.com/browse/PED-7355
- https://jira.suse.com/browse/PED-12241

## Solution

- Ensure libstorage-ng generates the corresponding files if it considers they are missing.
- Copy the files to the target system at the end of installation.

## Testing

- Tested manually at Tumbleweed (YaST) :heavy_check_mark: 
- Tested manually at SLES 16 (Agama) :heavy_check_mark: 
- Added unit tests

## Bonus

[This change](https://github.com/openSUSE/libstorage-ng/pull/1022) that was very recently introduced at libstorage-ng and needed the corresponding adaptation at YaST (we have unit tests to ensure we keep both lists in sync). That's what's the last commit of this pull request is about.

The libstorage-ng change is at the devel project but is still not in Factory or SLFO. But better to fix it now than to open another separate PR just for that. And our CI runs against the devel project, anyways.