### PR TITLE
Fix iSCSI driver name

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 16 13:00:00 UTC 2025 - José Iván López González <jlopez@suse.com>
+
+- Use correct iSCSI driver name (related to bsc#1244935).
+- 5.0.33
+
+-------------------------------------------------------------------
 Fri May 23 08:06:05 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Reorganize public methods of DiskAnalyzer (needed by

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.32
+Version:        5.0.33
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/disk.rb
+++ b/src/lib/y2storage/disk.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017] SUSE LLC
+# Copyright (c) [2017-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -84,7 +84,7 @@ module Y2Storage
     end
 
     # @see #systemd_remote?
-    SYSTEMD_REMOTE_DRIVERS = ["iscsi-tcp", "bnx2i", "qedi", "fcoe", "bnx2fc", "qedf"].freeze
+    SYSTEMD_REMOTE_DRIVERS = ["iscsi_tcp", "bnx2i", "qedi", "fcoe", "bnx2fc", "qedf"].freeze
     private_constant :SYSTEMD_REMOTE_DRIVERS
 
     # @see BlkDevice#systemd_remote?

--- a/test/y2storage/mount_point_test.rb
+++ b/test/y2storage/mount_point_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2018-2021] SUSE LLC
+
+# Copyright (c) [2018-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -655,7 +656,7 @@ describe Y2Storage::MountPoint do
       subject(:mount_point) { mountable.create_mount_point(path) }
 
       context "if the disk uses a driver that depends on a systemd service" do
-        let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["iscsi-tcp", "iscsi"]) }
+        let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["iscsi_tcp", "iscsi"]) }
 
         context "and the filesystem is mounted at /" do
           let(:path) { "/" }

--- a/test/y2storage/proposal_mount_options_test.rb
+++ b/test/y2storage/proposal_mount_options_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2021] SUSE LLC
+
+# Copyright (c) [2021-2025] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -159,7 +160,7 @@ describe Y2Storage::GuidedProposal do
           let(:home_fstype) { "ext3" }
 
           context "if the disk uses a driver that depends on a systemd service" do
-            let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["iscsi-tcp"]) }
+            let(:hwinfo) { Y2Storage::HWInfoDisk.new(driver: ["iscsi_tcp"]) }
 
             it "sets #mount_options to an array containing the 'data' and '_netdev' options" do
               proposal.propose


### PR DESCRIPTION
## Problem

The name of the iSCSI driver is wrong, which makes the method `#systemd_remote?` to wrongly report false for an iSCSI device. As side effect, the _netdev option is never added.

Related to https://bugzilla.suse.com/show_bug.cgi?id=1244935. 

## Solution

Use correct driver name.

## Testing

- Tested manually
