### PR TITLE
Make #candidate_device? public

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 13 13:29:23 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Make method DiskAnalyzer#candidate_device? public
+  (gh#agama-project/agama#2338).
+- 5.0.30
+
+-------------------------------------------------------------------
 Thu Apr 10 11:30:44 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Create /etc/lvm/devices if needed (jsc#PED-7355, jsc#PED-12241).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.29
+Version:        5.0.30
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/disk_analyzer.rb
+++ b/src/lib/y2storage/disk_analyzer.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2015-2021] SUSE LLC
+# Copyright (c) [2015-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -144,6 +144,21 @@ module Y2Storage
       @candidate_disks
     end
 
+    # Checks whether a device can be used as candidate for installation
+    #
+    # A device is candidate for installation if no filesystem belonging to the device is mounted and the
+    # device does not contain a repository for installation.
+    #
+    # Moreover, RAM disks are also discarded.
+    #
+    # @param device [BlkDevice]
+    # @return [Boolean]
+    def candidate_device?(device)
+      !contain_mounted_filesystem?(device) &&
+        !contain_installation_repository?(device) &&
+        !device.name.match?(/^\/dev\/ram\d+$/)
+    end
+
     # Look up devicegraph element by device name.
     #
     # @return [Device]
@@ -244,7 +259,7 @@ module Y2Storage
 
     # Finds software RAIDs that are considered valid candidates for a Linux installation
     #
-    # Apart from matching conditions of #candidate_disk?, a valid software RAID candidate must
+    # Apart from matching conditions of #candidate_device?, a valid software RAID candidate must
     # either, have a partition table or do not have children.
     #
     # See {#candidate_disks} for extra explanations (e.g. the relevance of EFI) and for
@@ -255,7 +270,7 @@ module Y2Storage
       return [] unless arch.efiboot?
 
       devicegraph.software_raids.select do |md|
-        (md.partition_table? || md.children.empty?) && candidate_disk?(md)
+        (md.partition_table? || md.children.empty?) && candidate_device?(md)
       end
     end
 
@@ -266,24 +281,9 @@ module Y2Storage
     # @return [Array<BlkDevice>]
     def candidate_disk_devices
       rejected_disk_devices = candidate_software_raids.map(&:ancestors).flatten
-      candidate_disk_devices = devicegraph.disk_devices.select { |d| candidate_disk?(d) }
+      candidate_disk_devices = devicegraph.disk_devices.select { |d| candidate_device?(d) }
 
       candidate_disk_devices - rejected_disk_devices
-    end
-
-    # Checks whether a device can be used as candidate disk for installation
-    #
-    # A device is candidate for installation if no filesystem belonging to the device is mounted and the
-    # device does not contain a repository for installation.
-    #
-    # Moreover, RAM disks are also discarded.
-    #
-    # @param device [BlkDevice]
-    # @return [Boolean]
-    def candidate_disk?(device)
-      !contain_mounted_filesystem?(device) &&
-        !contain_installation_repository?(device) &&
-        !device.name.match?(/^\/dev\/ram\d+$/)
     end
 
     # Checks whether a device contains a mounted filesystem


### PR DESCRIPTION
## Problem

Agama needs to check whether a device (drive or MD RAID) can be used as candidate for installation, but the method is private.

Needed for https://github.com/agama-project/agama/pull/2338.

## Solution

Make `DiskAnalyzer#candidate_device?` public.
