### PR TITLE
Avoid generating too long crypt names

### DIFF
--- a/package/yast2-storage-ng.changes
+++ b/package/yast2-storage-ng.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 12 10:09:27 UTC 2026 - José Iván López González <jlopez@suse.com>
+
+- Fix automatic generation of crypt names (bsc#1247173).
+- 5.0.50
+
+-------------------------------------------------------------------
 Fri Jun 19 13:25:53 UTC 2026 - José Iván López González <jlopez@suse.com>
 
 - Add method to get the required package objects (needed for

--- a/package/yast2-storage-ng.spec
+++ b/package/yast2-storage-ng.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage-ng
-Version:        5.0.49
+Version:        5.0.50
 Release:        0
 Summary:        YaST2 - Storage Configuration
 License:        GPL-2.0-only OR GPL-3.0-only

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -64,6 +64,11 @@ module Y2Storage
     #   @return [BlkDevice] nil if there is no such block device
     storage_class_forward :find_by_any_name, as: "BlkDevice"
 
+    # @!method self.valid_dm_table_name?(dm_table_name)
+    #   @param dm_table_name [String]
+    #   @return [Boolean]
+    storage_class_forward :valid_dm_table_name?
+
     # @!attribute name
     #   @return [String] kernel-style device name
     #     (e.g. "/dev/sda2" or "/dev/vg_name/lv_name")

--- a/src/lib/y2storage/blk_device.rb
+++ b/src/lib/y2storage/blk_device.rb
@@ -29,7 +29,7 @@ module Y2Storage
   # Base class for most devices having a device name, udev path and udev ids.
   #
   # This is a wrapper for Storage::BlkDevice
-  class BlkDevice < Device
+  class BlkDevice < Device # rubocop:disable Metrics/ClassLength
     wrap_class Storage::BlkDevice,
       downcast_to: ["Partitionable", "Partition", "Encryption", "LvmLv", "StrayBlkDevice"]
 

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -573,7 +573,7 @@ module Y2Storage
       candidates = []
       candidates << blk_device.dm_table_name unless blk_device.dm_table_name.empty?
       candidates << mount_point_to_dm_name unless mount_point.nil?
-      candidates += blk_device.udev_ids if blk_device.udev_ids.any?
+      candidates += blk_device.udev_ids
       candidates << blk_device.basename
 
       candidates.map { |c| generate_auto_dm_table_name(c) }

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -53,6 +53,11 @@ module Y2Storage
     #   @return [Array<Encryption>] all the encryption devices in the given devicegraph
     storage_class_forward :all, as: "Encryption"
 
+    # @!method self.valid_dm_table_name?(dm_table_name)
+    #   @param dm_table_name [String]
+    #   @return [Boolean]
+    storage_class_forward :valid_dm_table_name?
+
     # @!method in_etc_crypttab?
     #   @return [Boolean] whether the device is included in /etc/crypttab
     storage_forward :in_etc_crypttab?
@@ -193,36 +198,16 @@ module Y2Storage
       super
     end
 
-    # Generates an unused device mapper name for the encryption device
+    # Generates a device mapper name for the encryption device
     #
     # This name is used for devices with auto dm names, see {.update_dm_names}.
     #
+    # @note If there is no valid candidate name, then a fallback name like "cr_device_1" is used
+    #
     # @return [String]
     def auto_dm_table_name
-      # TODO: Better encryption names can be generated for indirectly used encryption devices (e.g., an
-      # encrypted device used as LVM PV). But this implies to update the auto generated device mapper
-      # names at some quite points, for example, when a device is added/removed to a LVM VG, MD RAID,
-      # etc.
-      #
-      # Another option could be to update the encryption names just before the commit action, but in that
-      # case, the devicegraph would contain temporary encryption names all the time. Temporary names are
-      # a problem if they are presented to the user in the UI.
-      #
-      # Note that any change to the encryption name generation could affect to the pervasive encryption
-      # key generation, specially when probed encryption names are modified. Right now, probed names are
-      # not touched.
-      name =
-        if !blk_device.dm_table_name.empty?
-          blk_device.dm_table_name
-        elsif !mount_point.nil?
-          mount_point_to_dm_name
-        elsif blk_device.udev_ids.any?
-          blk_device.udev_ids.first
-        else
-          blk_device.basename
-        end
-
-      self.class.ensure_unused_dm_name(devicegraph, "cr_#{name}")
+      name = candidate_auto_dm_table_names.find { |c| self.class.valid_dm_table_name?(c) }
+      name || generate_auto_dm_table_name("device")
     end
 
     # Whether {#dm_table_name} was automatically set by YaST.
@@ -568,6 +553,38 @@ module Y2Storage
       elsif !in_mount_points && in_encryption
         self.crypt_options = crypt_options - [crypttab_option]
       end
+    end
+
+    # Candidate device mapper names for the encryption device
+    #
+    # TODO: Better encryption names can be generated for indirectly used encryption devices (e.g., an
+    # encrypted device used as LVM PV). But this implies to update the auto generated device mapper
+    # names at some quite points, for example, when a device is added/removed to a LVM VG, MD RAID,
+    # etc.
+    #
+    # Another option could be to update the encryption names just before the commit action, but in that
+    # case, the devicegraph would contain temporary encryption names all the time. Temporary names are
+    # a problem if they are presented to the user in the UI.
+    #
+    # Note that any change to the encryption name generation could affect to the pervasive encryption
+    # key generation, specially when probed encryption names are modified. Right now, probed names are
+    # not touched.
+    def candidate_auto_dm_table_names
+      candidates = []
+      candidates << blk_device.dm_table_name unless blk_device.dm_table_name.empty?
+      candidates << mount_point_to_dm_name unless mount_point.nil?
+      candidates += blk_device.udev_ids if blk_device.udev_ids.any?
+      candidates << blk_device.basename
+
+      candidates.map { |c| generate_auto_dm_table_name(c) }
+    end
+
+    # Generates an unused device mapper name for the encryption device based on the given name
+    #
+    # @param name [String]
+    # @return [String]
+    def generate_auto_dm_table_name(name)
+      self.class.ensure_unused_dm_name(devicegraph, "cr_#{name}")
     end
 
     # Generates a base dm name from the mount point path

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -53,11 +53,6 @@ module Y2Storage
     #   @return [Array<Encryption>] all the encryption devices in the given devicegraph
     storage_class_forward :all, as: "Encryption"
 
-    # @!method self.valid_dm_table_name?(dm_table_name)
-    #   @param dm_table_name [String]
-    #   @return [Boolean]
-    storage_class_forward :valid_dm_table_name?
-
     # @!method in_etc_crypttab?
     #   @return [Boolean] whether the device is included in /etc/crypttab
     storage_forward :in_etc_crypttab?

--- a/src/lib/y2storage/encryption.rb
+++ b/src/lib/y2storage/encryption.rb
@@ -193,6 +193,11 @@ module Y2Storage
       super
     end
 
+    # Base name to use as fallback for the auto generated DM name when none of the candidate names
+    # is valid, see {#auto_dm_table_name}.
+    DM_BASE_NAME_FALLBACK = "device".freeze
+    private_constant :DM_BASE_NAME_FALLBACK
+
     # Generates a device mapper name for the encryption device
     #
     # This name is used for devices with auto dm names, see {.update_dm_names}.
@@ -202,7 +207,7 @@ module Y2Storage
     # @return [String]
     def auto_dm_table_name
       name = candidate_auto_dm_table_names.find { |c| self.class.valid_dm_table_name?(c) }
-      name || generate_auto_dm_table_name("device")
+      name || generate_auto_dm_table_name(DM_BASE_NAME_FALLBACK)
     end
 
     # Whether {#dm_table_name} was automatically set by YaST.

--- a/test/y2storage/encryption_test.rb
+++ b/test/y2storage/encryption_test.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env rspec
 
-# Copyright (c) [2018-2021] SUSE LLC
+# Copyright (c) [2018-2026] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -130,6 +130,21 @@ describe Y2Storage::Encryption do
           end
 
           include_examples "repeated dm name", "cr_disk-1122-part2"
+        end
+
+        context "and udev ids are too long" do
+          let(:udev_ids) do
+            [
+              "cr_nvme-nvme.1c5c-465341434e343332393130313043423356-534b2068796e69782050433731312" \
+              "048465335313247444539583037334e-00000001-part2"
+            ]
+          end
+
+          it "generates an encryption name based on the underlying device name" do
+            expect(subject.auto_dm_table_name).to eq("cr_sda2")
+          end
+
+          include_examples "repeated dm name", "cr_sda2"
         end
 
         context "and no udev ids are recognized for the underlying device" do


### PR DESCRIPTION
## Problem

In some cases the udev ids are too long, and basing the crypt name on such ids ends up in a too long name (more than 128 characters), making `cryptsetup` to fail.

https://bugzilla.suse.com/show_bug.cgi?id=1247173

## Solution

Validate the automatic generated crypt name, ensuring the proposed name is valid. A valid crypt name ("cr_device_X") is used as fallback if none of the candidate names are valid.
