### PR TITLE
Mount securityfs

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 15 10:59:55 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Make sure to mount sys/kernel/security for the final steps of
+  the installation (related to jsc#PED-10703).
+- 5.0.47
+
+-------------------------------------------------------------------
 Thu May 14 08:03:48 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Set BLS LEGACY bootloader as BLS (related to jsc#PED-10703).

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.46
+Version:        5.0.47
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/clients/inst_prepdisk.rb
+++ b/src/lib/y2storage/clients/inst_prepdisk.rb
@@ -79,10 +79,7 @@ module Y2Storage
         mount_in_target("/proc", "proc", "-t proc")
         mount_in_target("/sys", "sysfs", "-t sysfs")
         mount_in_target(EFIVARS_PATH, "efivarfs", "-t efivarfs") if mount_efivars?
-        devicegraph = manager.staging
-        if devicegraph.encryptions.any? { |e| e.method&.is?(:systemd_fde) }
-          mount_in_target("/sys/kernel/security", "securityfs", "-t securityfs")
-        end
+        mount_in_target("/sys/kernel/security", "securityfs", "-t securityfs")
         # systemd makes default for mount bind sharable, but it causes troubles with
         # systemd credentials that created another mount point under /run when someone
         # logs in. Result is that later /run cannot be unmounted. There is no benefit now


### PR DESCRIPTION
## Problem

We found yet another trace of the architectural mayhem caused during the initial BLS implementation. See #1425.

## Solution

Stop accessing the staging devicegraph and checking its content from places that should never have done that.

## Testing

- Tested manually in a system with TPM.
- Not tested in a system without TPM but that securityfs seems to be there in all modern Linux systems. And, if not, I would only expect a warning in the logs as the biggest "problem".
