### PR TITLE
Use session keyring to pass keys to sdbootutil 

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 15 13:43:54 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Use the session keyring instead of the user one to communicate
+  with sdbootutil (related to jsc#PED-10703).
+- 5.0.48 
+
+-------------------------------------------------------------------
 Fri May 15 10:59:55 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Make sure to mount sys/kernel/security for the final steps of

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.47
+Version:        5.0.48
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/encryption_processes/sdboot.rb
+++ b/src/lib/y2storage/encryption_processes/sdboot.rb
@@ -99,7 +99,7 @@ module Y2Storage
           return
         end
 
-        Yast::Execute.on_target!("keyctl", "padd", "user", kind, "@u",
+        Yast::Execute.on_target!("keyctl", "padd", "user", kind, "@s",
           recorder: Yast::ReducedRecorder.new(skip: :stdin),
           stdin:    password)
       rescue Cheetah::ExecutionFailed => e

--- a/test/y2storage/encryption_processes/sdboot_test.rb
+++ b/test/y2storage/encryption_processes/sdboot_test.rb
@@ -97,7 +97,7 @@ describe Y2Storage::EncryptionProcesses::Sdboot do
       it "exports password for cryptenroll" do
         expect(Yast::Execute).to receive(:on_target!)
           .with(
-            "keyctl", "padd", "user", "cryptenroll", "@u",
+            "keyctl", "padd", "user", "cryptenroll", "@s",
             hash_including(stdin: password)
           )
 
@@ -107,7 +107,7 @@ describe Y2Storage::EncryptionProcesses::Sdboot do
       it "exports password for sdbootutil" do
         expect(Yast::Execute).to receive(:on_target!)
           .with(
-            "keyctl", "padd", "user", "sdbootutil", "@u",
+            "keyctl", "padd", "user", "sdbootutil", "@s",
             hash_including(stdin: password)
           )
 

--- a/test/y2storage/tpm_bls_encryption_test.rb
+++ b/test/y2storage/tpm_bls_encryption_test.rb
@@ -52,12 +52,12 @@ describe "TPM BLS encryption" do
     it "adds password used by systemd-cryptenroll" do
       expect(Yast::Execute)
         .to(receive(:on_target!))
-        .with("keyctl", "padd", "user", "cryptenroll", "@u",
+        .with("keyctl", "padd", "user", "cryptenroll", "@s",
           hash_including(stdin: "notsecret-sda1"))
 
       expect(Yast::Execute)
         .to(receive(:on_target!))
-        .with("keyctl", "padd", "user", "cryptenroll", "@u",
+        .with("keyctl", "padd", "user", "cryptenroll", "@s",
           hash_including(stdin: "notsecret-sda2"))
 
       manager.staging.finish_installation
@@ -66,12 +66,12 @@ describe "TPM BLS encryption" do
     it "adds password used by sdbootutil" do
       expect(Yast::Execute)
         .to(receive(:on_target!))
-        .with("keyctl", "padd", "user", "sdbootutil", "@u",
+        .with("keyctl", "padd", "user", "sdbootutil", "@s",
           hash_including(stdin: "notsecret-sda1"))
 
       expect(Yast::Execute)
         .to(receive(:on_target!))
-        .with("keyctl", "padd", "user", "sdbootutil", "@u",
+        .with("keyctl", "padd", "user", "sdbootutil", "@s",
           hash_including(stdin: "notsecret-sda2"))
 
       manager.staging.finish_installation


### PR DESCRIPTION
## Problem

During manual testing it was detected that `sdbootutil` is not able to find the keys stored in the keyring `@u` when running in Agama, even though that's the keyring that YaST is using (and supposedly is working).

## Solution

Use the keyring `@s`, which seems to work according to manual testing.

## Testing

Tested manually