### PR TITLE
Add TPM BLS encryption method

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue May 12 15:49:27 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Add TPM BLS encrytion method (related to jsc#PED-10703).
+
+-------------------------------------------------------------------
 Mon May  4 11:06:16 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Add device parameter to EncryptionProcess#finish_installation

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -27,7 +27,6 @@ Source:         %{name}-%{version}.tar.bz2
 
 # RB_FILESYSTEM_MOUNT_READ_ONLY
 BuildRequires:	libstorage-ng-ruby >= 4.5.246
-# Arch.has_tpm2
 BuildRequires:  yast2 >= 5.0.13
 BuildRequires:  yast2-devtools >= 4.2.2
 # yast/rspec/helpers.rb
@@ -50,7 +49,6 @@ Requires:       findutils
 Requires:       libstorage-ng-ruby >= 4.5.246
 # Require libstorage bindings for the current Ruby version (bsc#1235598)
 Requires:       libstorage-ng-ruby-%{rb_ver}
-# Arch.has_tpm2
 Requires:       yast2 >= 5.0.13
 # Y2Packager::Repository
 Requires:       yast2-packager >= 3.3.7

--- a/src/lib/y2storage/encryption_authentication.rb
+++ b/src/lib/y2storage/encryption_authentication.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2025] SUSE LLC
+# Copyright (c) [2025-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -17,8 +17,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "y2storage/tpm"
 require "yast"
-Yast.import "Arch"
 
 module Y2Storage
   # Class for describing an authentication type of encrypted block devices.
@@ -60,7 +60,7 @@ module Y2Storage
 
     # Sorted list of all possible authentications
     def self.all
-      Yast::Arch.has_tpm2 ? ALL.dup : NONE_TPM.dup
+      Tpm.instance.policy_authorize_nv? ? ALL.dup : NONE_TPM.dup
     end
 
     # Finds a function by its value

--- a/src/lib/y2storage/encryption_method.rb
+++ b/src/lib/y2storage/encryption_method.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2019-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -21,6 +21,7 @@ require "y2storage/encryption_method/luks1"
 require "y2storage/encryption_method/pervasive_luks2"
 require "y2storage/encryption_method/luks2"
 require "y2storage/encryption_method/tpm_fde"
+require "y2storage/encryption_method/tpm_bls"
 require "y2storage/encryption_method/systemd_fde"
 require "y2storage/encryption_method/random_swap"
 require "y2storage/encryption_method/protected_swap"
@@ -51,6 +52,8 @@ module Y2Storage
     LUKS2 = Luks2.new
     # Instance of the TpmFde method to be always returned by the module
     TPM_FDE = TpmFde.new
+    # Instance of the TpmBls method to be always returned by the module
+    TPM_BLS = TpmBls.new
     # Instance of the SystemdFde method to be always returned by the module
     SYSTEMD_FDE = SystemdFde.new
     # Instance of the RandomSwap method to be always returned by the module
@@ -63,7 +66,8 @@ module Y2Storage
     # Sorted list of all the method instances
     # @see .all
     ALL = [
-      LUKS1, PERVASIVE_LUKS2, LUKS2, TPM_FDE, SYSTEMD_FDE, RANDOM_SWAP, PROTECTED_SWAP, SECURE_SWAP
+      LUKS1, PERVASIVE_LUKS2, LUKS2, TPM_FDE, TPM_BLS, SYSTEMD_FDE, RANDOM_SWAP, PROTECTED_SWAP,
+      SECURE_SWAP
     ]
     private_constant :ALL
 

--- a/src/lib/y2storage/encryption_method/tpm_bls.rb
+++ b/src/lib/y2storage/encryption_method/tpm_bls.rb
@@ -21,15 +21,17 @@
 
 require "y2storage/encryption_method/base"
 require "y2storage/encryption_processes/sdboot"
+require "y2storage/tpm"
 require "yast"
-
-Yast.import "Arch"
+require "yast2/execute"
 
 module Y2Storage
   module EncryptionMethod
     # BLS compliant encryption method that allows to encrypt a device using LUKS2 and configure the
     # unlocking process via the system TPM.
     class TpmBls < Base
+      include Yast
+
       def initialize
         textdomain "storage"
 
@@ -51,7 +53,7 @@ module Y2Storage
       #
       # @return [Boolean]
       def possible?
-        arch.efiboot? && Yast::Arch.has_tpm2
+        arch.efiboot? && tpm.policy_authorize_nv?
       end
 
       # Creates an encryption device for the given block device.
@@ -70,12 +72,19 @@ module Y2Storage
       private
 
       # @see Base#encryption_process
+      # @return [EncryptionProcesses::Sdboot]
       def encryption_process
         EncryptionProcesses::Sdboot.new(self)
       end
 
+      # @return [Y2Storage::Arch]
       def arch
         StorageManager.instance.arch
+      end
+
+      # @return [Y2Storage::Tpm]
+      def tpm
+        Tpm.instance
       end
     end
   end

--- a/src/lib/y2storage/encryption_method/tpm_bls.rb
+++ b/src/lib/y2storage/encryption_method/tpm_bls.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/encryption_method/base"
+require "y2storage/encryption_processes/sdboot"
+require "yast"
+
+Yast.import "Arch"
+
+module Y2Storage
+  module EncryptionMethod
+    # BLS compliant encryption method that allows to encrypt a device using LUKS2 and configure the
+    # unlocking process via the system TPM.
+    class TpmBls < Base
+      def initialize
+        textdomain "storage"
+
+        super(:tpm_bls, _("BLS Compliant Encryption With TPM Unlocking"))
+      end
+
+      # @see Base#available?
+      #
+      # So far, the encryption method is implemented to be used only by Agama (which doesn't honor
+      # the {#available?} method). Probably this method will replace SystemdFde used by YaST.
+      #
+      # @return [Boolean]
+      def available?
+        false
+      end
+
+      # Whether the target system meets the requisites to setup devices using this encryption
+      # method.
+      #
+      # @return [Boolean]
+      def possible?
+        arch.efiboot? && Yast::Arch.has_tpm2
+      end
+
+      # Creates an encryption device for the given block device.
+      #
+      # @param blk_device [Y2Storage::BlkDevice]
+      # @param dm_name [String]
+      # @param pbkdf [PbkdFunction, nil] Password-based key derivation function to be used by the
+      #   created LUKS2 device.
+      # @param label [String] optional LUKS2 label.
+      #
+      # @return [Y2Storage::Encryption]
+      def create_device(blk_device, dm_name, pbkdf: nil, label: "")
+        encryption_process.create_device(blk_device, dm_name, pbkdf: pbkdf, label: label)
+      end
+
+      private
+
+      # @see Base#encryption_process
+      def encryption_process
+        EncryptionProcesses::Sdboot.new(self)
+      end
+
+      def arch
+        StorageManager.instance.arch
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/encryption_processes/sdboot.rb
+++ b/src/lib/y2storage/encryption_processes/sdboot.rb
@@ -27,7 +27,7 @@ require "yast2/execute"
 
 module Y2Storage
   module EncryptionProcesses
-    # Encryption process that allows to setup device unlocking based on the sdbootutil provied by
+    # Encryption process that allows to setup device unlocking based on the sdbootutil provided by
     # SUSE.
     #
     # Check the documentation of sdbootutil for further information:
@@ -58,7 +58,7 @@ module Y2Storage
       # @see Base#finish_installation
       # @param device [Encryption]
       def finish_installation(device)
-        # Only TPM unlucking is supported by Agama so far.
+        # Only TPM unlocking is supported by Agama so far.
         return unless authentication&.is?(:tpm2)
 
         # Password used by systemd-cryptenroll to unlock the device (LUKS2)

--- a/src/lib/y2storage/encryption_processes/sdboot.rb
+++ b/src/lib/y2storage/encryption_processes/sdboot.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2storage/encryption_authentication"
+require "y2storage/encryption_processes/base"
+require "y2storage/encryption_type"
+require "yast"
+require "yast2/execute"
+
+module Y2Storage
+  module EncryptionProcesses
+    # Encryption process that allows to setup device unlocking based on the sdbootutil provied by
+    # SUSE.
+    #
+    # Check the documentation of sdbootutil for further information:
+    # https://github.com/openSUSE/sdbootutil
+    class Sdboot < Base
+      include Yast::Logger
+
+      # Creates an encryption layer over the given block device.
+      #
+      # @param blk_device [Y2Storage::BlkDevice]
+      # @param dm_name [String]
+      # @param pbkdf [PbkdFunction, nil] PBKDF of the LUKS2 device.
+      # @param label [String, nil] label of the LUKS device.
+      #
+      # @return [Encryption]
+      def create_device(blk_device, dm_name, pbkdf: nil, label: nil)
+        enc = super(blk_device, dm_name)
+        enc.label = label if label
+        enc.pbkdf = pbkdf if pbkdf
+        enc
+      end
+
+      # @see EncryptionProcesses::Base#encryption_type
+      def encryption_type
+        EncryptionType::LUKS2
+      end
+
+      # @see Base#finish_installation
+      # @param device [Encryption]
+      def finish_installation(device)
+        # Only TPM unlucking is supported by Agama so far.
+        return unless authentication&.is?(:tpm2)
+
+        # Password used by systemd-cryptenroll to unlock the device (LUKS2)
+        export_password(device.password, "cryptenroll")
+
+        # Password used by sdbootutil as a recovery PIN
+        export_password(device.password, "sdbootutil")
+
+        enroll_authentication(device)
+      end
+
+      private
+
+      SDBOOTUTIL = "/usr/bin/sdbootutil"
+      private_constant :SDBOOTUTIL
+
+      # "keyctl padd" command adds a key to the Linux kernel keyring.
+      #
+      # The kernel keyring is used to securely pass passwords between processes without exposing
+      # them:
+      #   - Not visible in process listings (ps, top)
+      #   - Not visible in command history
+      #   - Not visible in environment variables
+      #   - Only accessible by processes with proper permissions
+      #
+      # In this case:
+      #   - The password is stored with description "cryptenroll" for systemd-cryptenroll to
+      #     retrieve
+      #   - The password is stored with description "sdbootutil" for sdbootutil to retrieve
+      #
+      # Both tools know to look for their respective keys in the user keyring to unlock/enroll the
+      # LUKS2 device without the password being passed as a command-line argument.
+      #
+      # A new key is always added (padd) because systemd is supposed to drop the key once it is
+      # used.
+      #
+      # @param password [String]
+      # @param kind [String]
+      def export_password(password, kind)
+        if password.empty?
+          log.error("Cannot pass empty password via the keyring.")
+          return
+        end
+
+        Yast::Execute.on_target!("keyctl", "padd", "user", kind, "@u",
+          recorder: Yast::ReducedRecorder.new(skip: :stdin),
+          stdin:    password)
+      rescue Cheetah::ExecutionFailed => e
+        log.error(
+          format(
+            "Cannot pass the password via the keyring:\n" \
+            "Command `%{command}`.\n" \
+            "Error output: %{stderr}",
+            command: e.commands.inspect,
+            stderr:  e.stderr
+          )
+        )
+      end
+
+      # @param device [Encryption]
+      def enroll_authentication(device)
+        return unless authentication
+
+        Yast::Execute.on_target!(
+          SDBOOTUTIL,
+          "enroll",
+          "--method=#{authentication.value}",
+          "--devices=#{device.blk_device.name}"
+        )
+      rescue Cheetah::ExecutionFailed => e
+        log.error(
+          format(
+            "Cannot enroll authentication:\n" \
+            "Command `%{command}`.\n" \
+            "Error output: %{stderr}",
+            command: e.commands.inspect,
+            stderr:  e.stderr
+          )
+        )
+      end
+
+      # @return [EncryptionAuthentication, nil]
+      def authentication
+        return unless method.is?(:tpm_bls)
+
+        EncryptionAuthentication::TPM2
+      end
+    end
+  end
+end

--- a/src/lib/y2storage/encryption_processes/sdboot.rb
+++ b/src/lib/y2storage/encryption_processes/sdboot.rb
@@ -57,9 +57,6 @@ module Y2Storage
       # @see Base#finish_installation
       # @param device [Encryption]
       def finish_installation(device)
-        # Only TPM unlocking is supported by Agama so far.
-        return unless method.is?(:tpm_bls)
-
         # Password used by systemd-cryptenroll to unlock the device (LUKS2)
         export_password(device.password, "cryptenroll")
 

--- a/src/lib/y2storage/encryption_processes/sdboot.rb
+++ b/src/lib/y2storage/encryption_processes/sdboot.rb
@@ -19,7 +19,6 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "y2storage/encryption_authentication"
 require "y2storage/encryption_processes/base"
 require "y2storage/encryption_type"
 require "yast"
@@ -59,7 +58,7 @@ module Y2Storage
       # @param device [Encryption]
       def finish_installation(device)
         # Only TPM unlocking is supported by Agama so far.
-        return unless authentication&.is?(:tpm2)
+        return unless method.is?(:tpm_bls)
 
         # Password used by systemd-cryptenroll to unlock the device (LUKS2)
         export_password(device.password, "cryptenroll")
@@ -67,7 +66,7 @@ module Y2Storage
         # Password used by sdbootutil as a recovery PIN
         export_password(device.password, "sdbootutil")
 
-        enroll_authentication(device)
+        enroll_tpm_authentication(device)
       end
 
       private
@@ -119,13 +118,11 @@ module Y2Storage
       end
 
       # @param device [Encryption]
-      def enroll_authentication(device)
-        return unless authentication
-
+      def enroll_tpm_authentication(device)
         Yast::Execute.on_target!(
           SDBOOTUTIL,
           "enroll",
-          "--method=#{authentication.value}",
+          "--method=tpm2",
           "--devices=#{device.blk_device.name}"
         )
       rescue Cheetah::ExecutionFailed => e
@@ -138,13 +135,6 @@ module Y2Storage
             stderr:  e.stderr
           )
         )
-      end
-
-      # @return [EncryptionAuthentication, nil]
-      def authentication
-        return unless method.is?(:tpm_bls)
-
-        EncryptionAuthentication::TPM2
       end
     end
   end

--- a/src/lib/y2storage/tpm.rb
+++ b/src/lib/y2storage/tpm.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "singleton"
+require "yast"
+require "yast2/execute"
+
+module Y2Storage
+  # Class to get information about TPM (Trusted Platform Module).
+  class Tpm
+    include Singleton
+    include Yast
+
+    # Whether a TPM2 is present.
+    #
+    # @return [Boolean]
+    def version2?
+      version == "2"
+    end
+
+    # Whether the TPM supports PolicyAuthorizeNV.
+    #
+    # @return [Boolean]
+    def policy_authorize_nv?
+      # systemd-pcrlock is using PolicyAuthorizeNV to store the policy inside
+      # the TPM2's non volatile RAM. This feature is supported after TPM2 1.38
+      # revision, and without it systemd-pcrlock will fail. These calls check
+      # for version > 1.38 (bsc#1250403)
+      return false unless version2?
+
+      capabilities&.include?("TPM2_CC_PolicyAuthorizeNV") || false
+    end
+
+    private
+
+    # TPM version.
+    #
+    # @return [String, nil] nil if the version is not detected.
+    def version
+      return @version if @version_checked
+
+      @version_checked = true
+      @version = read_version
+    end
+
+    # TPM capabilities.
+    #
+    # @return [String, nil] nil if the capabilities cannot be read.
+    def capabilities
+      return @capabilities if @capabilities_checked
+
+      @capabilities_checked = true
+      @capabilities = read_capabilities
+    end
+
+    # Reads the TPM version.
+    #
+    # @return [String, nil] nil if version cannot be read.
+    def read_version
+      Yast::SCR.Read(path(".target.string"), "/sys/class/tpm/tpm0/tpm_version_major")&.strip
+    end
+
+    # Reads the TPM capabilities
+    #
+    # @return [String, nil] nil if capabilities cannot be read.
+    def read_capabilities
+      Yast::Execute.locally!("tpm2_getcap", "commands", stdout: :capture)
+    rescue Cheetah::ExecutionFailed
+      nil
+    end
+  end
+end

--- a/test/y2partitioner/widgets/encrypt_auth_selector_test.rb
+++ b/test/y2partitioner/widgets/encrypt_auth_selector_test.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env rspec
-# Copyright (c) [2025] SUSE LLC
+
+# Copyright (c) [2025-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -19,11 +20,10 @@
 # find current contact information at www.suse.com.
 
 require_relative "../test_helper"
-
 require "cwm/rspec"
 require "y2partitioner/widgets/encrypt_auth_selector"
 require "y2storage/encryption_authentication"
-Yast.import "Arch"
+require "y2storage/tpm"
 
 describe Y2Partitioner::Widgets::EncryptAuthSelector do
   subject(:widget) { described_class.new(controller) }
@@ -33,6 +33,12 @@ describe Y2Partitioner::Widgets::EncryptAuthSelector do
     double("Controllers::Encryption",
       authentication: Y2Storage::EncryptionAuthentication.find(initial_authentication))
   end
+
+  before do
+    allow(Y2Storage::Tpm).to receive(:instance).and_return(tpm)
+  end
+
+  let(:tpm) { instance_double(Y2Storage::Tpm, policy_authorize_nv?: true) }
 
   include_examples "CWM::ComboBox"
 
@@ -59,10 +65,6 @@ describe Y2Partitioner::Widgets::EncryptAuthSelector do
   end
 
   describe "#items" do
-    before do
-      allow(Yast::Arch).to receive(:has_tpm2).and_return(true)
-    end
-
     it "includes all available authentication" do
       items = widget.items.map(&:first)
 

--- a/test/y2storage/encryption_authentication_test.rb
+++ b/test/y2storage/encryption_authentication_test.rb
@@ -44,11 +44,13 @@ describe Y2Storage::EncryptionAuthentication do
 
   describe "#all" do
     before do
-      allow(Yast::Arch).to receive(:has_tpm2).and_return(tpm2)
+      allow(Y2Storage::Tpm).to receive(:instance).and_return(tpm)
     end
 
-    context "tpm2 is avalable" do
-      let(:tpm2) { true }
+    let(:tpm) { instance_double(Y2Storage::Tpm, policy_authorize_nv?: policy_authorize_nv) }
+
+    context "tpm2 is available" do
+      let(:policy_authorize_nv) { true }
 
       it "includes tpm2 and tpm2+pin" do
         expect(Y2Storage::EncryptionAuthentication.all)
@@ -59,8 +61,8 @@ describe Y2Storage::EncryptionAuthentication do
       end
     end
 
-    context "tpm2 is not avalable" do
-      let(:tpm2) { false }
+    context "tpm2 is not available" do
+      let(:policy_authorize_nv) { false }
 
       it "includes not tpm2 and tpm2+pin" do
         expect(Y2Storage::EncryptionAuthentication.all)

--- a/test/y2storage/encryption_method/tpm_bls_test.rb
+++ b/test/y2storage/encryption_method/tpm_bls_test.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::EncryptionMethod::TpmBls do
+  describe "#initialize" do
+    it "sets the correct encryption method id" do
+      expect(subject.id).to eq(:tpm_bls)
+    end
+
+    it "sets a descriptive name" do
+      expect(subject.to_human_string).to match(/BLS.*TPM/i)
+    end
+  end
+
+  describe ".used_for?" do
+    let(:encryption) { instance_double(Y2Storage::Encryption) }
+
+    it "returns false" do
+      expect(subject.used_for?(encryption)).to eq(false)
+    end
+  end
+
+  describe ".only_for_swap?" do
+    it "returns false" do
+      expect(subject.only_for_swap?).to eq(false)
+    end
+  end
+
+  describe "#password_required?" do
+    it "returns true" do
+      expect(subject.password_required?).to eq(true)
+    end
+  end
+
+  describe "#possible?" do
+    before do
+      Y2Storage::StorageManager.create_test_instance
+
+      allow(Yast::Arch).to receive(:has_tpm2).and_return(tpm_present)
+      allow(Y2Storage::Arch).to receive(:new).and_return(arch)
+    end
+
+    let(:arch) { instance_double(Y2Storage::Arch, efiboot?: efi) }
+
+    context "when the system boots using EFI and has TPM2" do
+      let(:efi) { true }
+      let(:tpm_present) { true }
+
+      it "returns true" do
+        expect(subject.possible?).to eq(true)
+      end
+    end
+
+    context "when the system boots using EFI but has no TPM2" do
+      let(:efi) { true }
+      let(:tpm_present) { false }
+
+      it "returns false" do
+        expect(subject.possible?).to eq(false)
+      end
+    end
+
+    context "when the system has TPM2 but does not use EFI" do
+      let(:efi) { false }
+      let(:tpm_present) { true }
+
+      it "returns false" do
+        expect(subject.possible?).to eq(false)
+      end
+    end
+
+    context "when the system does not use EFI and has no TPM2" do
+      let(:efi) { false }
+      let(:tpm_present) { false }
+
+      it "returns false" do
+        expect(subject.possible?).to eq(false)
+      end
+    end
+  end
+
+  describe "#available?" do
+    it "returns false" do
+      expect(subject.available?).to eq(false)
+    end
+  end
+
+  describe "#create_device" do
+    before do
+      Y2Storage::StorageManager.create_test_instance
+
+      allow(Y2Storage::EncryptionProcesses::Sdboot).to receive(:new)
+        .with(subject)
+        .and_return(encryption_process)
+    end
+
+    let(:blk_device) { instance_double(Y2Storage::BlkDevice) }
+    let(:dm_name) { "cr_test" }
+    let(:encryption_process) { instance_double(Y2Storage::EncryptionProcesses::Sdboot) }
+    let(:encrypted_device) { instance_double(Y2Storage::Encryption) }
+
+    it "delegates to the encryption process" do
+      expect(encryption_process).to receive(:create_device)
+        .with(blk_device, dm_name, hash_including(pbkdf: nil, label: ""))
+        .and_return(encrypted_device)
+
+      result = subject.create_device(blk_device, dm_name)
+      expect(result).to eq(encrypted_device)
+    end
+
+    it "passes pbkdf parameter to the encryption process" do
+      pbkdf = instance_double(Y2Storage::PbkdFunction)
+
+      expect(encryption_process).to receive(:create_device)
+        .with(blk_device, dm_name, hash_including(pbkdf: pbkdf, label: ""))
+        .and_return(encrypted_device)
+
+      subject.create_device(blk_device, dm_name, pbkdf: pbkdf)
+    end
+
+    it "passes label parameter to the encryption process" do
+      label = "test_label"
+
+      expect(encryption_process).to receive(:create_device)
+        .with(blk_device, dm_name, hash_including(pbkdf: nil, label: label))
+        .and_return(encrypted_device)
+
+      subject.create_device(blk_device, dm_name, label: label)
+    end
+  end
+end

--- a/test/y2storage/encryption_method/tpm_bls_test.rb
+++ b/test/y2storage/encryption_method/tpm_bls_test.rb
@@ -54,45 +54,48 @@ describe Y2Storage::EncryptionMethod::TpmBls do
   end
 
   describe "#possible?" do
+    subject { described_class.new }
+
     before do
       Y2Storage::StorageManager.create_test_instance
 
-      allow(Yast::Arch).to receive(:has_tpm2).and_return(tpm_present)
+      allow(Y2Storage::Tpm).to receive(:instance).and_return(tpm)
       allow(Y2Storage::Arch).to receive(:new).and_return(arch)
     end
 
+    let(:tpm) { instance_double(Y2Storage::Tpm, policy_authorize_nv?: policy_authorize_nv) }
     let(:arch) { instance_double(Y2Storage::Arch, efiboot?: efi) }
 
-    context "when the system boots using EFI and has TPM2" do
+    context "when the system boots using EFI and has usable TPM2" do
       let(:efi) { true }
-      let(:tpm_present) { true }
+      let(:policy_authorize_nv) { true }
 
       it "returns true" do
         expect(subject.possible?).to eq(true)
       end
     end
 
-    context "when the system boots using EFI but has no TPM2" do
+    context "when the system boots using EFI but TPM does not support PolicyAuthorizeNV" do
       let(:efi) { true }
-      let(:tpm_present) { false }
+      let(:policy_authorize_nv) { false }
 
       it "returns false" do
         expect(subject.possible?).to eq(false)
       end
     end
 
-    context "when the system has TPM2 but does not use EFI" do
+    context "when the system has usable TPM2 but does not use EFI" do
       let(:efi) { false }
-      let(:tpm_present) { true }
+      let(:policy_authorize_nv) { true }
 
       it "returns false" do
         expect(subject.possible?).to eq(false)
       end
     end
 
-    context "when the system does not use EFI and has no TPM2" do
+    context "when the system does not use EFI and has no usable TPM2" do
       let(:efi) { false }
-      let(:tpm_present) { false }
+      let(:policy_authorize_nv) { false }
 
       it "returns false" do
         expect(subject.possible?).to eq(false)

--- a/test/y2storage/encryption_method_test.rb
+++ b/test/y2storage/encryption_method_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2019-2020] SUSE LLC
+# Copyright (c) [2019-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -51,6 +51,10 @@ describe Y2Storage::EncryptionMethod do
 
     it "contains a method for TPM full-disk encryption" do
       expect(described_class.all.map(&:to_sym)).to include(:tpm_fde)
+    end
+
+    it "contains a BLS-compliant method with TPM unlocking" do
+      expect(described_class.all.map(&:to_sym)).to include(:tpm_bls)
     end
   end
 

--- a/test/y2storage/encryption_processes/sdboot_test.rb
+++ b/test/y2storage/encryption_processes/sdboot_test.rb
@@ -21,6 +21,7 @@
 
 require_relative "../spec_helper"
 require "y2storage"
+require "cheetah"
 
 describe Y2Storage::EncryptionProcesses::Sdboot do
   let(:method) { Y2Storage::EncryptionMethod::TPM_BLS }
@@ -141,7 +142,7 @@ describe Y2Storage::EncryptionProcesses::Sdboot do
       before do
         allow(Yast::Execute).to receive(:on_target!)
           .with("keyctl", any_args)
-          .and_raise(Cheetah::ExecutionFailed.new("", "", "", "keyctl error"))
+          .and_raise(Cheetah::ExecutionFailed.new(["keyctl"], 1, "", "keyctl error"))
       end
 
       it "still attempts to enroll authentication" do
@@ -156,7 +157,7 @@ describe Y2Storage::EncryptionProcesses::Sdboot do
       before do
         allow(Yast::Execute).to receive(:on_target!)
           .with("/usr/bin/sdbootutil", any_args)
-          .and_raise(Cheetah::ExecutionFailed.new("", "", "", "enrollment error"))
+          .and_raise(Cheetah::ExecutionFailed.new(["/usr/bin/sdbootutil"], 1, "", "enrollment error"))
         allow(subject).to receive(:log).and_return(logger)
       end
 
@@ -168,7 +169,7 @@ describe Y2Storage::EncryptionProcesses::Sdboot do
       end
     end
 
-    context "when method is not tpm_bls" do
+    context "when method is not TPM BLS" do
       let(:method) { Y2Storage::EncryptionMethod::Luks2.new }
 
       it "returns early without executing commands" do

--- a/test/y2storage/encryption_processes/sdboot_test.rb
+++ b/test/y2storage/encryption_processes/sdboot_test.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "y2storage"
+
+describe Y2Storage::EncryptionProcesses::Sdboot do
+  let(:method) { Y2Storage::EncryptionMethod::TPM_BLS }
+  let(:manager) { Y2Storage::StorageManager.instance }
+
+  subject { described_class.new(method) }
+
+  before { fake_scenario("mixed_disks") }
+
+  describe "#encryption_type" do
+    it "returns LUKS2" do
+      expect(subject.encryption_type).to eq(Y2Storage::EncryptionType::LUKS2)
+    end
+  end
+
+  describe "#create_device" do
+    let(:blk_device) { manager.staging.find_by_name("/dev/sda2") }
+    let(:dm_name) { "cr_test" }
+
+    it "creates an encryption device with LUKS2 type" do
+      encryption = subject.create_device(blk_device, dm_name)
+      expect(encryption.type.is?(:luks2)).to eq(true)
+    end
+
+    context "when label is provided" do
+      let(:label) { "test_label" }
+
+      it "sets the label on the encryption device" do
+        encryption = subject.create_device(blk_device, dm_name, label: label)
+        expect(encryption.label).to eq(label)
+      end
+    end
+
+    context "when label is nil" do
+      it "does not set the label" do
+        encryption = subject.create_device(blk_device, dm_name, label: nil)
+        expect(encryption.label).to eq("")
+      end
+    end
+
+    context "when pbkdf is provided" do
+      let(:pbkdf) { Y2Storage::PbkdFunction::PBKDF2 }
+
+      it "sets the pbkdf on the encryption device" do
+        encryption = subject.create_device(blk_device, dm_name, pbkdf: pbkdf)
+        expect(encryption.pbkdf).to eq(pbkdf)
+      end
+    end
+
+    context "when pbkdf is nil" do
+      it "does not set the pbkdf" do
+        encryption = subject.create_device(blk_device, dm_name, pbkdf: nil)
+        expect(encryption.pbkdf).to be_nil
+      end
+    end
+  end
+
+  describe "#finish_installation" do
+    let(:blk_device) { manager.staging.find_by_name("/dev/sda2") }
+    let(:dm_name) { "cr_test" }
+    let(:password) { "test_password" }
+    let(:device) do
+      subject.create_device(blk_device, dm_name).tap do |enc|
+        enc.password = password
+      end
+    end
+
+    before do
+      allow(Yast::Execute).to receive(:on_target!)
+    end
+
+    context "when password is not empty" do
+      it "exports password for cryptenroll" do
+        expect(Yast::Execute).to receive(:on_target!)
+          .with(
+            "keyctl", "padd", "user", "cryptenroll", "@u",
+            hash_including(stdin: password)
+          )
+
+        subject.finish_installation(device)
+      end
+
+      it "exports password for sdbootutil" do
+        expect(Yast::Execute).to receive(:on_target!)
+          .with(
+            "keyctl", "padd", "user", "sdbootutil", "@u",
+            hash_including(stdin: password)
+          )
+
+        subject.finish_installation(device)
+      end
+
+      it "enrolls TPM2 authentication" do
+        expect(Yast::Execute).to receive(:on_target!)
+          .with(
+            "/usr/bin/sdbootutil",
+            "enroll",
+            "--method=tpm2",
+            "--devices=/dev/sda2"
+          )
+
+        subject.finish_installation(device)
+      end
+    end
+
+    context "when password is empty" do
+      let(:password) { "" }
+
+      it "still attempts to enroll authentication" do
+        expect(Yast::Execute).to receive(:on_target!)
+          .with("/usr/bin/sdbootutil", "enroll", "--method=tpm2", "--devices=/dev/sda2")
+
+        subject.finish_installation(device)
+      end
+    end
+
+    context "when keyctl command fails" do
+      before do
+        allow(Yast::Execute).to receive(:on_target!)
+          .with("keyctl", any_args)
+          .and_raise(Cheetah::ExecutionFailed.new("", "", "", "keyctl error"))
+      end
+
+      it "still attempts to enroll authentication" do
+        expect(Yast::Execute).to receive(:on_target!)
+          .with("/usr/bin/sdbootutil", any_args)
+
+        subject.finish_installation(device)
+      end
+    end
+
+    context "when sdbootutil enrollment fails" do
+      before do
+        allow(Yast::Execute).to receive(:on_target!)
+          .with("/usr/bin/sdbootutil", any_args)
+          .and_raise(Cheetah::ExecutionFailed.new("", "", "", "enrollment error"))
+        allow(subject).to receive(:log).and_return(logger)
+      end
+
+      let(:logger) { double(error: nil) }
+
+      it "logs the error" do
+        expect(logger).to receive(:error).with(/Cannot enroll/)
+        expect { subject.finish_installation(device) }.not_to raise_error
+      end
+    end
+
+    context "when method is not tpm_bls" do
+      let(:method) { Y2Storage::EncryptionMethod::Luks2.new }
+
+      it "returns early without executing commands" do
+        expect(Yast::Execute).not_to receive(:on_target!)
+          .with("keyctl", any_args)
+        expect(Yast::Execute).not_to receive(:on_target!)
+          .with("/usr/bin/sdbootutil", any_args)
+
+        expect { subject.finish_installation(device) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/test/y2storage/encryption_processes/sdboot_test.rb
+++ b/test/y2storage/encryption_processes/sdboot_test.rb
@@ -168,18 +168,5 @@ describe Y2Storage::EncryptionProcesses::Sdboot do
         expect { subject.finish_installation(device) }.not_to raise_error
       end
     end
-
-    context "when method is not TPM BLS" do
-      let(:method) { Y2Storage::EncryptionMethod::Luks2.new }
-
-      it "returns early without executing commands" do
-        expect(Yast::Execute).not_to receive(:on_target!)
-          .with("keyctl", any_args)
-        expect(Yast::Execute).not_to receive(:on_target!)
-          .with("/usr/bin/sdbootutil", any_args)
-
-        expect { subject.finish_installation(device) }.not_to raise_error
-      end
-    end
   end
 end

--- a/test/y2storage/tpm_bls_encryption_test.rb
+++ b/test/y2storage/tpm_bls_encryption_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage"
+require "yast2/execute"
+
+describe "TPM BLS encryption" do
+  let(:manager) { Y2Storage::StorageManager.instance }
+  let(:tpm_bls) { Y2Storage::EncryptionMethod::TPM_BLS }
+
+  before { fake_scenario("mixed_disks") }
+
+  describe "Y2Storage::BlkDevice#encrypt" do
+    let(:blk_device) { manager.staging.find_by_name("/dev/sda1") }
+
+    it "creates an encryption device with type LUKS2 and method TPM BLS" do
+      enc = blk_device.encrypt(method: tpm_bls)
+      expect(enc.type.is?(:luks2)).to eq(true)
+      expect(enc.method.is?(:tpm_bls)).to eq(true)
+    end
+  end
+
+  describe "finish installation" do
+    before do
+      allow(Yast::Execute).to receive(:on_target!)
+
+      sda1 = manager.staging.find_by_name("/dev/sda1")
+      sda2 = manager.staging.find_by_name("/dev/sda2")
+      sda1.encrypt(method: tpm_bls, password: "notsecret-sda1")
+      sda2.encrypt(method: tpm_bls, password: "notsecret-sda2")
+    end
+
+    it "adds password used by systemd-cryptenroll" do
+      expect(Yast::Execute)
+        .to(receive(:on_target!))
+        .with("keyctl", "padd", "user", "cryptenroll", "@u",
+          hash_including(stdin: "notsecret-sda1"))
+
+      expect(Yast::Execute)
+        .to(receive(:on_target!))
+        .with("keyctl", "padd", "user", "cryptenroll", "@u",
+          hash_including(stdin: "notsecret-sda2"))
+
+      manager.staging.finish_installation
+    end
+
+    it "adds password used by sdbootutil" do
+      expect(Yast::Execute)
+        .to(receive(:on_target!))
+        .with("keyctl", "padd", "user", "sdbootutil", "@u",
+          hash_including(stdin: "notsecret-sda1"))
+
+      expect(Yast::Execute)
+        .to(receive(:on_target!))
+        .with("keyctl", "padd", "user", "sdbootutil", "@u",
+          hash_including(stdin: "notsecret-sda2"))
+
+      manager.staging.finish_installation
+    end
+
+    it "enrolls authentication" do
+      expect(Yast::Execute)
+        .to(receive(:on_target!))
+        .with(/sdbootutil/, "enroll", "--method=tpm2", "--devices=/dev/sda1")
+
+      expect(Yast::Execute)
+        .to(receive(:on_target!))
+        .with(/sdbootutil/, "enroll", "--method=tpm2", "--devices=/dev/sda2")
+
+      manager.staging.finish_installation
+    end
+  end
+end

--- a/test/y2storage/tpm_test.rb
+++ b/test/y2storage/tpm_test.rb
@@ -1,0 +1,180 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2026] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "y2storage/tpm"
+require "yast2/execute"
+
+describe Y2Storage::Tpm do
+  subject(:tpm) { described_class.instance }
+
+  before do
+    allow(Yast::SCR).to receive(:Read)
+    allow(Yast::Execute).to receive(:locally!)
+    # Reset singleton state before each test
+    described_class.instance.instance_variable_set(:@version_checked, nil)
+    described_class.instance.instance_variable_set(:@version, nil)
+    described_class.instance.instance_variable_set(:@capabilities_checked, nil)
+    described_class.instance.instance_variable_set(:@capabilities, nil)
+  end
+
+  describe "#version2?" do
+    before do
+      allow(Yast::SCR).to receive(:Read)
+        .with(path(".target.string"), "/sys/class/tpm/tpm0/tpm_version_major")
+        .and_return(version)
+    end
+
+    context "when TPM version is 2" do
+      let(:version) { "2\n" }
+
+      it "returns true" do
+        expect(tpm.version2?).to eq(true)
+      end
+    end
+
+    context "when TPM version is 1" do
+      let(:version) { "1\n" }
+
+      it "returns false" do
+        expect(tpm.version2?).to eq(false)
+      end
+    end
+
+    context "when TPM version cannot be read" do
+      let(:version) { nil }
+
+      it "returns false" do
+        expect(tpm.version2?).to eq(false)
+      end
+    end
+
+    context "when TPM version is empty" do
+      let(:version) { "" }
+
+      it "returns false" do
+        expect(tpm.version2?).to eq(false)
+      end
+    end
+
+    context "when version is read multiple times" do
+      let(:version) { "2\n" }
+
+      it "caches the version check" do
+        tpm.version2?
+        tpm.version2?
+
+        expect(Yast::SCR).to have_received(:Read).once
+      end
+    end
+  end
+
+  describe "#policy_authorize_nv?" do
+    before do
+      allow(Yast::SCR).to receive(:Read)
+        .with(path(".target.string"), "/sys/class/tpm/tpm0/tpm_version_major")
+        .and_return(version)
+      allow(Yast::Execute).to receive(:locally!)
+        .with("tpm2_getcap", "commands", stdout: :capture)
+        .and_return(capabilities)
+    end
+
+    context "when TPM version is not 2" do
+      let(:version) { "1\n" }
+      let(:capabilities) { nil }
+
+      it "returns false" do
+        expect(tpm.policy_authorize_nv?).to eq(false)
+      end
+
+      it "does not check capabilities" do
+        tpm.policy_authorize_nv?
+        expect(Yast::Execute).not_to have_received(:locally!)
+      end
+    end
+
+    context "when TPM version is 2" do
+      let(:version) { "2\n" }
+
+      context "and capabilities include TPM2_CC_PolicyAuthorizeNV" do
+        let(:capabilities) do
+          <<~OUTPUT
+            TPM2_CC_CreateLoaded
+            TPM2_CC_PolicyAuthorizeNV
+            TPM2_CC_EncryptDecrypt2
+          OUTPUT
+        end
+
+        it "returns true" do
+          expect(tpm.policy_authorize_nv?).to eq(true)
+        end
+      end
+
+      context "and capabilities do not include TPM2_CC_PolicyAuthorizeNV" do
+        let(:capabilities) do
+          <<~OUTPUT
+            TPM2_CC_NV_UndefineSpaceSpecial
+            TPM2_CC_CreateLoaded
+            TPM2_CC_EncryptDecrypt2
+          OUTPUT
+        end
+
+        it "returns false" do
+          expect(tpm.policy_authorize_nv?).to eq(false)
+        end
+      end
+
+      context "and capabilities cannot be read due to command failure" do
+        let(:capabilities) { nil }
+
+        before do
+          allow(Yast::Execute).to receive(:locally!)
+            .with("tpm2_getcap", "commands", stdout: :capture)
+            .and_raise(Cheetah::ExecutionFailed.new(nil, nil, nil, nil))
+        end
+
+        it "returns false" do
+          expect(tpm.policy_authorize_nv?).to eq(false)
+        end
+      end
+
+      context "when capabilities are read multiple times" do
+        let(:capabilities) { "TPM2_CC_PolicyAuthorizeNV\n" }
+
+        it "caches the capabilities check" do
+          tpm.policy_authorize_nv?
+          tpm.policy_authorize_nv?
+
+          expect(Yast::Execute).to have_received(:locally!).once
+        end
+      end
+    end
+
+    context "when version is nil" do
+      let(:version) { nil }
+      let(:capabilities) { nil }
+
+      it "returns false" do
+        expect(tpm.policy_authorize_nv?).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds support for BLS-compliant encryption with TPM unlocking.

Changes

* New encryption method: `TpmBls` - BLS-compliant LUKS2 encryption with TPM unlocking via sdbootutil
* New `Tpm` class: Provides TPM detection and capability checking (replaces `Yast::Arch` calls)
* New `Sdboot` encryption process: Handles device encryption setup and TPM enrollment using sdbootutil

Currently `TmpBls` is marked as unavailable in YaST (`available? = false`) as it's primarily implemented for Agama, but may eventually replace `SystemdFde`.
