### PR TITLE
Fix BLS LEGACY bootloader type

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May 14 08:03:48 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Set BLS LEGACY bootloader as BLS (related to jsc#PED-10703).
+- 5.0.46
+
+-------------------------------------------------------------------
 Wed May 13 08:50:12 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Allow checking if a bootloader type is BLS-compliant (related to

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.45
+Version:        5.0.46
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/bootloader_type.rb
+++ b/src/lib/y2storage/bootloader_type.rb
@@ -47,7 +47,7 @@ module Y2Storage
     # Special value used to specify a BLS-capable bootloader that must be installed in a way that is
     # backwards compatible with Grub2. Used by YaST to ensure things keep working with its partial
     # and debatable implementation of BLS.
-    BLS_LEGACY = new("bls-legacy")
+    BLS_LEGACY = new("bls-legacy", bls: true)
 
     # Instance of the bootloader type to be always returned by the class
     #


### PR DESCRIPTION
## Problem

The bootloader type BLS LEGACY was not initialized as a BLS bootloader.


## Solution

Properly intitialize BLS LEGACY bootloader.