### PR TITLE
Supporting LUKS2 encryption with TPM2/FIDO2 authentication. (jsc#PED-10703)

### DIFF
--- a/src/lib/y2partitioner/actions/controllers/encryption.rb
+++ b/src/lib/y2partitioner/actions/controllers/encryption.rb
@@ -278,6 +278,7 @@ module Y2Partitioner
         # @return [EncryptionAuthentication, nil] nil if the method does not support it.
         def initial_authentication
           return nil unless encryption.respond_to?(:authentication)
+
           encryption.authentication
         end
 

--- a/src/lib/y2partitioner/actions/controllers/encryption.rb
+++ b/src/lib/y2partitioner/actions/controllers/encryption.rb
@@ -66,7 +66,7 @@ module Y2Partitioner
         # @return [PbkdFunction] Password-based key derivation function (PBKDF) for the LUKS2 device
         attr_accessor :pbkdf
 
-        # @return [EncryptionAuthentication] Authentication for systemd_fde devices
+        # @return [EncryptionAuthentication, nil] Authentication for systemd_fde devices
         attr_accessor :authentication
 
         # Contructor
@@ -277,7 +277,7 @@ module Y2Partitioner
         #
         # @return [EncryptionAuthentication, nil] nil if the method does not support it.
         def initial_authentication
-          return nil unless encryption.respond_to?(:authentication)
+          return nil unless encryption&.supports_authentication?
 
           encryption.authentication
         end

--- a/src/lib/y2partitioner/actions/filesystem_steps.rb
+++ b/src/lib/y2partitioner/actions/filesystem_steps.rb
@@ -54,9 +54,8 @@ module Y2Partitioner
     #     end
     #   end
     module FilesystemSteps
-
       include Yast::Logger
-      
+
       def self.included(base)
         base.skip_stack :filesystem_role
       end

--- a/src/lib/y2partitioner/actions/filesystem_steps.rb
+++ b/src/lib/y2partitioner/actions/filesystem_steps.rb
@@ -54,8 +54,6 @@ module Y2Partitioner
     #     end
     #   end
     module FilesystemSteps
-      include Yast::Logger
-
       def self.included(base)
         base.skip_stack :filesystem_role
       end
@@ -81,7 +79,6 @@ module Y2Partitioner
       def filesystem_commit
         fs_controller.finish
         encrypt_controller.finish
-
         UIState.instance.select_row(fs_controller.blk_device.sid)
         :finish
       end

--- a/src/lib/y2partitioner/widgets/encrypt.rb
+++ b/src/lib/y2partitioner/widgets/encrypt.rb
@@ -240,9 +240,7 @@ module Y2Partitioner
             "<li><i>TPM2: </i>A crypto-device that is already present in your system.</li>" \
             "<li><i>TPM2 and PIN: </i>Like TPM2, but a password must be enter together.</li>" \
             "<li><i>FIDO2: </i>External key device.</li>" \
-            "</ul>"
-           ),
-          label: encrypt_method.to_human_string
+            "</ul>"), label: encrypt_method.to_human_string
         )
       end
 

--- a/src/lib/y2partitioner/widgets/encrypt.rb
+++ b/src/lib/y2partitioner/widgets/encrypt.rb
@@ -232,9 +232,16 @@ module Y2Partitioner
 
         format(
           # TRANSLATORS: help text for Regular Luks2 encryption method together wit TPM2 support
-          _("<p><b>%{label}</b>: allows to encrypt the device using LUKS2 and TPM2. "\
+          _("<p><b>%{label}</b>: allows to encrypt the device using LUKS2. "\
             "You have to provide the encryption password and the password-based key derivation " \
-            "function (PBKDF) that will be used to protect that passphrase.</p>"),
+            "function (PBKDF) that will be used to protect that passphrase.</p>"\
+            "<p>Additional methods can be used for unlocking the device:</p>" \
+            "<ul>" \
+            "<li><i>TPM2: </i>A crypto-device that is already present in your system.</li>" \
+            "<li><i>TPM2 and PIN: </i>Like TPM2, but a password must be enter together.</li>" \
+            "<li><i>FIDO2: </i>External key device.</li>" \
+            "</ul>"
+           ),
           label: encrypt_method.to_human_string
         )
       end

--- a/src/lib/y2partitioner/widgets/encrypt.rb
+++ b/src/lib/y2partitioner/widgets/encrypt.rb
@@ -235,7 +235,7 @@ module Y2Partitioner
           _("<p><b>%{label}</b>: allows to encrypt the device using LUKS2. "\
             "You have to provide the encryption password and the password-based key derivation " \
             "function (PBKDF) that will be used to protect that passphrase.</p>"\
-            "<p>Additional methods can be used for unlocking the device:</p>" \
+            "<p>Additional <b>authentication</b> methods can be used for unlocking the device:</p>" \
             "<ul>" \
             "<li><i>TPM2: </i>A crypto-device that is already present in your system.</li>" \
             "<li><i>TPM2 and PIN: </i>Like TPM2, but a password must be enter together.</li>" \

--- a/src/lib/y2partitioner/widgets/encrypt.rb
+++ b/src/lib/y2partitioner/widgets/encrypt.rb
@@ -235,9 +235,11 @@ module Y2Partitioner
           _("<p><b>%{label}</b>: allows to encrypt the device using LUKS2. "\
             "You have to provide the encryption password and the password-based key derivation " \
             "function (PBKDF) that will be used to protect that passphrase.</p>" \
-            "<p>Additional <b>authentication</b> methods can be used for unlocking the device:</p>%{auth_list}"),
-          label: encrypt_method.to_human_string,
-          auth_list: Y2Storage::EncryptionAuthentication.auth_list_help_text)
+            "<p>Additional <b>authentication</b> methods can be used for unlocking the device:</p>" \
+            "%{auth_list}"),
+          label:     encrypt_method.to_human_string,
+          auth_list: Y2Storage::EncryptionAuthentication.auth_list_help_text
+        )
       end
 
       # Help text for the Random Swap encryption method

--- a/src/lib/y2partitioner/widgets/encrypt.rb
+++ b/src/lib/y2partitioner/widgets/encrypt.rb
@@ -234,14 +234,10 @@ module Y2Partitioner
           # TRANSLATORS: help text for Regular Luks2 encryption method together wit TPM2 support
           _("<p><b>%{label}</b>: allows to encrypt the device using LUKS2. "\
             "You have to provide the encryption password and the password-based key derivation " \
-            "function (PBKDF) that will be used to protect that passphrase.</p>"\
-            "<p>Additional <b>authentication</b> methods can be used for unlocking the device:</p>" \
-            "<ul>" \
-            "<li><i>TPM2: </i>A crypto-device that is already present in your system.</li>" \
-            "<li><i>TPM2 and PIN: </i>Like TPM2, but a password must be enter together.</li>" \
-            "<li><i>FIDO2: </i>External key device.</li>" \
-            "</ul>"), label: encrypt_method.to_human_string
-        )
+            "function (PBKDF) that will be used to protect that passphrase.</p>" \
+            "<p>Additional <b>authentication</b> methods can be used for unlocking the device:</p>%{auth_list}"),
+          label: encrypt_method.to_human_string,
+          auth_list: Y2Storage::EncryptionAuthentication.auth_list_help_text)
       end
 
       # Help text for the Random Swap encryption method

--- a/src/lib/y2partitioner/widgets/encrypt_auth_selector.rb
+++ b/src/lib/y2partitioner/widgets/encrypt_auth_selector.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2024] SUSE LLC
+# Copyright (c) [2025] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2partitioner/widgets/encrypt_method_options.rb
+++ b/src/lib/y2partitioner/widgets/encrypt_method_options.rb
@@ -215,19 +215,11 @@ module Y2Partitioner
     end
 
     # Internal widget to display the SystemdFde encryption options
-    class SystemdFdeOptions < LuksOptions
+    class SystemdFdeOptions < Luks2Options
       private
 
-      # @see LuksOptions#widgets
       def widgets
         super.concat([pbkdf_widget, auth_widget])
-      end
-
-      # Widget to set the authentication function
-      #
-      # @return [Widgets::EncryptPbkdf]
-      def pbkdf_widget
-        @pbkdf_widget ||= Widgets::PbkdfSelector.new(@controller, enable: enable_on_init)
       end
 
       # Widget to set the authentication type of the LUKS2 device

--- a/src/lib/y2partitioner/widgets/encrypt_method_options.rb
+++ b/src/lib/y2partitioner/widgets/encrypt_method_options.rb
@@ -219,7 +219,7 @@ module Y2Partitioner
       private
 
       def widgets
-        super.concat([pbkdf_widget, auth_widget])
+        [password_widget, pbkdf_widget, auth_widget]
       end
 
       # Widget to set the authentication type of the LUKS2 device

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -328,6 +328,7 @@ module Y2Storage
     # @return [Encryption]
     def encrypt(method: EncryptionMethod::LUKS1, dm_name: nil, password: nil, **method_args)
       enc = encrypt_with_method(method, dm_name, **method_args)
+
       enc.auto_dm_name = enc.dm_table_name.empty?
       enc.password = password if password
       enc.ensure_suitable_mount_by

--- a/src/lib/y2storage/boot_requirements_strategies/base.rb
+++ b/src/lib/y2storage/boot_requirements_strategies/base.rb
@@ -88,8 +88,8 @@ module Y2Storage
           error_message =
             _(
               "The grub boot loader cannot access the file system mounted at /boot. " \
-              "Only LUKS1 and LUKS2 with PBKDF2 encryption is supported. An options would be to use "\
-              "another bootloader like systemd_boot or grub2_bls in the boot loader section."
+              "Only LUKS1 and LUKS2 with PBKDF2 encryption is supported. Another boot loader can be "\
+              "selected in the boot loader section, for example systemd_boot or grub2_bls."
             )
           res << SetupError.new(message: error_message)
         end

--- a/src/lib/y2storage/clients/inst_disk_proposal.rb
+++ b/src/lib/y2storage/clients/inst_disk_proposal.rb
@@ -48,7 +48,6 @@ module Y2Storage
 
         @devicegraph = storage_manager.staging
         @proposal = storage_manager.proposal
-
         # Save staging revision to check later if the system was reprobed
         save_staging_revision
 

--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -79,8 +79,8 @@ module Y2Storage
         mount_in_target("/proc", "proc", "-t proc")
         mount_in_target("/sys", "sysfs", "-t sysfs")
         mount_in_target(EFIVARS_PATH, "efivarfs", "-t efivarfs") if mount_efivars?
-        devicegraph = Y2Storage::StorageManager.instance.staging
-        if devicegraph.encryptions&.any? { |e| e.method.id == :systemd_fde }
+        devicegraph = manager.staging
+        if devicegraph.encryptions.any? { |e| e.method&.is?(:systemd_fde) }
           mount_in_target("/sys/kernel/security", "securityfs", "-t securityfs")
         end
         # systemd makes default for mount bind sharable, but it causes troubles with

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -239,10 +239,10 @@ module Y2Storage
           # TRANSLATORS: %{widget_label} refers to the label of the described widget
           format(_("<p><b>%{widget_label}:</b> Which method will be used for unlocking the devices:</p>" \
               "<ul>" \
-              "<li><i>Only password:</i> <p>Password is required.</p></li>" \
-              "<li><i>TPM2:</i> <p>A crypto-device that is already present in your system.</p></li>" \
-              "<li><i>TPM2 and PIN:</i> <p>Like TPM2, but a password must be enter together.</p></li>" \
-              "<li><i>FIDO2:</i> <p>External key device.</p></li>" \
+              "<li><i>Only password: </i>Password is required.</li>" \
+              "<li><i>TPM2: </i>A crypto-device that is already present in your system.</li>" \
+              "<li><i>TPM2 and PIN: </i>Like TPM2, but a password must be enter together.</li>" \
+              "<li><i>FIDO2: </i>External key device.</li>" \
               "</ul>"
                   ), widget_label: _(WIDGET_LABELS[:authentication])
           )

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -230,30 +230,27 @@ module Y2Storage
               "</p>"
             ),
             disk_encryption_label: _(WIDGET_LABELS[:enable_disk_encryption]),
-            encrption_method: settings.encryption_method.to_human_string
+            encrption_method:      settings.encryption_method.to_human_string
           )
           # rubocop:enable Metrics/MethodLength
         end
 
         def authentication_help_text
           # TRANSLATORS: %{widget_label} refers to the label of the described widget
-          format(_("<p><b>%{widget_label}:</b> Which method will be used for unlocking the devices:</p>" \
-              "<ul>" \
-              "<li><i>Only password: </i>Password is required.</li>" \
-              "<li><i>TPM2: </i>A crypto-device that is already present in your system.</li>" \
-              "<li><i>TPM2 and PIN: </i>Like TPM2, but a password must be enter together.</li>" \
-              "<li><i>FIDO2: </i>External key device.</li>" \
-              "</ul>"
-                  ), widget_label: _(WIDGET_LABELS[:authentication])
-          )
+          format(_("<p><b>%{widget_label}:</b> Which method will be used for unlocking the devices:" \
+                   "</p><ul>" \
+                   "<li><i>Only password: </i>Password is required.</li>" \
+                   "<li><i>TPM2: </i>A crypto-device that is already present in your system.</li>" \
+                   "<li><i>TPM2 and PIN: </i>Like TPM2, but a password must be enter together.</li>" \
+                   "<li><i>FIDO2: </i>External key device.</li>" \
+                   "</ul>"), widget_label: _(WIDGET_LABELS[:authentication]))
         end
 
         def separate_vgs_help_text
           # TRANSLATORS: %{widget_label} refers to the label of the described widget
           format(_("<p><b>%{widget_label}:</b> indicates to the <i>Guided Setup</i> that you want " \
                    "to put some of those special paths in an isolated Volume Group.</p>"),
-                 widget_label: _(WIDGET_LABELS[:use_separate_vgs])
-          )
+            widget_label: _(WIDGET_LABELS[:use_separate_vgs]))
         end
 
         private

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -168,14 +168,15 @@ module Y2Storage
           widget_update(:separate_vgs, settings.separate_vgs)
           widget_update(:encryption, settings.use_encryption)
           encryption_handler(focus: false)
+          if settings.encryption_method == EncryptionMethod::SYSTEMD_FDE
+            widget_update(:authentication,
+              settings.encryption_authentication.value)
+          end
+
           return unless settings.use_encryption
 
           widget_update(:password, settings.encryption_password)
           widget_update(:repeat_password, settings.encryption_password)
-          return unless settings.encryption_method == EncryptionMethod::SYSTEMD_FDE
-
-          widget_update(:authentication,
-            settings.encryption_authentication.value)
         end
 
         def update_settings!

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -55,7 +55,9 @@ module Y2Storage
         def encryption_handler(focus: true)
           widget_update(:password, using_encryption?, attr: :Enabled)
           widget_update(:repeat_password, using_encryption?, attr: :Enabled)
-          widget_update(:authentication, using_encryption?, attr: :Enabled)
+          if settings.encryption_method == EncryptionMethod::SYSTEMD_FDE
+            widget_update(:authentication, using_encryption?, attr: :Enabled)
+          end
           return unless focus && using_encryption?
 
           Yast::UI.SetFocus(Id(:password))
@@ -170,6 +172,7 @@ module Y2Storage
 
           widget_update(:password, settings.encryption_password)
           widget_update(:repeat_password, settings.encryption_password)
+          return unless settings.encryption_method == EncryptionMethod::SYSTEMD_FDE
           widget_update(:authentication, settings.encryption_authentication)
         end
 

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -174,7 +174,8 @@ module Y2Storage
           widget_update(:repeat_password, settings.encryption_password)
           return unless settings.encryption_method == EncryptionMethod::SYSTEMD_FDE
 
-          widget_update(:authentication, settings.encryption_authentication)
+          widget_update(:authentication,
+            settings.encryption_authentication.value)
         end
 
         def update_settings!

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -243,12 +243,9 @@ module Y2Storage
         def authentication_help_text
           # TRANSLATORS: %{widget_label} refers to the label of the described widget
           format(_("<p><b>%{widget_label}:</b> Which method will be used for unlocking the devices:" \
-                   "</p><ul>" \
-                   "<li><i>Only password: </i>Password is required.</li>" \
-                   "<li><i>TPM2: </i>A crypto-device that is already present in your system.</li>" \
-                   "<li><i>TPM2 and PIN: </i>Like TPM2, but a password must be enter together.</li>" \
-                   "<li><i>FIDO2: </i>External key device.</li>" \
-                   "</ul>"), widget_label: _(WIDGET_LABELS[:authentication]))
+                   "</p>%{auth_list}",
+                   widget_label: _(WIDGET_LABELS[:authentication]),
+                   auth_list: Y2Storage::EncryptionAuthentication.auth_list_help_text))
         end
 
         def separate_vgs_help_text

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -243,9 +243,9 @@ module Y2Storage
         def authentication_help_text
           # TRANSLATORS: %{widget_label} refers to the label of the described widget
           format(_("<p><b>%{widget_label}:</b> Which method will be used for unlocking the devices:" \
-                   "</p>%{auth_list}",
+                   "</p>%{auth_list}"),
             widget_label: _(WIDGET_LABELS[:authentication]),
-            auth_list:    Y2Storage::EncryptionAuthentication.auth_list_help_text))
+            auth_list:    Y2Storage::EncryptionAuthentication.auth_list_help_text)
         end
 
         def separate_vgs_help_text

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -244,8 +244,8 @@ module Y2Storage
           # TRANSLATORS: %{widget_label} refers to the label of the described widget
           format(_("<p><b>%{widget_label}:</b> Which method will be used for unlocking the devices:" \
                    "</p>%{auth_list}",
-                   widget_label: _(WIDGET_LABELS[:authentication]),
-                   auth_list: Y2Storage::EncryptionAuthentication.auth_list_help_text))
+            widget_label: _(WIDGET_LABELS[:authentication]),
+            auth_list:    Y2Storage::EncryptionAuthentication.auth_list_help_text))
         end
 
         def separate_vgs_help_text

--- a/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
+++ b/src/lib/y2storage/dialogs/guided_setup/select_scheme.rb
@@ -173,6 +173,7 @@ module Y2Storage
           widget_update(:password, settings.encryption_password)
           widget_update(:repeat_password, settings.encryption_password)
           return unless settings.encryption_method == EncryptionMethod::SYSTEMD_FDE
+
           widget_update(:authentication, settings.encryption_authentication)
         end
 

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -83,6 +83,7 @@ module Y2Storage
       def handle_event(input)
         return unless @actions_presenter.can_handle?(input)
 
+        @actions_presenter.update_status(input)
         Yast::UI.ChangeWidget(Id(:summary), :Value, actions_html)
       end
 

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -316,9 +316,7 @@ module Y2Storage
 
         auth_list = []
         @devicegraph.encryptions&.each do |d|
-          puts("xxxxxxxxxx #{d.authentication} xx #{d.blk_device.name}")
           if d.authentication && d.blk_device
-            puts("   xxxx #{d.authentication.name} #{d.blk_device.name}")
             auth_list << ("using " + d.authentication.name + " for " + d.blk_device.name)
           end
         end

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -313,7 +313,6 @@ module Y2Storage
       def encryption_authentication
         return "" unless @devicegraph.encryptions&.length
 
-        ret = para(_("Authentication for encrypted devices:"))
         auth_list = []
         @devicegraph.encryptions&.each do |d|
           if d.authentication && d.blk_device
@@ -321,7 +320,7 @@ module Y2Storage
           end
         end
         if auth_list.size > 0
-          ret + list(auth_list)
+          para(_("Authentication for encrypted devices:")) + list(auth_list)
         else
           ""
         end

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -312,6 +312,7 @@ module Y2Storage
 
       def encryption_authentication
         return "" unless @devicegraph.encryptions&.length
+
         ret = para(_("Authentication for encrypted devices:"))
         auth_list = []
         @devicegraph.encryptions&.each do |d|
@@ -320,9 +321,9 @@ module Y2Storage
           end
         end
         if auth_list.size > 0
-          return ret + list(auth_list)
+          ret + list(auth_list)
         else
-          return ""
+          ""
         end
       end
 

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -314,11 +314,13 @@ module Y2Storage
       def encryption_authentication
         auth_list = @devicegraph.encryptions
           .select(&:supports_authentication?)
-          .map { |e| format(_("using %s for %s"), e.authentication.name,
-                            e.blk_device.name) }
-          
+          .map do |e|
+          format(_("using %s for %s"), e.authentication.name,
+            e.blk_device.name)
+        end
+
         return "" if auth_list.none?
-        
+
         para(_("Authentication for encrypted devices:")) + list(auth_list)
       end
 

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -316,7 +316,9 @@ module Y2Storage
 
         auth_list = []
         @devicegraph.encryptions&.each do |d|
+          puts("xxxxxxxxxx #{d.authentication} #{d.blk_device}")
           if d.authentication && d.blk_device
+            puts("   xxxx #{d.authentication.name} #{d.blk_device.name}")
             auth_list << ("using " + d.authentication.name + " for " + d.blk_device.name)
           end
         end

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -316,7 +316,7 @@ module Y2Storage
 
         auth_list = []
         @devicegraph.encryptions&.each do |d|
-          puts("xxxxxxxxxx #{d.authentication} #{d.blk_device}")
+          puts("xxxxxxxxxx #{d.authentication} xx #{d.blk_device.name}")
           if d.authentication && d.blk_device
             puts("   xxxx #{d.authentication.name} #{d.blk_device.name}")
             auth_list << ("using " + d.authentication.name + " for " + d.blk_device.name)

--- a/src/lib/y2storage/dialogs/proposal.rb
+++ b/src/lib/y2storage/dialogs/proposal.rb
@@ -312,19 +312,14 @@ module Y2Storage
       end
 
       def encryption_authentication
-        return "" unless @devicegraph.encryptions&.length
-
-        auth_list = []
-        @devicegraph.encryptions&.each do |d|
-          if d.authentication && d.blk_device
-            auth_list << ("using " + d.authentication.name + " for " + d.blk_device.name)
-          end
-        end
-        if auth_list.size > 0
-          para(_("Authentication for encrypted devices:")) + list(auth_list)
-        else
-          ""
-        end
+        auth_list = @devicegraph.encryptions
+          .select(&:supports_authentication?)
+          .map { |e| format(_("using %s for %s"), e.authentication.name,
+                            e.blk_device.name) }
+          
+        return "" if auth_list.none?
+        
+        para(_("Authentication for encrypted devices:")) + list(auth_list)
       end
 
       # Actions needed to reach the desired devicegraph

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -495,7 +495,7 @@ module Y2Storage
     #
     # @return [Boolean]
     def supports_authentication?
-      method.id == :systemd_fde
+      method.is?(:systemd_fde)
     end
 
     # Whether the attribute #cipher makes sense for this object

--- a/src/lib/y2storage/encryption_authentication.rb
+++ b/src/lib/y2storage/encryption_authentication.rb
@@ -22,6 +22,10 @@ Yast.import "Arch"
 
 module Y2Storage
   # Class for describing an authentication type of encrypted block devices.
+  #
+  # The value will only be used for systemd_fde encryption. It will be
+  # set in yast-storage-ng BUT will be only used in yast-bootmanager after the
+  # bootmanager has been installed.
   class EncryptionAuthentication
     include Yast::I18n
     extend Yast::I18n

--- a/src/lib/y2storage/encryption_authentication.rb
+++ b/src/lib/y2storage/encryption_authentication.rb
@@ -45,12 +45,12 @@ module Y2Storage
     # TRANSLATORS: authentication type for encrypted devices.
     TPM2PIN = new("tpm2+pin", N_("TPM2 and PIN"))
     # TRANSLATORS: authenticationtype for encrypted devices.
-    FIDO2 = new("fido2", N_("FIDO2"))    
+    FIDO2 = new("fido2", N_("FIDO2"))
 
     # All possible instances
     ALL = [PASSWORD, TPM2, TPM2PIN, FIDO2].freeze
     private_constant :ALL
-    NONE_TPM = [PASSWORD, FIDO2].freeze    
+    NONE_TPM = [PASSWORD, FIDO2].freeze
     private_constant :NONE_TPM
 
     # Sorted list of all possible authentications

--- a/src/lib/y2storage/encryption_authentication.rb
+++ b/src/lib/y2storage/encryption_authentication.rb
@@ -77,7 +77,7 @@ module Y2Storage
                "<li><i>%{tpm2_and_pin}: </i>Like TPM2, but a password must be enter together.</li>" \
                "<li><i>%{fido2}: </i>External key device.</li>" \
                "</ul>", only_password: PASSWORD.name, tpm2: TPM2.name,
-               tpm2_and_pin: TPM2PIN.name, fido2: FIDO2.name))
+        tpm2_and_pin: TPM2PIN.name, fido2: FIDO2.name))
     end
 
     # @return [String] value
@@ -104,6 +104,5 @@ module Y2Storage
     def is?(*names)
       names.any? { |n| n.to_sym == to_sym }
     end
-
   end
 end

--- a/src/lib/y2storage/encryption_authentication.rb
+++ b/src/lib/y2storage/encryption_authentication.rb
@@ -25,6 +25,7 @@ module Y2Storage
   class EncryptionAuthentication
     include Yast::I18n
     extend Yast::I18n
+    include Yast2::Equatable
 
     # Constructor, to be used internally by the class
     #
@@ -91,16 +92,5 @@ module Y2Storage
       names.any? { |n| n.to_sym == to_sym }
     end
 
-    # @return [Boolean]
-    def ==(other)
-      other.class == self.class && other.value == value
-    end
-
-    alias_method :eql?, :==
-
-    # @return [Boolean]
-    def ===(other)
-      other.instance_of?(self.class) && is?(other)
-    end
   end
 end

--- a/src/lib/y2storage/encryption_authentication.rb
+++ b/src/lib/y2storage/encryption_authentication.rb
@@ -71,6 +71,8 @@ module Y2Storage
     #
     # @return [String] help text
     def self.auth_list_help_text
+      textdomain "storage"
+
       format(_("<ul>" \
                "<li><i>%{only_password}: </i>Password is required.</li>" \
                "<li><i>%{tpm2}: </i>A crypto-device that is already present in your system.</li>" \

--- a/src/lib/y2storage/encryption_authentication.rb
+++ b/src/lib/y2storage/encryption_authentication.rb
@@ -67,6 +67,19 @@ module Y2Storage
       ALL.find { |opt| opt.value == value.to_s }
     end
 
+    # Help text with a list of all supported authentications.
+    #
+    # @return [String] help text
+    def self.auth_list_help_text
+      format(_("<ul>" \
+               "<li><i>%{only_password}: </i>Password is required.</li>" \
+               "<li><i>%{tpm2}: </i>A crypto-device that is already present in your system.</li>" \
+               "<li><i>%{tpm2_and_pin}: </i>Like TPM2, but a password must be enter together.</li>" \
+               "<li><i>%{fido2}: </i>External key device.</li>" \
+               "</ul>", only_password: PASSWORD.name, tpm2: TPM2.name,
+               tpm2_and_pin: TPM2PIN.name, fido2: FIDO2.name))
+    end
+
     # @return [String] value
     attr_reader :value
 

--- a/src/lib/y2storage/encryption_authentication.rb
+++ b/src/lib/y2storage/encryption_authentication.rb
@@ -76,8 +76,8 @@ module Y2Storage
                "<li><i>%{tpm2}: </i>A crypto-device that is already present in your system.</li>" \
                "<li><i>%{tpm2_and_pin}: </i>Like TPM2, but a password must be enter together.</li>" \
                "<li><i>%{fido2}: </i>External key device.</li>" \
-               "</ul>", only_password: PASSWORD.name, tpm2: TPM2.name,
-        tpm2_and_pin: TPM2PIN.name, fido2: FIDO2.name))
+               "</ul>"), only_password: PASSWORD.name, tpm2: TPM2.name,
+        tpm2_and_pin: TPM2PIN.name, fido2: FIDO2.name)
     end
 
     # @return [String] value

--- a/src/lib/y2storage/encryption_method.rb
+++ b/src/lib/y2storage/encryption_method.rb
@@ -52,7 +52,7 @@ module Y2Storage
     # Instance of the TpmFde method to be always returned by the module
     TPM_FDE = TpmFde.new
     # Instance of the SystemdFde method to be always returned by the module
-    SYSTEMD_FDE = SystemdFde.new    
+    SYSTEMD_FDE = SystemdFde.new
     # Instance of the RandomSwap method to be always returned by the module
     RANDOM_SWAP = RandomSwap.new
     # Instance of the ProtectedSwap method to be always returned by the module

--- a/src/lib/y2storage/encryption_method/systemd_fde.rb
+++ b/src/lib/y2storage/encryption_method/systemd_fde.rb
@@ -23,6 +23,7 @@ require "y2storage/encryption_method/base"
 require "y2storage/encryption_processes/systemd_fde"
 require "y2storage/pbkd_function"
 require "y2storage/yast_feature"
+require "y2storage/arch"
 
 Yast.import "Mode"
 Yast.import "Package"

--- a/src/lib/y2storage/encryption_method/systemd_fde.rb
+++ b/src/lib/y2storage/encryption_method/systemd_fde.rb
@@ -57,7 +57,6 @@ module Y2Storage
       #
       # @return [Boolean]
       def available?
-        puts ("xxxxxxxxxxxxxxx #{Y2Storage::Arch.new.efiboot?}")
         Y2Storage::Arch.new.efiboot?
       end
 

--- a/src/lib/y2storage/encryption_method/systemd_fde.rb
+++ b/src/lib/y2storage/encryption_method/systemd_fde.rb
@@ -57,6 +57,7 @@ module Y2Storage
       #
       # @return [Boolean]
       def available?
+        puts ("xxxxxxxxxxxxxxx #{Y2Storage::Arch.new.efiboot?}")
         Y2Storage::Arch.new.efiboot?
       end
 

--- a/src/lib/y2storage/encryption_method/systemd_fde.rb
+++ b/src/lib/y2storage/encryption_method/systemd_fde.rb
@@ -31,9 +31,9 @@ Yast.import "Arch"
 module Y2Storage
   module EncryptionMethod
     # Encryption method that allows to encrypt a device using LUKS2 and configure the unlocking
-    # process via the system TPM using the sdbootutil created by SUSE.
+    # process via the system TPM or FIDO2 using the sdbootutil created by SUSE.
     #
-    # Check the documentation of fde-tools for further information.
+    # Check the documentation of sdbootutil for further information.
     # https://github.com/openSUSE/sdbootutil
     class SystemdFde < Base
       def initialize

--- a/src/lib/y2storage/encryption_processes/systemd_fde.rb
+++ b/src/lib/y2storage/encryption_processes/systemd_fde.rb
@@ -30,7 +30,7 @@ module Y2Storage
       # @param blk_device [Y2Storage::BlkDevice]
       # @param dm_name [String]
       # @param authentication [EncryptionAuthentication] authentications for the crypted device
-      # @param pbkdf [PbkdFunction] PBKDF of the LUKS device, only relevant for LUKS2
+      # @param pbkdf [PbkdFunction, nil] PBKDF of the LUKS device, only relevant for LUKS2
       # @param label [String, nil] label of the LUKS device, only relevant for LUKS2
       #
       # @return [Encryption]

--- a/src/lib/y2storage/encryption_processes/systemd_fde.rb
+++ b/src/lib/y2storage/encryption_processes/systemd_fde.rb
@@ -29,9 +29,9 @@ module Y2Storage
       #
       # @param blk_device [Y2Storage::BlkDevice]
       # @param dm_name [String]
+      # @param authentication [EncryptionAuthentication] authentications for the crypted device
       # @param pbkdf [PbkdFunction] PBKDF of the LUKS device, only relevant for LUKS2
       # @param label [String, nil] label of the LUKS device, only relevant for LUKS2
-      # @param authentication [EncryptionAuthentication] authentications for the crypted device
       #
       # @return [Encryption]
       def create_device(blk_device, dm_name, authentication, pbkdf: nil, label: nil)

--- a/src/lib/y2storage/encryption_processes/systemd_fde.rb
+++ b/src/lib/y2storage/encryption_processes/systemd_fde.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019-2021] SUSE LLC
+# Copyright (c) [2025] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -684,18 +684,21 @@ module Y2Storage
         # Notify create_file_system that this partition is encrypted
         @file_system_data[parent]["encryption"] = encryption.name
       end
-      if args["pbkdf"]
-        name = args["pbkdf"]
+
+      name = args["pbkdf"]
+      if name
         pbkdf = PbkdFunction.find(name)
         raise ArgumentError, "Unsupported pbkdf type #{name}" unless pbkdf
 
         encryption.pbkdf = pbkdf
       end
-      if args["authentication"]
-        name = args["authentication"]
+      name = args["authentication"]
+      if name
         authentication = EncryptionAuthentication.find(name)
-        raise ArgumentError, "Unsupported authentication #{name}" unless authentication
-
+        unless authentication
+          raise ArgumentError,
+            "Unsupported authentication #{name}"
+        end
         encryption.authentication = authentication
       end
 

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -688,12 +688,14 @@ module Y2Storage
         name = args["pbkdf"]
         pbkdf = PbkdFunction.find(name)
         raise ArgumentError, "Unsupported pbkdf type #{name}" unless pbkdf
+
         encryption.pbkdf = pbkdf
       end
       if args["authentication"]
         name = args["authentication"]
         authentication = EncryptionAuthentication.find(name)
         raise ArgumentError, "Unsupported authentication #{name}" unless authentication
+
         encryption.authentication = authentication
       end
 

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -684,6 +684,19 @@ module Y2Storage
         # Notify create_file_system that this partition is encrypted
         @file_system_data[parent]["encryption"] = encryption.name
       end
+      if args["pbkdf"]
+        name = args["pbkdf"]
+        pbkdf = PbkdFunction.find(name)
+        raise ArgumentError, "Unsupported pbkdf type #{name}" unless pbkdf
+        encryption.pbkdf = pbkdf
+      end
+      if args["authentication"]
+        name = args["authentication"]
+        authentication = EncryptionAuthentication.find(name)
+        raise ArgumentError, "Unsupported authentication #{name}" unless authentication
+        encryption.authentication = authentication
+      end
+
       encryption
     end
 

--- a/src/lib/y2storage/fake_device_factory.rb
+++ b/src/lib/y2storage/fake_device_factory.rb
@@ -79,7 +79,7 @@ module Y2Storage
           "size", "start", "align", "name", "type", "id"
         ].concat(FILE_SYSTEM_PARAM),
         "file_system"     => [],
-        "encryption"      => ["name", "type", "password"],
+        "encryption"      => ["name", "type", "password", "pbkdf", "authentication"],
         "free"            => ["size", "start"],
         "lvm_vg"          => ["vg_name", "extent_size"],
         "lvm_lv"          => [

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -118,7 +118,6 @@ module Y2Storage
       #
       # @param plain_device [BlkDevice]
       # @return [BlkDevice]
-      # rubocop:disable Metrics/AbcSize
       def final_device!(plain_device)
         result = super
         if create_encryption?
@@ -144,7 +143,6 @@ module Y2Storage
 
         result
       end
-      # rubocop:enable Metrics/AbcSize
 
       def self.included(base)
         base.extend(ClassMethods)

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -137,15 +137,10 @@ module Y2Storage
           assign_enc_attr(result, :cipher)
           assign_enc_attr(result, :authentication)
           assign_enc_attr(result, :key_size) { |value| value / 8 }
-          log.info "Device encrypted. Returning a new device"
+          log.info "Device encrypted. Returning a new device #{result.inspect}"
         else
           log.info "No need to encrypt. Returning the existing device #{result.inspect}"
         end
-        log.info "Returned device #{result.inspect}"
-        log.info "      pbkdf: #{result.pbkdf}"
-        log.info "      cipher: #{result.cipher}"
-        log.info "      label: #{result.label}"
-        log.info "      authentication: #{result.authentication}"
 
         result
       end

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -136,7 +136,7 @@ module Y2Storage
           assign_enc_attr(result, :cipher)
           assign_enc_attr(result, :authentication)
           assign_enc_attr(result, :key_size) { |value| value / 8 }
-          log.info "Device encrypted. Returning a new device #{result.inspect}"
+          log.info "Device encrypted. Returning the new device #{result.inspect}"
         else
           log.info "No need to encrypt. Returning the existing device #{result.inspect}"
         end

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -118,6 +118,7 @@ module Y2Storage
       #
       # @param plain_device [BlkDevice]
       # @return [BlkDevice]
+      # rubocop:disable Metrics/AbcSize
       def final_device!(plain_device)
         result = super
         if create_encryption?
@@ -136,16 +137,19 @@ module Y2Storage
           assign_enc_attr(result, :cipher)
           assign_enc_attr(result, :authentication)
           assign_enc_attr(result, :key_size) { |value| value / 8 }
-          log.info "Device encrypted. Returning the new device #{result.inspect}"
-          log.info "      pbkdf: #{result.pbkdf}"
-          log.info "      cipher: #{result.cipher}"
-          log.info "      label: #{result.label}"
-          log.info "      authentication: #{result.authentication}"
+          log.info "Device encrypted. Returning a new device"
         else
           log.info "No need to encrypt. Returning the existing device #{result.inspect}"
         end
+        log.info "Returned device #{result.inspect}"
+        log.info "      pbkdf: #{result.pbkdf}"
+        log.info "      cipher: #{result.cipher}"
+        log.info "      label: #{result.label}"
+        log.info "      authentication: #{result.authentication}"
+
         result
       end
+      # rubocop:enable Metrics/AbcSize
 
       def self.included(base)
         base.extend(ClassMethods)

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -46,7 +46,6 @@ module Y2Storage
       #   @return [EncryptionAuthentication] encryption authentication type
       attr_accessor :encryption_authentication
 
-      
       # @!attribute encryption_password
       #   @return [String, nil] password used to encrypt the device.
       secret_attr :encryption_password

--- a/src/lib/y2storage/planned/lvm_vg.rb
+++ b/src/lib/y2storage/planned/lvm_vg.rb
@@ -72,7 +72,7 @@ module Y2Storage
       # Returns the encryption authentication type
       #
       # @return [EncryptionAuthentication]
-      attr_accessor :pvs_encryption_authentication      
+      attr_accessor :pvs_encryption_authentication
 
       # PBKDF used to encrypt the newly created physical volumes if {#pvs_encryption_password} is set
       # and LUKS2 is used

--- a/src/lib/y2storage/proposal/lvm_helper.rb
+++ b/src/lib/y2storage/proposal/lvm_helper.rb
@@ -109,6 +109,7 @@ module Y2Storage
         @reused_volume_group.pvs_encryption_password = settings.encryption_password
         @reused_volume_group.pvs_encryption_method = settings.encryption_method
         @reused_volume_group.pvs_encryption_pbkdf = settings.encryption_pbkdf
+        @reused_volume_group.pvs_encryption_authentication = settings.encryption_authentication
       end
 
       # Returns the planned volume group
@@ -143,6 +144,7 @@ module Y2Storage
         vg.pvs_encryption_password = settings.encryption_password
         vg.pvs_encryption_method = settings.encryption_method
         vg.pvs_encryption_pbkdf = settings.encryption_pbkdf
+        vg.pvs_encryption_authentication = settings.encryption_authentication
         vg.size_strategy = vg_strategy
         vg
       end

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -166,8 +166,8 @@ module Y2Storage
     # @return [Array<String>, nil]
     attr_reader :explicit_candidate_devices
 
-    # TODO: it makes sense to encapsulate #encryption_password, #encryption_method and
-    # #encryption_pbkdf #encryption_authentication in some new class (eg. EncryptionSettings),
+    # TODO: it makes sense to encapsulate #encryption_password, #encryption_method,
+    # #encryption_pbkdf and #encryption_authentication in some new class (eg. EncryptionSettings),
     # posponed for now
 
     # @!attribute encryption_password

--- a/src/lib/y2storage/proposal_settings.rb
+++ b/src/lib/y2storage/proposal_settings.rb
@@ -467,6 +467,9 @@ module Y2Storage
       enc_pbkdf = PbkdFunction.find(feature(:proposal, :encryption_pbkdf))
       self.encryption_pbkdf = enc_pbkdf if enc_pbkdf
 
+      enc_authentication = EncryptionAuthentication.find(feature(:proposal, :encryption_authentication))
+      self.encryption_authentication = enc_authentication if enc_authentication
+
       # Password potentially injected by a previous step
       enc = feature(:proposal, :encryption)
 

--- a/src/lib/y2storage/yaml_writer.rb
+++ b/src/lib/y2storage/yaml_writer.rb
@@ -490,9 +490,7 @@ module Y2Storage
       }
 
       content["pbkdf"] = encryption.pbkdf_value unless encryption.pbkdf_value.empty?
-      if encryption.authentication
-        content["authentication"] = encryption.authentication.value
-      end
+      content["authentication"] = encryption.authentication.value if encryption.authentication
 
       if !encryption.password.empty?
         content["password"] = @record_passwords ? encryption.password : "***"

--- a/test/y2partitioner/actions/controllers/encryption_test.rb
+++ b/test/y2partitioner/actions/controllers/encryption_test.rb
@@ -155,6 +155,7 @@ describe Y2Partitioner::Actions::Controllers::Encryption do
 
           before do
             allow(encryption).to receive(:exists_in_devicegraph?).and_return in_system
+            allow(encryption).to receive(:supports_authentication?).and_return false
           end
 
           context "with a preexisting encryption" do

--- a/test/y2partitioner/widgets/encrypt_auth_selector_test.rb
+++ b/test/y2partitioner/widgets/encrypt_auth_selector_test.rb
@@ -30,7 +30,8 @@ describe Y2Partitioner::Widgets::EncryptAuthSelector do
 
   let(:initial_authentication) { "fido2" }
   let(:controller) do
-    double("Controllers::Encryption", authentication: Y2Storage::EncryptionAuthentication.find(initial_authentication))
+    double("Controllers::Encryption",
+      authentication: Y2Storage::EncryptionAuthentication.find(initial_authentication))
   end
 
   include_examples "CWM::ComboBox"

--- a/test/y2partitioner/widgets/encrypt_auth_selector_test.rb
+++ b/test/y2partitioner/widgets/encrypt_auth_selector_test.rb
@@ -1,0 +1,88 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/encrypt_auth_selector"
+require "y2storage/encryption_authentication"
+Yast.import "Arch"
+
+describe Y2Partitioner::Widgets::EncryptAuthSelector do
+  subject(:widget) { described_class.new(controller) }
+
+  let(:initial_authentication) { "fido2" }
+  let(:controller) do
+    double("Controllers::Encryption", authentication: Y2Storage::EncryptionAuthentication.find(initial_authentication))
+  end
+
+  include_examples "CWM::ComboBox"
+
+  describe "#init" do
+    it "sets the current authentication value" do
+      expect(widget).to receive(:value=).with(initial_authentication)
+
+      widget.init
+    end
+  end
+
+  describe "#value" do
+    let(:selected_authentication) { "tpm2" }
+
+    before do
+      allow(Yast::UI).to receive(:QueryWidget)
+        .with(Id(widget.widget_id), :Value)
+        .and_return(selected_authentication)
+    end
+
+    it "returns the selected authentication method" do
+      expect(widget.value).to eq(selected_authentication)
+    end
+  end
+
+  describe "#items" do
+    before do
+      allow(Yast::Arch).to receive(:has_tpm2).and_return(true)
+    end
+
+    it "includes all available authentication" do
+      items = widget.items.map(&:first)
+
+      expect(items).to contain_exactly("password", "tpm2", "tpm2+pin", "fido2")
+    end
+  end
+
+  describe "#store" do
+    let(:selected_authentication) { "password" }
+
+    before do
+      allow(Yast::UI).to receive(:QueryWidget)
+        .with(Id(widget.widget_id), :Value)
+        .and_return(selected_authentication)
+    end
+
+    it "sets the selected authentication" do
+      authentication = Y2Storage::EncryptionAuthentication.find(selected_authentication)
+      expect(controller).to receive(:authentication=).with(authentication)
+
+      widget.store
+    end
+  end
+end

--- a/test/y2storage/boot_requirements_strategies/zipl_test.rb
+++ b/test/y2storage/boot_requirements_strategies/zipl_test.rb
@@ -44,14 +44,14 @@ describe Y2Storage::BootRequirementsStrategies::ZIPL do
 
       it "returns a warning" do
         messages = subject.warnings.map(&:message)
-        expect(messages).to include(/The boot loader cannot access the file system/)
+        expect(messages).to include(/The grub boot loader cannot access the file system/)
       end
     end
 
     context "and the zipl partition is unencrypted" do
       it "does not return any warning" do
         messages = subject.warnings.map(&:message)
-        expect(messages).to_not include(/The boot loader cannot access the file system/)
+        expect(messages).to_not include(/The grub boot loader cannot access the file system/)
       end
     end
 
@@ -60,7 +60,7 @@ describe Y2Storage::BootRequirementsStrategies::ZIPL do
 
       it "returns a warning" do
         messages = subject.warnings.map(&:message)
-        expect(messages).to include(/The boot loader cannot access the file system/)
+        expect(messages).to include(/The grub boot loader cannot access the file system/)
       end
     end
   end

--- a/test/y2storage/clients/inst_disk_proposal_test.rb
+++ b/test/y2storage/clients/inst_disk_proposal_test.rb
@@ -20,6 +20,7 @@
 
 require_relative "../spec_helper"
 require "y2storage/clients/inst_disk_proposal"
+require "y2storage/proposal_settings"
 
 describe Y2Storage::Clients::InstDiskProposal do
   subject(:client) { described_class.new }
@@ -119,7 +120,7 @@ describe Y2Storage::Clients::InstDiskProposal do
 
     context "after receiving :next from the proposal dialog" do
       let(:new_devicegraph) { double("Y2Storage::Devicegraph", used_features: 0) }
-      let(:settings) { instance_double(Storage::ProposalSettings) }
+      let(:settings) { instance_double(Y2Storage::ProposalSettings) }
       let(:new_proposal) do
         double("Y2Storage::GuidedProposal",
           devices:  new_devicegraph,
@@ -467,7 +468,7 @@ describe Y2Storage::Clients::InstDiskProposal do
 
     context "processing the guided setup result" do
       let(:devicegraph) { double("Y2Storage::Devicegraph") }
-      let(:settings) { double("Storage::ProposalSettings") }
+      let(:settings) { instance_double(Y2Storage::ProposalSettings) }
       let(:proposal) { double("Y2Storage::GuidedProposal", devices: devicegraph, settings: settings) }
       let(:second_proposal_dialog) { double("Y2Storage::Dialogs::Proposal").as_null_object }
 
@@ -564,7 +565,7 @@ describe Y2Storage::Clients::InstDiskProposal do
 
       let(:devicegraph) { double("Y2Storage::Devicegraph") }
       let(:new_devicegraph) { double("Y2Storage::Devicegraph") }
-      let(:settings) { instance_double(Storage::ProposalSettings) }
+      let(:settings) { instance_double(Y2Storage::ProposalSettings) }
       let(:proposal) { instance_double(Y2Storage::GuidedProposal, settings: settings) }
       let(:expert_dialog) { double("Y2Partitioner::Dialogs::Main") }
       let(:second_proposal_dialog) { double("Y2Storage::Dialogs::Proposal").as_null_object }

--- a/test/y2storage/clients/inst_disk_proposal_test.rb
+++ b/test/y2storage/clients/inst_disk_proposal_test.rb
@@ -564,7 +564,7 @@ describe Y2Storage::Clients::InstDiskProposal do
 
       let(:devicegraph) { double("Y2Storage::Devicegraph") }
       let(:new_devicegraph) { double("Y2Storage::Devicegraph") }
-      let(:settings) { double("Storage::ProposalSettings") }
+      let(:settings) { instance_double(Storage::ProposalSettings) }
       let(:proposal) { double("Y2Storage::GuidedProposal", settings: settings) }
       let(:expert_dialog) { double("Y2Partitioner::Dialogs::Main") }
       let(:second_proposal_dialog) { double("Y2Storage::Dialogs::Proposal").as_null_object }

--- a/test/y2storage/clients/inst_disk_proposal_test.rb
+++ b/test/y2storage/clients/inst_disk_proposal_test.rb
@@ -565,7 +565,7 @@ describe Y2Storage::Clients::InstDiskProposal do
       let(:devicegraph) { double("Y2Storage::Devicegraph") }
       let(:new_devicegraph) { double("Y2Storage::Devicegraph") }
       let(:settings) { instance_double(Storage::ProposalSettings) }
-      let(:proposal) { double("Y2Storage::GuidedProposal", settings: settings) }
+      let(:proposal) { instance_double(Y2Storage::GuidedProposal, settings: settings) }
       let(:expert_dialog) { double("Y2Partitioner::Dialogs::Main") }
       let(:second_proposal_dialog) { double("Y2Storage::Dialogs::Proposal").as_null_object }
 

--- a/test/y2storage/clients/inst_disk_proposal_test.rb
+++ b/test/y2storage/clients/inst_disk_proposal_test.rb
@@ -119,7 +119,7 @@ describe Y2Storage::Clients::InstDiskProposal do
 
     context "after receiving :next from the proposal dialog" do
       let(:new_devicegraph) { double("Y2Storage::Devicegraph", used_features: 0) }
-      let(:settings) { double("Storage::ProposalSettings") }
+      let(:settings) { instance_double(Storage::ProposalSettings) }
       let(:new_proposal) do
         double("Y2Storage::GuidedProposal",
           devices:  new_devicegraph,

--- a/test/y2storage/clients/inst_disk_proposal_test.rb
+++ b/test/y2storage/clients/inst_disk_proposal_test.rb
@@ -119,7 +119,7 @@ describe Y2Storage::Clients::InstDiskProposal do
 
     context "after receiving :next from the proposal dialog" do
       let(:new_devicegraph) { double("Y2Storage::Devicegraph", used_features: 0) }
-      let(:settings) { double("Storage::ProposalSettings", encryption_use_tpm2: false) }
+      let(:settings) { double("Storage::ProposalSettings") }
       let(:new_proposal) do
         double("Y2Storage::GuidedProposal",
           devices:  new_devicegraph,
@@ -564,7 +564,7 @@ describe Y2Storage::Clients::InstDiskProposal do
 
       let(:devicegraph) { double("Y2Storage::Devicegraph") }
       let(:new_devicegraph) { double("Y2Storage::Devicegraph") }
-      let(:settings) { double("Storage::ProposalSettings", encryption_use_tpm2: false) }
+      let(:settings) { double("Storage::ProposalSettings") }
       let(:proposal) { double("Y2Storage::GuidedProposal", settings: settings) }
       let(:expert_dialog) { double("Y2Partitioner::Dialogs::Main") }
       let(:second_proposal_dialog) { double("Y2Storage::Dialogs::Proposal").as_null_object }

--- a/test/y2storage/dialogs/guided_setup/select_scheme_test.rb
+++ b/test/y2storage/dialogs/guided_setup/select_scheme_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-# coding: utf-8
+
 # Copyright (c) [2017] SUSE LLC
 #
 # All Rights Reserved.

--- a/test/y2storage/dialogs/guided_setup/select_scheme_test.rb
+++ b/test/y2storage/dialogs/guided_setup/select_scheme_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env rspec
-
+# coding: utf-8
 # Copyright (c) [2017] SUSE LLC
 #
 # All Rights Reserved.

--- a/test/y2storage/dialogs/guided_setup/select_scheme_test.rb
+++ b/test/y2storage/dialogs/guided_setup/select_scheme_test.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env rspec
+
 # Copyright (c) [2017] SUSE LLC
 #
 # All Rights Reserved.
@@ -134,33 +135,34 @@ describe Y2Storage::Dialogs::GuidedSetup::SelectScheme do
       end
     end
 
-    describe "checkbox for #tpm2" do
+    describe "comboBox for #authentication" do
       before do
-        allow(subject).to receive(:CheckBox)
+        allow(subject).to receive(:ComboBox)
       end
 
-      context "and no TPM2 device is available" do
+      context "and encryption method is not systemd-fde" do
         before do
-          allow(Yast::Arch).to receive(:has_tpm2).and_return(false)
+          settings.encryption_method = Y2Storage::EncryptionMethod::LUKS2
         end
 
-        it "does not include an option to select TPM2 support for encryption" do
-          expect(subject).to_not receive(:CheckBox).with(Id(:tpm2), any_args)
+        it "does not include an option to select authentication method" do
+          expect(subject).to_not receive(:ComboBox).with(Id(:authentication), any_args)
 
           subject.run
         end
       end
 
-      context "and TPM2 device is available" do
+      context "and encryption method is systemd-fde" do
         before do
-          allow(Yast::Arch).to receive(:has_tpm2).and_return(true)
+          settings.encryption_method = Y2Storage::EncryptionMethod::SYSTEMD_FDE
         end
 
-        it "does include an option to select TPM2 support for encryption" do
-          expect(subject).to receive(:CheckBox).with(Id(:tpm2), any_args)
+        it "does include an option to select authentication method" do
+          expect(subject).to receive(:ComboBox).with(Id(:authentication), any_args)
 
           subject.run
         end
+
       end
     end
 
@@ -210,13 +212,13 @@ describe Y2Storage::Dialogs::GuidedSetup::SelectScheme do
         select_widget(:password, value: password)
         select_widget(:repeat_password, value: repeat_password)
         settings.encryption_password = nil
-        allow(Yast::Arch).to receive(:has_tpm2).and_return(true)
+        settings.encryption_method = Y2Storage::EncryptionMethod::SYSTEMD_FDE
       end
 
-      it "enables password and TPM2 fields" do
+      it "enables password and authentication fields" do
         expect_enable(:password)
         expect_enable(:repeat_password)
-        expect_enable(:tpm2)
+        expect_enable(:authentication)
         subject.run
       end
 

--- a/test/y2storage/dialogs/proposal_test.rb
+++ b/test/y2storage/dialogs/proposal_test.rb
@@ -37,7 +37,7 @@ describe Y2Storage::Dialogs::Proposal do
 
   describe "#run" do
     let(:devicegraph0) do
-      double("Storage::Devicegraph", encryptions: encryptions,
+      instance_double(Storage::Devicegraph, encryptions: encryptions,
         actiongraph: actiongraph0, blk_devices: blk_devices)
     end
     let(:actiongraph0) { double("Storage::Actiongraph") }

--- a/test/y2storage/dialogs/proposal_test.rb
+++ b/test/y2storage/dialogs/proposal_test.rb
@@ -127,7 +127,7 @@ describe Y2Storage::Dialogs::Proposal do
     end
 
     let(:proposal) do
-      double("Y2Storage::GuidedProposal",
+      instance_double("Y2Storage::GuidedProposal",
         settings:                 settings,
         proposed?:                proposed,
         auto_settings_adjustment: adjustment)

--- a/test/y2storage/dialogs/proposal_test.rb
+++ b/test/y2storage/dialogs/proposal_test.rb
@@ -508,7 +508,7 @@ describe Y2Storage::Dialogs::Proposal do
               [
                 double("Y2Storage::Encryption", authentication: nil,
                   blk_device: double("Y2Storage::Disk", name: "/dev/sda")),
-                double("Y2Storage::Encryption", authentication: nil,
+                instance_double(Y2Storage::Encryption, authentication: nil,
                   blk_device: double("Y2Storage::Disk", name: "/dev/sdb"))
               ]
             end

--- a/test/y2storage/dialogs/proposal_test.rb
+++ b/test/y2storage/dialogs/proposal_test.rb
@@ -482,7 +482,7 @@ describe Y2Storage::Dialogs::Proposal do
                   double("Y2Storage::Encryption",
                     authentication: Y2Storage::EncryptionAuthentication::FIDO2,
                     blk_device:     double("Y2Storage::Disk", name: "/dev/sda")),
-                  double("Y2Storage::Encryption",
+                  instance_double(Y2Storage::Encryption,
                     authentication: Y2Storage::EncryptionAuthentication::FIDO2,
                     blk_device:     double("Y2Storage::Disk", name: "/dev/sdb"))
                 ]

--- a/test/y2storage/dialogs/proposal_test.rb
+++ b/test/y2storage/dialogs/proposal_test.rb
@@ -47,7 +47,7 @@ describe Y2Storage::Dialogs::Proposal do
     let(:presenter_content0) { "<li>Action 1</li><li>Action 2</li>" }
 
     let(:devicegraph1) do
-      double("Storage::Devicegraph", actiongraph: actiongraph1,
+      instance_double(Storage::Devicegraph, actiongraph: actiongraph1,
         encryptions: encryptions, blk_devices: blk_devices)
     end
     let(:actiongraph1) { double("Storage::Actiongraph") }

--- a/test/y2storage/dialogs/proposal_test.rb
+++ b/test/y2storage/dialogs/proposal_test.rb
@@ -37,7 +37,7 @@ describe Y2Storage::Dialogs::Proposal do
 
   describe "#run" do
     let(:devicegraph0) do
-      instance_double(Storage::Devicegraph, encryptions: encryptions,
+      instance_double(Y2Storage::Devicegraph, encryptions: encryptions,
         actiongraph: actiongraph0, blk_devices: blk_devices)
     end
     let(:actiongraph0) { double("Storage::Actiongraph") }
@@ -47,7 +47,7 @@ describe Y2Storage::Dialogs::Proposal do
     let(:presenter_content0) { "<li>Action 1</li><li>Action 2</li>" }
 
     let(:devicegraph1) do
-      instance_double(Storage::Devicegraph, actiongraph: actiongraph1,
+      instance_double(Y2Storage::Devicegraph, actiongraph: actiongraph1,
         encryptions: encryptions, blk_devices: blk_devices)
     end
     let(:actiongraph1) { double("Storage::Actiongraph") }
@@ -470,6 +470,9 @@ describe Y2Storage::Dialogs::Proposal do
 
           context "and the user has selected device encryption SYSTEMD_FDE" do
             context "and FIDO2 authentication for encryption" do
+              before do
+                allow_any_instance_of(Y2Storage::Encryption).to receive(:supports_authentication?).and_return true
+	      end
               let(:settings) do
                 settings = Y2Storage::ProposalSettings.new_for_current_product
                 settings.encryption_authentication = Y2Storage::EncryptionAuthentication::FIDO2
@@ -479,11 +482,13 @@ describe Y2Storage::Dialogs::Proposal do
               end
               let(:encryptions) do
                 [
-                  double("Y2Storage::Encryption",
+                  instance_double(Y2Storage::Encryption,
                     authentication: Y2Storage::EncryptionAuthentication::FIDO2,
+                    supports_authentication?: true,
                     blk_device:     double("Y2Storage::Disk", name: "/dev/sda")),
                   instance_double(Y2Storage::Encryption,
                     authentication: Y2Storage::EncryptionAuthentication::FIDO2,
+                    supports_authentication?: true,
                     blk_device:     double("Y2Storage::Disk", name: "/dev/sdb"))
                 ]
               end
@@ -506,9 +511,11 @@ describe Y2Storage::Dialogs::Proposal do
             end
             let(:encryptions) do
               [
-                double("Y2Storage::Encryption", authentication: nil,
+                instance_double(Y2Storage::Encryption, authentication: nil,
+		  supports_authentication?: false,
                   blk_device: double("Y2Storage::Disk", name: "/dev/sda")),
                 instance_double(Y2Storage::Encryption, authentication: nil,
+                  supports_authentication?: false,
                   blk_device: double("Y2Storage::Disk", name: "/dev/sdb"))
               ]
             end

--- a/test/y2storage/dialogs/proposal_test.rb
+++ b/test/y2storage/dialogs/proposal_test.rb
@@ -487,11 +487,11 @@ describe Y2Storage::Dialogs::Proposal do
                   instance_double(Y2Storage::Encryption,
                     authentication:           Y2Storage::EncryptionAuthentication::FIDO2,
                     supports_authentication?: true,
-                    blk_device:               double("Y2Storage::Disk", name: "/dev/sda")),
+                    blk_device:               instance_double("Y2Storage::Disk", name: "/dev/sda")),
                   instance_double(Y2Storage::Encryption,
                     authentication:           Y2Storage::EncryptionAuthentication::FIDO2,
                     supports_authentication?: true,
-                    blk_device:               double("Y2Storage::Disk", name: "/dev/sdb"))
+                    blk_device:               instance_double("Y2Storage::Disk", name: "/dev/sdb"))
                 ]
               end
 
@@ -515,10 +515,10 @@ describe Y2Storage::Dialogs::Proposal do
               [
                 instance_double(Y2Storage::Encryption, authentication: nil,
                   supports_authentication?: false,
-                  blk_device: double("Y2Storage::Disk", name: "/dev/sda")),
+                  blk_device: instance_double("Y2Storage::Disk", name: "/dev/sda")),
                 instance_double(Y2Storage::Encryption, authentication: nil,
                   supports_authentication?: false,
-                  blk_device: double("Y2Storage::Disk", name: "/dev/sdb"))
+                  blk_device: instance_double("Y2Storage::Disk", name: "/dev/sdb"))
               ]
             end
 

--- a/test/y2storage/dialogs/proposal_test.rb
+++ b/test/y2storage/dialogs/proposal_test.rb
@@ -471,8 +471,10 @@ describe Y2Storage::Dialogs::Proposal do
           context "and the user has selected device encryption SYSTEMD_FDE" do
             context "and FIDO2 authentication for encryption" do
               before do
-                allow_any_instance_of(Y2Storage::Encryption).to receive(:supports_authentication?).and_return true
-	      end
+                allow_any_instance_of(Y2Storage::Encryption).to receive(
+                                                                  :supports_authentication?
+                                                                ).and_return true
+              end
               let(:settings) do
                 settings = Y2Storage::ProposalSettings.new_for_current_product
                 settings.encryption_authentication = Y2Storage::EncryptionAuthentication::FIDO2
@@ -483,13 +485,13 @@ describe Y2Storage::Dialogs::Proposal do
               let(:encryptions) do
                 [
                   instance_double(Y2Storage::Encryption,
-                    authentication: Y2Storage::EncryptionAuthentication::FIDO2,
+                    authentication:           Y2Storage::EncryptionAuthentication::FIDO2,
                     supports_authentication?: true,
-                    blk_device:     double("Y2Storage::Disk", name: "/dev/sda")),
+                    blk_device:               double("Y2Storage::Disk", name: "/dev/sda")),
                   instance_double(Y2Storage::Encryption,
-                    authentication: Y2Storage::EncryptionAuthentication::FIDO2,
+                    authentication:           Y2Storage::EncryptionAuthentication::FIDO2,
                     supports_authentication?: true,
-                    blk_device:     double("Y2Storage::Disk", name: "/dev/sdb"))
+                    blk_device:               double("Y2Storage::Disk", name: "/dev/sdb"))
                 ]
               end
 
@@ -512,7 +514,7 @@ describe Y2Storage::Dialogs::Proposal do
             let(:encryptions) do
               [
                 instance_double(Y2Storage::Encryption, authentication: nil,
-		  supports_authentication?: false,
+                  supports_authentication?: false,
                   blk_device: double("Y2Storage::Disk", name: "/dev/sda")),
                 instance_double(Y2Storage::Encryption, authentication: nil,
                   supports_authentication?: false,

--- a/test/y2storage/encryption_authentication_test.rb
+++ b/test/y2storage/encryption_authentication_test.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage/encryption_authentication"
+
+describe Y2Storage::EncryptionAuthentication do
+  subject { Y2Storage::EncryptionAuthentication::FIDO2 }
+
+  describe "#is?" do
+    it "returns true for an equivalent function object" do
+      expect(subject.is?(Y2Storage::EncryptionAuthentication.find("fido2"))).to eq true
+    end
+
+    it "returns false for a non-equivalent function object" do
+      expect(subject.is?(Y2Storage::EncryptionAuthentication.find("tpm2"))).to eq false
+    end
+
+    it "returns true for a list of symbols including the equivalent one" do
+      expect(subject.is?(:fido2, :authentication)).to eq true
+    end
+
+    it "returns false for list of symbols not including the equivalent one" do
+      expect(subject.is?(:tpm2, :authentication)).to eq false
+    end
+  end
+
+  describe "#===" do
+    it "returns true for the equivalent object" do
+      value =
+        case subject
+        when Y2Storage::EncryptionAuthentication.find("fido2")
+          true
+        else
+          false
+        end
+      expect(value).to eq true
+    end
+
+    it "returns false for the equivalent symbol" do
+      value =
+        case subject
+        when :fido2
+          true
+        else
+          false
+        end
+      expect(value).to eq false
+    end
+  end
+end

--- a/test/y2storage/encryption_authentication_test.rb
+++ b/test/y2storage/encryption_authentication_test.rb
@@ -42,6 +42,34 @@ describe Y2Storage::EncryptionAuthentication do
     end
   end
 
+  describe "#all" do
+    before do
+      allow(Yast::Arch).to receive(:has_tpm2).and_return(tpm2)
+    end
+
+    context "tpm2 is avalable" do
+      let(:tpm2) { true }
+
+      it "includes tpm2 and tpm2+pin" do
+        expect(Y2Storage::EncryptionAuthentication.all)
+          .to eq [Y2Storage::EncryptionAuthentication::PASSWORD,
+                  Y2Storage::EncryptionAuthentication::TPM2,
+                  Y2Storage::EncryptionAuthentication::TPM2PIN,
+                  Y2Storage::EncryptionAuthentication::FIDO2]
+      end
+    end
+
+    context "tpm2 is not avalable" do
+      let(:tpm2) { false }
+
+      it "includes not tpm2 and tpm2+pin" do
+        expect(Y2Storage::EncryptionAuthentication.all)
+          .to eq [Y2Storage::EncryptionAuthentication::PASSWORD,
+                  Y2Storage::EncryptionAuthentication::FIDO2]
+      end
+    end
+  end
+
   describe "#===" do
     it "returns true for the equivalent object" do
       value =

--- a/test/y2storage/encryption_method/systemd_fde_test.rb
+++ b/test/y2storage/encryption_method/systemd_fde_test.rb
@@ -1,0 +1,74 @@
+# Copyright (c) [2025] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::EncryptionMethod::SystemdFde do
+  describe ".used_for?" do
+    let(:encryption) { double(Y2Storage::Encryption, type: type) }
+
+    context "when the encryption type is LUKS1" do
+      let(:type) { Y2Storage::EncryptionType::LUKS1 }
+
+      it "returns false" do
+        expect(subject.used_for?(encryption)).to eq(false)
+      end
+    end
+
+    context "when the encryption type is plain" do
+      let(:type) { Y2Storage::EncryptionType::PLAIN }
+
+      it "returns false" do
+        expect(subject.used_for?(encryption)).to eq(false)
+      end
+    end
+
+    context "when the encryption type is LUKS2" do
+      let(:type) { Y2Storage::EncryptionType::LUKS2 }
+
+      it "returns false" do
+        expect(subject.used_for?(encryption)).to eq(false)
+      end
+    end
+  end
+
+  describe "#available?" do
+    before do
+      allow(Y2Storage::Arch).to receive(:new).and_return(arch)
+    end
+    let(:arch) { instance_double("Y2Storage::Arch", efiboot?: efi) }
+    
+    context "if the system boots using EFI" do
+      let(:efi) { true }
+      
+      it "#available? returns true" do
+        expect(subject.available?).to eq true
+      end
+    end
+
+    context "if the system does not use EFI" do
+      let(:efi) { false }
+
+      it "#available? returns false" do
+        expect(subject.available?).to eq false
+      end
+    end
+  end
+end

--- a/test/y2storage/encryption_method/systemd_fde_test.rb
+++ b/test/y2storage/encryption_method/systemd_fde_test.rb
@@ -54,10 +54,10 @@ describe Y2Storage::EncryptionMethod::SystemdFde do
       allow(Y2Storage::Arch).to receive(:new).and_return(arch)
     end
     let(:arch) { instance_double("Y2Storage::Arch", efiboot?: efi) }
-    
+
     context "if the system boots using EFI" do
       let(:efi) { true }
-      
+
       it "#available? returns true" do
         expect(subject.available?).to eq true
       end

--- a/test/y2storage/encryption_method_test.rb
+++ b/test/y2storage/encryption_method_test.rb
@@ -59,16 +59,15 @@ describe Y2Storage::EncryptionMethod do
       File.read(File.join(DATA_PATH, "lszcrypt", "#{file}.txt"))
     end
 
-    let(:storage_arch) { instance_double("::Storage::Arch") }
-
     before do
-      allow(storage_arch).to receive(:efiboot?).and_return(true)
+      allow(Y2Storage::Arch).to receive(:new).and_return(arch)
       allow(Yast::Execute).to receive(:locally!).with(/lszcrypt/, anything).and_return(lszcrypt)
       allow(File).to receive(:read).and_call_original
       allow(File).to receive(:read).with(/^\/sys\/bus\/ap\/devices\/card/).and_return mkvps_content
       mock_env(env_vars)
     end
 
+    let(:arch) { instance_double("Y2Storage::Arch", efiboot?: true) }
     let(:lszcrypt) { "" }
     let(:env_vars) { {} }
     let(:mkvps_content) { "" }

--- a/test/y2storage/encryption_method_test.rb
+++ b/test/y2storage/encryption_method_test.rb
@@ -76,7 +76,7 @@ describe Y2Storage::EncryptionMethod do
       context "but none of them have a valid master key" do
         it "returns methods for LUKS1, LUKS2 and random swap" do
           expect(described_class.available.map(&:to_sym))
-            .to contain_exactly(:luks1, :luks2, :random_swap)
+            .to contain_exactly(:luks1, :luks2, :random_swap, :systemd_fde)
         end
       end
 
@@ -89,7 +89,7 @@ describe Y2Storage::EncryptionMethod do
 
         it "returns methods for LUKS1, LUKS2, pervasive LUKS2 and random swap" do
           expect(described_class.available.map(&:to_sym))
-            .to contain_exactly(:luks1, :luks2, :pervasive_luks2, :random_swap)
+            .to contain_exactly(:luks1, :luks2, :pervasive_luks2, :random_swap, :systemd_fde)
         end
       end
     end
@@ -99,7 +99,7 @@ describe Y2Storage::EncryptionMethod do
 
       it "returns methods for LUKS1, LUKS2 and random swap" do
         expect(described_class.available.map(&:to_sym))
-          .to contain_exactly(:luks1, :luks2, :random_swap)
+          .to contain_exactly(:luks1, :luks2, :random_swap, :systemd_fde)
       end
     end
 
@@ -108,7 +108,7 @@ describe Y2Storage::EncryptionMethod do
 
       it "returns methods for LUKS1, LUKS2 and random swap" do
         expect(described_class.available.map(&:to_sym))
-          .to contain_exactly(:luks1, :luks2, :random_swap)
+          .to contain_exactly(:luks1, :luks2, :random_swap, :systemd_fde])
       end
     end
 
@@ -120,7 +120,7 @@ describe Y2Storage::EncryptionMethod do
 
       it "returns methods for LUKS1, LUKS2 and random swap" do
         expect(described_class.available.map(&:to_sym))
-          .to contain_exactly(:luks1, :luks2, :random_swap)
+          .to contain_exactly(:luks1, :luks2, :random_swap, :systemd_fde)
       end
     end
 

--- a/test/y2storage/encryption_method_test.rb
+++ b/test/y2storage/encryption_method_test.rb
@@ -77,7 +77,7 @@ describe Y2Storage::EncryptionMethod do
       let(:lszcrypt) { lszcrypt_output("ok") }
 
       context "but none of them have a valid master key" do
-        it "returns methods for LUKS1, LUKS2 and random swap" do
+        it "returns methods for LUKS1, LUKS2, systemd_fde and random swap" do
           expect(described_class.available.map(&:to_sym))
             .to contain_exactly(:luks1, :luks2, :random_swap, :systemd_fde)
         end

--- a/test/y2storage/encryption_method_test.rb
+++ b/test/y2storage/encryption_method_test.rb
@@ -108,7 +108,7 @@ describe Y2Storage::EncryptionMethod do
 
       it "returns methods for LUKS1, LUKS2 and random swap" do
         expect(described_class.available.map(&:to_sym))
-          .to contain_exactly(:luks1, :luks2, :random_swap, :systemd_fde])
+          .to contain_exactly(:luks1, :luks2, :random_swap, :systemd_fde)
       end
     end
 

--- a/test/y2storage/encryption_method_test.rb
+++ b/test/y2storage/encryption_method_test.rb
@@ -60,6 +60,7 @@ describe Y2Storage::EncryptionMethod do
     end
 
     before do
+      allow(storage_arch).to receive(:efiboot?).and_return(true)
       allow(Yast::Execute).to receive(:locally!).with(/lszcrypt/, anything).and_return(lszcrypt)
       allow(File).to receive(:read).and_call_original
       allow(File).to receive(:read).with(/^\/sys\/bus\/ap\/devices\/card/).and_return mkvps_content

--- a/test/y2storage/encryption_method_test.rb
+++ b/test/y2storage/encryption_method_test.rb
@@ -59,6 +59,8 @@ describe Y2Storage::EncryptionMethod do
       File.read(File.join(DATA_PATH, "lszcrypt", "#{file}.txt"))
     end
 
+    let(:storage_arch) { instance_double("::Storage::Arch") }
+
     before do
       allow(storage_arch).to receive(:efiboot?).and_return(true)
       allow(Yast::Execute).to receive(:locally!).with(/lszcrypt/, anything).and_return(lszcrypt)

--- a/test/y2storage/encryption_processes/systemd_fde_test.rb
+++ b/test/y2storage/encryption_processes/systemd_fde_test.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::EncryptionProcesses::SystemdFde do
+  let(:method) { double }
+  subject(:process) { described_class.new(method) }
+
+  describe "#create_device" do
+    context "with fido2 key support" do
+      let(:devicegraph) { Y2Partitioner::DeviceGraphs.instance.current }
+      let(:blk_device) { Y2Storage::BlkDevice.find_by_name(devicegraph, "/dev/sda") }
+      let(:dm_name) { "cr_sda" }
+      let(:authentication) { Y2Storage::EncryptionAuthentication.find("fido2") }
+
+      before do
+        devicegraph_stub("empty_hard_disk_50GiB.yml")
+      end
+
+      it "returns an encryption device with the given label (if any is given)" do
+        encryption = process.create_device(blk_device, dm_name, authentication, label: "lbl")
+
+        expect(encryption.is?(:encryption)).to eq(true)
+        expect(encryption.label).to eq "lbl"
+      end
+
+      it "creates an luks2 encryption device for given block device" do
+        expect(blk_device).to receive(:create_encryption)
+          .with(anything, Y2Storage::EncryptionType::LUKS2)
+          .and_call_original
+
+        process.create_device(blk_device, dm_name, authentication)
+      end
+
+      it "does not set any specific encryption option" do
+        encryption = subject.create_device(blk_device, dm_name, authentication)
+
+        expect(encryption.crypt_options).to be_empty
+      end
+
+      it "does not set any specific open option" do
+        encryption = subject.create_device(blk_device, dm_name, authentication)
+
+        expect(encryption.open_options).to be_empty
+      end
+    end
+  end
+
+  describe "#encryption_type" do
+    it "returns LUKS2 encryption" do
+      encryption_type = subject.encryption_type()
+
+      expect(encryption_type).to eq Y2Storage::EncryptionType::LUKS2
+    end
+  end
+end


### PR DESCRIPTION
## Problem

We would like to give the user an easy way to use TPM2 or FIDO2 devices to authenticate to LUKS2 encrypted
partitions. (jsc#PED-10703)

Added a new encryption method EncryptionMethod::SYSTEMD_FDE which includes LUKS2 encryption and TPM2, TPM2+PIN and FIDO2 authentication.

The authentication can be set in the guided proposal (configure able in the control.xm by setting the encryption variables) and in the expert partitioner. 

## Testing

- Added a new unit test or adapted already existing tests.
- Tested manually

## Screenshots

![Screenshot_opensusetumbleweed-2_2025-04-15_10:16:10](https://github.com/user-attachments/assets/e024be63-2137-4531-b388-2847f600255a)
![Screenshot_opensusetumbleweed-2_2025-04-15_10:15:42](https://github.com/user-attachments/assets/efb1b79a-2a18-4369-8275-9caf7c73fad9)
![Screenshot_opensusetumbleweed-2_2025-04-15_10:18:03](https://github.com/user-attachments/assets/55a24417-1831-45d0-af15-632932691b68)
![Screenshot_opensusetumbleweed-2_2025-04-15_10:17:39](https://github.com/user-attachments/assets/f82813a5-a932-4da3-90e5-42fb0a22c54d)


