### PR TITLE
Extend BootloaderType class

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 13 08:50:12 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Allow checking if a bootloader type is BLS-compliant (related to
+  jsc#PED-10703).
+- 5.0.45
+
+-------------------------------------------------------------------
 Tue May 12 15:58:21 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - New BlsEfi strategy to be used by Agama to create partitions for

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.44
+Version:        5.0.45
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/bootloader_type.rb
+++ b/src/lib/y2storage/bootloader_type.rb
@@ -27,18 +27,20 @@ module Y2Storage
     # Constructor, to be used internally by the class
     #
     # @param value [String] see {#value}
-    def initialize(value)
+    # @param bls [Boolean] Whether it is a BLS bootloader.
+    def initialize(value, bls: false)
       @value = value
+      @bls = bls
     end
 
     # Instance of the bootloader type to be always returned by the class
     GRUB2 = new("grub2")
 
     # Instance of the bootloader type to be always returned by the class
-    SYSTEMD_BOOT = new("systemd-boot")
+    SYSTEMD_BOOT = new("systemd-boot", bls: true)
 
     # Instance of the bootloader type to be always returned by the class
-    GRUB2_BLS = new("grub2-bls")
+    GRUB2_BLS = new("grub2-bls", bls: true)
 
     # Instance of the bootloader type to be always returned by the class
     #
@@ -77,6 +79,13 @@ module Y2Storage
     # @return [Symbol]
     def to_sym
       value.to_sym
+    end
+
+    # Whether it is a BLS bootloader.
+    #
+    # @return [Boolean]
+    def bls?
+      !!@bls
     end
 
     # Checks whether the object corresponds to any of the given enum values.

--- a/src/lib/y2storage/bootloader_type.rb
+++ b/src/lib/y2storage/bootloader_type.rb
@@ -81,7 +81,9 @@ module Y2Storage
       value.to_sym
     end
 
-    # Whether it is a BLS bootloader.
+    # Whether it is a BLS-compliant bootloader.
+    #
+    # @see https://uapi-group.org/specifications/specs/boot_loader_specification
     #
     # @return [Boolean]
     def bls?


### PR DESCRIPTION
## Problem

Agama needs to know if a `BootloaderType` is BLS-compliant.

Needed for https://github.com/agama-project/agama/pull/3448.

## Solution

Add `#bls?` method to check if the bootloader is BLS-compliant.
