### PR TITLE
Simplify check for TpmFde encryption method

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 29 09:00:40 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adjusted the criteria to check whether TPM-based full-disk
+  encryption is available at Agama (bsc#1257315).
+- 5.0.40
+
+-------------------------------------------------------------------
 Thu Jan 15 08:26:47 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
 
 - Drop the yast2-ycp-ui-bindings dependency to avoid installing

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.39
+Version:        5.0.40
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/encryption_method/tpm_fde.rb
+++ b/src/lib/y2storage/encryption_method/tpm_fde.rb
@@ -80,8 +80,8 @@ module Y2Storage
         false
       end
 
-      # Whether both the target system and the product being installed meet the requisites
-      # to setup devices using this encryption method.
+      # Whether the target system meets the requisites to setup devices using this
+      # encryption method.
       #
       # The encryption method must be used at least for the root filesystem (eg. is not possible to
       # use it for /var but not for /), but that can't hardly be controlled here. A separate
@@ -89,7 +89,7 @@ module Y2Storage
       #
       # @return [Boolean]
       def possible?
-        tpm_system? && tpm_product?
+        Y2Storage::Arch.new.efiboot? && tpm_present?
       end
 
       # Creates an encryption device for the given block device
@@ -109,15 +109,6 @@ module Y2Storage
         EncryptionProcesses::TpmFdeTools.new(self)
       end
 
-      # Whether the system is capable of using the encryption method
-      #
-      # @see #possible?
-      #
-      # @return [Boolean]
-      def tpm_system?
-        Y2Storage::Arch.new.efiboot? && tpm_present?
-      end
-
       # Whether a TPM2 chip is present and working
       #
       # @see #possible?
@@ -127,20 +118,6 @@ module Y2Storage
         return @tpm_present unless @tpm_present.nil?
 
         @tpm_present = EncryptionProcesses::FdeTools.new.tpm_present?
-      end
-
-      # Whether the product being installed has the ability to configure the encryption method
-      #
-      # @see #possible?
-      #
-      # @return [Boolean]
-      def tpm_product?
-        # TODO: We should likely do some memoization of the result. But it is not clear when
-        # such memoization would be invalidated (eg. new packages available due to some change
-        # in selected product or to new repositories).
-
-        # Beware: apart from true and false, AvailableAll can return nil if things go wrong
-        !!Yast::Package.AvailableAll(YastFeature::ENCRYPTION_TPM_FDE.pkg_list)
       end
     end
   end

--- a/test/support/devices_planner_context.rb
+++ b/test/support/devices_planner_context.rb
@@ -44,6 +44,10 @@ RSpec.shared_context "devices planner" do
 
     Yast::ProductFeatures.Import("partitioning" => control_file_content)
 
+    # Needed because of the more than questionable implementation of preferred_bootloader
+    allow(Y2Storage::BootRequirementsStrategies::Analyzer)
+      .to receive(:bls_bootloader_proposed?).and_return false
+
     allow(Y2Storage::BootRequirementsChecker).to receive(:new).and_return boot_checker
     allow(boot_checker).to receive(:needed_partitions).and_return(
       [

--- a/test/y2storage/encryption_method/tpm_fde_test.rb
+++ b/test/y2storage/encryption_method/tpm_fde_test.rb
@@ -70,8 +70,6 @@ describe Y2Storage::EncryptionMethod::TpmFde do
       end
 
       allow(Y2Storage::Arch).to receive(:new).and_return(arch)
-
-      allow(Yast::Package).to receive(:AvailableAll).and_return pkgs_available
     end
 
     let(:arch) { instance_double("Y2Storage::Arch", efiboot?: efi) }
@@ -89,36 +87,16 @@ describe Y2Storage::EncryptionMethod::TpmFde do
       context "and there is a working TPM2 chip" do
         let(:tpm_present) { true }
 
-        context "and the needed packages can be installed in the target system" do
-          let(:pkgs_available) { true }
-
-          it "#possible? returns true and #available? returns false" do
-            expect(subject.available?).to eq false
-            expect(subject.possible?).to eq true
-          end
-        end
-
-        context "and the needed packages can not be installed in the target system" do
-          let(:pkgs_available) { false }
-
-          include_examples "TPM_FDE impossible and not available"
+        it "#possible? returns true and #available? returns false" do
+          expect(subject.available?).to eq false
+          expect(subject.possible?).to eq true
         end
       end
 
       context "and there is no TPM2 chip" do
         let(:tpm_present) { false }
 
-        context "and the needed packages can be installed in the target system" do
-          let(:pkgs_available) { true }
-
-          include_examples "TPM_FDE impossible and not available"
-        end
-
-        context "and the needed packages can not be installed in the target system" do
-          let(:pkgs_available) { false }
-
-          include_examples "TPM_FDE impossible and not available"
-        end
+        include_examples "TPM_FDE impossible and not available"
       end
     end
 
@@ -128,33 +106,13 @@ describe Y2Storage::EncryptionMethod::TpmFde do
       context "and there is a working TPM2 chip" do
         let(:tpm_present) { true }
 
-        context "and the needed packages can be installed in the target system" do
-          let(:pkgs_available) { true }
-
-          include_examples "TPM_FDE impossible and not available"
-        end
-
-        context "and the needed packages can not be installed in the target system" do
-          let(:pkgs_available) { false }
-
-          include_examples "TPM_FDE impossible and not available"
-        end
+        include_examples "TPM_FDE impossible and not available"
       end
 
       context "and there is no TPM2 chip" do
         let(:tpm_present) { false }
 
-        context "and the needed packages can be installed in the target system" do
-          let(:pkgs_available) { true }
-
-          include_examples "TPM_FDE impossible and not available"
-        end
-
-        context "and the needed packages can not be installed in the target system" do
-          let(:pkgs_available) { false }
-
-          include_examples "TPM_FDE impossible and not available"
-        end
+        include_examples "TPM_FDE impossible and not available"
       end
     end
   end


### PR DESCRIPTION
## Problem

When the TpmFde encryption method was introduced in Agama, it was only supported in a few distribution since it needed the experimental package `fde-tools`. Hence, the availability of that package was considered a condition for the availability of the encryption method.

That has been always problematic since the availability of a certain package is something that can change over time during installation. But it became a serious issue recently, because newer versions of Agama (based on the new APIv2) parallelize more operations than before. So it can happen that the availability of those package is checked even before the software stack has configured all repositories. That makes it impossible to use the TpmFde encryption method in an unattended installation.

## Solution

Stop checking for the package availability. That's something we had already agreed to do some time ago.

On the one hand, the package is not longer experimental and it should be in all (open)SUSE distributions.

On the other hand, we already have a mechanism (the storage features) to enforce the installation of a package if a certain feature is used. That is honored for TpmFde since the introduction of #1363. That mechanism is good enough to manage package dependencies for all storage technologies, so there is not reason to use a different mechanism for the TpmFde availability.

## Extra

This pull request also introduces a fix for the unit tests. They got broken by #1413, which short-circuits the volumes configuration in a rather hacky way. After that change, the unit tests only worked if executed in a certain order and if no `/etc/YaST2/ProductFeatures` file was present in the system running the tests.

Unit tests should work properly now... until we have a chance to fix that code to use a cleaner approach.