### PR TITLE
Prevent failure when encrypting a partitionable (bsc#1246970)

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 24 10:59:19 UTC 2025 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed an error when encrypting a disk that originally contains
+  partitions (bsc#1246970, related to bsc#1246939)
+- 5.0.34
+
+-------------------------------------------------------------------
 Wed Jul 16 13:00:00 UTC 2025 - José Iván López González <jlopez@suse.com>
 
 - Use correct iSCSI driver name (related to bsc#1244935).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.33
+Version:        5.0.34
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/planned/can_be_encrypted.rb
+++ b/src/lib/y2storage/planned/can_be_encrypted.rb
@@ -130,6 +130,7 @@ module Y2Storage
             args[:apqns] = encryption_pervasive_apqns
             args[:key_type] = encryption_pervasive_key_type
           end
+          plain_device.remove_descendants
           result = plain_device.encrypt(method: method, password: encryption_password, **args)
           assign_enc_attr(result, :pbkdf)
           assign_enc_attr(result, :label)

--- a/test/y2storage/planned/can_be_encrypted_test.rb
+++ b/test/y2storage/planned/can_be_encrypted_test.rb
@@ -42,6 +42,8 @@ describe Y2Storage::Planned::CanBeEncrypted do
     # TODO: test also #encrypted? => true
     let(:plain_device) { instance_double("Y2Storage::BlkDevice", encrypted?: false) }
 
+    before { allow(plain_device).to receive(:remove_descendants) }
+
     context "if the planned device has no encryption method or password" do
       let(:method) { nil }
       let(:password) { nil }


### PR DESCRIPTION
## Problem

Agama fails to calculate a storage proposal if the configuration specifies that a disk that initially contained partitions must be directly encrypted and formatted as a whole.

Do doubt pre-existing partitions should be destroyed as part of the process, but Agama struggles with that.

The problem does not happen if the disk is formatted but not encrypted.

## Solution

Handle the situation in `CanBeEncrypted` in the same what that it was already handled at `CanBeFormatted`. That is, removing descendants of the devicegraph before proceeding.

## Testing

- Added a new unit test
- Tested manually in an Agama instance