### PR TITLE
Improve encryption processes

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,14 +1,21 @@
 -------------------------------------------------------------------
+Mon May  4 11:06:16 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Add device parameter to EncryptionProcess#finish_installation
+  (related to jsc#PED-10703).
+- 5.0.43
+
+-------------------------------------------------------------------
 Wed Mar 25 17:45:35 UTC 2026 - Michal Filka <mfilka@suse.com>
 
 - jsc#PED-14507
-  - Removed reference to update-desktop-files from spec file 
+  - Removed reference to update-desktop-files from spec file
   - 5.0.42
 -------------------------------------------------------------------
 Tue Mar 10 09:00:28 UTC 2026 - Michal Filka <mfilka@suse.com>
 
 - jsc#PED-14507
-  - Removed reference to update-desktop-files from spec file 
+  - Removed reference to update-desktop-files from spec file
   - 5.0.42
 -------------------------------------------------------------------
 Fri Mar  6 10:50:26 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
@@ -321,7 +328,7 @@ Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 Wed Jul  5 13:42:12 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Ensure adding storage support software packages for MicroOS
-  which uses its custom partitions_proposal client, not the 
+  which uses its custom partitions_proposal client, not the
   standard inst_disk_proposal client (bsc#1212452)
   https://github.com/yast/yast-storage-ng/pull/1351
 - 4.6.12

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.42
+Version:        5.0.43
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2017-2020] SUSE LLC
+# Copyright (c) [2017-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -373,7 +373,7 @@ module Y2Storage
     # before unmounting the target system, when all the so-called finish clients
     # are executed
     def finish_installation
-      encryption_process&.finish_installation
+      encryption_process&.finish_installation(self)
     end
 
     # Features that must be supported in the target system to finish the encryption

--- a/src/lib/y2storage/encryption_processes/base.rb
+++ b/src/lib/y2storage/encryption_processes/base.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019-2023] SUSE LLC
+# Copyright (c) [2019-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -76,7 +76,9 @@ module Y2Storage
 
       # Executes the actions that must be performed at the end of the installation,
       # before unmounting the target system
-      def finish_installation; end
+      #
+      # @param _device [Encryption]
+      def finish_installation(_device); end
 
       # Open options for the encryption device
       #

--- a/src/lib/y2storage/encryption_processes/pervasive.rb
+++ b/src/lib/y2storage/encryption_processes/pervasive.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019-2025] SUSE LLC
+# Copyright (c) [2019-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -140,7 +140,9 @@ module Y2Storage
       #
       # Copies the keys from the zkey repository of the inst-sys to the
       # repository of the target system.
-      def finish_installation
+      #
+      # @param _device [Encryption]
+      def finish_installation(_device)
         secure_key.copy_to_repository(Yast::Installation.destdir)
       end
 

--- a/src/lib/y2storage/encryption_processes/tpm_fde_tools.rb
+++ b/src/lib/y2storage/encryption_processes/tpm_fde_tools.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2023] SUSE LLC
+# Copyright (c) [2023-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -122,7 +122,9 @@ module Y2Storage
       end
 
       # @see Base#finish_installation
-      def finish_installation
+      #
+      # @param _device [Encryption]
+      def finish_installation(_device)
         # This procedure is only needed once
         return if self.class.devices.empty?
 


### PR DESCRIPTION
### Problem

The encryption process methods like `#pre_commit` or `#post_commit` have a `device` parameter, allowing to access to the encryption device data. But the method `#finish_installation` has no parameters.

### Solution

Add a `device` parameter to the `#finish_installation` method. The encryption device now passes itself to the encryption process during the finish installation phase, allowing implementations to access device information if needed.

Needed for Agama, see https://github.com/agama-project/agama/pull/3448.