### PR TITLE
Provide more info about packages

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,9 +1,16 @@
 -------------------------------------------------------------------
+Fri Jun 19 13:25:53 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Add method to get the required package objects (needed for
+  gh#agama-project/agama#3649).
+- 5.0.49
+
+-------------------------------------------------------------------
 Fri May 15 13:43:54 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Use the session keyring instead of the user one to communicate
   with sdbootutil (related to jsc#PED-10703).
-- 5.0.48 
+- 5.0.48
 
 -------------------------------------------------------------------
 Fri May 15 10:59:55 UTC 2026 - Ancor Gonzalez Sosa <ancor@suse.com>

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.48
+Version:        5.0.49
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/feature.rb
+++ b/src/lib/y2storage/feature.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2023] SUSE LLC
+# Copyright (c) [2023-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -31,60 +31,7 @@ module Y2Storage
   #
   # This is the abstract base class for both.
   class Feature
-    include Yast::Logger
-
-    # Constructor
-    #
-    # @param id [Symbol] see {#id}
-    # @param packages [Array<Package>] see {#all_packages}
-    def initialize(id, packages)
-      @id = id
-      @all_packages = packages
-    end
-
-    # Symbol representation of the feature
-    #
-    # For StorageFeature objects, this has the same form than the corresponding constant
-    # name in libstorage-ng, eg. :UF_NTFS
-    #
-    # @return [Symbol]
-    attr_reader :id
-
-    alias_method :to_sym, :id
-
-    # Names of the packages that should be installed if the feature is going to be used
-    #
-    # @return [Array<String>]
-    def pkg_list
-      packages.map(&:name)
-    end
-
-    # Drop the cache about which packages related to the feature are available
-    def drop_cache
-      @packages = nil
-    end
-
-    private
-
-    # All packages that would be relevant for the feature, no matter if they are really available
-    # @return [Array<Feature::Package>]
-    attr_reader :all_packages
-
-    # List of available packages associated to the feature
-    #
-    # @return [Array<Feature::Package>]
-    def packages
-      return @packages unless @packages.nil?
-
-      unavailable, @packages = all_packages.partition(&:unavailable_optional?)
-      if unavailable.any?
-        log.warn("WARNING: Skipping unavailable support packages #{unavailable.map(&:name)}")
-      end
-
-      @packages
-    end
-
-    # Internal class to represent a package associated to a feature
+    # Nested class to represent a package associated to a feature
     class Package
       Yast.import "Package"
 
@@ -119,5 +66,57 @@ module Y2Storage
         optional? && !Yast::Package.Available(name)
       end
     end
+
+    include Yast::Logger
+
+    # Constructor
+    #
+    # @param id [Symbol] see {#id}
+    # @param packages [Array<Package>] see {#all_packages}
+    def initialize(id, packages)
+      @id = id
+      @all_packages = packages
+    end
+
+    # Symbol representation of the feature
+    #
+    # For StorageFeature objects, this has the same form than the corresponding constant
+    # name in libstorage-ng, eg. :UF_NTFS
+    #
+    # @return [Symbol]
+    attr_reader :id
+    alias_method :to_sym, :id
+
+    # List of available packages associated to the feature
+    #
+    # @return [Array<Feature::Package>]
+    def packages
+      return @packages unless @packages.nil?
+
+      unavailable, @packages = all_packages.partition(&:unavailable_optional?)
+      if unavailable.any?
+        log.warn("WARNING: Skipping unavailable support packages #{unavailable.map(&:name)}")
+      end
+
+      @packages
+    end
+
+    # Names of the packages that should be installed if the feature is going to be used
+    #
+    # @return [Array<String>]
+    def pkg_list
+      packages.map(&:name)
+    end
+
+    # Drop the cache about which packages related to the feature are available
+    def drop_cache
+      @packages = nil
+    end
+
+    private
+
+    # All packages that would be relevant for the feature, no matter if they are really available
+    # @return [Array<Feature::Package>]
+    attr_reader :all_packages
   end
 end

--- a/src/lib/y2storage/storage_features_list.rb
+++ b/src/lib/y2storage/storage_features_list.rb
@@ -72,6 +72,13 @@ module Y2Storage
       @pkg_list
     end
 
+    # Returns the list of required packages.
+    #
+    # @return [Array<Feature::Package>]
+    def packages
+      @features.flat_map(&:packages).uniq(&:name)
+    end
+
     # Concatenate the give features into the current list
     #
     # @param other_list [#to_a]

--- a/test/y2storage/storage_features_list_test.rb
+++ b/test/y2storage/storage_features_list_test.rb
@@ -2,7 +2,7 @@
 #
 # encoding: utf-8
 
-# Copyright (c) [2017-2023] SUSE LLC
+# Copyright (c) [2017-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -123,6 +123,86 @@ describe Y2Storage::StorageFeaturesList do
 
       it "includes the packages related to both kind of features" do
         expect(list.pkg_list).to include("device-mapper", "cryptsetup", "fde-tools")
+      end
+    end
+  end
+
+  describe "#packages" do
+    subject(:list) { described_class.from_bitfield(bits) }
+
+    context "if several features require the same package" do
+      let(:bits) do
+        Storage::UF_EXT2 | Storage::UF_LUKS | Storage::UF_EXT3 | Storage::UF_PLAIN_ENCRYPTION
+      end
+
+      it "returns an array of Feature::Package objects" do
+        expect(list.packages).to all(be_a(Y2Storage::Feature::Package))
+      end
+
+      it "includes the package only once (no duplicates)" do
+        package_names = list.packages.map(&:name).sort
+        expect(package_names).to eq ["cryptsetup", "device-mapper", "e2fsprogs"]
+      end
+    end
+
+    context "if some packages are optional" do
+      let(:bits) { Storage::UF_NTFS | Storage::UF_EXT3 }
+
+      before do
+        Y2Storage::StorageFeature.drop_cache
+        allow(Yast::Package).to receive(:Available).and_return false
+        allow(Yast::Package).to receive(:Available).with("ntfsprogs").and_return true
+      end
+
+      it "returns Feature::Package objects with correct optional flag" do
+        packages = list.packages
+        e2fsprogs = packages.find { |p| p.name == "e2fsprogs" }
+        ntfsprogs = packages.find { |p| p.name == "ntfsprogs" }
+
+        expect(e2fsprogs.optional?).to be false
+        expect(ntfsprogs.optional?).to be true
+      end
+
+      it "includes the non-optional packages even if they are not available" do
+        package_names = list.packages.map(&:name)
+        expect(package_names).to include "e2fsprogs"
+      end
+
+      it "includes the optional packages that are available" do
+        package_names = list.packages.map(&:name)
+        expect(package_names).to include "ntfsprogs"
+      end
+
+      it "does not include the optional packages that are not available" do
+        package_names = list.packages.map(&:name)
+        expect(package_names).to_not include "ntfs-3g"
+      end
+    end
+
+    context "for a list created with a zero bit-field" do
+      let(:bits) { 0 }
+
+      it "returns an empty array" do
+        expect(list.packages).to eq []
+      end
+    end
+
+    context "when the list includes both storage and YaST features" do
+      let(:bits) { Storage::UF_LUKS }
+
+      before do
+        Y2Storage::YastFeature.drop_cache
+
+        list.concat(Y2Storage::YastFeature.all)
+      end
+
+      it "returns Feature::Package objects from both kinds of features" do
+        expect(list.packages).to all(be_a(Y2Storage::Feature::Package))
+      end
+
+      it "includes the packages related to both kind of features" do
+        package_names = list.packages.map(&:name)
+        expect(package_names).to include("device-mapper", "cryptsetup", "fde-tools")
       end
     end
   end


### PR DESCRIPTION
## Problem

Agama is going to assume all packages are available in order to avoid calling to YaST software. But Agama needs to know what packages are optional. Right now there is no way to know what packages are optional. 

Needed for https://github.com/agama-project/agama/pull/3649.

## Solution

Extend the class `StorageFeatureList`. Now it provides the method `#packages` which returns a list of `Package` objects. Agama can check if each package is optional.

NOTE: rubocop failure is not related to this PR.
