### PR TITLE
New public function to check whether a software RAID is candidate for installation

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 23 08:06:05 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Make method DiskAnalyzer#candidate_software_raid? public
+  (gh#agama-project/agama#2388).
+- 5.0.32
+
+-------------------------------------------------------------------
 Tue May 13 15:01:47 UTC 2025 - Stefan Schubert <schubi@suse.de>
 
 - Supporting systemd-fde encryption and TPM2/FIDO2

--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Fri May 23 08:06:05 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
-- Make method DiskAnalyzer#candidate_software_raid? public
-  (gh#agama-project/agama#2388).
+- Reorganize public methods of DiskAnalyzer (needed by
+  gh#agama-project/agama#2388).
 - 5.0.32
 
 -------------------------------------------------------------------

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.31
+Version:        5.0.32
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/disk_analyzer.rb
+++ b/src/lib/y2storage/disk_analyzer.rb
@@ -144,36 +144,34 @@ module Y2Storage
       @candidate_disks
     end
 
-    # Checks whether a device can be used as candidate for installation
+    # Checks whether a device can be used for the installation
     #
-    # A device is candidate for installation if no filesystem belonging to the device is mounted and the
-    # device does not contain a repository for installation.
+    # A device is visible for installation purposes if no filesystem belonging to the device is
+    # mounted and the device does not contain a repository for installation.
     #
     # Moreover, RAM disks are also discarded.
     #
     # @param device [BlkDevice]
     # @return [Boolean]
-    def candidate_device?(device)
+    def available_device?(device)
       !contain_mounted_filesystem?(device) &&
         !contain_installation_repository?(device) &&
         !device.name.match?(/^\/dev\/ram\d+$/)
     end
 
-    # Checks whether the given software RAID can be considered a valid candidate for a Linux
-    # installation
+    # Checks whether it makes sense to create the boot-related partitions at the given device
     #
-    # Apart from matching conditions of #candidate_device?, a valid software RAID candidate must
-    # either, have a partition table or do not have children.
-    #
-    # See {#candidate_disks} for extra explanations (e.g. the relevance of EFI) and for
+    # Apart from the disk devices, some software RAIDs are considered as acceptable under some
+    # circumstances. See {#candidate_disks} for extra explanations (e.g. the relevance of EFI) and for
     # Fate/Bugzilla references.
     #
-    # @param md [Md]
+    # @param device [BlkDevice]
     # @return [Boolean]
-    def candidate_software_raid?(md)
+    def supports_boot_partitions?(device)
+      return true if device.is?(:disk_device)
       return false unless arch.efiboot?
 
-      (md.partition_table? || md.children.empty?) && candidate_device?(md)
+      device.is?(:software_raid) && (device.partition_table? || device.children.empty?)
     end
 
     # Look up devicegraph element by device name.
@@ -280,7 +278,7 @@ module Y2Storage
     #
     # @return [Array<Md>]
     def candidate_software_raids
-      devicegraph.software_raids.select { |md| candidate_software_raid?(md) }
+      devicegraph.software_raids.select { |md| available_device?(md) && supports_boot_partitions?(md) }
     end
 
     # Finds disk devices that are considered valid candidates
@@ -290,7 +288,7 @@ module Y2Storage
     # @return [Array<BlkDevice>]
     def candidate_disk_devices
       rejected_disk_devices = candidate_software_raids.map(&:ancestors).flatten
-      candidate_disk_devices = devicegraph.disk_devices.select { |d| candidate_device?(d) }
+      candidate_disk_devices = devicegraph.disk_devices.select { |d| available_device?(d) }
 
       candidate_disk_devices - rejected_disk_devices
     end


### PR DESCRIPTION
## Problem

Agama needs to check whether a software RAID can be used as candidate for installation according to the current YaST heuristics, but the method is private.

Needed for https://github.com/agama-project/agama/pull/2388

## Solution

Extract some logic to a new `DiskAnalyzer#candidate_software_raid?` public method.